### PR TITLE
Fix npm authentication in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `NODE_AUTH_TOKEN` environment variable to the release workflow
- The `actions/setup-node` action with `registry-url` creates an `.npmrc` that expects `NODE_AUTH_TOKEN`, not `NPM_TOKEN`

## Context
The release workflow was failing with errors like:
```
npm notice Access token expired or revoked. Please try logging in again.
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@formspec%2fcore
```

## Test plan
- [ ] Verify `NPM_TOKEN` secret is valid and not expired in GitHub repository settings
- [ ] Merge this PR and observe that the release workflow succeeds