### PR TITLE
Add changeset for enum object options feature

### DIFF
--- a/.changeset/enum-object-options.md
+++ b/.changeset/enum-object-options.md
@@ -1,0 +1,31 @@
+---
+"@formspec/core": minor
+"@formspec/dsl": minor
+"@formspec/build": minor
+---
+
+Add support for object-based enum options with separate id and label
+
+Enum fields can now use object options with `id` and `label` properties, allowing the stored value to differ from the display text.
+
+### New types
+
+- `EnumOption` - Interface for object-based enum options with `id` and `label`
+- `EnumOptionValue` - Union type accepting both string and object options
+
+### Usage
+
+```typescript
+// String options (existing behavior)
+field.enum("status", ["draft", "sent", "paid"])
+
+// Object options (new)
+field.enum("priority", [
+  { id: "low", label: "Low Priority" },
+  { id: "high", label: "High Priority" },
+])
+```
+
+### JSON Schema generation
+
+Object-based enum options generate `oneOf` schemas with `const` and `title` properties instead of the `enum` keyword, preserving both the value and display label in the schema.


### PR DESCRIPTION
## Summary

Adds a changeset for PR #6 which introduced support for object-based enum options.

This changeset documents the minor version bump for `@formspec/core`, `@formspec/dsl`, and `@formspec/build` packages.