### PR TITLE
Add runtime warning when decorated classes lack type metadata

### DIFF
--- a/.changeset/runtime-type-metadata-warning.md
+++ b/.changeset/runtime-type-metadata-warning.md
@@ -16,9 +16,9 @@ without running `formspec codegen` first, the function now emits a warning:
   To fix this, run: formspec codegen <your-file.ts> -o ./__formspec_types__.ts
   Then import the generated file BEFORE calling toFormSpec():
 
-    import './__formspec_types__.js';
+    import './__formspec_types__';
     import { toFormSpec } from '@formspec/decorators';
-    const spec = toFormSpec(MyForm);
+    const schemas = toFormSpec(MyForm);
 ```
 
 This addresses DX evaluation feedback that silent degradation (all fields becoming

--- a/packages/decorators/src/__tests__/to-formspec.test.ts
+++ b/packages/decorators/src/__tests__/to-formspec.test.ts
@@ -19,6 +19,7 @@ import {
   ShowWhen,
   Group,
   toFormSpec,
+  buildFormSchemas,
   getDecoratorMetadata,
   getTypeMetadata,
   type TypeMetadata,
@@ -498,7 +499,33 @@ describe("missing type metadata warning", () => {
       expect.stringContaining("formspec codegen")
     );
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("import './__formspec_types__.js'")
+      expect.stringContaining("import './__formspec_types__'")
     );
+  });
+
+  it("should emit warning when buildFormSchemas is called on decorated class without type metadata", () => {
+    class BuildSchemasWarnForm {
+      @Label("Name")
+      name!: string;
+    }
+
+    buildFormSchemas(BuildSchemasWarnForm);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[FormSpec] Warning: buildFormSchemas(BuildSchemasWarnForm) called without type metadata")
+    );
+  });
+
+  it("should only warn once per class for buildFormSchemas", () => {
+    class BuildSchemasOnceForm {
+      @Label("Name")
+      name!: string;
+    }
+
+    buildFormSchemas(BuildSchemasOnceForm);
+    buildFormSchemas(BuildSchemasOnceForm);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/decorators/src/index.ts
+++ b/packages/decorators/src/index.ts
@@ -602,9 +602,9 @@ function warnIfMissingTypeMetadata(
     `  - Enum options from TypeScript types will not be available\n\n` +
     `  To fix this, run: formspec codegen <your-file.ts> -o ./__formspec_types__.ts\n` +
     `  Then import the generated file BEFORE calling ${functionName}():\n\n` +
-    `    import './__formspec_types__.js';\n` +
+    `    import './__formspec_types__';\n` +
     `    import { ${functionName} } from '@formspec/decorators';\n` +
-    `    const spec = ${functionName}(${className});\n`
+    `    const schemas = ${functionName}(${className});\n`
   );
 }
 


### PR DESCRIPTION
## Summary

When `toFormSpec()` or `buildFormSchemas()` is called on a decorated class without running `formspec codegen` first, the function now emits a warning with actionable instructions.

## Problem

DX Evaluation #4 identified this as a **High severity** issue:

> **H1: Silent Degradation Without Type Metadata**
> When called without type metadata (before importing codegen output), the functions return degraded results silently - all fields become "text", all fields become "required".
>
> **Expected**: Warning, error, or at minimum a different return type indicating incomplete information.
>
> **Impact**: A developer might not realize their form is incomplete until runtime bugs appear in production.

## Solution

Added `warnIfMissingTypeMetadata()` helper that emits a helpful warning:

```
[FormSpec] Warning: toFormSpec(MyForm) called without type metadata.
  - All fields will default to type "text"
  - All fields will be marked as required
  - Enum options from TypeScript types will not be available

  To fix this, run: formspec codegen <your-file.ts> -o ./__formspec_types__.ts
  Then import the generated file BEFORE calling toFormSpec():

    import './__formspec_types__.js';
    import { toFormSpec } from '@formspec/decorators';
    const spec = toFormSpec(MyForm);
```

The warning:
- Uses `WeakSet` to track warned classes (prevents duplicate warnings)
- Only warns for decorated classes (plain classes without decorators are not warned)
- Includes actionable instructions pointing to the codegen command

## Test plan

- [x] Added 5 new tests for warning behavior
- [x] All 33 decorator tests pass
- [x] Warning appears in test output (as expected)