### PR TITLE
Enable GitHub Pages auto-enablement in deploy workflow

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary

Fix the failing deploy-playground.yml workflow by enabling auto-enablement of GitHub Pages.

## Problem

The workflow was failing with:
```
Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions
```

## Solution

Add `enablement: true` to the `actions/configure-pages@v5` step, which will automatically enable GitHub Pages for the repository on the first run.

## Test plan

- [ ] Merge this PR
- [ ] Verify the deploy-playground workflow succeeds
- [ ] Verify the playground is accessible at https://mike-north.github.io/formspec/