### PR TITLE
Address PR #43 review feedback

### DIFF
--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -175,7 +175,12 @@ export function analyzeField(
 
 /**
  * Given a type node, checks if it references a type alias and extracts
- * any JSDoc constraint/display-metadata tags from the alias declaration.
+ * JSDoc constraint tags from the alias declaration.
+ *
+ * Only constraint tags (`@Minimum`, `@Maximum`, `@Pattern`, etc.) are
+ * propagated — display metadata (`@Field_displayName`, `@Field_description`)
+ * is intentionally excluded because display metadata is a field-level
+ * concern, not a type-level one.
  *
  * This makes `type Percent = number` with `@Minimum 0 @Maximum 100`
  * propagate constraints to any field typed as `Percent`.

--- a/packages/build/src/analyzer/type-converter.ts
+++ b/packages/build/src/analyzer/type-converter.ts
@@ -149,7 +149,7 @@ function getObjectPropertyInfos(
   type: ts.ObjectType,
   checker: ts.TypeChecker
 ): ObjectPropertyInfo[] {
-  const classFieldMap = getNamedTypeFieldInfoMap(type, checker);
+  const fieldInfoMap = getNamedTypeFieldInfoMap(type, checker);
   const result: ObjectPropertyInfo[] = [];
 
   for (const prop of type.getProperties()) {
@@ -158,7 +158,7 @@ function getObjectPropertyInfos(
 
     const propType = checker.getTypeOfSymbolAtLocation(prop, declaration);
     const optional = !!(prop.flags & ts.SymbolFlags.Optional);
-    const fieldInfo = classFieldMap?.get(prop.name) ?? undefined;
+    const fieldInfo = fieldInfoMap?.get(prop.name) ?? undefined;
 
     result.push({ name: prop.name, type: propType, optional, fieldInfo });
   }


### PR DESCRIPTION
## Summary

- Update `extractTypeAliasConstraints` docstring to reflect that only constraint tags propagate (display metadata intentionally excluded)
- Rename `classFieldMap` → `fieldInfoMap` in `getObjectPropertyInfos` to match the renamed `getNamedTypeFieldInfoMap` helper

## Test plan

- [x] 235 tests passing