### PR TITLE
feat(core): add Canonical IR type definitions and IR_VERSION constant

### DIFF
--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -5,7 +5,24 @@
 ```ts
 
 // @public
+export type AnnotationNode = DisplayNameAnnotationNode | DescriptionAnnotationNode | PlaceholderAnnotationNode | DefaultValueAnnotationNode | DeprecatedAnnotationNode | FormatHintAnnotationNode | CustomAnnotationNode;
+
+// @public
 export type AnyField = TextField<string> | NumberField<string> | BooleanField<string> | StaticEnumField<string, readonly EnumOptionValue[]> | DynamicEnumField<string, string> | DynamicSchemaField<string> | ArrayField<string, readonly FormElement[]> | ObjectField<string, readonly FormElement[]>;
+
+// @public
+export interface ArrayCardinalityConstraintNode {
+    // (undocumented)
+    readonly constraintKind: "uniqueItems";
+    // (undocumented)
+    readonly kind: "constraint";
+    // (undocumented)
+    readonly path?: PathTarget;
+    // (undocumented)
+    readonly provenance: Provenance;
+    // (undocumented)
+    readonly value: true;
+}
 
 // @public
 export interface ArrayField<N extends string, Items extends readonly FormElement[]> {
@@ -17,6 +34,14 @@ export interface ArrayField<N extends string, Items extends readonly FormElement
     readonly name: N;
     readonly required?: boolean;
     readonly _type: "field";
+}
+
+// @public
+export interface ArrayTypeNode {
+    // (undocumented)
+    readonly items: TypeNode;
+    // (undocumented)
+    readonly kind: "array";
 }
 
 // @public
@@ -37,6 +62,17 @@ export interface Conditional<FieldName extends string, Value, Elements extends r
 }
 
 // @public
+export interface ConditionalLayoutNode {
+    readonly elements: readonly FormIRElement[];
+    readonly fieldName: string;
+    // (undocumented)
+    readonly kind: "conditional";
+    // (undocumented)
+    readonly provenance: Provenance;
+    readonly value: JsonValue;
+}
+
+// @public
 export const CONSTRAINT_TAG_DEFINITIONS: {
     readonly Minimum: "number";
     readonly Maximum: "number";
@@ -49,10 +85,49 @@ export const CONSTRAINT_TAG_DEFINITIONS: {
 };
 
 // @public
+export type ConstraintNode = NumericConstraintNode | LengthConstraintNode | PatternConstraintNode | ArrayCardinalityConstraintNode | EnumMemberConstraintNode | CustomConstraintNode;
+
+// @public
 export type ConstraintTagName = keyof typeof CONSTRAINT_TAG_DEFINITIONS;
 
 // @public
 export function createInitialFieldState<T>(value: T): FieldState<T>;
+
+// @public
+export interface CustomAnnotationNode {
+    readonly annotationId: string;
+    // (undocumented)
+    readonly annotationKind: "custom";
+    // (undocumented)
+    readonly kind: "annotation";
+    // (undocumented)
+    readonly provenance: Provenance;
+    // (undocumented)
+    readonly value: JsonValue;
+}
+
+// @public
+export interface CustomConstraintNode {
+    readonly compositionRule: "intersect" | "override";
+    readonly constraintId: string;
+    // (undocumented)
+    readonly constraintKind: "custom";
+    // (undocumented)
+    readonly kind: "constraint";
+    // (undocumented)
+    readonly path?: PathTarget;
+    readonly payload: JsonValue;
+    // (undocumented)
+    readonly provenance: Provenance;
+}
+
+// @public
+export interface CustomTypeNode {
+    // (undocumented)
+    readonly kind: "custom";
+    readonly payload: JsonValue;
+    readonly typeId: string;
+}
 
 // @public
 export interface DataSourceOption<T = unknown> {
@@ -69,6 +144,52 @@ export interface DataSourceRegistry {
 export type DataSourceValueType<Source extends string> = Source extends keyof DataSourceRegistry ? DataSourceRegistry[Source] extends {
     id: infer ID;
 } ? ID : string : string;
+
+// @public
+export interface DefaultValueAnnotationNode {
+    // (undocumented)
+    readonly annotationKind: "defaultValue";
+    // (undocumented)
+    readonly kind: "annotation";
+    // (undocumented)
+    readonly provenance: Provenance;
+    readonly value: JsonValue;
+}
+
+// @public
+export interface DeprecatedAnnotationNode {
+    // (undocumented)
+    readonly annotationKind: "deprecated";
+    // (undocumented)
+    readonly kind: "annotation";
+    readonly message?: string;
+    // (undocumented)
+    readonly provenance: Provenance;
+}
+
+// @public
+export interface DescriptionAnnotationNode {
+    // (undocumented)
+    readonly annotationKind: "description";
+    // (undocumented)
+    readonly kind: "annotation";
+    // (undocumented)
+    readonly provenance: Provenance;
+    // (undocumented)
+    readonly value: string;
+}
+
+// @public
+export interface DisplayNameAnnotationNode {
+    // (undocumented)
+    readonly annotationKind: "displayName";
+    // (undocumented)
+    readonly kind: "annotation";
+    // (undocumented)
+    readonly provenance: Provenance;
+    // (undocumented)
+    readonly value: string;
+}
 
 // @public
 export interface DynamicEnumField<N extends string, Source extends string> {
@@ -92,6 +213,36 @@ export interface DynamicSchemaField<N extends string> {
 }
 
 // @public
+export interface DynamicTypeNode {
+    // (undocumented)
+    readonly dynamicKind: "enum" | "schema";
+    // (undocumented)
+    readonly kind: "dynamic";
+    readonly parameterFields: readonly string[];
+    readonly sourceKey: string;
+}
+
+// @public
+export interface EnumMember {
+    readonly displayName?: string;
+    readonly value: string | number;
+}
+
+// @public
+export interface EnumMemberConstraintNode {
+    // (undocumented)
+    readonly constraintKind: "allowedMembers";
+    // (undocumented)
+    readonly kind: "constraint";
+    // (undocumented)
+    readonly members: readonly (string | number)[];
+    // (undocumented)
+    readonly path?: PathTarget;
+    // (undocumented)
+    readonly provenance: Provenance;
+}
+
+// @public
 export interface EnumOption {
     // (undocumented)
     readonly id: string;
@@ -101,6 +252,14 @@ export interface EnumOption {
 
 // @public
 export type EnumOptionValue = string | EnumOption;
+
+// @public
+export interface EnumTypeNode {
+    // (undocumented)
+    readonly kind: "enum";
+    // (undocumented)
+    readonly members: readonly EnumMember[];
+}
 
 // @public
 export interface EqualsPredicate<K extends string, V> {
@@ -117,6 +276,22 @@ export interface FetchOptionsResponse<T = unknown> {
 }
 
 // @public
+export interface FieldNode {
+    readonly annotations: readonly AnnotationNode[];
+    readonly constraints: readonly ConstraintNode[];
+    // (undocumented)
+    readonly kind: "field";
+    readonly mergeHistory?: readonly {
+        readonly node: ConstraintNode | AnnotationNode;
+        readonly dominated: boolean;
+    }[];
+    readonly name: string;
+    readonly provenance: Provenance;
+    readonly required: boolean;
+    readonly type: TypeNode;
+}
+
+// @public
 export interface FieldState<T> {
     readonly dirty: boolean;
     readonly errors: readonly string[];
@@ -126,7 +301,31 @@ export interface FieldState<T> {
 }
 
 // @public
+export interface FormatHintAnnotationNode {
+    // (undocumented)
+    readonly annotationKind: "formatHint";
+    readonly format: string;
+    // (undocumented)
+    readonly kind: "annotation";
+    // (undocumented)
+    readonly provenance: Provenance;
+}
+
+// @public
 export type FormElement = AnyField | Group<readonly FormElement[]> | Conditional<string, unknown, readonly FormElement[]>;
+
+// @public
+export interface FormIR {
+    readonly elements: readonly FormIRElement[];
+    readonly irVersion: typeof IR_VERSION;
+    // (undocumented)
+    readonly kind: "form-ir";
+    readonly provenance: Provenance;
+    readonly typeRegistry: Readonly<Record<string, TypeDefinition>>;
+}
+
+// @public
+export type FormIRElement = FieldNode | LayoutNode;
 
 // @public
 export interface FormSpec<Elements extends readonly FormElement[]> {
@@ -157,6 +356,42 @@ export interface Group<Elements extends readonly FormElement[]> {
 }
 
 // @public
+export interface GroupLayoutNode {
+    readonly elements: readonly FormIRElement[];
+    // (undocumented)
+    readonly kind: "group";
+    // (undocumented)
+    readonly label: string;
+    // (undocumented)
+    readonly provenance: Provenance;
+}
+
+// @public
+export const IR_VERSION: "0.1.0";
+
+// @public
+export type JsonValue = null | boolean | number | string | readonly JsonValue[] | {
+    readonly [key: string]: JsonValue;
+};
+
+// @public
+export type LayoutNode = GroupLayoutNode | ConditionalLayoutNode;
+
+// @public
+export interface LengthConstraintNode {
+    // (undocumented)
+    readonly constraintKind: "minLength" | "maxLength" | "minItems" | "maxItems";
+    // (undocumented)
+    readonly kind: "constraint";
+    // (undocumented)
+    readonly path?: PathTarget;
+    // (undocumented)
+    readonly provenance: Provenance;
+    // (undocumented)
+    readonly value: number;
+}
+
+// @public
 export interface NumberField<N extends string> {
     readonly _field: "number";
     readonly label?: string;
@@ -165,6 +400,19 @@ export interface NumberField<N extends string> {
     readonly name: N;
     readonly required?: boolean;
     readonly _type: "field";
+}
+
+// @public
+export interface NumericConstraintNode {
+    // (undocumented)
+    readonly constraintKind: "minimum" | "maximum" | "exclusiveMinimum" | "exclusiveMaximum" | "multipleOf";
+    // (undocumented)
+    readonly kind: "constraint";
+    readonly path?: PathTarget;
+    // (undocumented)
+    readonly provenance: Provenance;
+    // (undocumented)
+    readonly value: number;
 }
 
 // @public
@@ -178,7 +426,85 @@ export interface ObjectField<N extends string, Properties extends readonly FormE
 }
 
 // @public
+export interface ObjectProperty {
+    readonly annotations: readonly AnnotationNode[];
+    readonly constraints: readonly ConstraintNode[];
+    // (undocumented)
+    readonly name: string;
+    // (undocumented)
+    readonly optional: boolean;
+    // (undocumented)
+    readonly provenance: Provenance;
+    // (undocumented)
+    readonly type: TypeNode;
+}
+
+// @public
+export interface ObjectTypeNode {
+    readonly additionalProperties: boolean;
+    // (undocumented)
+    readonly kind: "object";
+    readonly properties: readonly ObjectProperty[];
+}
+
+// @public
+export interface PathTarget {
+    readonly segments: readonly string[];
+}
+
+// @public
+export interface PatternConstraintNode {
+    // (undocumented)
+    readonly constraintKind: "pattern";
+    // (undocumented)
+    readonly kind: "constraint";
+    // (undocumented)
+    readonly path?: PathTarget;
+    readonly pattern: string;
+    // (undocumented)
+    readonly provenance: Provenance;
+}
+
+// @public
+export interface PlaceholderAnnotationNode {
+    // (undocumented)
+    readonly annotationKind: "placeholder";
+    // (undocumented)
+    readonly kind: "annotation";
+    // (undocumented)
+    readonly provenance: Provenance;
+    // (undocumented)
+    readonly value: string;
+}
+
+// @public
 export type Predicate<K extends string = string, V = unknown> = EqualsPredicate<K, V>;
+
+// @public
+export interface PrimitiveTypeNode {
+    // (undocumented)
+    readonly kind: "primitive";
+    // (undocumented)
+    readonly primitiveKind: "string" | "number" | "boolean" | "null";
+}
+
+// @public
+export interface Provenance {
+    readonly column: number;
+    readonly file: string;
+    readonly length?: number;
+    readonly line: number;
+    readonly surface: "tsdoc" | "chain-dsl" | "extension" | "inferred";
+    readonly tagName?: string;
+}
+
+// @public
+export interface ReferenceTypeNode {
+    // (undocumented)
+    readonly kind: "reference";
+    readonly name: string;
+    readonly typeArguments: readonly TypeNode[];
+}
 
 // @public
 export interface StaticEnumField<N extends string, O extends readonly EnumOptionValue[]> {
@@ -198,6 +524,24 @@ export interface TextField<N extends string> {
     readonly placeholder?: string;
     readonly required?: boolean;
     readonly _type: "field";
+}
+
+// @public
+export interface TypeDefinition {
+    readonly name: string;
+    readonly provenance: Provenance;
+    readonly type: TypeNode;
+}
+
+// @public
+export type TypeNode = PrimitiveTypeNode | EnumTypeNode | ArrayTypeNode | ObjectTypeNode | UnionTypeNode | ReferenceTypeNode | DynamicTypeNode | CustomTypeNode;
+
+// @public
+export interface UnionTypeNode {
+    // (undocumented)
+    readonly kind: "union";
+    // (undocumented)
+    readonly members: readonly TypeNode[];
 }
 
 // @public

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,9 +21,17 @@
     "build": "tsup && tsc --emitDeclarationOnly && api-extractor run --local",
     "clean": "rm -rf dist temp",
     "typecheck": "tsc --noEmit",
+    "test": "tsd",
+    "test:types": "tsd",
     "api-extractor": "api-extractor run",
     "api-extractor:local": "api-extractor run --local",
     "api-documenter": "api-documenter markdown -i temp -o docs"
+  },
+  "devDependencies": {
+    "tsd": "^0.31.0"
+  },
+  "tsd": {
+    "directory": "src/__tests__"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/__tests__/ir.test-d.ts
+++ b/packages/core/src/__tests__/ir.test-d.ts
@@ -1,0 +1,731 @@
+/**
+ * Type-level tests for the Canonical IR types.
+ *
+ * Verifies structural correctness of the IR type definitions at compile time.
+ * Run with: pnpm --filter @formspec/core run test:types
+ *
+ * @see {@link https://github.com/stripe/formspec-workspace/blob/main/scratch/design/001-canonical-ir.md}
+ */
+
+import { expectType, expectNotType, expectAssignable, expectError } from "tsd";
+import { IR_VERSION } from "../index.js";
+import type {
+  JsonValue,
+  Provenance,
+  PathTarget,
+  TypeNode,
+  PrimitiveTypeNode,
+  EnumMember,
+  EnumTypeNode,
+  ArrayTypeNode,
+  ObjectProperty,
+  ObjectTypeNode,
+  UnionTypeNode,
+  ReferenceTypeNode,
+  DynamicTypeNode,
+  CustomTypeNode,
+  ConstraintNode,
+  NumericConstraintNode,
+  LengthConstraintNode,
+  PatternConstraintNode,
+  ArrayCardinalityConstraintNode,
+  EnumMemberConstraintNode,
+  CustomConstraintNode,
+  AnnotationNode,
+  DisplayNameAnnotationNode,
+  DescriptionAnnotationNode,
+  PlaceholderAnnotationNode,
+  DefaultValueAnnotationNode,
+  DeprecatedAnnotationNode,
+  FormatHintAnnotationNode,
+  CustomAnnotationNode,
+  FieldNode,
+  LayoutNode,
+  GroupLayoutNode,
+  ConditionalLayoutNode,
+  FormIRElement,
+  TypeDefinition,
+  FormIR,
+} from "../index.js";
+
+// =============================================================================
+// IR_VERSION constant
+// =============================================================================
+
+expectType<"0.1.0">(IR_VERSION);
+expectNotType<"1.0.0">(IR_VERSION);
+expectNotType<string>(IR_VERSION);
+
+// =============================================================================
+// JsonValue
+// =============================================================================
+
+// Primitives are assignable to JsonValue
+expectAssignable<JsonValue>(null);
+expectAssignable<JsonValue>(true);
+expectAssignable<JsonValue>(42);
+expectAssignable<JsonValue>("hello");
+
+// Arrays and objects are assignable
+expectAssignable<JsonValue>(["a", 1, null]);
+expectAssignable<JsonValue>({ key: "value" });
+expectAssignable<JsonValue>({ nested: { count: 1 } });
+
+// Non-serializable types are not assignable
+expectError<JsonValue>(undefined);
+// eslint-disable-next-line @typescript-eslint/no-empty-function -- testing that functions are rejected as JsonValue
+expectError<JsonValue>(() => {});
+expectError<JsonValue>(Symbol("x"));
+
+// =============================================================================
+// Provenance
+// =============================================================================
+
+const baseProvenance: Provenance = {
+  surface: "chain-dsl",
+  file: "/path/to/form.ts",
+  line: 10,
+  column: 0,
+};
+
+expectAssignable<Provenance>(baseProvenance);
+
+// All valid surface values
+expectAssignable<Provenance>({ ...baseProvenance, surface: "tsdoc" });
+expectAssignable<Provenance>({ ...baseProvenance, surface: "chain-dsl" });
+expectAssignable<Provenance>({ ...baseProvenance, surface: "extension" });
+expectAssignable<Provenance>({ ...baseProvenance, surface: "inferred" });
+
+// Optional fields
+expectAssignable<Provenance>({ ...baseProvenance, length: 5 });
+expectAssignable<Provenance>({ ...baseProvenance, tagName: "@minimum" });
+expectAssignable<Provenance>({ ...baseProvenance, length: 5, tagName: "@minimum" });
+
+// Invalid surface is an error
+expectError<Provenance>({ ...baseProvenance, surface: "unknown-surface" });
+
+// =============================================================================
+// PathTarget
+// =============================================================================
+
+const pathTarget: PathTarget = { segments: ["address", "zip"] };
+expectAssignable<PathTarget>(pathTarget);
+expectAssignable<PathTarget>({ segments: [] });
+expectAssignable<PathTarget>({ segments: ["value"] });
+
+// =============================================================================
+// TypeNode discriminated union
+// =============================================================================
+
+// PrimitiveTypeNode
+const stringNode: PrimitiveTypeNode = { kind: "primitive", primitiveKind: "string" };
+const numberNode: PrimitiveTypeNode = { kind: "primitive", primitiveKind: "number" };
+const boolNode: PrimitiveTypeNode = { kind: "primitive", primitiveKind: "boolean" };
+const nullNode: PrimitiveTypeNode = { kind: "primitive", primitiveKind: "null" };
+
+expectAssignable<TypeNode>(stringNode);
+expectAssignable<TypeNode>(numberNode);
+expectAssignable<TypeNode>(boolNode);
+expectAssignable<TypeNode>(nullNode);
+
+// "integer" is NOT a valid primitiveKind (integers use multipleOf: 1 on number)
+expectError<PrimitiveTypeNode>({ kind: "primitive", primitiveKind: "integer" });
+
+// EnumTypeNode
+const enumNode: EnumTypeNode = {
+  kind: "enum",
+  members: [{ value: "draft" }, { value: "sent", displayName: "Sent" }, { value: 1 }],
+};
+expectAssignable<TypeNode>(enumNode);
+
+const enumMember: EnumMember = { value: "active" };
+expectAssignable<EnumMember>(enumMember);
+expectAssignable<EnumMember>({ value: 42 });
+expectAssignable<EnumMember>({ value: "active", displayName: "Active" });
+
+// ArrayTypeNode
+const arrayNode: ArrayTypeNode = { kind: "array", items: stringNode };
+expectAssignable<TypeNode>(arrayNode);
+
+// Nested array
+const nestedArray: ArrayTypeNode = { kind: "array", items: arrayNode };
+expectAssignable<TypeNode>(nestedArray);
+
+// ObjectTypeNode
+const objectProp: ObjectProperty = {
+  name: "street",
+  type: stringNode,
+  optional: false,
+  constraints: [],
+  annotations: [],
+  provenance: baseProvenance,
+};
+
+const objectNode: ObjectTypeNode = {
+  kind: "object",
+  properties: [objectProp],
+  additionalProperties: false,
+};
+expectAssignable<TypeNode>(objectNode);
+
+// UnionTypeNode (e.g., nullable type T | null)
+const unionNode: UnionTypeNode = {
+  kind: "union",
+  members: [stringNode, nullNode],
+};
+expectAssignable<TypeNode>(unionNode);
+
+// ReferenceTypeNode
+const refNode: ReferenceTypeNode = {
+  kind: "reference",
+  name: "my-module#Address",
+  typeArguments: [],
+};
+expectAssignable<TypeNode>(refNode);
+
+// Generic reference
+const genericRef: ReferenceTypeNode = {
+  kind: "reference",
+  name: "Array",
+  typeArguments: [stringNode],
+};
+expectAssignable<TypeNode>(genericRef);
+
+// DynamicTypeNode
+const dynEnumNode: DynamicTypeNode = {
+  kind: "dynamic",
+  dynamicKind: "enum",
+  sourceKey: "countries",
+  parameterFields: ["region"],
+};
+expectAssignable<TypeNode>(dynEnumNode);
+
+const dynSchemaNode: DynamicTypeNode = {
+  kind: "dynamic",
+  dynamicKind: "schema",
+  sourceKey: "productSchema",
+  parameterFields: [],
+};
+expectAssignable<TypeNode>(dynSchemaNode);
+
+// CustomTypeNode
+const customTypeNode: CustomTypeNode = {
+  kind: "custom",
+  typeId: "x-stripe/monetary/MonetaryAmount",
+  payload: { currency: "usd" },
+};
+expectAssignable<TypeNode>(customTypeNode);
+
+// =============================================================================
+// ConstraintNode discriminated union
+// =============================================================================
+
+// All constraint nodes share kind: "constraint"
+const provNode = baseProvenance;
+
+// NumericConstraintNode
+const minConstraint: NumericConstraintNode = {
+  kind: "constraint",
+  constraintKind: "minimum",
+  value: 0,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(minConstraint);
+
+const maxConstraint: NumericConstraintNode = {
+  kind: "constraint",
+  constraintKind: "maximum",
+  value: 100,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(maxConstraint);
+
+const multipleOfConstraint: NumericConstraintNode = {
+  kind: "constraint",
+  constraintKind: "multipleOf",
+  value: 1,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(multipleOfConstraint);
+
+// NumericConstraintNode with optional path
+const minWithPath: NumericConstraintNode = {
+  kind: "constraint",
+  constraintKind: "minimum",
+  value: 0,
+  path: { segments: ["amount"] },
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(minWithPath);
+
+// LengthConstraintNode
+const minLengthConstraint: LengthConstraintNode = {
+  kind: "constraint",
+  constraintKind: "minLength",
+  value: 1,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(minLengthConstraint);
+
+const minItemsConstraint: LengthConstraintNode = {
+  kind: "constraint",
+  constraintKind: "minItems",
+  value: 1,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(minItemsConstraint);
+
+// PatternConstraintNode
+const patternConstraint: PatternConstraintNode = {
+  kind: "constraint",
+  constraintKind: "pattern",
+  pattern: "^[A-Z]{2}$",
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(patternConstraint);
+
+// ArrayCardinalityConstraintNode — value must be literal true
+const uniqueItemsConstraint: ArrayCardinalityConstraintNode = {
+  kind: "constraint",
+  constraintKind: "uniqueItems",
+  value: true,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(uniqueItemsConstraint);
+
+// uniqueItems value must be true, not false
+expectError<ArrayCardinalityConstraintNode>({
+  kind: "constraint",
+  constraintKind: "uniqueItems",
+  value: false,
+  provenance: provNode,
+});
+
+// EnumMemberConstraintNode
+const allowedMembersConstraint: EnumMemberConstraintNode = {
+  kind: "constraint",
+  constraintKind: "allowedMembers",
+  members: ["draft", "sent"],
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(allowedMembersConstraint);
+
+// Mixed string/number members
+const mixedMembersConstraint: EnumMemberConstraintNode = {
+  kind: "constraint",
+  constraintKind: "allowedMembers",
+  members: ["active", 1, "inactive"],
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(mixedMembersConstraint);
+
+// CustomConstraintNode
+const customConstraint: CustomConstraintNode = {
+  kind: "constraint",
+  constraintKind: "custom",
+  constraintId: "x-stripe/payments/currency-code",
+  payload: { allowedCurrencies: ["usd", "eur"] },
+  compositionRule: "intersect",
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(customConstraint);
+
+const customOverrideConstraint: CustomConstraintNode = {
+  kind: "constraint",
+  constraintKind: "custom",
+  constraintId: "x-stripe/payments/currency-code",
+  payload: null,
+  compositionRule: "override",
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(customOverrideConstraint);
+
+// compositionRule must be "intersect" or "override"
+expectError<CustomConstraintNode>({
+  kind: "constraint",
+  constraintKind: "custom",
+  constraintId: "x-example/pkg/rule",
+  payload: null,
+  compositionRule: "merge",
+  provenance: provNode,
+});
+
+// =============================================================================
+// AnnotationNode discriminated union
+// =============================================================================
+
+// All annotation nodes share kind: "annotation"
+
+const displayNameAnnotation: DisplayNameAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "displayName",
+  value: "Email Address",
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(displayNameAnnotation);
+
+const descriptionAnnotation: DescriptionAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "description",
+  value: "The user's email address",
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(descriptionAnnotation);
+
+const placeholderAnnotation: PlaceholderAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "placeholder",
+  value: "you@example.com",
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(placeholderAnnotation);
+
+const defaultValueAnnotation: DefaultValueAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "defaultValue",
+  value: "draft",
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(defaultValueAnnotation);
+
+// defaultValue accepts any JsonValue
+const defaultValueNull: DefaultValueAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "defaultValue",
+  value: null,
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(defaultValueNull);
+
+const defaultValueObj: DefaultValueAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "defaultValue",
+  value: { amount: 0, currency: "usd" },
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(defaultValueObj);
+
+const deprecatedAnnotation: DeprecatedAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "deprecated",
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(deprecatedAnnotation);
+
+// deprecated with optional message
+const deprecatedWithMessage: DeprecatedAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "deprecated",
+  message: "Use newField instead",
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(deprecatedWithMessage);
+
+const formatHintAnnotation: FormatHintAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "formatHint",
+  format: "textarea",
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(formatHintAnnotation);
+
+const customAnnotation: CustomAnnotationNode = {
+  kind: "annotation",
+  annotationKind: "custom",
+  annotationId: "x-stripe/ui/masked-input",
+  value: { maskChar: "*" },
+  provenance: provNode,
+};
+expectAssignable<AnnotationNode>(customAnnotation);
+
+// =============================================================================
+// FieldNode
+// =============================================================================
+
+const fieldNode: FieldNode = {
+  kind: "field",
+  name: "email",
+  type: stringNode,
+  required: true,
+  constraints: [minLengthConstraint],
+  annotations: [displayNameAnnotation],
+  provenance: provNode,
+};
+expectAssignable<FormIRElement>(fieldNode);
+
+// Optional mergeHistory
+const fieldWithHistory: FieldNode = {
+  ...fieldNode,
+  mergeHistory: [
+    { node: minLengthConstraint, dominated: false },
+    { node: displayNameAnnotation, dominated: true },
+  ],
+};
+expectAssignable<FieldNode>(fieldWithHistory);
+
+// =============================================================================
+// LayoutNode: GroupLayoutNode and ConditionalLayoutNode
+// =============================================================================
+
+const groupNode: GroupLayoutNode = {
+  kind: "group",
+  label: "Personal Information",
+  elements: [fieldNode],
+  provenance: provNode,
+};
+expectAssignable<LayoutNode>(groupNode);
+expectAssignable<FormIRElement>(groupNode);
+
+// Nested groups
+const nestedGroup: GroupLayoutNode = {
+  kind: "group",
+  label: "Outer",
+  elements: [groupNode, fieldNode],
+  provenance: provNode,
+};
+expectAssignable<GroupLayoutNode>(nestedGroup);
+
+const conditionalNode: ConditionalLayoutNode = {
+  kind: "conditional",
+  fieldName: "accountType",
+  value: "business",
+  elements: [fieldNode],
+  provenance: provNode,
+};
+expectAssignable<LayoutNode>(conditionalNode);
+expectAssignable<FormIRElement>(conditionalNode);
+
+// =============================================================================
+// TypeDefinition
+// =============================================================================
+
+const typeDef: TypeDefinition = {
+  name: "my-module#Address",
+  type: objectNode,
+  provenance: provNode,
+};
+expectAssignable<TypeDefinition>(typeDef);
+
+// =============================================================================
+// FormIR (top-level)
+// =============================================================================
+
+const formIR: FormIR = {
+  kind: "form-ir",
+  irVersion: "0.1.0",
+  elements: [fieldNode, groupNode, conditionalNode],
+  typeRegistry: {
+    "my-module#Address": typeDef,
+  },
+  provenance: provNode,
+};
+expectAssignable<FormIR>(formIR);
+
+// Empty form is valid
+const emptyFormIR: FormIR = {
+  kind: "form-ir",
+  irVersion: "0.1.0",
+  elements: [],
+  typeRegistry: {},
+  provenance: provNode,
+};
+expectAssignable<FormIR>(emptyFormIR);
+
+// =============================================================================
+// Negative tests — discriminant guards
+// =============================================================================
+
+// ConstraintNode must have kind: "constraint"
+expectError<ConstraintNode>({
+  kind: "annotation",
+  constraintKind: "minimum",
+  value: 0,
+  provenance: provNode,
+});
+
+// AnnotationNode must have kind: "annotation"
+expectError<AnnotationNode>({
+  kind: "constraint",
+  annotationKind: "displayName",
+  value: "Name",
+  provenance: provNode,
+});
+
+// FieldNode must have kind: "field"
+expectError<FieldNode>({
+  kind: "group",
+  name: "email",
+  type: stringNode,
+  required: true,
+  constraints: [],
+  annotations: [],
+  provenance: provNode,
+});
+
+// GroupLayoutNode must have kind: "group"
+expectError<GroupLayoutNode>({
+  kind: "field",
+  label: "Group",
+  elements: [],
+  provenance: provNode,
+});
+
+// ConditionalLayoutNode must have kind: "conditional"
+expectError<ConditionalLayoutNode>({
+  kind: "group",
+  fieldName: "type",
+  value: "business",
+  elements: [],
+  provenance: provNode,
+});
+
+// FormIR must have kind: "form-ir"
+expectError<FormIR>({
+  kind: "field",
+  irVersion: "0.1.0",
+  elements: [],
+  typeRegistry: {},
+  provenance: provNode,
+});
+
+// FormIR.irVersion must be exactly IR_VERSION, not an arbitrary string
+expectError<FormIR>({
+  kind: "form-ir",
+  irVersion: "9.9.9",
+  elements: [],
+  typeRegistry: {},
+  provenance: provNode,
+});
+
+// =============================================================================
+// MISSING CONSTRAINT VARIANT COVERAGE
+// =============================================================================
+
+const exclusiveMinConstraint: NumericConstraintNode = {
+  kind: "constraint",
+  constraintKind: "exclusiveMinimum",
+  value: 0,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(exclusiveMinConstraint);
+
+const exclusiveMaxConstraint: NumericConstraintNode = {
+  kind: "constraint",
+  constraintKind: "exclusiveMaximum",
+  value: 100,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(exclusiveMaxConstraint);
+
+const maxLengthConstraint: LengthConstraintNode = {
+  kind: "constraint",
+  constraintKind: "maxLength",
+  value: 255,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(maxLengthConstraint);
+
+const maxItemsConstraint: LengthConstraintNode = {
+  kind: "constraint",
+  constraintKind: "maxItems",
+  value: 50,
+  provenance: provNode,
+};
+expectAssignable<ConstraintNode>(maxItemsConstraint);
+
+// =============================================================================
+// DISCRIMINATED UNION NARROWING TESTS
+// =============================================================================
+
+// TypeNode narrows on `kind`
+declare const typeNodeVar: TypeNode;
+if (typeNodeVar.kind === "primitive") {
+  expectType<PrimitiveTypeNode>(typeNodeVar);
+}
+if (typeNodeVar.kind === "enum") {
+  expectType<EnumTypeNode>(typeNodeVar);
+}
+if (typeNodeVar.kind === "array") {
+  expectType<ArrayTypeNode>(typeNodeVar);
+}
+if (typeNodeVar.kind === "object") {
+  expectType<ObjectTypeNode>(typeNodeVar);
+}
+if (typeNodeVar.kind === "union") {
+  expectType<UnionTypeNode>(typeNodeVar);
+}
+if (typeNodeVar.kind === "reference") {
+  expectType<ReferenceTypeNode>(typeNodeVar);
+}
+if (typeNodeVar.kind === "dynamic") {
+  expectType<DynamicTypeNode>(typeNodeVar);
+}
+if (typeNodeVar.kind === "custom") {
+  expectType<CustomTypeNode>(typeNodeVar);
+}
+
+// ConstraintNode narrows on `constraintKind`
+declare const constraintVar: ConstraintNode;
+if (constraintVar.constraintKind === "minimum") {
+  expectType<NumericConstraintNode>(constraintVar);
+}
+if (constraintVar.constraintKind === "pattern") {
+  expectType<PatternConstraintNode>(constraintVar);
+}
+if (constraintVar.constraintKind === "minLength") {
+  expectType<LengthConstraintNode>(constraintVar);
+}
+if (constraintVar.constraintKind === "uniqueItems") {
+  expectType<ArrayCardinalityConstraintNode>(constraintVar);
+}
+if (constraintVar.constraintKind === "allowedMembers") {
+  expectType<EnumMemberConstraintNode>(constraintVar);
+}
+if (constraintVar.constraintKind === "custom") {
+  expectType<CustomConstraintNode>(constraintVar);
+}
+
+// AnnotationNode narrows on `annotationKind`
+declare const annotationVar: AnnotationNode;
+if (annotationVar.annotationKind === "displayName") {
+  expectType<DisplayNameAnnotationNode>(annotationVar);
+}
+if (annotationVar.annotationKind === "description") {
+  expectType<DescriptionAnnotationNode>(annotationVar);
+}
+if (annotationVar.annotationKind === "placeholder") {
+  expectType<PlaceholderAnnotationNode>(annotationVar);
+}
+if (annotationVar.annotationKind === "defaultValue") {
+  expectType<DefaultValueAnnotationNode>(annotationVar);
+}
+if (annotationVar.annotationKind === "deprecated") {
+  expectType<DeprecatedAnnotationNode>(annotationVar);
+}
+if (annotationVar.annotationKind === "formatHint") {
+  expectType<FormatHintAnnotationNode>(annotationVar);
+}
+if (annotationVar.annotationKind === "custom") {
+  expectType<CustomAnnotationNode>(annotationVar);
+}
+
+// LayoutNode narrows on `kind`
+declare const layoutVar: LayoutNode;
+if (layoutVar.kind === "group") {
+  expectType<GroupLayoutNode>(layoutVar);
+}
+if (layoutVar.kind === "conditional") {
+  expectType<ConditionalLayoutNode>(layoutVar);
+}
+
+// FormIRElement narrows on `kind`
+declare const elementVar: FormIRElement;
+if (elementVar.kind === "field") {
+  expectType<FieldNode>(elementVar);
+}
+if (elementVar.kind === "group") {
+  expectType<GroupLayoutNode>(elementVar);
+}
+if (elementVar.kind === "conditional") {
+  expectType<ConditionalLayoutNode>(elementVar);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@
  * - Form element types (fields, groups, conditionals)
  * - Field and form state types
  * - Data source registry for dynamic enums
+ * - Canonical IR types (FormIR, FieldNode, TypeNode, ConstraintNode, AnnotationNode, etc.)
  *
  * @packageDocumentation
  */
@@ -50,11 +51,50 @@ export type {
   // Decorators
   FormSpecDecoratorName,
   ConstraintTagName,
+
+  // Canonical IR
+  JsonValue,
+  Provenance,
+  PathTarget,
+  TypeNode,
+  PrimitiveTypeNode,
+  EnumMember,
+  EnumTypeNode,
+  ArrayTypeNode,
+  ObjectProperty,
+  ObjectTypeNode,
+  UnionTypeNode,
+  ReferenceTypeNode,
+  DynamicTypeNode,
+  CustomTypeNode,
+  ConstraintNode,
+  NumericConstraintNode,
+  LengthConstraintNode,
+  PatternConstraintNode,
+  ArrayCardinalityConstraintNode,
+  EnumMemberConstraintNode,
+  CustomConstraintNode,
+  AnnotationNode,
+  DisplayNameAnnotationNode,
+  DescriptionAnnotationNode,
+  PlaceholderAnnotationNode,
+  DefaultValueAnnotationNode,
+  DeprecatedAnnotationNode,
+  FormatHintAnnotationNode,
+  CustomAnnotationNode,
+  FieldNode,
+  LayoutNode,
+  GroupLayoutNode,
+  ConditionalLayoutNode,
+  FormIRElement,
+  TypeDefinition,
+  FormIR,
 } from "./types/index.js";
 
-// Re-export functions
+// Re-export functions and constants
 export {
   createInitialFieldState,
   FORMSPEC_DECORATOR_NAMES,
   CONSTRAINT_TAG_DEFINITIONS,
+  IR_VERSION,
 } from "./types/index.js";

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -36,3 +36,43 @@ export type { EqualsPredicate, Predicate } from "./predicate.js";
 
 export { FORMSPEC_DECORATOR_NAMES, CONSTRAINT_TAG_DEFINITIONS } from "./decorators.js";
 export type { FormSpecDecoratorName, ConstraintTagName } from "./decorators.js";
+
+export { IR_VERSION } from "./ir.js";
+export type {
+  JsonValue,
+  Provenance,
+  PathTarget,
+  TypeNode,
+  PrimitiveTypeNode,
+  EnumMember,
+  EnumTypeNode,
+  ArrayTypeNode,
+  ObjectProperty,
+  ObjectTypeNode,
+  UnionTypeNode,
+  ReferenceTypeNode,
+  DynamicTypeNode,
+  CustomTypeNode,
+  ConstraintNode,
+  NumericConstraintNode,
+  LengthConstraintNode,
+  PatternConstraintNode,
+  ArrayCardinalityConstraintNode,
+  EnumMemberConstraintNode,
+  CustomConstraintNode,
+  AnnotationNode,
+  DisplayNameAnnotationNode,
+  DescriptionAnnotationNode,
+  PlaceholderAnnotationNode,
+  DefaultValueAnnotationNode,
+  DeprecatedAnnotationNode,
+  FormatHintAnnotationNode,
+  CustomAnnotationNode,
+  FieldNode,
+  LayoutNode,
+  GroupLayoutNode,
+  ConditionalLayoutNode,
+  FormIRElement,
+  TypeDefinition,
+  FormIR,
+} from "./ir.js";

--- a/packages/core/src/types/ir.ts
+++ b/packages/core/src/types/ir.ts
@@ -1,0 +1,512 @@
+/**
+ * Canonical Intermediate Representation (IR) types for FormSpec.
+ *
+ * The IR is the shared intermediate structure that both authoring surfaces
+ * (chain DSL and TSDoc-annotated types) compile to. All downstream operations
+ * — JSON Schema generation, UI Schema generation, constraint validation,
+ * diagnostics — consume the IR exclusively.
+ *
+ * All types are plain, serializable objects (no live compiler references).
+ *
+ * @see {@link https://github.com/stripe/formspec-workspace/blob/main/scratch/design/001-canonical-ir.md}
+ */
+
+// =============================================================================
+// IR VERSION
+// =============================================================================
+
+/**
+ * The current IR format version. Centralized here so all canonicalizers
+ * and consumers reference a single source of truth.
+ */
+export const IR_VERSION = "0.1.0" as const;
+
+// =============================================================================
+// UTILITY TYPES
+// =============================================================================
+
+/**
+ * A JSON-serializable value. All IR nodes must be representable as JSON.
+ */
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+// =============================================================================
+// PROVENANCE
+// =============================================================================
+
+/**
+ * Describes the origin of an IR node.
+ * Enables diagnostics that point to the source of a contradiction or error.
+ */
+export interface Provenance {
+  /** The authoring surface that produced this node. */
+  readonly surface: "tsdoc" | "chain-dsl" | "extension" | "inferred";
+  /** Absolute path to the source file. */
+  readonly file: string;
+  /** 1-based line number in the source file. */
+  readonly line: number;
+  /** 0-based column number in the source file. */
+  readonly column: number;
+  /** Length of the source span in characters (for IDE underline ranges). */
+  readonly length?: number;
+  /**
+   * The specific tag, call, or construct that produced this node.
+   * Examples: `@minimum`, `field.number({ min: 0 })`, `optional`
+   */
+  readonly tagName?: string;
+}
+
+// =============================================================================
+// PATH TARGET
+// =============================================================================
+
+/**
+ * A path targeting a sub-field within a complex type.
+ * Used by constraints and annotations to target nested properties.
+ */
+export interface PathTarget {
+  /**
+   * Sequence of property names forming a path from the annotated field's type
+   * to the target sub-field.
+   * e.g., `["value"]` or `["address", "zip"]`
+   */
+  readonly segments: readonly string[];
+}
+
+// =============================================================================
+// TYPE NODES
+// =============================================================================
+
+/**
+ * Discriminated union of all type representations in the IR.
+ */
+export type TypeNode =
+  | PrimitiveTypeNode
+  | EnumTypeNode
+  | ArrayTypeNode
+  | ObjectTypeNode
+  | UnionTypeNode
+  | ReferenceTypeNode
+  | DynamicTypeNode
+  | CustomTypeNode;
+
+/**
+ * Primitive types mapping directly to JSON Schema primitives.
+ *
+ * Note: integer is NOT a primitive kind — integer semantics are expressed
+ * via a `multipleOf: 1` constraint on a number type.
+ */
+export interface PrimitiveTypeNode {
+  readonly kind: "primitive";
+  readonly primitiveKind: "string" | "number" | "boolean" | "null";
+}
+
+/** A member of a static enum type. */
+export interface EnumMember {
+  /** The serialized value stored in data. */
+  readonly value: string | number;
+  /** Optional per-member display name. */
+  readonly displayName?: string;
+}
+
+/** Static enum type — members known at build time. */
+export interface EnumTypeNode {
+  readonly kind: "enum";
+  readonly members: readonly EnumMember[];
+}
+
+/** Array type with a single items type. */
+export interface ArrayTypeNode {
+  readonly kind: "array";
+  readonly items: TypeNode;
+}
+
+/** A named property within an object type. */
+export interface ObjectProperty {
+  readonly name: string;
+  readonly type: TypeNode;
+  readonly optional: boolean;
+  /**
+   * Use-site constraints on this property.
+   * Distinct from constraints on the property's type — these are
+   * use-site constraints (e.g., `@minimum :amount 0` targets the
+   * `amount` property of a `MonetaryAmount` field).
+   */
+  readonly constraints: readonly ConstraintNode[];
+  /** Use-site annotations on this property. */
+  readonly annotations: readonly AnnotationNode[];
+  readonly provenance: Provenance;
+}
+
+/** Object type with named properties. */
+export interface ObjectTypeNode {
+  readonly kind: "object";
+  /**
+   * Named properties of this object. Order is preserved from the source
+   * declaration for deterministic output.
+   */
+  readonly properties: readonly ObjectProperty[];
+  /**
+   * Whether additional properties beyond those listed are permitted.
+   * Canonicalizers and IR producers must always emit an explicit boolean
+   * value here (typically `false`, since FormSpec object types are closed
+   * by default).
+   */
+  readonly additionalProperties: boolean;
+}
+
+/** Union type for non-enum unions. Nullable types are `T | null` using this. */
+export interface UnionTypeNode {
+  readonly kind: "union";
+  readonly members: readonly TypeNode[];
+}
+
+/** Named type reference — preserved as references for `$defs`/`$ref` emission. */
+export interface ReferenceTypeNode {
+  readonly kind: "reference";
+  /**
+   * The fully-qualified name of the referenced type.
+   * For TypeScript interfaces/type aliases: `"<module>#<TypeName>"`.
+   * For built-in types: the primitive kind string.
+   */
+  readonly name: string;
+  /**
+   * Type arguments if this is a generic instantiation.
+   * e.g., `Array<string>` → `{ name: "Array", typeArguments: [PrimitiveTypeNode("string")] }`
+   */
+  readonly typeArguments: readonly TypeNode[];
+}
+
+/** Dynamic type — schema resolved at runtime from a named data source. */
+export interface DynamicTypeNode {
+  readonly kind: "dynamic";
+  readonly dynamicKind: "enum" | "schema";
+  /** Key identifying the runtime data source or schema provider. */
+  readonly sourceKey: string;
+  /**
+   * For dynamic enums: field names whose current values are passed as
+   * parameters to the data source resolver.
+   */
+  readonly parameterFields: readonly string[];
+}
+
+/** Custom type registered by an extension. */
+export interface CustomTypeNode {
+  readonly kind: "custom";
+  /**
+   * The extension-qualified type identifier.
+   * Format: `"<vendor-prefix>/<extension-name>/<type-name>"`
+   * e.g., `"x-stripe/monetary/MonetaryAmount"`
+   */
+  readonly typeId: string;
+  /**
+   * Opaque payload serialized by the extension that registered this type.
+   * Must be JSON-serializable.
+   */
+  readonly payload: JsonValue;
+}
+
+// =============================================================================
+// CONSTRAINT NODES
+// =============================================================================
+
+/**
+ * Discriminated union of all constraint types.
+ * Constraints are set-influencing: they narrow the set of valid values.
+ */
+export type ConstraintNode =
+  | NumericConstraintNode
+  | LengthConstraintNode
+  | PatternConstraintNode
+  | ArrayCardinalityConstraintNode
+  | EnumMemberConstraintNode
+  | CustomConstraintNode;
+
+/**
+ * Numeric constraints: bounds and multipleOf.
+ *
+ * `minimum` and `maximum` are inclusive; `exclusiveMinimum` and
+ * `exclusiveMaximum` are exclusive bounds (matching JSON Schema 2020-12
+ * semantics).
+ *
+ * Type applicability: may only attach to fields with `PrimitiveTypeNode("number")`
+ * or a `ReferenceTypeNode` that resolves to one.
+ */
+export interface NumericConstraintNode {
+  readonly kind: "constraint";
+  readonly constraintKind:
+    | "minimum"
+    | "maximum"
+    | "exclusiveMinimum"
+    | "exclusiveMaximum"
+    | "multipleOf";
+  readonly value: number;
+  /** If present, targets a nested sub-field rather than the field itself. */
+  readonly path?: PathTarget;
+  readonly provenance: Provenance;
+}
+
+/**
+ * String length and array item count constraints.
+ *
+ * `minLength`/`maxLength` apply to strings; `minItems`/`maxItems` apply to
+ * arrays. They share the same node shape because the composition rules are
+ * identical.
+ *
+ * Type applicability: `minLength`/`maxLength` require `PrimitiveTypeNode("string")`;
+ * `minItems`/`maxItems` require `ArrayTypeNode`.
+ */
+export interface LengthConstraintNode {
+  readonly kind: "constraint";
+  readonly constraintKind: "minLength" | "maxLength" | "minItems" | "maxItems";
+  readonly value: number;
+  readonly path?: PathTarget;
+  readonly provenance: Provenance;
+}
+
+/**
+ * String pattern constraint (ECMA-262 regex without delimiters).
+ *
+ * Multiple `pattern` constraints on the same field compose via intersection:
+ * all patterns must match simultaneously.
+ *
+ * Type applicability: requires `PrimitiveTypeNode("string")`.
+ */
+export interface PatternConstraintNode {
+  readonly kind: "constraint";
+  readonly constraintKind: "pattern";
+  /** ECMA-262 regular expression, without delimiters. */
+  readonly pattern: string;
+  readonly path?: PathTarget;
+  readonly provenance: Provenance;
+}
+
+/** Array uniqueness constraint. */
+export interface ArrayCardinalityConstraintNode {
+  readonly kind: "constraint";
+  readonly constraintKind: "uniqueItems";
+  readonly value: true;
+  readonly path?: PathTarget;
+  readonly provenance: Provenance;
+}
+
+/** Enum member subset constraint (refinement — only narrows). */
+export interface EnumMemberConstraintNode {
+  readonly kind: "constraint";
+  readonly constraintKind: "allowedMembers";
+  readonly members: readonly (string | number)[];
+  readonly path?: PathTarget;
+  readonly provenance: Provenance;
+}
+
+/** Extension-registered custom constraint. */
+export interface CustomConstraintNode {
+  readonly kind: "constraint";
+  readonly constraintKind: "custom";
+  /** Extension-qualified ID: `"<vendor-prefix>/<extension-name>/<constraint-name>"` */
+  readonly constraintId: string;
+  /** JSON-serializable payload defined by the extension. */
+  readonly payload: JsonValue;
+  /** How this constraint composes with others of the same `constraintId`. */
+  readonly compositionRule: "intersect" | "override";
+  readonly path?: PathTarget;
+  readonly provenance: Provenance;
+}
+
+// =============================================================================
+// ANNOTATION NODES
+// =============================================================================
+
+/**
+ * Discriminated union of all annotation types.
+ * Annotations are value-influencing: they describe or present a field
+ * but do not affect which values are valid.
+ */
+export type AnnotationNode =
+  | DisplayNameAnnotationNode
+  | DescriptionAnnotationNode
+  | PlaceholderAnnotationNode
+  | DefaultValueAnnotationNode
+  | DeprecatedAnnotationNode
+  | FormatHintAnnotationNode
+  | CustomAnnotationNode;
+
+/** Human-readable label for the field, shown as a form input label. */
+export interface DisplayNameAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "displayName";
+  readonly value: string;
+  readonly provenance: Provenance;
+}
+
+/** Longer explanatory text shown beneath or alongside the field. */
+export interface DescriptionAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "description";
+  readonly value: string;
+  readonly provenance: Provenance;
+}
+
+/** Input placeholder text shown when the field has no value. */
+export interface PlaceholderAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "placeholder";
+  readonly value: string;
+  readonly provenance: Provenance;
+}
+
+/** Default value pre-populated in the form if the field is not explicitly set. */
+export interface DefaultValueAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "defaultValue";
+  /** Must be JSON-serializable and type-compatible (verified during Validate phase). */
+  readonly value: JsonValue;
+  readonly provenance: Provenance;
+}
+
+/** Marks the field as deprecated with an optional human-readable message. */
+export interface DeprecatedAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "deprecated";
+  /** Optional deprecation message. */
+  readonly message?: string;
+  readonly provenance: Provenance;
+}
+
+/** UI rendering hint — does not affect schema validation. */
+export interface FormatHintAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "formatHint";
+  /** Renderer-specific format identifier: "textarea", "radio", "date", "color", etc. */
+  readonly format: string;
+  readonly provenance: Provenance;
+}
+
+/** Extension-registered custom annotation. */
+export interface CustomAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "custom";
+  /** Extension-qualified ID: `"<vendor-prefix>/<extension-name>/<annotation-name>"` */
+  readonly annotationId: string;
+  readonly value: JsonValue;
+  readonly provenance: Provenance;
+}
+
+// =============================================================================
+// FIELD NODE
+// =============================================================================
+
+/** A single form field after canonicalization. */
+export interface FieldNode {
+  readonly kind: "field";
+  /** The field's key in the data schema. */
+  readonly name: string;
+  /** The resolved type of this field. */
+  readonly type: TypeNode;
+  /** Whether this field is required in the data schema. */
+  readonly required: boolean;
+  /** Set-influencing constraints, after merging. */
+  readonly constraints: readonly ConstraintNode[];
+  /** Value-influencing annotations, after merging. */
+  readonly annotations: readonly AnnotationNode[];
+  /** Where this field was declared. */
+  readonly provenance: Provenance;
+  /**
+   * Debug only — ordered list of constraint/annotation nodes that participated
+   * in merging, including dominated ones.
+   */
+  readonly mergeHistory?: readonly {
+    readonly node: ConstraintNode | AnnotationNode;
+    readonly dominated: boolean;
+  }[];
+}
+
+// =============================================================================
+// LAYOUT NODES
+// =============================================================================
+
+/** Union of layout node types. */
+export type LayoutNode = GroupLayoutNode | ConditionalLayoutNode;
+
+/** A visual grouping of form elements. */
+export interface GroupLayoutNode {
+  readonly kind: "group";
+  readonly label: string;
+  /** Elements contained in this group — may be fields or nested groups. */
+  readonly elements: readonly FormIRElement[];
+  readonly provenance: Provenance;
+}
+
+/** Conditional visibility based on another field's value. */
+export interface ConditionalLayoutNode {
+  readonly kind: "conditional";
+  /** The field whose value triggers visibility. */
+  readonly fieldName: string;
+  /** The value that makes the condition true (SHOW). */
+  readonly value: JsonValue;
+  /** Elements shown when the condition is met. */
+  readonly elements: readonly FormIRElement[];
+  readonly provenance: Provenance;
+}
+
+/** Union of all IR element types. */
+export type FormIRElement = FieldNode | LayoutNode;
+
+// =============================================================================
+// TYPE REGISTRY
+// =============================================================================
+
+/**
+ * A named type definition stored in the type registry.
+ *
+ * Invariant: `name` must equal the key under which this definition is stored
+ * in `FormIR.typeRegistry`. IR producers must enforce this — consumers may
+ * rely on it without re-checking.
+ */
+export interface TypeDefinition {
+  /**
+   * The fully-qualified reference name.
+   * Must equal the key under which this entry is stored in `FormIR.typeRegistry`.
+   */
+  readonly name: string;
+  /** The resolved type node. */
+  readonly type: TypeNode;
+  /** Where this type was declared. */
+  readonly provenance: Provenance;
+}
+
+// =============================================================================
+// FORM IR (TOP-LEVEL)
+// =============================================================================
+
+/**
+ * The complete Canonical Intermediate Representation for a form.
+ *
+ * Output of the Canonicalize phase; input to Validate, Generate (JSON Schema),
+ * and Generate (UI Schema) phases.
+ *
+ * Serializable to JSON — no live compiler objects.
+ */
+export interface FormIR {
+  readonly kind: "form-ir";
+  /**
+   * Schema version for the IR format itself.
+   * Must equal `IR_VERSION` — typed exactly to prevent stale-version bugs.
+   */
+  readonly irVersion: typeof IR_VERSION;
+  /** Top-level elements of the form: fields and layout nodes. */
+  readonly elements: readonly FormIRElement[];
+  /**
+   * Registry of named types referenced by fields in this form.
+   * Keys are fully-qualified type names matching `ReferenceTypeNode.name`.
+   */
+  readonly typeRegistry: Readonly<Record<string, TypeDefinition>>;
+  /** Provenance of the form definition itself. */
+  readonly provenance: Provenance;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test-d.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,7 +207,11 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.7)(tsx@4.21.0)(yaml@2.8.2)
 
-  packages/core: {}
+  packages/core:
+    devDependencies:
+      tsd:
+        specifier: ^0.31.0
+        version: 0.31.2
 
   packages/decorators:
     devDependencies:


### PR DESCRIPTION
## Summary

Introduces the canonical intermediate representation (IR) types that form the backbone of the FormSpec v2 pipeline. Defines `TypeNode`, `ConstraintNode`, `AnnotationNode`, `FieldNode`, `LayoutNode`, and `FormIR` in `@formspec/core` — the shared vocabulary all other packages (DSL canonicalizer, schema generators, TSDoc analyzer) speak. Establishing these types first ensures every subsequent phase produces and consumes a single, well-typed data structure.

## Stack

<!-- gst:stack -->
| | PR | Phase | Description |
|---|---|---|---|
| ▶ | #50 | IR Types | Canonical IR type definitions in @formspec/core |
| | #51 | Chain DSL Canonicalizer | DSL → FormIR *(merged)* |
| | #52 | JSON Schema Gen | IR → JSON Schema 2020-12 generator |
| | #53 | UI Schema Gen | IR → JSON Forms UI Schema generator |
| | #54 | TSDoc Analyzer | analyzeClassToIR / analyzeInterfaceToIR → FieldNode[] |
| | #55 | Pipeline Wiring | Wire IR pipeline, delete legacy code paths |
| | #56 | Constraint Validation | Constraint validator with contradiction detection |
| | #57 | Remove Decorators | Remove @formspec/decorators, keep JSDoc analysis |
| | #58 | Extension API | defineExtension, defineConstraint, defineAnnotation + registry |
| | #59 | ESLint Plugin | createConstraintRule factory, constraint-type-mismatch rule |
| | #60 | Parity Testing | ProvenanceFree\<T\> + compareIR() cross-DSL parity |
| | #61 | Ajv Vocabulary | Ajv vocabulary for x-formspec-* keywords |
| | #62 | Language Server | Completion, hover, and go-to-definition providers |
| | #63 | CLI + Playground | --emit-ir, --validate-only flags + playground support |
<!-- /gst:stack -->