### PR TITLE
feat(build): add IR-based UI Schema generator

### DIFF
--- a/packages/build/src/__tests__/ir-ui-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-ui-schema-generator.test.ts
@@ -1,0 +1,591 @@
+/**
+ * Tests for the IR-based UI Schema generator (`generateUiSchemaFromIR`).
+ *
+ * Each test constructs a `FormIR` directly and asserts on the resulting
+ * UI Schema structure. No round-trip comparison against legacy output.
+ */
+import { describe, it, expect } from "vitest";
+import { formspec, field, group, when, is } from "@formspec/dsl";
+import type {
+  FormIR,
+  FieldNode,
+  GroupLayoutNode,
+  ConditionalLayoutNode,
+  Provenance,
+} from "@formspec/core";
+import type { UISchemaElement, ControlElement, GroupLayout, Rule } from "../ui-schema/types.js";
+import { generateUiSchemaFromIR } from "../ui-schema/ir-generator.js";
+import { canonicalizeChainDSL } from "../canonicalize/index.js";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+const CHAIN_DSL_PROVENANCE: Provenance = {
+  surface: "chain-dsl",
+  file: "",
+  line: 0,
+  column: 0,
+};
+
+/**
+ * Safely access an array element by index, throwing if out of bounds.
+ * Satisfies `noUncheckedIndexedAccess` without non-null assertions.
+ */
+function at<T>(arr: readonly T[], index: number): T {
+  const value = arr[index];
+  if (value === undefined) {
+    throw new Error(
+      `Expected element at index ${String(index)}, but array has length ${String(arr.length)}`
+    );
+  }
+  return value;
+}
+
+function isControlElement(el: UISchemaElement): el is ControlElement {
+  return el.type === "Control";
+}
+
+function isGroupLayout(el: UISchemaElement): el is GroupLayout {
+  return el.type === "Group";
+}
+
+/** Narrow a UISchemaElement to ControlElement and assert type. */
+function expectControl(elements: readonly UISchemaElement[], index: number): ControlElement {
+  const el = at(elements, index);
+  if (!isControlElement(el)) {
+    throw new Error(`Expected Control at index ${String(index)}, got ${el.type}`);
+  }
+  return el;
+}
+
+/** Narrow a UISchemaElement to GroupLayout and assert type. */
+function expectGroupLayout(elements: readonly UISchemaElement[], index: number): GroupLayout {
+  const el = at(elements, index);
+  if (!isGroupLayout(el)) {
+    throw new Error(`Expected Group at index ${String(index)}, got ${el.type}`);
+  }
+  return el;
+}
+
+/** Build a minimal FormIR with no elements, suitable for empty-form tests. */
+function emptyFormIR(): FormIR {
+  return {
+    kind: "form-ir",
+    irVersion: "0.1.0",
+    elements: [],
+    typeRegistry: {},
+    provenance: CHAIN_DSL_PROVENANCE,
+  };
+}
+
+/** Build a minimal FormIR from a list of pre-constructed IR elements. */
+function formIRFromElements(elements: FormIR["elements"]): FormIR {
+  return {
+    kind: "form-ir",
+    irVersion: "0.1.0",
+    elements,
+    typeRegistry: {},
+    provenance: CHAIN_DSL_PROVENANCE,
+  };
+}
+
+/** Build a FieldNode with no annotations, constraints, or provenance detail. */
+function simpleFieldNode(name: string): FieldNode {
+  return {
+    kind: "field",
+    name,
+    type: { kind: "primitive", primitiveKind: "string" },
+    required: false,
+    constraints: [],
+    annotations: [],
+    provenance: CHAIN_DSL_PROVENANCE,
+  };
+}
+
+/** Build a FieldNode with a displayName annotation. */
+function labelledFieldNode(name: string, label: string): FieldNode {
+  return {
+    ...simpleFieldNode(name),
+    annotations: [
+      {
+        kind: "annotation",
+        annotationKind: "displayName",
+        value: label,
+        provenance: CHAIN_DSL_PROVENANCE,
+      },
+    ],
+  };
+}
+
+/** Build a GroupLayoutNode wrapping the given elements. */
+function groupNode(label: string, elements: FormIR["elements"]): GroupLayoutNode {
+  return {
+    kind: "group",
+    label,
+    elements,
+    provenance: CHAIN_DSL_PROVENANCE,
+  };
+}
+
+/** Build a ConditionalLayoutNode. */
+function conditionalNode(
+  fieldName: string,
+  value: string,
+  elements: FormIR["elements"]
+): ConditionalLayoutNode {
+  return {
+    kind: "conditional",
+    fieldName,
+    value,
+    elements,
+    provenance: CHAIN_DSL_PROVENANCE,
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("generateUiSchemaFromIR", () => {
+  // ---------------------------------------------------------------------------
+  // 1. Empty form
+  // ---------------------------------------------------------------------------
+
+  describe("empty form", () => {
+    it("should produce a VerticalLayout with no elements", () => {
+      const result = generateUiSchemaFromIR(emptyFormIR());
+
+      expect(result).toEqual({ type: "VerticalLayout", elements: [] });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Simple field → Control with correct scope
+  // ---------------------------------------------------------------------------
+
+  describe("simple field", () => {
+    it("should produce a Control element with the correct scope", () => {
+      const ir = formIRFromElements([simpleFieldNode("name")]);
+      const result = generateUiSchemaFromIR(ir);
+
+      expect(result.type).toBe("VerticalLayout");
+      expect(result.elements).toHaveLength(1);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.scope).toBe("#/properties/name");
+    });
+
+    it("should not include a label when no displayName annotation is present", () => {
+      const ir = formIRFromElements([simpleFieldNode("email")]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.label).toBeUndefined();
+    });
+
+    it("should not include a rule on an unconditional field", () => {
+      const ir = formIRFromElements([simpleFieldNode("active")]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.rule).toBeUndefined();
+    });
+
+    it("should encode field names with underscores correctly in scope", () => {
+      const ir = formIRFromElements([simpleFieldNode("my_field")]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.scope).toBe("#/properties/my_field");
+    });
+
+    it("should produce multiple Control elements for multiple top-level fields", () => {
+      const ir = formIRFromElements([
+        simpleFieldNode("first"),
+        simpleFieldNode("second"),
+        simpleFieldNode("third"),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      expect(result.elements).toHaveLength(3);
+      expect(expectControl(result.elements, 0).scope).toBe("#/properties/first");
+      expect(expectControl(result.elements, 1).scope).toBe("#/properties/second");
+      expect(expectControl(result.elements, 2).scope).toBe("#/properties/third");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Field with label annotation → Control with label
+  // ---------------------------------------------------------------------------
+
+  describe("field with displayName annotation", () => {
+    it("should include the label on the Control element", () => {
+      const ir = formIRFromElements([labelledFieldNode("name", "Full Name")]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.label).toBe("Full Name");
+    });
+
+    it("should use the first displayName annotation when multiple annotations are present", () => {
+      const fieldNode: FieldNode = {
+        ...simpleFieldNode("field"),
+        annotations: [
+          {
+            kind: "annotation",
+            annotationKind: "displayName",
+            value: "First Label",
+            provenance: CHAIN_DSL_PROVENANCE,
+          },
+          {
+            kind: "annotation",
+            annotationKind: "placeholder",
+            value: "Enter value",
+            provenance: CHAIN_DSL_PROVENANCE,
+          },
+        ],
+      };
+      const ir = formIRFromElements([fieldNode]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.label).toBe("First Label");
+    });
+
+    it("should not produce a label when only non-displayName annotations are present", () => {
+      const fieldNode: FieldNode = {
+        ...simpleFieldNode("field"),
+        annotations: [
+          {
+            kind: "annotation",
+            annotationKind: "placeholder",
+            value: "Enter value",
+            provenance: CHAIN_DSL_PROVENANCE,
+          },
+        ],
+      };
+      const ir = formIRFromElements([fieldNode]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.label).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Group → GroupLayout with nested elements
+  // ---------------------------------------------------------------------------
+
+  describe("group", () => {
+    it("should produce a GroupLayout with the correct label", () => {
+      const ir = formIRFromElements([
+        groupNode("Personal Info", [simpleFieldNode("name"), simpleFieldNode("age")]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      expect(result.elements).toHaveLength(1);
+      const groupEl = expectGroupLayout(result.elements, 0);
+      expect(groupEl.label).toBe("Personal Info");
+    });
+
+    it("should recursively convert nested elements inside a group", () => {
+      const ir = formIRFromElements([
+        groupNode("Customer", [
+          labelledFieldNode("name", "Name"),
+          labelledFieldNode("email", "Email"),
+        ]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const groupEl = expectGroupLayout(result.elements, 0);
+      expect(groupEl.elements).toHaveLength(2);
+
+      const nameControl = expectControl(groupEl.elements, 0);
+      expect(nameControl.scope).toBe("#/properties/name");
+      expect(nameControl.label).toBe("Name");
+
+      const emailControl = expectControl(groupEl.elements, 1);
+      expect(emailControl.scope).toBe("#/properties/email");
+      expect(emailControl.label).toBe("Email");
+    });
+
+    it("should not attach a rule to a group that is not inside a conditional", () => {
+      const ir = formIRFromElements([groupNode("Section", [simpleFieldNode("field1")])]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const groupEl = expectGroupLayout(result.elements, 0);
+      expect(groupEl.rule).toBeUndefined();
+    });
+
+    it("should produce an empty elements array for an empty group", () => {
+      const ir = formIRFromElements([groupNode("Empty", [])]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const groupEl = expectGroupLayout(result.elements, 0);
+      expect(groupEl.elements).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Conditional → children get SHOW rule
+  // ---------------------------------------------------------------------------
+
+  describe("conditional", () => {
+    it("should flatten conditional children into the parent container", () => {
+      const ir = formIRFromElements([
+        simpleFieldNode("status"),
+        conditionalNode("status", "draft", [simpleFieldNode("notes")]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      // The conditional itself is not an element — its children are flattened
+      expect(result.elements).toHaveLength(2);
+      expect(at(result.elements, 0).type).toBe("Control");
+      expect(at(result.elements, 1).type).toBe("Control");
+    });
+
+    it("should attach a SHOW rule to each child of a conditional", () => {
+      const ir = formIRFromElements([
+        conditionalNode("status", "draft", [simpleFieldNode("notes"), simpleFieldNode("refs")]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      expect(result.elements).toHaveLength(2);
+
+      const expectedRule: Rule = {
+        effect: "SHOW",
+        condition: {
+          scope: "#/properties/status",
+          schema: { const: "draft" },
+        },
+      };
+
+      const notesControl = expectControl(result.elements, 0);
+      expect(notesControl.rule).toEqual(expectedRule);
+
+      const refsControl = expectControl(result.elements, 1);
+      expect(refsControl.rule).toEqual(expectedRule);
+    });
+
+    it("should set the correct scope on the rule condition", () => {
+      const ir = formIRFromElements([
+        conditionalNode("type", "premium", [simpleFieldNode("discount")]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.rule?.condition.scope).toBe("#/properties/type");
+    });
+
+    it("should set the correct const value on the rule condition schema", () => {
+      const ir = formIRFromElements([conditionalNode("count", "5", [simpleFieldNode("extra")])]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.rule?.condition.schema).toEqual({ const: "5" });
+    });
+
+    it("should attach the conditional rule to a Group nested inside a conditional", () => {
+      const ir = formIRFromElements([
+        conditionalNode("status", "active", [
+          groupNode("Active Section", [simpleFieldNode("field1")]),
+        ]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      // The group is a flattened child of the conditional
+      expect(result.elements).toHaveLength(1);
+      const groupEl = expectGroupLayout(result.elements, 0);
+      expect(groupEl.rule).toEqual({
+        effect: "SHOW",
+        condition: { scope: "#/properties/status", schema: { const: "active" } },
+      });
+    });
+
+    it("should also apply the rule to nested fields inside a conditionally-shown group", () => {
+      const ir = formIRFromElements([
+        conditionalNode("mode", "advanced", [groupNode("Advanced", [simpleFieldNode("detail")])]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const groupEl = expectGroupLayout(result.elements, 0);
+      // The nested field inside the group gets the rule too
+      const nestedControl = expectControl(groupEl.elements, 0);
+      expect(nestedControl.rule).toEqual({
+        effect: "SHOW",
+        condition: { scope: "#/properties/mode", schema: { const: "advanced" } },
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 6. Nested conditional → combined allOf rule
+  // ---------------------------------------------------------------------------
+
+  describe("nested conditional", () => {
+    it("should combine parent and child conditional rules using allOf", () => {
+      const ir = formIRFromElements([
+        conditionalNode("status", "draft", [
+          conditionalNode("type", "internal", [simpleFieldNode("secret")]),
+        ]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      expect(result.elements).toHaveLength(1);
+      const control = expectControl(result.elements, 0);
+
+      expect(control.rule).toBeDefined();
+      expect(control.rule?.effect).toBe("SHOW");
+      expect(control.rule?.condition.scope).toBe("#");
+      expect(control.rule?.condition.schema).toEqual({
+        allOf: [
+          { properties: { status: { const: "draft" } } },
+          { properties: { type: { const: "internal" } } },
+        ],
+      });
+    });
+
+    it("should produce allOf with both parent and child field names as property keys", () => {
+      const ir = formIRFromElements([
+        conditionalNode("category", "A", [
+          conditionalNode("subcategory", "X", [simpleFieldNode("detail")]),
+        ]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      const allOf = control.rule?.condition.schema.allOf;
+      expect(allOf).toHaveLength(2);
+
+      expect(at(allOf ?? [], 0)).toEqual({ properties: { category: { const: "A" } } });
+      expect(at(allOf ?? [], 1)).toEqual({ properties: { subcategory: { const: "X" } } });
+    });
+
+    it("should flatten 3-level nesting into a single allOf with 3 entries", () => {
+      // Regression test: combineRules must flatten an already-combined parent rule
+      // rather than nesting allOf inside allOf. Without the fix, the 3rd condition
+      // would produce allOf: [allOf: [...], child] which is invalid.
+      const ir = formIRFromElements([
+        conditionalNode("a", "1", [
+          conditionalNode("b", "2", [conditionalNode("c", "3", [simpleFieldNode("deep")])]),
+        ]),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.rule?.condition.scope).toBe("#");
+      const allOf = control.rule?.condition.schema.allOf;
+      expect(allOf).toHaveLength(3);
+
+      expect(at(allOf ?? [], 0)).toEqual({ properties: { a: { const: "1" } } });
+      expect(at(allOf ?? [], 1)).toEqual({ properties: { b: { const: "2" } } });
+      expect(at(allOf ?? [], 2)).toEqual({ properties: { c: { const: "3" } } });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 7. Object field → single Control (via canonicalizeChainDSL)
+  // ---------------------------------------------------------------------------
+
+  describe("object field", () => {
+    it("should produce a single Control for an object field (not a GroupLayout)", () => {
+      const ir = canonicalizeChainDSL(
+        formspec(field.object("address", field.text("street"), field.text("city")))
+      );
+      const result = generateUiSchemaFromIR(ir);
+
+      // An object field is a single Control pointing to the object property,
+      // not a GroupLayout — it is up to the renderer to handle nested display.
+      expect(result.elements).toHaveLength(1);
+      const control = expectControl(result.elements, 0);
+      expect(control.scope).toBe("#/properties/address");
+    });
+
+    it("should not include sub-properties as separate controls for an object field", () => {
+      const ir = canonicalizeChainDSL(
+        formspec(field.object("person", field.text("firstName"), field.text("lastName")))
+      );
+      const result = generateUiSchemaFromIR(ir);
+
+      expect(result.elements).toHaveLength(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 8. Array field → single Control (via canonicalizeChainDSL)
+  // ---------------------------------------------------------------------------
+
+  describe("array field", () => {
+    it("should produce a single Control for an array field", () => {
+      const ir = canonicalizeChainDSL(
+        formspec(field.array("items", field.text("description"), field.number("qty")))
+      );
+      const result = generateUiSchemaFromIR(ir);
+
+      expect(result.elements).toHaveLength(1);
+      const control = expectControl(result.elements, 0);
+      expect(control.scope).toBe("#/properties/items");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 9. Output validation
+  // ---------------------------------------------------------------------------
+
+  describe("output validation", () => {
+    it("should pass Zod validation on complex output without throwing", () => {
+      const ir = canonicalizeChainDSL(
+        formspec(
+          group("Section", field.text("a", { label: "A" }), field.number("b")),
+          when(is("a", "x"), field.boolean("c"))
+        )
+      );
+
+      // Should not throw — Zod validation is performed internally
+      expect(() => generateUiSchemaFromIR(ir)).not.toThrow();
+    });
+
+    it("should produce a VerticalLayout root for any valid form IR", () => {
+      const ir = canonicalizeChainDSL(
+        formspec(field.text("name", { label: "Name" }), field.number("age"))
+      );
+      const result = generateUiSchemaFromIR(ir);
+
+      expect(result.type).toBe("VerticalLayout");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 10. Negative cases
+  // ---------------------------------------------------------------------------
+
+  describe("negative cases", () => {
+    it("should not include a rule property when the field is not in any conditional", () => {
+      const ir = formIRFromElements([simpleFieldNode("foo"), simpleFieldNode("bar")]);
+      const result = generateUiSchemaFromIR(ir);
+
+      for (const el of result.elements) {
+        expect(el.rule).toBeUndefined();
+      }
+    });
+
+    it("should not propagate the rule to sibling fields outside the conditional", () => {
+      const ir = formIRFromElements([
+        simpleFieldNode("always"),
+        conditionalNode("flag", "yes", [simpleFieldNode("conditional")]),
+        simpleFieldNode("alsoAlways"),
+      ]);
+      const result = generateUiSchemaFromIR(ir);
+
+      expect(result.elements).toHaveLength(3);
+
+      // First and last fields have no rule
+      expect(expectControl(result.elements, 0).rule).toBeUndefined();
+      expect(expectControl(result.elements, 2).rule).toBeUndefined();
+
+      // Middle field (from conditional) has the rule
+      expect(expectControl(result.elements, 1).rule).toBeDefined();
+    });
+  });
+});

--- a/packages/build/src/internals.ts
+++ b/packages/build/src/internals.ts
@@ -36,6 +36,7 @@ export type { JsonSchema2020 } from "./json-schema/ir-generator.js";
 
 // UI Schema utilities
 export { generateUiSchemaFromFields } from "./ui-schema/generator.js";
+export { generateUiSchemaFromIR } from "./ui-schema/ir-generator.js";
 
 // Generators: method schema
 export { generateMethodSchemas, collectFormSpecReferences } from "./generators/method-schema.js";

--- a/packages/build/src/ui-schema/ir-generator.ts
+++ b/packages/build/src/ui-schema/ir-generator.ts
@@ -1,0 +1,278 @@
+/**
+ * JSON Forms UI Schema generator that operates on the canonical FormIR.
+ *
+ * This generator consumes the IR produced by the Canonicalize phase and
+ * produces a JSON Forms UI Schema. All downstream UI Schema generation
+ * should use this module for UI Schema generation.
+ */
+
+import type { FormIR, FormIRElement, FieldNode, GroupLayoutNode } from "@formspec/core";
+import type {
+  UISchema,
+  UISchemaElement,
+  ControlElement,
+  GroupLayout,
+  Rule,
+  RuleConditionSchema,
+} from "./types.js";
+import { uiSchema as uiSchemaValidator } from "./schema.js";
+import { z } from "zod";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Parses a value through a Zod schema, converting validation errors to a
+ * descriptive Error.
+ */
+function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown, label: string): T {
+  try {
+    return schema.parse(value);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(
+        `Generated ${label} failed validation:\n${error.issues.map((i) => `  ${i.path.join(".")}: ${i.message}`).join("\n")}`
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Escapes a JSON Pointer token per RFC 6901:
+ * `~` → `~0`, `/` → `~1`.
+ */
+function escapeJsonPointerToken(token: string): string {
+  return token.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+/**
+ * Converts a field name to a JSON Pointer scope string.
+ *
+ * Field names containing `~` or `/` are escaped per RFC 6901 so the
+ * generated scope always points to the correct schema location.
+ */
+function fieldToScope(fieldName: string): string {
+  return `#/properties/${escapeJsonPointerToken(fieldName)}`;
+}
+
+/**
+ * Creates a SHOW rule for a single conditional field/value pair.
+ */
+function createShowRule(fieldName: string, value: unknown): Rule {
+  return {
+    effect: "SHOW",
+    condition: {
+      scope: fieldToScope(fieldName),
+      schema: { const: value },
+    },
+  };
+}
+
+/**
+ * Converts a simple rule condition (scope `#/properties/<name>`) to an allOf
+ * entry of the form `{ properties: { <name>: <schema> } }`.
+ */
+function conditionToAllOfEntry(condition: Rule["condition"]): RuleConditionSchema {
+  return {
+    properties: {
+      [condition.scope.replace("#/properties/", "")]: condition.schema,
+    },
+  };
+}
+
+/**
+ * Combines two SHOW rules into a single rule using an allOf condition.
+ *
+ * When elements are nested inside multiple conditionals, all parent conditions
+ * must be met for the element to be visible. This function merges the two
+ * conditions into a single rule using allOf so that JSON Forms evaluates
+ * all predicates simultaneously.
+ *
+ * Handles 3+ levels of nesting by flattening: if the parent rule is already a
+ * combined rule (scope `"#"` with an existing `allOf` array), the child entry
+ * is appended to that array rather than creating a new nested allOf.
+ */
+function combineRules(parentRule: Rule, childRule: Rule): Rule {
+  const parentCondition = parentRule.condition;
+  const childCondition = childRule.condition;
+  const childEntry = conditionToAllOfEntry(childCondition);
+
+  // If the parent is already a combined rule (scope "#" with allOf), flatten by
+  // appending the new child entry to the existing allOf array.
+  if (
+    parentCondition.scope === "#" &&
+    parentCondition.schema.allOf !== undefined &&
+    parentCondition.schema.allOf.length > 0
+  ) {
+    return {
+      effect: "SHOW",
+      condition: {
+        scope: "#",
+        schema: {
+          allOf: [...parentCondition.schema.allOf, childEntry],
+        },
+      },
+    };
+  }
+
+  // Otherwise, combine two simple conditions into a new allOf condition.
+  const parentEntry = conditionToAllOfEntry(parentCondition);
+
+  return {
+    effect: "SHOW",
+    condition: {
+      scope: "#",
+      schema: {
+        allOf: [parentEntry, childEntry],
+      },
+    },
+  };
+}
+
+// =============================================================================
+// ELEMENT CONVERSION
+// =============================================================================
+
+/**
+ * Converts a FieldNode from the IR to a ControlElement.
+ *
+ * The label is sourced from the first `displayName` annotation on the field,
+ * matching how the chain DSL propagates the `label` option through the
+ * canonicalization phase.
+ */
+function fieldNodeToControl(field: FieldNode, parentRule?: Rule): ControlElement {
+  const displayNameAnnotation = field.annotations.find((a) => a.annotationKind === "displayName");
+
+  const control: ControlElement = {
+    type: "Control",
+    scope: fieldToScope(field.name),
+    ...(displayNameAnnotation !== undefined && { label: displayNameAnnotation.value }),
+    ...(parentRule !== undefined && { rule: parentRule }),
+  };
+
+  return control;
+}
+
+/**
+ * Converts a GroupLayoutNode from the IR to a GroupLayout element.
+ *
+ * The group's children are recursively converted; the optional parent rule is
+ * forwarded to nested elements so that a group inside a conditional inherits
+ * the visibility rule.
+ */
+function groupNodeToLayout(group: GroupLayoutNode, parentRule?: Rule): GroupLayout {
+  return {
+    type: "Group",
+    label: group.label,
+    elements: irElementsToUiSchema(group.elements, parentRule),
+    ...(parentRule !== undefined && { rule: parentRule }),
+  };
+}
+
+/**
+ * Converts an array of IR elements to UI Schema elements.
+ *
+ * @param elements - The IR elements to convert
+ * @param parentRule - Optional rule inherited from a parent ConditionalLayoutNode
+ * @returns Array of UI Schema elements
+ */
+function irElementsToUiSchema(
+  elements: readonly FormIRElement[],
+  parentRule?: Rule
+): UISchemaElement[] {
+  const result: UISchemaElement[] = [];
+
+  for (const element of elements) {
+    switch (element.kind) {
+      case "field": {
+        result.push(fieldNodeToControl(element, parentRule));
+        break;
+      }
+
+      case "group": {
+        result.push(groupNodeToLayout(element, parentRule));
+        break;
+      }
+
+      case "conditional": {
+        // Build the rule for this conditional level.
+        const newRule = createShowRule(element.fieldName, element.value);
+        // Combine with the inherited parent rule for nested conditionals.
+        const combinedRule = parentRule !== undefined ? combineRules(parentRule, newRule) : newRule;
+        // Children are flattened into the parent container with the combined
+        // rule attached.
+        const childElements = irElementsToUiSchema(element.elements, combinedRule);
+        result.push(...childElements);
+        break;
+      }
+
+      default: {
+        const _exhaustive: never = element;
+        // Use `element` (before narrowing) for the error message since `_exhaustive`
+        // is typed as `never` and cannot be accessed at runtime.
+        throw new Error(
+          `Unhandled IR element kind: ${(element as FormIRElement).kind}`
+        );
+      }
+    }
+  }
+
+  return result;
+}
+
+// =============================================================================
+// PUBLIC API
+// =============================================================================
+
+/**
+ * Generates a JSON Forms UI Schema from a canonical `FormIR`.
+ *
+ * Mapping rules:
+ * - `FieldNode` → `ControlElement` with `scope: "#/properties/<name>"`
+ * - `displayName` annotation → `label` on the `ControlElement`
+ * - `GroupLayoutNode` → `GroupLayout` with recursively converted `elements`
+ * - `ConditionalLayoutNode` → children flattened with a `SHOW` rule
+ * - Nested conditionals → combined `allOf` rule
+ * - Root wrapper is always `{ type: "VerticalLayout", elements: [...] }`
+ *
+ * @example
+ * ```typescript
+ * const ir = canonicalizeDSL(
+ *   formspec(
+ *     group("Customer", field.text("name", { label: "Name" })),
+ *     when(is("status", "draft"), field.text("notes", { label: "Notes" })),
+ *   )
+ * );
+ *
+ * const uiSchema = generateUiSchemaFromIR(ir);
+ * // {
+ * //   type: "VerticalLayout",
+ * //   elements: [
+ * //     {
+ * //       type: "Group",
+ * //       label: "Customer",
+ * //       elements: [{ type: "Control", scope: "#/properties/name", label: "Name" }]
+ * //     },
+ * //     {
+ * //       type: "Control",
+ * //       scope: "#/properties/notes",
+ * //       label: "Notes",
+ * //       rule: { effect: "SHOW", condition: { scope: "#/properties/status", schema: { const: "draft" } } }
+ * //     }
+ * //   ]
+ * // }
+ * ```
+ *
+ * @param ir - The canonical FormIR produced by the Canonicalize phase
+ * @returns A validated JSON Forms UI Schema
+ */
+export function generateUiSchemaFromIR(ir: FormIR): UISchema {
+  const result: UISchema = {
+    type: "VerticalLayout",
+    elements: irElementsToUiSchema(ir.elements),
+  };
+
+  return parseOrThrow(uiSchemaValidator, result, "UI Schema");
+}


### PR DESCRIPTION
## Summary

Implements the JSON Forms UI Schema generator that converts a `FormIR` into a JSON Forms UI Schema object. This phase produces the `uischema` (element trees with `VerticalLayout`, `HorizontalLayout`, `Group`, `Control`, and `Categorization` elements) that drives the JSON Forms renderer, including proper `scope` references using JSON Pointer paths, `rule`-based visibility for conditional fields, and label/description annotations. The generator is intentionally separate from the JSON Schema generator so the two outputs can evolve independently.

## Stack

<!-- gst:stack -->
| | PR | Phase | Description |
|---|---|---|---|
| | #50 | IR Types | Canonical IR type definitions in @formspec/core |
| | #51 | Chain DSL Canonicalizer | DSL → FormIR *(merged)* |
| | #52 | JSON Schema Gen | IR → JSON Schema 2020-12 generator |
| ▶ | #53 | UI Schema Gen | IR → JSON Forms UI Schema generator |
| | #54 | TSDoc Analyzer | analyzeClassToIR / analyzeInterfaceToIR → FieldNode[] |
| | #55 | Pipeline Wiring | Wire IR pipeline, delete legacy code paths |
| | #56 | Constraint Validation | Constraint validator with contradiction detection |
| | #57 | Remove Decorators | Remove @formspec/decorators, keep JSDoc analysis |
| | #58 | Extension API | defineExtension, defineConstraint, defineAnnotation + registry |
| | #59 | ESLint Plugin | createConstraintRule factory, constraint-type-mismatch rule |
| | #60 | Parity Testing | ProvenanceFree\<T\> + compareIR() cross-DSL parity |
| | #61 | Ajv Vocabulary | Ajv vocabulary for x-formspec-* keywords |
| | #62 | Language Server | Completion, hover, and go-to-definition providers |
| | #63 | CLI + Playground | --emit-ir, --validate-only flags + playground support |
<!-- /gst:stack -->