### PR TITLE
Add path-target constraints, camelCase normalization, and E2E tests

### DIFF
--- a/.changeset/v2-pipeline-rewrite.md
+++ b/.changeset/v2-pipeline-rewrite.md
@@ -12,10 +12,17 @@
 Rewrite build pipeline around Canonical IR with constraint validation and extension API
 
 **@formspec/core**
+
 - Add Canonical IR type definitions (`FormIR`, `FieldIR`, `GroupIR`, `ConditionalIR`) and `IR_VERSION` constant
 - Add Extension API types (`ExtensionDefinition`, `ExtensionRegistry`)
+- Flip `BUILTIN_CONSTRAINT_DEFINITIONS` keys from PascalCase to camelCase (matching JSON Schema keywords)
+- Add `normalizeConstraintTagName` and `isBuiltinConstraintName` utilities
+- Add `multipleOf`, `minItems`, `maxItems` built-in constraints
 
 **@formspec/build**
+
+- Centralize constraint name normalization (import from `@formspec/core` instead of per-package implementations)
+- Add transitive type alias constraint propagation
 - Rewrite TSDoc analyzer to produce IR directly (replaces legacy `FormElement` intermediate)
 - Add IR → JSON Schema 2020-12 generator with `$defs`/`$ref` support
 - Add IR → JSON Forms UI Schema generator
@@ -25,20 +32,28 @@ Rewrite build pipeline around Canonical IR with constraint validation and extens
 - Add chain DSL and TSDoc parity test suite
 
 **@formspec/cli**
+
 - Add `--emit-ir` flag to output Canonical IR
 - Add `--validate-only` flag for schema validation without writing files
 
 **@formspec/eslint-plugin**
+
 - Add constraint rule factory for type-aware constraint validation
+- Add `multipleOf`/`minItems`/`maxItems` to type-mismatch and consistent-constraints rules
+- Centralize constraint name normalization (import from `@formspec/core`)
 
 **@formspec/playground**
+
 - Add IR viewer and constraint validation panels
 
 **@formspec/constraints**
+
 - Fix constraint propagation through nested class types
 
 **@formspec/runtime**
+
 - Adjust exports after decorator DSL removal
 
 **formspec**
+
 - Update umbrella re-exports for new public API surface

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -192,10 +192,10 @@ constraints:
 
 ### JSDoc Constraint Rules
 
-| Rule | Purpose |
-| --- | --- |
+| Rule                       | Purpose                                                                          |
+| -------------------------- | -------------------------------------------------------------------------------- |
 | `constraint-type-mismatch` | `@Minimum`/`@Maximum` only on `number`; `@MinLength`/`@Pattern` only on `string` |
-| `consistent-constraints` | `@Minimum ≤ @Maximum`; no conflicting bounds |
+| `consistent-constraints`   | `@Minimum ≤ @Maximum`; no conflicting bounds                                     |
 
 ### Chain DSL Rules
 
@@ -212,20 +212,20 @@ constraints:
 | --------------------------- | -------------------- | --------------------------------------------------------------------------------- |
 | `@formspec/build`           | Public API           | `buildFormSchemas`, `writeSchemas`, `generateSchemasFromClass`, schema generators |
 | `@formspec/build/browser`   | Browser (playground) | Schema generators without Node.js fs/path                                         |
-| `@formspec/build/internals` | CLI (unstable)       | `createProgramContext`, `analyzeClass`, `generateClassSchemas` |
+| `@formspec/build/internals` | CLI (unstable)       | `createProgramContext`, `analyzeClass`, `generateClassSchemas`                    |
 
 ## Testing Strategy
 
 ### Test Layers
 
-| Layer                | Framework  | Location                                   | Purpose                                    |
-| -------------------- | ---------- | ------------------------------------------ | ------------------------------------------ |
-| **Unit**             | Vitest     | `src/__tests__/*.test.ts`                  | Individual functions in isolation          |
-| **Type**             | tsd        | `src/__tests__/*.test-d.ts`                | Type inference correctness                 |
-| **Integration**      | Vitest     | `src/__tests__/integration.test.ts`        | Full pipeline (DSL → schema)               |
-| **Fixture-based**    | Vitest     | `src/__tests__/fixtures/`                  | Real TypeScript files through the analyzer |
-| **ESLint rule**      | RuleTester | `src/__tests__/rules/*.test.ts`            | Valid/invalid code patterns per rule       |
-| **Example projects** | Vitest     | `examples/*/test/schemas.test.ts`          | Schema snapshot validation                 |
+| Layer                | Framework  | Location                            | Purpose                                    |
+| -------------------- | ---------- | ----------------------------------- | ------------------------------------------ |
+| **Unit**             | Vitest     | `src/__tests__/*.test.ts`           | Individual functions in isolation          |
+| **Type**             | tsd        | `src/__tests__/*.test-d.ts`         | Type inference correctness                 |
+| **Integration**      | Vitest     | `src/__tests__/integration.test.ts` | Full pipeline (DSL → schema)               |
+| **Fixture-based**    | Vitest     | `src/__tests__/fixtures/`           | Real TypeScript files through the analyzer |
+| **ESLint rule**      | RuleTester | `src/__tests__/rules/*.test.ts`     | Valid/invalid code patterns per rule       |
+| **Example projects** | Vitest     | `examples/*/test/schemas.test.ts`   | Schema snapshot validation                 |
 
 ### Test Infrastructure
 

--- a/README.md
+++ b/README.md
@@ -267,18 +267,18 @@ Added to dynamic enum fields with dependencies. Lists field names whose values a
 
 FormSpec is organized as a monorepo with the following packages:
 
-| Package | Description |
-| --- | --- |
-| `formspec` | Main package with all re-exports (recommended) |
-| `@formspec/core` | Core type definitions |
-| `@formspec/dsl` | DSL functions (`field`, `group`, `when`, `formspec`) |
-| `@formspec/build` | Schema generators |
-| `@formspec/runtime` | Resolver helpers |
-| `@formspec/constraints` | Constraint definitions and validators |
-| `@formspec/validator` | JSON Schema validation for secure runtimes |
-| `@formspec/eslint-plugin` | ESLint rules for FormSpec |
-| `@formspec/language-server` | Language server for editor integration |
-| `@formspec/playground` | Interactive browser editor (private) |
+| Package                     | Description                                          |
+| --------------------------- | ---------------------------------------------------- |
+| `formspec`                  | Main package with all re-exports (recommended)       |
+| `@formspec/core`            | Core type definitions                                |
+| `@formspec/dsl`             | DSL functions (`field`, `group`, `when`, `formspec`) |
+| `@formspec/build`           | Schema generators                                    |
+| `@formspec/runtime`         | Resolver helpers                                     |
+| `@formspec/constraints`     | Constraint definitions and validators                |
+| `@formspec/validator`       | JSON Schema validation for secure runtimes           |
+| `@formspec/eslint-plugin`   | ESLint rules for FormSpec                            |
+| `@formspec/language-server` | Language server for editor integration               |
+| `@formspec/playground`      | Interactive browser editor (private)                 |
 
 For most use cases, just import from `formspec`:
 

--- a/e2e/expected/chain-dsl/conditional-form.schema.json
+++ b/e2e/expected/chain-dsl/conditional-form.schema.json
@@ -3,11 +3,7 @@
   "type": "object",
   "properties": {
     "paymentMethod": {
-      "enum": [
-        "card",
-        "bank_transfer",
-        "crypto"
-      ],
+      "enum": ["card", "bank_transfer", "crypto"],
       "title": "Payment Method"
     },
     "cardNumber": {
@@ -31,9 +27,5 @@
       "title": "Save for later"
     }
   },
-  "required": [
-    "paymentMethod",
-    "cardNumber",
-    "accountNumber"
-  ]
+  "required": ["paymentMethod", "cardNumber", "accountNumber"]
 }

--- a/e2e/expected/chain-dsl/contact-form.schema.json
+++ b/e2e/expected/chain-dsl/contact-form.schema.json
@@ -15,11 +15,7 @@
       "title": "Email"
     },
     "contactMethod": {
-      "enum": [
-        "email",
-        "phone",
-        "mail"
-      ],
+      "enum": ["email", "phone", "mail"],
       "title": "Preferred Contact Method"
     },
     "phoneNumber": {
@@ -37,9 +33,5 @@
       "title": "Subscribe to Newsletter"
     }
   },
-  "required": [
-    "firstName",
-    "lastName",
-    "contactMethod"
-  ]
+  "required": ["firstName", "lastName", "contactMethod"]
 }

--- a/e2e/expected/chain-dsl/enum-variants.schema.json
+++ b/e2e/expected/chain-dsl/enum-variants.schema.json
@@ -3,11 +3,7 @@
   "type": "object",
   "properties": {
     "simpleStatus": {
-      "enum": [
-        "draft",
-        "active",
-        "archived"
-      ],
+      "enum": ["draft", "active", "archived"],
       "title": "Status"
     },
     "labeledPriority": {
@@ -35,13 +31,9 @@
     "city": {
       "type": "string",
       "x-formspec-source": "cities",
-      "x-formspec-params": [
-        "country"
-      ],
+      "x-formspec-params": ["country"],
       "title": "City"
     }
   },
-  "required": [
-    "labeledPriority"
-  ]
+  "required": ["labeledPriority"]
 }

--- a/e2e/expected/chain-dsl/nested-form.schema.json
+++ b/e2e/expected/chain-dsl/nested-form.schema.json
@@ -22,10 +22,7 @@
           "title": "ZIP"
         }
       },
-      "required": [
-        "street",
-        "city"
-      ],
+      "required": ["street", "city"],
       "additionalProperties": false,
       "title": "Billing Address"
     },
@@ -45,10 +42,7 @@
           "title": "ZIP"
         }
       },
-      "required": [
-        "street",
-        "city"
-      ],
+      "required": ["street", "city"],
       "additionalProperties": false,
       "title": "Shipping Address"
     },
@@ -73,9 +67,7 @@
             "title": "Price"
           }
         },
-        "required": [
-          "description"
-        ],
+        "required": ["description"],
         "additionalProperties": false
       },
       "minItems": 1,
@@ -83,9 +75,5 @@
       "title": "Line Items"
     }
   },
-  "required": [
-    "customerName",
-    "billingAddress",
-    "lineItems"
-  ]
+  "required": ["customerName", "billingAddress", "lineItems"]
 }

--- a/e2e/expected/tsdoc-class/constrained-form.schema.json
+++ b/e2e/expected/tsdoc-class/constrained-form.schema.json
@@ -6,26 +6,28 @@
       "type": "string"
     },
     "age": {
-      "type": "number"
+      "type": "number",
+      "minimum": 0,
+      "maximum": 150
     },
     "email": {
-      "type": "string"
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 100,
+      "pattern": "^[^@]+@[^@]+$"
     },
     "tags": {
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1,
+      "maxItems": 10
     },
     "legacyField": {
       "type": "string",
       "deprecated": true
     }
   },
-  "required": [
-    "name",
-    "age",
-    "email",
-    "tags"
-  ]
+  "required": ["name", "age", "email", "tags"]
 }

--- a/e2e/expected/tsdoc-class/inherited-constraints.schema.json
+++ b/e2e/expected/tsdoc-class/inherited-constraints.schema.json
@@ -3,17 +3,20 @@
   "type": "object",
   "properties": {
     "cpuUsage": {
-      "type": "number"
+      "type": "integer",
+      "minimum": 10,
+      "maximum": 100
     },
     "memoryUsage": {
-      "type": "number"
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
     },
     "diskUsage": {
-      "type": "number"
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
     }
   },
-  "required": [
-    "cpuUsage",
-    "memoryUsage"
-  ]
+  "required": ["cpuUsage", "memoryUsage"]
 }

--- a/e2e/expected/tsdoc-class/nested-objects.schema.json
+++ b/e2e/expected/tsdoc-class/nested-objects.schema.json
@@ -27,18 +27,11 @@
               "type": "string"
             }
           },
-          "required": [
-            "street",
-            "city",
-            "country"
-          ],
+          "required": ["street", "city", "country"],
           "additionalProperties": false
         }
       },
-      "required": [
-        "name",
-        "email"
-      ],
+      "required": ["name", "email"],
       "additionalProperties": false
     },
     "items": {
@@ -53,10 +46,7 @@
             "type": "number"
           }
         },
-        "required": [
-          "productId",
-          "quantity"
-        ],
+        "required": ["productId", "quantity"],
         "additionalProperties": false
       }
     },
@@ -64,9 +54,5 @@
       "type": "string"
     }
   },
-  "required": [
-    "orderId",
-    "customer",
-    "items"
-  ]
+  "required": ["orderId", "customer", "items"]
 }

--- a/e2e/expected/tsdoc-class/nullable-types.schema.json
+++ b/e2e/expected/tsdoc-class/nullable-types.schema.json
@@ -29,10 +29,7 @@
       ]
     },
     "status": {
-      "enum": [
-        "active",
-        "inactive"
-      ]
+      "enum": ["active", "inactive"]
     },
     "tags": {
       "type": "array",
@@ -41,10 +38,5 @@
       }
     }
   },
-  "required": [
-    "name",
-    "nickname",
-    "score",
-    "status"
-  ]
+  "required": ["name", "nickname", "score", "status"]
 }

--- a/e2e/expected/tsdoc-class/product-form.schema.json
+++ b/e2e/expected/tsdoc-class/product-form.schema.json
@@ -12,11 +12,7 @@
       "type": "number"
     },
     "currency": {
-      "enum": [
-        "usd",
-        "eur",
-        "gbp"
-      ]
+      "enum": ["usd", "eur", "gbp"]
     },
     "active": {
       "type": "boolean"
@@ -31,12 +27,7 @@
       "$ref": "#/$defs/Record"
     }
   },
-  "required": [
-    "name",
-    "price",
-    "currency",
-    "active"
-  ],
+  "required": ["name", "price", "currency", "active"],
   "$defs": {
     "Record": {
       "type": "object",

--- a/e2e/expected/tsdoc-class/shared-types.schema.json
+++ b/e2e/expected/tsdoc-class/shared-types.schema.json
@@ -15,11 +15,7 @@
       "type": "string"
     }
   },
-  "required": [
-    "orderId",
-    "billingAddress",
-    "shippingAddress"
-  ],
+  "required": ["orderId", "billingAddress", "shippingAddress"],
   "$defs": {
     "Address": {
       "type": "object",
@@ -37,12 +33,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "street",
-        "city",
-        "zip",
-        "country"
-      ],
+      "required": ["street", "city", "zip", "country"],
       "additionalProperties": false
     }
   }

--- a/e2e/expected/tsdoc-interface/server-config.schema.json
+++ b/e2e/expected/tsdoc-interface/server-config.schema.json
@@ -9,10 +9,7 @@
       "type": "number"
     },
     "protocol": {
-      "enum": [
-        "http",
-        "https"
-      ]
+      "enum": ["http", "https"]
     },
     "maxConnections": {
       "type": "number"
@@ -33,11 +30,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "host",
-        "port",
-        "name"
-      ],
+      "required": ["host", "port", "name"],
       "additionalProperties": false
     },
     "allowedOrigins": {
@@ -47,11 +40,5 @@
       }
     }
   },
-  "required": [
-    "hostname",
-    "port",
-    "protocol",
-    "enableLogging",
-    "database"
-  ]
+  "required": ["hostname", "port", "protocol", "enableLogging", "database"]
 }

--- a/e2e/expected/tsdoc-type-alias/constrained-types.schema.json
+++ b/e2e/expected/tsdoc-type-alias/constrained-types.schema.json
@@ -17,11 +17,7 @@
     "alertChannels": {
       "type": "array",
       "items": {
-        "enum": [
-          "email",
-          "slack",
-          "pagerduty"
-        ]
+        "enum": ["email", "slack", "pagerduty"]
       }
     },
     "retryPolicy": {
@@ -34,18 +30,9 @@
           "type": "number"
         }
       },
-      "required": [
-        "maxRetries",
-        "backoffMs"
-      ],
+      "required": ["maxRetries", "backoffMs"],
       "additionalProperties": false
     }
   },
-  "required": [
-    "cpuThreshold",
-    "memoryThreshold",
-    "adminEmail",
-    "enableAlerts",
-    "alertChannels"
-  ]
+  "required": ["cpuThreshold", "memoryThreshold", "adminEmail", "enableAlerts", "alertChannels"]
 }

--- a/e2e/fixtures/tsdoc-class/path-target-constraints.ts
+++ b/e2e/fixtures/tsdoc-class/path-target-constraints.ts
@@ -4,12 +4,12 @@ interface MonetaryAmount {
 }
 
 export class Invoice {
-  /** @Minimum :value 0 @Maximum :value 9999999.99 */
+  /** @minimum :value 0 @maximum :value 9999999.99 */
   total!: MonetaryAmount;
 
-  /** @MinLength :currency 3 @MaxLength :currency 3 @Pattern :currency ^[A-Z]{3}$ */
+  /** @minLength :currency 3 @maxLength :currency 3 @pattern :currency ^[A-Z]{3}$ */
   discount!: MonetaryAmount;
 
-  /** @Minimum :value 0 */
+  /** @minimum :value 0 */
   lineItems!: MonetaryAmount[];
 }

--- a/e2e/tests/tsdoc-constrained-class.test.ts
+++ b/e2e/tests/tsdoc-constrained-class.test.ts
@@ -1,5 +1,9 @@
 /**
  * Tests TSDoc comment tag extraction for constraint and annotation tags.
+ *
+ * Constraint tags use lowercase/camelCase names matching JSON Schema keywords:
+ * `@minimum`, `@maximum`, `@minLength`, `@maxLength`, `@pattern`,
+ * `@minItems`, `@maxItems`, `@deprecated`.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as fs from "node:fs";
@@ -41,28 +45,43 @@ describe("TSDoc Constrained Class", () => {
     expect(schema).toHaveProperty("properties");
   });
 
-  // V2: @displayName TSDoc tag is not currently mapped to title in schema output
-  it("@displayName tag: name field has string type", () => {
-    expect(properties["name"]?.["type"]).toBe("string");
+  describe("name field — @displayName annotation (no constraint assertions)", () => {
+    it("has string type", () => {
+      expect(properties["name"]?.["type"]).toBe("string");
+    });
   });
 
-  // V2: @minimum/@maximum TSDoc tags are not currently emitted to JSON Schema
-  it("@minimum/@maximum tag: age field has number type", () => {
-    expect(properties["age"]?.["type"]).toBe("number");
+  describe("age field — @minimum 0 @maximum 150", () => {
+    it("has number type with minimum and maximum constraints", () => {
+      expect(properties["age"]?.["type"]).toBe("number");
+      expect(properties["age"]?.["minimum"]).toBe(0);
+      expect(properties["age"]?.["maximum"]).toBe(150);
+    });
   });
 
-  // V2: @minLength/@maxLength/@pattern TSDoc tags are not currently emitted to JSON Schema
-  it("@minLength/@maxLength/@pattern tag: email field has string type", () => {
-    expect(properties["email"]?.["type"]).toBe("string");
+  describe("email field — @minLength 5 @maxLength 100 @pattern", () => {
+    it("has string type with length and pattern constraints", () => {
+      expect(properties["email"]?.["type"]).toBe("string");
+      expect(properties["email"]?.["minLength"]).toBe(5);
+      expect(properties["email"]?.["maxLength"]).toBe(100);
+      expect(properties["email"]?.["pattern"]).toBe("^[^@]+@[^@]+$");
+    });
   });
 
-  // V2: @minItems/@maxItems TSDoc tags are not currently emitted to JSON Schema
-  it("@minItems/@maxItems tag: tags field is an array type", () => {
-    expect(properties["tags"]?.["type"]).toBe("array");
+  describe("tags field — @minItems 1 @maxItems 10", () => {
+    it("has array type with item cardinality constraints", () => {
+      expect(properties["tags"]?.["type"]).toBe("array");
+      expect(properties["tags"]?.["items"]).toEqual({ type: "string" });
+      expect(properties["tags"]?.["minItems"]).toBe(1);
+      expect(properties["tags"]?.["maxItems"]).toBe(10);
+    });
   });
 
-  it("@deprecated on optional field", () => {
-    expect(properties["legacyField"]?.["deprecated"]).toBe(true);
+  describe("legacyField — @deprecated", () => {
+    it("has string type with deprecated flag", () => {
+      expect(properties["legacyField"]?.["type"]).toBe("string");
+      expect(properties["legacyField"]?.["deprecated"]).toBe(true);
+    });
   });
 
   it("required fields are correct", () => {

--- a/e2e/tests/tsdoc-inherited-constraints.test.ts
+++ b/e2e/tests/tsdoc-inherited-constraints.test.ts
@@ -1,9 +1,14 @@
 /**
  * Tests fields typed with constrained type aliases in TSDoc-annotated classes.
  *
- * The current V2 pipeline resolves aliases to their base types but does not
- * propagate TSDoc constraints from type alias declarations. Fields typed to
- * Percentage or Integer aliases receive only `type: "number"` in the output.
+ * Verifies that constraints declared on type aliases (e.g., `@minimum 0`
+ * on `Percentage`) propagate transitively to fields. The alias chain
+ * `Integer` → `Percentage` → field means fields typed as `Percentage`
+ * inherit constraints from both `Percentage` AND `Integer`.
+ *
+ * Special case: `@multipleOf 1` on a number type promotes it to
+ * `type: "integer"` in JSON Schema (the `multipleOf` keyword is suppressed
+ * because `integer` is a subtype of `number` that implies it).
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as fs from "node:fs";
@@ -48,19 +53,29 @@ describe("TSDoc Inherited Constraints", () => {
     }
   });
 
-  // V2: type alias TSDoc constraints and inheritance are not processed —
-  // fields typed to Percentage/Integer aliases all receive base type: number
-  describe("JSON Schema — constraint inheritance", () => {
-    it("cpuUsage field has type number (base type of Percentage alias)", () => {
-      expect(properties["cpuUsage"]?.["type"]).toBe("number");
+  describe("JSON Schema — transitive constraint inheritance", () => {
+    // Integer (@multipleOf 1) → Percentage (@minimum 0 @maximum 100) → fields
+    // multipleOf:1 on number promotes type to "integer" (keyword suppressed)
+
+    it("cpuUsage: field-level @minimum overrides alias, inherits Integer → integer type", () => {
+      // Integer's @multipleOf 1 propagates transitively → type promoted to "integer"
+      expect(properties["cpuUsage"]?.["type"]).toBe("integer");
+      // Field-level @minimum 10 overrides Percentage's @minimum 0
+      expect(properties["cpuUsage"]?.["minimum"]).toBe(10);
+      // Inherited from Percentage alias: @maximum 100
+      expect(properties["cpuUsage"]?.["maximum"]).toBe(100);
     });
 
-    it("memoryUsage field has type number (base type of Percentage alias)", () => {
-      expect(properties["memoryUsage"]?.["type"]).toBe("number");
+    it("memoryUsage: inherits full Percentage + Integer constraint chain", () => {
+      expect(properties["memoryUsage"]?.["type"]).toBe("integer");
+      expect(properties["memoryUsage"]?.["minimum"]).toBe(0);
+      expect(properties["memoryUsage"]?.["maximum"]).toBe(100);
     });
 
-    it("diskUsage field has type number (base type of Percentage alias)", () => {
-      expect(properties["diskUsage"]?.["type"]).toBe("number");
+    it("diskUsage (optional): same constraints as memoryUsage", () => {
+      expect(properties["diskUsage"]?.["type"]).toBe("integer");
+      expect(properties["diskUsage"]?.["minimum"]).toBe(0);
+      expect(properties["diskUsage"]?.["maximum"]).toBe(100);
     });
 
     it("required contains only the non-optional fields", () => {
@@ -71,8 +86,7 @@ describe("TSDoc Inherited Constraints", () => {
     });
   });
 
-  // V2: UI elements render as plain Controls without min/max attributes
-  describe("UI Schema — constraint inheritance", () => {
+  describe("UI Schema — controls", () => {
     it("cpuUsage UI element is a Control", () => {
       const el = elements.find((e) => e["scope"] === "#/properties/cpuUsage");
       expect(el).toBeDefined();

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -106,11 +106,11 @@ The analyzer extracts type information and JSDoc constraint tags (e.g., `/** @Mi
 
 ### Entry Points
 
-| Entry Point               | Audience           | Description                                                                                       |
-| ------------------------- | ------------------ | ------------------------------------------------------------------------------------------------- |
-| `@formspec/build`         | Public API         | `buildFormSchemas`, `writeSchemas`, `generateSchemasFromClass`, schema generators                 |
-| `@formspec/build/browser` | Browser (playground) | Schema generators without Node.js `fs`/`path` — safe for bundlers                              |
-| `@formspec/build/internals` | CLI (unstable)   | Internal APIs: `createProgramContext`, `analyzeClass`, `generateClassSchemas`                     |
+| Entry Point                 | Audience             | Description                                                                       |
+| --------------------------- | -------------------- | --------------------------------------------------------------------------------- |
+| `@formspec/build`           | Public API           | `buildFormSchemas`, `writeSchemas`, `generateSchemasFromClass`, schema generators |
+| `@formspec/build/browser`   | Browser (playground) | Schema generators without Node.js `fs`/`path` — safe for bundlers                 |
+| `@formspec/build/internals` | CLI (unstable)       | Internal APIs: `createProgramContext`, `analyzeClass`, `generateClassSchemas`     |
 
 ## Generated Output
 
@@ -149,25 +149,25 @@ The analyzer extracts type information and JSDoc constraint tags (e.g., `/** @Mi
 
 ### Functions
 
-| Function                             | Description                                                        |
-| ------------------------------------ | ------------------------------------------------------------------ |
-| `buildFormSchemas(form)`             | Generate both JSON Schema and UI Schema                            |
-| `generateJsonSchema(form)`           | Generate only JSON Schema                                          |
-| `generateUiSchema(form)`             | Generate only UI Schema                                            |
-| `writeSchemas(form, options)`        | Build and write schemas to disk                                    |
-| `generateSchemasFromClass(options)`  | Generate schemas from a TypeScript class via static analysis       |
-| `generateSchemas(options)`           | Generate schemas from a TypeScript type via static analysis        |
+| Function                            | Description                                                  |
+| ----------------------------------- | ------------------------------------------------------------ |
+| `buildFormSchemas(form)`            | Generate both JSON Schema and UI Schema                      |
+| `generateJsonSchema(form)`          | Generate only JSON Schema                                    |
+| `generateUiSchema(form)`            | Generate only UI Schema                                      |
+| `writeSchemas(form, options)`       | Build and write schemas to disk                              |
+| `generateSchemasFromClass(options)` | Generate schemas from a TypeScript class via static analysis |
+| `generateSchemas(options)`          | Generate schemas from a TypeScript type via static analysis  |
 
 ### Types
 
-| Type                      | Description                             |
-| ------------------------- | --------------------------------------- |
-| `BuildResult`             | Return type of `buildFormSchemas`       |
-| `WriteSchemasOptions`     | Options for `writeSchemas`              |
-| `WriteSchemasResult`      | Return type of `writeSchemas`           |
-| `JsonSchema2020`          | JSON Schema 2020-12 type                |
+| Type                       | Description                            |
+| -------------------------- | -------------------------------------- |
+| `BuildResult`              | Return type of `buildFormSchemas`      |
+| `WriteSchemasOptions`      | Options for `writeSchemas`             |
+| `WriteSchemasResult`       | Return type of `writeSchemas`          |
+| `JsonSchema2020`           | JSON Schema 2020-12 type               |
 | `GenerateFromClassOptions` | Options for `generateSchemasFromClass` |
-| `UISchema`                | JSON Forms UI Schema type               |
+| `UISchema`                 | JSON Forms UI Schema type              |
 
 ## License
 

--- a/packages/build/src/__tests__/alias-chain-propagation.test.ts
+++ b/packages/build/src/__tests__/alias-chain-propagation.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for transitive type alias constraint propagation.
+ *
+ * Verifies that constraints declared on type aliases propagate transitively
+ * through alias chains (e.g., Integer → Percentage → field), and that
+ * excessively deep chains throw a clear error.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as path from "node:path";
+import type { FieldNode, ConstraintNode } from "@formspec/core";
+import { createProgramContext, findClassByName } from "../analyzer/program.js";
+import { analyzeClassToIR } from "../analyzer/class-analyzer.js";
+
+const fixturePath = path.join(__dirname, "fixtures", "alias-chains.ts");
+
+function analyzeClass(className: string) {
+  const ctx = createProgramContext(fixturePath);
+  const classDecl = findClassByName(ctx.sourceFile, className);
+  if (!classDecl) throw new Error(`Class "${className}" not found`);
+  return analyzeClassToIR(classDecl, ctx.checker, fixturePath);
+}
+
+function findField(fields: readonly FieldNode[], name: string): FieldNode {
+  const field = fields.find((f) => f.name === name);
+  if (!field) throw new Error(`Field "${name}" not found`);
+  return field;
+}
+
+function findConstraint(
+  constraints: readonly ConstraintNode[],
+  kind: string
+): ConstraintNode | undefined {
+  return constraints.find((c) => c.constraintKind === kind);
+}
+
+describe("transitive type alias constraint propagation", () => {
+  describe("2-level chain: Integer → Percentage → field", () => {
+    it("propagates constraints from both Percentage and Integer", () => {
+      const analysis = analyzeClass("TwoLevelChain");
+      const mem = findField(analysis.fields, "memoryUsage");
+
+      // From Percentage: @Minimum 0, @Maximum 100
+      expect(findConstraint(mem.constraints, "minimum")).toMatchObject({ value: 0 });
+      expect(findConstraint(mem.constraints, "maximum")).toMatchObject({ value: 100 });
+      // From Integer (transitive): @MultipleOf 1
+      expect(findConstraint(mem.constraints, "multipleOf")).toMatchObject({ value: 1 });
+    });
+
+    it("collects both alias-level and field-level constraints for the same kind", () => {
+      const analysis = analyzeClass("TwoLevelChain");
+      const cpu = findField(analysis.fields, "cpuUsage");
+
+      // cpuUsage has @Minimum from both the Percentage alias (0) and the field (10)
+      const minimums = cpu.constraints.filter((c) => c.constraintKind === "minimum");
+      expect(minimums).toHaveLength(2);
+
+      // Alias constraints are collected first, field-level second.
+      // Downstream schema generation picks the appropriate winner.
+      const values = minimums.map((c) => "value" in c && c.value);
+      expect(values).toContain(0);
+      expect(values).toContain(10);
+    });
+  });
+
+  describe("3-level chain: Base → Mid → Leaf → field", () => {
+    it("propagates constraints from all three alias levels", () => {
+      const analysis = analyzeClass("ThreeLevelChain");
+      const value = findField(analysis.fields, "value");
+
+      // From Leaf: @MultipleOf 5
+      expect(findConstraint(value.constraints, "multipleOf")).toMatchObject({ value: 5 });
+      // From Mid: @Maximum 1000
+      expect(findConstraint(value.constraints, "maximum")).toMatchObject({ value: 1000 });
+      // From Base: @Minimum 0
+      expect(findConstraint(value.constraints, "minimum")).toMatchObject({ value: 0 });
+    });
+
+    it("collects exactly 3 constraints from the chain", () => {
+      const analysis = analyzeClass("ThreeLevelChain");
+      const value = findField(analysis.fields, "value");
+
+      expect(value.constraints).toHaveLength(3);
+      const kinds = new Set(value.constraints.map((c) => c.constraintKind));
+      expect(kinds).toEqual(new Set(["multipleOf", "maximum", "minimum"]));
+    });
+  });
+
+  describe("no alias chain", () => {
+    it("field-level constraints work without any alias", () => {
+      const analysis = analyzeClass("NoAlias");
+      const count = findField(analysis.fields, "count");
+
+      expect(findConstraint(count.constraints, "minimum")).toMatchObject({ value: 0 });
+      expect(count.constraints).toHaveLength(1);
+    });
+  });
+
+  describe("max depth exceeded", () => {
+    it("throws when alias chain exceeds 8 levels", () => {
+      expect(() => analyzeClass("ExceedsMaxDepth")).toThrow(
+        /type alias chain exceeds maximum depth of 8/i
+      );
+    });
+  });
+});

--- a/packages/build/src/__tests__/constraint-definitions.test.ts
+++ b/packages/build/src/__tests__/constraint-definitions.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for constraint definition utilities exported from @formspec/core.
+ *
+ * Covers normalizeConstraintTagName and isBuiltinConstraintName.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  normalizeConstraintTagName,
+  isBuiltinConstraintName,
+  BUILTIN_CONSTRAINT_DEFINITIONS,
+} from "@formspec/core";
+
+describe("normalizeConstraintTagName", () => {
+  it("lowercases a PascalCase tag name", () => {
+    expect(normalizeConstraintTagName("Minimum")).toBe("minimum");
+  });
+
+  it("preserves an already-camelCase tag name (idempotent)", () => {
+    expect(normalizeConstraintTagName("minimum")).toBe("minimum");
+  });
+
+  it("handles multi-word PascalCase", () => {
+    expect(normalizeConstraintTagName("MinLength")).toBe("minLength");
+  });
+
+  it("preserves multi-word camelCase", () => {
+    expect(normalizeConstraintTagName("minLength")).toBe("minLength");
+  });
+
+  it("handles single character", () => {
+    expect(normalizeConstraintTagName("X")).toBe("x");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeConstraintTagName("")).toBe("");
+  });
+
+  it("does not fully lowercase all-caps input (only first char)", () => {
+    // Intentional: handles PascalCase→camelCase only, not arbitrary casing
+    expect(normalizeConstraintTagName("MINIMUM")).toBe("mINIMUM");
+  });
+});
+
+describe("isBuiltinConstraintName", () => {
+  it("returns true for a known camelCase constraint name", () => {
+    expect(isBuiltinConstraintName("minimum")).toBe(true);
+  });
+
+  it("returns true for all defined constraint names", () => {
+    for (const key of Object.keys(BUILTIN_CONSTRAINT_DEFINITIONS)) {
+      expect(isBuiltinConstraintName(key)).toBe(true);
+    }
+  });
+
+  it("returns false for PascalCase input (callers must normalize first)", () => {
+    expect(isBuiltinConstraintName("Minimum")).toBe(false);
+  });
+
+  it("returns false for an unknown name", () => {
+    expect(isBuiltinConstraintName("notAConstraint")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isBuiltinConstraintName("")).toBe(false);
+  });
+
+  it("returns false for all-caps input", () => {
+    expect(isBuiltinConstraintName("MINIMUM")).toBe(false);
+  });
+});

--- a/packages/build/src/__tests__/constraint-validator.test.ts
+++ b/packages/build/src/__tests__/constraint-validator.test.ts
@@ -1015,7 +1015,9 @@ describe("validateIR", () => {
       const result = validateIR(ir);
 
       // Should NOT produce a "cannot be traversed" diagnostic
-      expect(result.diagnostics.filter((d) => d.message.includes("cannot be traversed"))).toHaveLength(0);
+      expect(
+        result.diagnostics.filter((d) => d.message.includes("cannot be traversed"))
+      ).toHaveLength(0);
     });
   });
 });

--- a/packages/build/src/__tests__/fixtures/alias-chains.ts
+++ b/packages/build/src/__tests__/fixtures/alias-chains.ts
@@ -1,0 +1,57 @@
+// Fixtures for type alias constraint propagation tests.
+
+// --- 2-level chain: Integer → Percentage → field ---
+
+/** @multipleOf 1 */
+type Integer = number;
+
+/** @minimum 0 @maximum 100 */
+type Percentage = Integer;
+
+export class TwoLevelChain {
+  /** @minimum 10 */
+  cpuUsage!: Percentage;
+  memoryUsage!: Percentage;
+}
+
+// --- 3-level chain: Base → Mid → Leaf → field ---
+
+/** @minimum 0 */
+type Base = number;
+
+/** @maximum 1000 */
+type Mid = Base;
+
+/** @multipleOf 5 */
+type Leaf = Mid;
+
+export class ThreeLevelChain {
+  value!: Leaf;
+}
+
+// --- No alias: field uses a primitive directly ---
+
+export class NoAlias {
+  /** @minimum 0 */
+  count!: number;
+}
+
+// --- 10-level alias chain: exceeds MAX_ALIAS_CHAIN_DEPTH (8) ---
+// The field references D9 (depth 0). Following the chain:
+// D9→D8 (1) → D7 (2) → D6 (3) → D5 (4) → D4 (5) → D3 (6) → D2 (7) → D1 (8, throws)
+// D1 is still a type reference to D0, so the depth-8 check fires before resolving it.
+
+type D0 = number;
+type D1 = D0;
+type D2 = D1;
+type D3 = D2;
+type D4 = D3;
+type D5 = D4;
+type D6 = D5;
+type D7 = D6;
+type D8 = D7;
+type D9 = D8;
+
+export class ExceedsMaxDepth {
+  value!: D9;
+}

--- a/packages/build/src/__tests__/fixtures/example-a-builtins.ts
+++ b/packages/build/src/__tests__/fixtures/example-a-builtins.ts
@@ -1,29 +1,29 @@
 export class ExampleAForm {
   /** @Field_displayName Full Name
    *  @Field_description Your legal name
-   *  @MinLength 2
-   *  @MaxLength 100
+   *  @minLength 2
+   *  @maxLength 100
    */
   name!: string;
 
   /** @Field_displayName Age
-   *  @Minimum 0
-   *  @Maximum 150
+   *  @minimum 0
+   *  @maximum 150
    */
   age!: number;
 
   /** @Field_displayName Score
-   *  @ExclusiveMinimum 0
+   *  @exclusiveMinimum 0
    */
   score!: number;
 
   /** @Field_displayName Email
-   *  @Pattern ^[^@]+@[^@]+$
+   *  @pattern ^[^@]+@[^@]+$
    */
   email?: string;
 
   /** @Field_displayName Country
-   *  @EnumOptions [{"id":"us","label":"United States"},{"id":"ca","label":"Canada"}]
+   *  @enumOptions [{"id":"us","label":"United States"},{"id":"ca","label":"Canada"}]
    */
   country!: "us" | "ca";
 

--- a/packages/build/src/__tests__/fixtures/example-interface-types.ts
+++ b/packages/build/src/__tests__/fixtures/example-interface-types.ts
@@ -11,15 +11,15 @@ export interface SimpleConfig {
   /**
    * @Field_displayName Full Name
    * @Field_description The user's legal name
-   * @MinLength 1
-   * @MaxLength 200
+   * @minLength 1
+   * @maxLength 200
    */
   name: string;
 
-  /** @Field_displayName Age @Minimum 0 @Maximum 150 */
+  /** @Field_displayName Age @minimum 0 @maximum 150 */
   age: number;
 
-  /** @Field_displayName Email @Pattern ^[^@]+@[^@]+$ */
+  /** @Field_displayName Email @pattern ^[^@]+@[^@]+$ */
   email?: string;
 
   /** @Field_displayName Active */
@@ -29,13 +29,13 @@ export interface SimpleConfig {
 export interface WithEnumOptions {
   /**
    * @Field_displayName Status
-   * @EnumOptions ["draft","active","archived"]
+   * @enumOptions ["draft","active","archived"]
    */
   status: "draft" | "active" | "archived";
 
   /**
    * @Field_displayName Priority
-   * @EnumOptions [{"id":"low","label":"Low Priority"},{"id":"high","label":"High Priority"}]
+   * @enumOptions [{"id":"low","label":"Low Priority"},{"id":"high","label":"High Priority"}]
    */
   priority: "low" | "high";
 }
@@ -63,10 +63,10 @@ export interface DeprecatedFieldInterface {
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Testing type alias analysis
 export type SimpleTypeAlias = {
-  /** @Field_displayName Label @MinLength 1 */
+  /** @Field_displayName Label @minLength 1 */
   label: string;
 
-  /** @Field_displayName Count @Minimum 0 */
+  /** @Field_displayName Count @minimum 0 */
   count: number;
 
   /** @Field_displayName Description */
@@ -77,7 +77,7 @@ export type SimpleTypeAlias = {
 export type TypeAliasWithEnumOptions = {
   /**
    * @Field_displayName Color
-   * @EnumOptions ["red","green","blue"]
+   * @enumOptions ["red","green","blue"]
    */
   color: "red" | "green" | "blue";
 };
@@ -88,13 +88,13 @@ export type UnionAlias = "a" | "b" | "c";
 
 // --- Constrained primitive type aliases ---
 
-/** @Minimum 0 @Maximum 100 */
+/** @minimum 0 @maximum 100 */
 export type Percent = number;
 
-/** @MinLength 1 @MaxLength 255 @Pattern ^[^@]+@[^@]+$ */
+/** @minLength 1 @maxLength 255 @pattern ^[^@]+@[^@]+$ */
 export type Email = string;
 
-/** @Field_displayName Discount Rate @Field_description Percentage discount applied @Minimum 0 @Maximum 100 */
+/** @Field_displayName Discount Rate @Field_description Percentage discount applied @minimum 0 @maximum 100 */
 export type AnnotatedPercent = number;
 
 export interface ConfigWithAliasedTypes {
@@ -111,19 +111,19 @@ export interface ConfigWithAliasedTypes {
 // --- Nested types ---
 
 export interface Address {
-  /** @Field_displayName Street @MinLength 1 @MaxLength 200 */
+  /** @Field_displayName Street @minLength 1 @maxLength 200 */
   street: string;
-  /** @Field_displayName City @MinLength 1 */
+  /** @Field_displayName City @minLength 1 */
   city: string;
-  /** @Field_displayName Zip @Pattern ^[0-9]{5}$ */
+  /** @Field_displayName Zip @pattern ^[0-9]{5}$ */
   zip?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- Testing type alias analysis
 export type ContactInfo = {
-  /** @Field_displayName Email @Pattern ^[^@]+@[^@]+$ */
+  /** @Field_displayName Email @pattern ^[^@]+@[^@]+$ */
   email: string;
-  /** @Field_displayName Phone @MaxLength 20 */
+  /** @Field_displayName Phone @maxLength 20 */
   phone?: string;
 };
 

--- a/packages/build/src/__tests__/ir-analyzer.test.ts
+++ b/packages/build/src/__tests__/ir-analyzer.test.ts
@@ -322,7 +322,7 @@ describe("analyzeInterfaceToIR", () => {
 
     const nameField = findField(analysis.fields, "name");
     const minLength = findConstraint(nameField.constraints, "minLength");
-    expect(minLength.provenance.tagName).toBe("@MinLength");
+    expect(minLength.provenance.tagName).toBe("@minLength");
     expect(minLength.provenance.file).toBe(interfaceFixturePath);
     expect(minLength.provenance.line).toBeGreaterThan(0);
   });

--- a/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
+++ b/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
@@ -254,7 +254,7 @@ describe("extractJSDocConstraintNodes", () => {
     expect(result).toHaveLength(0);
   });
 
-  it("is case-sensitive: ignores lowercase @minimum", () => {
+  it("accepts lowercase (camelCase) constraint tags", () => {
     const prop = getPropertyFromSource(`
       class Foo {
         /** @minimum 5 */
@@ -263,7 +263,8 @@ describe("extractJSDocConstraintNodes", () => {
     `);
 
     const result = extractJSDocConstraintNodes(prop);
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ constraintKind: "minimum", value: 5 });
   });
 
   it("returns empty array for node with no JSDoc", () => {
@@ -287,7 +288,7 @@ describe("extractJSDocConstraintNodes", () => {
 
     const result = extractJSDocConstraintNodes(prop, "/test.ts");
     expect(result).toHaveLength(1);
-    expect(result[0]?.provenance.tagName).toBe("@Minimum");
+    expect(result[0]?.provenance.tagName).toBe("@minimum");
     expect(result[0]?.provenance.file).toBe("/test.ts");
     expect(result[0]?.provenance.surface).toBe("tsdoc");
     expect(result[0]?.provenance.line).toBeGreaterThan(0);

--- a/packages/build/src/__tests__/ir-json-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-json-schema-generator.test.ts
@@ -1385,7 +1385,7 @@ describe("generateJsonSchemaFromIR", () => {
                   file: "/test.ts",
                   line: 1,
                   column: 0,
-                  tagName: "@Minimum",
+                  tagName: "@minimum",
                 },
               },
             ]
@@ -1433,7 +1433,7 @@ describe("generateJsonSchemaFromIR", () => {
                   file: "/test.ts",
                   line: 1,
                   column: 0,
-                  tagName: "@Pattern",
+                  tagName: "@pattern",
                 },
               },
             ]
@@ -1474,7 +1474,7 @@ describe("generateJsonSchemaFromIR", () => {
                   file: "/test.ts",
                   line: 1,
                   column: 0,
-                  tagName: "@Minimum",
+                  tagName: "@minimum",
                 },
               },
               {
@@ -1486,7 +1486,7 @@ describe("generateJsonSchemaFromIR", () => {
                   file: "/test.ts",
                   line: 1,
                   column: 0,
-                  tagName: "@MinItems",
+                  tagName: "@minItems",
                 },
               },
             ]
@@ -1542,7 +1542,7 @@ describe("generateJsonSchemaFromIR", () => {
                   file: "/test.ts",
                   line: 1,
                   column: 0,
-                  tagName: "@MinLength",
+                  tagName: "@minLength",
                 },
               },
             ]
@@ -1567,26 +1567,21 @@ describe("generateJsonSchemaFromIR", () => {
         kind: "form-ir",
         irVersion: IR_VERSION,
         elements: [
-          makeField(
-            "count",
-            { kind: "primitive", primitiveKind: "number" },
-            true,
-            [
-              {
-                kind: "constraint",
-                constraintKind: "minimum",
-                value: 0,
-                path: { segments: ["value"] },
-                provenance: {
-                  surface: "tsdoc",
-                  file: "/test.ts",
-                  line: 1,
-                  column: 0,
-                  tagName: "@Minimum",
-                },
+          makeField("count", { kind: "primitive", primitiveKind: "number" }, true, [
+            {
+              kind: "constraint",
+              constraintKind: "minimum",
+              value: 0,
+              path: { segments: ["value"] },
+              provenance: {
+                surface: "tsdoc",
+                file: "/test.ts",
+                line: 1,
+                column: 0,
+                tagName: "@minimum",
               },
-            ]
-          ),
+            },
+          ]),
         ],
         typeRegistry: {},
         provenance: PROVENANCE,
@@ -1619,7 +1614,7 @@ describe("generateJsonSchemaFromIR", () => {
                   file: "/test.ts",
                   line: 1,
                   column: 0,
-                  tagName: "@Minimum",
+                  tagName: "@minimum",
                 },
               },
               {
@@ -1632,7 +1627,7 @@ describe("generateJsonSchemaFromIR", () => {
                   file: "/test.ts",
                   line: 1,
                   column: 0,
-                  tagName: "@Maximum",
+                  tagName: "@maximum",
                 },
               },
             ],

--- a/packages/build/src/__tests__/jsdoc-constraints.test.ts
+++ b/packages/build/src/__tests__/jsdoc-constraints.test.ts
@@ -65,7 +65,7 @@ describe("extractJSDocConstraints", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ name: "Minimum", args: [34] });
+    expect(result[0]).toMatchObject({ name: "minimum", args: [34] });
   });
 
   it("parses @Maximum with an integer value", () => {
@@ -78,7 +78,7 @@ describe("extractJSDocConstraints", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ name: "Maximum", args: [100] });
+    expect(result[0]).toMatchObject({ name: "maximum", args: [100] });
   });
 
   it("parses @Pattern as a string value", () => {
@@ -91,7 +91,7 @@ describe("extractJSDocConstraints", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ name: "Pattern", args: ["^[a-z]+$"] });
+    expect(result[0]).toMatchObject({ name: "pattern", args: ["^[a-z]+$"] });
   });
 
   it("handles negative numbers", () => {
@@ -104,7 +104,7 @@ describe("extractJSDocConstraints", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ name: "Minimum", args: [-10] });
+    expect(result[0]).toMatchObject({ name: "minimum", args: [-10] });
   });
 
   it("handles decimal numbers", () => {
@@ -117,7 +117,7 @@ describe("extractJSDocConstraints", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ name: "Maximum", args: [3.14] });
+    expect(result[0]).toMatchObject({ name: "maximum", args: [3.14] });
   });
 
   it("handles negative decimal numbers", () => {
@@ -130,7 +130,7 @@ describe("extractJSDocConstraints", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ name: "Minimum", args: [-273.15] });
+    expect(result[0]).toMatchObject({ name: "minimum", args: [-273.15] });
   });
 
   it("ignores non-constraint tags like @deprecated and @param", () => {
@@ -179,11 +179,11 @@ describe("extractJSDocConstraints", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ name: "Minimum", args: [0] });
-    expect(result[1]).toMatchObject({ name: "Maximum", args: [100] });
+    expect(result[0]).toMatchObject({ name: "minimum", args: [0] });
+    expect(result[1]).toMatchObject({ name: "maximum", args: [100] });
   });
 
-  it("is case-sensitive: ignores lowercase @minimum", () => {
+  it("accepts lowercase (camelCase) constraint tags", () => {
     const prop = getPropertyFromSource(`
       class Foo {
         /** @minimum 5 */
@@ -192,7 +192,8 @@ describe("extractJSDocConstraints", () => {
     `);
 
     const result = extractJSDocConstraints(prop);
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ name: "minimum", args: [5] });
   });
 
   it("parses all supported numeric tags", () => {
@@ -206,12 +207,12 @@ describe("extractJSDocConstraints", () => {
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(6);
     expect(result.map((d) => d.name)).toEqual([
-      "Minimum",
-      "Maximum",
-      "ExclusiveMinimum",
-      "ExclusiveMaximum",
-      "MinLength",
-      "MaxLength",
+      "minimum",
+      "maximum",
+      "exclusiveMinimum",
+      "exclusiveMaximum",
+      "minLength",
+      "maxLength",
     ]);
   });
 
@@ -250,7 +251,7 @@ describe("extractJSDocConstraints", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ name: "Minimum", args: [0] });
+    expect(result[0]).toMatchObject({ name: "minimum", args: [0] });
   });
 });
 
@@ -269,7 +270,7 @@ describe("@EnumOptions JSON parsing", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ name: "EnumOptions", args: [["a", "b", "c"]] });
+    expect(result[0]).toMatchObject({ name: "enumOptions", args: [["a", "b", "c"]] });
   });
 
   it("parses a valid JSON object array (labeled options)", () => {
@@ -283,7 +284,7 @@ describe("@EnumOptions JSON parsing", () => {
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
-      name: "EnumOptions",
+      name: "enumOptions",
       args: [
         [
           { id: "low", label: "Low" },
@@ -315,7 +316,7 @@ describe("@EnumOptions JSON parsing", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ name: "EnumOptions", args: [[]] });
+    expect(result[0]).toMatchObject({ name: "enumOptions", args: [[]] });
   });
 
   it("skips an empty JSON object", () => {
@@ -413,10 +414,10 @@ describe("@EnumOptions JSON parsing", () => {
 
     const result = extractJSDocConstraints(prop);
     expect(result).toHaveLength(2);
-    expect(result.find((d) => d.name === "EnumOptions")).toMatchObject({
+    expect(result.find((d) => d.name === "enumOptions")).toMatchObject({
       args: [["a", "b"]],
     });
-    expect(result.find((d) => d.name === "MinLength")).toMatchObject({
+    expect(result.find((d) => d.name === "minLength")).toMatchObject({
       args: [1],
     });
   });

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -645,16 +645,35 @@ function buildFieldNodeInfoMap(
 // TYPE ALIAS CONSTRAINT PROPAGATION
 // =============================================================================
 
+/** Maximum depth for transitive type alias constraint propagation. */
+const MAX_ALIAS_CHAIN_DEPTH = 8;
+
 /**
  * Given a type node referencing a type alias, extracts IR ConstraintNodes
  * from the alias declaration's JSDoc tags.
+ *
+ * Follows alias chains transitively: if `type Percentage = Integer` and
+ * `type Integer = number`, constraints from both `Percentage` and `Integer`
+ * are collected. Constraints from closer aliases appear first in the result
+ * (higher precedence). Recursion is capped at {@link MAX_ALIAS_CHAIN_DEPTH}
+ * levels; exceeding the limit throws to surface pathological alias chains.
  */
 function extractTypeAliasConstraintNodes(
   typeNode: ts.TypeNode,
   checker: ts.TypeChecker,
-  file: string
+  file: string,
+  depth = 0
 ): ConstraintNode[] {
   if (!ts.isTypeReferenceNode(typeNode)) return [];
+
+  if (depth >= MAX_ALIAS_CHAIN_DEPTH) {
+    const aliasName = typeNode.typeName.getText();
+    throw new Error(
+      `Type alias chain exceeds maximum depth of ${String(MAX_ALIAS_CHAIN_DEPTH)} ` +
+        `at alias "${aliasName}" in ${file}. ` +
+        `Simplify the alias chain or check for circular references.`
+    );
+  }
 
   const symbol = checker.getSymbolAtLocation(typeNode.typeName);
   if (!symbol?.declarations) return [];
@@ -665,7 +684,14 @@ function extractTypeAliasConstraintNodes(
   // Don't extract from object type aliases
   if (ts.isTypeLiteralNode(aliasDecl.type)) return [];
 
-  return extractJSDocConstraintNodes(aliasDecl, file);
+  const constraints = extractJSDocConstraintNodes(aliasDecl, file);
+
+  // Transitively follow alias chains (e.g., Percentage → Integer → number)
+  // Constraints from parent aliases are appended after the immediate alias's
+  // constraints, giving the immediate alias higher precedence.
+  constraints.push(...extractTypeAliasConstraintNodes(aliasDecl.type, checker, file, depth + 1));
+
+  return constraints;
 }
 
 // =============================================================================

--- a/packages/build/src/analyzer/jsdoc-constraints.ts
+++ b/packages/build/src/analyzer/jsdoc-constraints.ts
@@ -3,7 +3,7 @@
  *
  * Extracts constraints and annotation tags from JSDoc comments on
  * class/interface fields and returns canonical IR nodes directly:
- * - {@link ConstraintNode} for set-influencing tags (@Minimum, @Pattern, etc.)
+ * - {@link ConstraintNode} for set-influencing tags (@minimum, @pattern, etc.)
  * - {@link AnnotationNode} for value-influencing tags (@Field_displayName, etc.)
  *
  * The IR extraction path uses the official `@microsoft/tsdoc` parser for
@@ -12,12 +12,13 @@
  * `@Field_displayName`).
  *
  * Supported constraints correspond to keys in {@link BUILTIN_CONSTRAINT_DEFINITIONS}
- * from `@formspec/core` (e.g., `@Minimum`, `@Maximum`, `@Pattern`).
+ * from `@formspec/core` (e.g., `@minimum`, `@maximum`, `@pattern`).
  */
 
 import * as ts from "typescript";
 import {
   BUILTIN_CONSTRAINT_DEFINITIONS,
+  normalizeConstraintTagName,
   type BuiltinConstraintName,
   type ConstraintNode,
   type AnnotationNode,
@@ -170,7 +171,8 @@ export function extractJSDocConstraints(node: ts.Node): ConstraintInfo[] {
   const jsDocTags = ts.getJSDocTags(node);
 
   for (const tag of jsDocTags) {
-    const tagName = tag.tagName.text;
+    // Normalize to camelCase canonical form (e.g., "Minimum" → "minimum")
+    const tagName = normalizeConstraintTagName(tag.tagName.text);
 
     if (!(tagName in BUILTIN_CONSTRAINT_DEFINITIONS)) {
       continue;

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -8,9 +8,11 @@
  * The parser recognises two categories of tags:
  *
  * 1. **Constraint tags** (all alphanumeric, TSDoc-compliant):
- *    `@Minimum`, `@Maximum`, `@ExclusiveMinimum`, `@ExclusiveMaximum`,
- *    `@MinLength`, `@MaxLength`, `@Pattern`, `@EnumOptions`
+ *    `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`,
+ *    `@multipleOf`, `@minLength`, `@maxLength`, `@minItems`, `@maxItems`,
+ *    `@pattern`, `@enumOptions`
  *    — Parsed via TSDocParser as custom block tags.
+ *    Both camelCase and PascalCase forms are accepted (e.g., `@Minimum`).
  *
  * 2. **Annotation tags** (`@Field_displayName`, `@Field_description`):
  *    These contain underscores which are not valid in TSDoc tag names.
@@ -41,7 +43,8 @@ import {
 } from "@microsoft/tsdoc";
 import {
   BUILTIN_CONSTRAINT_DEFINITIONS,
-  type BuiltinConstraintName,
+  normalizeConstraintTagName,
+  isBuiltinConstraintName,
   type ConstraintNode,
   type AnnotationNode,
   type Provenance,
@@ -56,20 +59,25 @@ import {
 
 /**
  * Constraint tag name → constraint kind mapping for numeric constraints.
+ * Keys are camelCase matching BUILTIN_CONSTRAINT_DEFINITIONS.
  */
 const NUMERIC_CONSTRAINT_MAP: Record<string, NumericConstraintNode["constraintKind"]> = {
-  Minimum: "minimum",
-  Maximum: "maximum",
-  ExclusiveMinimum: "exclusiveMinimum",
-  ExclusiveMaximum: "exclusiveMaximum",
+  minimum: "minimum",
+  maximum: "maximum",
+  exclusiveMinimum: "exclusiveMinimum",
+  exclusiveMaximum: "exclusiveMaximum",
+  multipleOf: "multipleOf",
 };
 
 /**
  * Constraint tag name → constraint kind mapping for length constraints.
+ * Keys are camelCase matching BUILTIN_CONSTRAINT_DEFINITIONS.
  */
 const LENGTH_CONSTRAINT_MAP: Record<string, LengthConstraintNode["constraintKind"]> = {
-  MinLength: "minLength",
-  MaxLength: "maxLength",
+  minLength: "minLength",
+  maxLength: "maxLength",
+  minItems: "minItems",
+  maxItems: "maxItems",
 };
 
 /**
@@ -77,17 +85,10 @@ const LENGTH_CONSTRAINT_MAP: Record<string, LengthConstraintNode["constraintKind
  * and must be extracted via the TS compiler JSDoc API rather than the
  * TSDoc DocNode tree to avoid content mangling.
  *
- * - `@Pattern`: regex patterns commonly contain `@` (e.g. email validation)
- * - `@EnumOptions`: JSON arrays may contain object literals with `{}`
+ * - `@pattern`: regex patterns commonly contain `@` (e.g. email validation)
+ * - `@enumOptions`: JSON arrays may contain object literals with `{}`
  */
-const TAGS_REQUIRING_RAW_TEXT = new Set(["Pattern", "EnumOptions"]);
-
-/**
- * Type guard that checks whether a tag name is a known BuiltinConstraintName.
- */
-function isBuiltinConstraintName(tagName: string): tagName is BuiltinConstraintName {
-  return tagName in BUILTIN_CONSTRAINT_DEFINITIONS;
-}
+const TAGS_REQUIRING_RAW_TEXT = new Set(["pattern", "enumOptions"]);
 
 /**
  * Creates a TSDocConfiguration with FormSpec custom block tag definitions
@@ -141,7 +142,7 @@ export interface TSDocParseResult {
  * official TSDoc parser and returns canonical IR constraint and annotation
  * nodes.
  *
- * For constraint tags (`@Minimum`, `@Pattern`, `@EnumOptions`, etc.),
+ * For constraint tags (`@minimum`, `@pattern`, `@enumOptions`, etc.),
  * the structured TSDoc parser is used. For annotation tags that contain
  * underscores (`@Field_displayName`, `@Field_description`), the TypeScript
  * compiler JSDoc API is used as a fallback.
@@ -180,7 +181,7 @@ export function parseTSDocTags(node: ts.Node, file = ""): TSDocParseResult {
       // Tags in TAGS_REQUIRING_RAW_TEXT are skipped here and handled via the
       // TS compiler API in Phase 1b below.
       for (const block of docComment.customBlocks) {
-        const tagName = block.blockTag.tagName.substring(1); // Remove leading @
+        const tagName = normalizeConstraintTagName(block.blockTag.tagName.substring(1)); // Remove leading @ and normalize to camelCase
         if (TAGS_REQUIRING_RAW_TEXT.has(tagName)) continue;
 
         const text = extractBlockText(block).trim();
@@ -205,12 +206,12 @@ export function parseTSDocTags(node: ts.Node, file = ""): TSDocParseResult {
   }
 
   // ----- Phase 1b: TS compiler API for tags with TSDoc-incompatible content -----
-  // @Pattern and @EnumOptions content can contain `@` and `{}` characters
+  // @pattern and @enumOptions content can contain `@` and `{}` characters
   // which the TSDoc parser treats as structural markers. We extract these
   // via the TS compiler API which preserves content verbatim.
   const jsDocTagsAll = ts.getJSDocTags(node);
   for (const tag of jsDocTagsAll) {
-    const tagName = tag.tagName.text;
+    const tagName = normalizeConstraintTagName(tag.tagName.text);
     if (!TAGS_REQUIRING_RAW_TEXT.has(tagName)) continue;
 
     const commentText = getTagCommentText(tag);
@@ -360,6 +361,8 @@ function extractPlainText(node: DocNode): string {
 /**
  * Parses a raw text value extracted from a TSDoc block tag into an IR
  * ConstraintNode based on the tag name and BUILTIN_CONSTRAINT_DEFINITIONS.
+ *
+ * @param tagName - camelCase-normalized constraint tag name (callers normalize before calling)
  */
 function parseConstraintValue(
   tagName: string,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,13 +64,13 @@ formspec generate <file> [className] [options]
 
 **Options:**
 
-| Option | Description | Default |
-| --- | --- | --- |
-| `-o, --output <dir>` | Output directory | `./generated` |
-| `-c, --compiled <path>` | Path to compiled JS file | auto-detected |
-| `--emit-ir` | Emit Canonical IR as JSON alongside generated schemas | |
-| `--validate-only` | Validate input without writing files | |
-| `-h, --help` | Show help message | |
+| Option                  | Description                                           | Default       |
+| ----------------------- | ----------------------------------------------------- | ------------- |
+| `-o, --output <dir>`    | Output directory                                      | `./generated` |
+| `-c, --compiled <path>` | Path to compiled JS file                              | auto-detected |
+| `--emit-ir`             | Emit Canonical IR as JSON alongside generated schemas |               |
+| `--validate-only`       | Validate input without writing files                  |               |
+| `-h, --help`            | Show help message                                     |               |
 
 **Examples:**
 
@@ -102,8 +102,8 @@ class UserRegistration {
 
   /**
    * @DisplayName Age
-   * @Minimum 18
-   * @Maximum 120
+   * @minimum 18
+   * @maximum 120
    */
   age?: number;
 
@@ -118,33 +118,36 @@ formspec generate ./src/user-registration.ts UserRegistration -o ./generated
 
 ### Supported Tags
 
-| Tag | Purpose | Example |
-| --- | --- | --- |
-| `@DisplayName` | Set field label | `/** @DisplayName Full Name */` |
-| `@Description` | Set field description | `/** @Description Your legal name */` |
-| `@Placeholder` | Set placeholder text | `/** @Placeholder Enter name... */` |
-| `@Minimum` | Set minimum value | `/** @Minimum 0 */` |
-| `@Maximum` | Set maximum value | `/** @Maximum 100 */` |
-| `@ExclusiveMinimum` | Set exclusive minimum | `/** @ExclusiveMinimum 0 */` |
-| `@ExclusiveMaximum` | Set exclusive maximum | `/** @ExclusiveMaximum 100 */` |
-| `@MinLength` | Set minimum string length | `/** @MinLength 1 */` |
-| `@MaxLength` | Set maximum string length | `/** @MaxLength 255 */` |
-| `@Pattern` | Set validation regex | `/** @Pattern ^[a-z]+$ */` |
-| `@EnumOptions` | Override enum display | `/** @EnumOptions [{"id":"us","label":"US"}] */` |
+| Tag                 | Purpose                   | Example                                          |
+| ------------------- | ------------------------- | ------------------------------------------------ |
+| `@DisplayName`      | Set field label           | `/** @DisplayName Full Name */`                  |
+| `@Description`      | Set field description     | `/** @Description Your legal name */`            |
+| `@Placeholder`      | Set placeholder text      | `/** @Placeholder Enter name... */`              |
+| `@minimum`          | Set minimum value         | `/** @minimum 0 */`                              |
+| `@maximum`          | Set maximum value         | `/** @maximum 100 */`                            |
+| `@exclusiveMinimum` | Set exclusive minimum     | `/** @exclusiveMinimum 0 */`                     |
+| `@exclusiveMaximum` | Set exclusive maximum     | `/** @exclusiveMaximum 100 */`                   |
+| `@multipleOf`       | Set numeric step          | `/** @multipleOf 0.01 */`                        |
+| `@minLength`        | Set minimum string length | `/** @minLength 1 */`                            |
+| `@maxLength`        | Set maximum string length | `/** @maxLength 255 */`                          |
+| `@minItems`         | Set minimum array length  | `/** @minItems 1 */`                             |
+| `@maxItems`         | Set maximum array length  | `/** @maxItems 10 */`                            |
+| `@pattern`          | Set validation regex      | `/** @pattern ^[a-z]+$ */`                       |
+| `@enumOptions`      | Override enum display     | `/** @enumOptions [{"id":"us","label":"US"}] */` |
 
 ### Type Inference
 
 The CLI automatically infers JSON Schema types from TypeScript:
 
-| TypeScript Type | JSON Schema | FormSpec Field |
-| --- | --- | --- |
-| `string` | `{ "type": "string" }` | text |
-| `number` | `{ "type": "number" }` | number |
-| `boolean` | `{ "type": "boolean" }` | boolean |
-| `"a" \| "b"` | `{ "enum": ["a", "b"] }` | enum |
-| `string[]` | `{ "type": "array", "items": {...} }` | array |
-| `{ a: string }` | `{ "type": "object", "properties": {...} }` | object |
-| `field?: T` | not in `required` array | optional |
+| TypeScript Type | JSON Schema                                 | FormSpec Field |
+| --------------- | ------------------------------------------- | -------------- |
+| `string`        | `{ "type": "string" }`                      | text           |
+| `number`        | `{ "type": "number" }`                      | number         |
+| `boolean`       | `{ "type": "boolean" }`                     | boolean        |
+| `"a" \| "b"`    | `{ "enum": ["a", "b"] }`                    | enum           |
+| `string[]`      | `{ "type": "array", "items": {...} }`       | array          |
+| `{ a: string }` | `{ "type": "object", "properties": {...} }` | object         |
+| `field?: T`     | not in `required` array                     | optional       |
 
 ## Chain DSL Support
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -110,28 +110,28 @@ function processForm(form: FormSpec<readonly FormElement[]>) {
 
 ### IR Types
 
-| Type             | Description                                                                                                                                                                       |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FormIR`         | Root IR node — contains elements, type registry, IR version                                                                                                                       |
-| `FormIRElement`  | Union of `FieldNode` and `LayoutNode`                                                                                                                                             |
-| `FieldNode`      | IR field with name, type, constraints, annotations                                                                                                                                |
-| `LayoutNode`     | Union of `GroupLayoutNode` and `ConditionalLayoutNode`                                                                                                                            |
-| `TypeNode`       | Union: `PrimitiveTypeNode`, `EnumTypeNode`, `ArrayTypeNode`, `ObjectTypeNode`, `UnionTypeNode`, `ReferenceTypeNode`, `DynamicTypeNode`, `CustomTypeNode`                          |
-| `ConstraintNode` | Union: `NumericConstraintNode`, `LengthConstraintNode`, `PatternConstraintNode`, `ArrayCardinalityConstraintNode`, `EnumMemberConstraintNode`, `CustomConstraintNode`             |
+| Type             | Description                                                                                                                                                                                                |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FormIR`         | Root IR node — contains elements, type registry, IR version                                                                                                                                                |
+| `FormIRElement`  | Union of `FieldNode` and `LayoutNode`                                                                                                                                                                      |
+| `FieldNode`      | IR field with name, type, constraints, annotations                                                                                                                                                         |
+| `LayoutNode`     | Union of `GroupLayoutNode` and `ConditionalLayoutNode`                                                                                                                                                     |
+| `TypeNode`       | Union: `PrimitiveTypeNode`, `EnumTypeNode`, `ArrayTypeNode`, `ObjectTypeNode`, `UnionTypeNode`, `ReferenceTypeNode`, `DynamicTypeNode`, `CustomTypeNode`                                                   |
+| `ConstraintNode` | Union: `NumericConstraintNode`, `LengthConstraintNode`, `PatternConstraintNode`, `ArrayCardinalityConstraintNode`, `EnumMemberConstraintNode`, `CustomConstraintNode`                                      |
 | `AnnotationNode` | Union: `DisplayNameAnnotationNode`, `DescriptionAnnotationNode`, `PlaceholderAnnotationNode`, `DefaultValueAnnotationNode`, `DeprecatedAnnotationNode`, `FormatHintAnnotationNode`, `CustomAnnotationNode` |
-| `Provenance`     | Source location tracking — file, line, column, surface                                                                                                                            |
-| `IR_VERSION`     | Current IR version (`"0.1.0"`)                                                                                                                                                    |
+| `Provenance`     | Source location tracking — file, line, column, surface                                                                                                                                                     |
+| `IR_VERSION`     | Current IR version (`"0.1.0"`)                                                                                                                                                                             |
 
 ### Extension API
 
 FormSpec's type system is extensible via registration functions:
 
-| Function                  | Description                                                                      |
-| ------------------------- | -------------------------------------------------------------------------------- |
-| `defineExtension(def)`    | Register a complete extension with constraints, annotations, types, and vocabulary keywords |
-| `defineConstraint(reg)`   | Register a custom constraint (e.g., `multipleOf`, `uniqueItems`)                 |
-| `defineAnnotation(reg)`   | Register a custom annotation (e.g., tooltip, help URL)                           |
-| `defineCustomType(reg)`   | Register a custom type node for JSON Schema generation                            |
+| Function                | Description                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| `defineExtension(def)`  | Register a complete extension with constraints, annotations, types, and vocabulary keywords |
+| `defineConstraint(reg)` | Register a custom constraint (e.g., `multipleOf`, `uniqueItems`)                            |
+| `defineAnnotation(reg)` | Register a custom annotation (e.g., tooltip, help URL)                                      |
+| `defineCustomType(reg)` | Register a custom type node for JSON Schema generation                                      |
 
 ```typescript
 import { defineExtension, defineConstraint, defineAnnotation } from "@formspec/core";

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -55,14 +55,17 @@ export interface BooleanField<N extends string> {
 
 // @public
 export const BUILTIN_CONSTRAINT_DEFINITIONS: {
-    readonly Minimum: "number";
-    readonly Maximum: "number";
-    readonly ExclusiveMinimum: "number";
-    readonly ExclusiveMaximum: "number";
-    readonly MinLength: "number";
-    readonly MaxLength: "number";
-    readonly Pattern: "string";
-    readonly EnumOptions: "json";
+    readonly minimum: "number";
+    readonly maximum: "number";
+    readonly exclusiveMinimum: "number";
+    readonly exclusiveMaximum: "number";
+    readonly multipleOf: "number";
+    readonly minLength: "number";
+    readonly maxLength: "number";
+    readonly minItems: "number";
+    readonly maxItems: "number";
+    readonly pattern: "string";
+    readonly enumOptions: "json";
 };
 
 // @public
@@ -412,6 +415,9 @@ export function isArrayField(element: FormElement): element is ArrayField<string
 export function isBooleanField(element: FormElement): element is BooleanField<string>;
 
 // @public
+export function isBuiltinConstraintName(tagName: string): tagName is BuiltinConstraintName;
+
+// @public
 export function isConditional(element: FormElement): element is Conditional<string, unknown, readonly FormElement[]>;
 
 // @public
@@ -459,6 +465,9 @@ export interface LengthConstraintNode {
     // (undocumented)
     readonly value: number;
 }
+
+// @public
+export function normalizeConstraintTagName(tagName: string): string;
 
 // @public
 export interface NumberField<N extends string> {

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -42,14 +42,14 @@ export function isBooleanField(element: FormElement): element is BooleanField<st
 
 /** Narrows a FormElement to a static enum field. */
 export function isStaticEnumField(
-  element: FormElement,
+  element: FormElement
 ): element is StaticEnumField<string, readonly EnumOptionValue[]> {
   return element._type === "field" && element._field === "enum";
 }
 
 /** Narrows a FormElement to a dynamic enum field. */
 export function isDynamicEnumField(
-  element: FormElement,
+  element: FormElement
 ): element is DynamicEnumField<string, string> {
   return element._type === "field" && element._field === "dynamic_enum";
 }
@@ -61,14 +61,14 @@ export function isDynamicSchemaField(element: FormElement): element is DynamicSc
 
 /** Narrows a FormElement to an array field. */
 export function isArrayField(
-  element: FormElement,
+  element: FormElement
 ): element is ArrayField<string, readonly FormElement[]> {
   return element._type === "field" && element._field === "array";
 }
 
 /** Narrows a FormElement to an object field. */
 export function isObjectField(
-  element: FormElement,
+  element: FormElement
 ): element is ObjectField<string, readonly FormElement[]> {
   return element._type === "field" && element._field === "object";
 }
@@ -80,7 +80,7 @@ export function isGroup(element: FormElement): element is Group<readonly FormEle
 
 /** Narrows a FormElement to a conditional wrapper. */
 export function isConditional(
-  element: FormElement,
+  element: FormElement
 ): element is Conditional<string, unknown, readonly FormElement[]> {
   return element._type === "conditional";
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,6 +94,8 @@ export type {
 export {
   createInitialFieldState,
   BUILTIN_CONSTRAINT_DEFINITIONS,
+  normalizeConstraintTagName,
+  isBuiltinConstraintName,
   IR_VERSION,
 } from "./types/index.js";
 

--- a/packages/core/src/types/constraint-definitions.ts
+++ b/packages/core/src/types/constraint-definitions.ts
@@ -9,18 +9,44 @@
 /**
  * Built-in constraint names mapped to their expected value type for parsing.
  * Constraints are surface-agnostic — they manifest as both TSDoc tags
- * (e.g., `@Minimum 0`) and chain DSL options (e.g., `{ minimum: 0 }`).
+ * (e.g., `@minimum 0`) and chain DSL options (e.g., `{ minimum: 0 }`).
+ *
+ * Keys use camelCase matching JSON Schema property names.
  */
 export const BUILTIN_CONSTRAINT_DEFINITIONS = {
-  Minimum: "number",
-  Maximum: "number",
-  ExclusiveMinimum: "number",
-  ExclusiveMaximum: "number",
-  MinLength: "number",
-  MaxLength: "number",
-  Pattern: "string",
-  EnumOptions: "json",
+  minimum: "number",
+  maximum: "number",
+  exclusiveMinimum: "number",
+  exclusiveMaximum: "number",
+  multipleOf: "number",
+  minLength: "number",
+  maxLength: "number",
+  minItems: "number",
+  maxItems: "number",
+  pattern: "string",
+  enumOptions: "json",
 } as const;
 
 /** Type of a built-in constraint name. */
 export type BuiltinConstraintName = keyof typeof BUILTIN_CONSTRAINT_DEFINITIONS;
+
+/**
+ * Normalizes a constraint tag name to camelCase.
+ *
+ * Allows users to write either `@Minimum` or `@minimum` — both are
+ * normalized to the camelCase canonical form `"minimum"` used as keys
+ * in {@link BUILTIN_CONSTRAINT_DEFINITIONS}.
+ */
+export function normalizeConstraintTagName(tagName: string): string {
+  return tagName.charAt(0).toLowerCase() + tagName.slice(1);
+}
+
+/**
+ * Type guard: checks whether a tag name is a known built-in constraint.
+ *
+ * Callers should normalize with {@link normalizeConstraintTagName} first
+ * if the input may be PascalCase.
+ */
+export function isBuiltinConstraintName(tagName: string): tagName is BuiltinConstraintName {
+  return tagName in BUILTIN_CONSTRAINT_DEFINITIONS;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -34,7 +34,11 @@ export type {
 
 export type { EqualsPredicate, Predicate } from "./predicate.js";
 
-export { BUILTIN_CONSTRAINT_DEFINITIONS } from "./constraint-definitions.js";
+export {
+  BUILTIN_CONSTRAINT_DEFINITIONS,
+  normalizeConstraintTagName,
+  isBuiltinConstraintName,
+} from "./constraint-definitions.js";
 export type { BuiltinConstraintName } from "./constraint-definitions.js";
 
 export { IR_VERSION } from "./ir.js";

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -23,9 +23,7 @@ pnpm add -D @formspec/eslint-plugin
 ```javascript
 import formspec from "@formspec/eslint-plugin";
 
-export default [
-  ...formspec.configs.recommended,
-];
+export default [...formspec.configs.recommended];
 ```
 
 ### Manual Configuration
@@ -50,12 +48,12 @@ export default [
 
 ## Rules
 
-| Rule | Description | Recommended | Strict |
-| --- | --- | --- | --- |
-| [`constraint-type-mismatch`](#constraint-type-mismatch) | JSDoc constraint tags must match field type | error | error |
-| [`consistent-constraints`](#consistent-constraints) | Constraint ranges must be valid (min ≤ max) | error | error |
-| [`constraints-allowed-field-types`](#constraints-allowed-field-types) | Field types validated against `.formspec.yml` | — | — |
-| [`constraints-allowed-layouts`](#constraints-allowed-layouts) | Layout elements validated against `.formspec.yml` | — | — |
+| Rule                                                                  | Description                                       | Recommended | Strict |
+| --------------------------------------------------------------------- | ------------------------------------------------- | ----------- | ------ |
+| [`constraint-type-mismatch`](#constraint-type-mismatch)               | JSDoc constraint tags must match field type       | error       | error  |
+| [`consistent-constraints`](#consistent-constraints)                   | Constraint ranges must be valid (min ≤ max)       | error       | error  |
+| [`constraints-allowed-field-types`](#constraints-allowed-field-types) | Field types validated against `.formspec.yml`     | —           | —      |
+| [`constraints-allowed-layouts`](#constraints-allowed-layouts)         | Layout elements validated against `.formspec.yml` | —           | —      |
 
 ### constraint-type-mismatch
 

--- a/packages/eslint-plugin/api-report/eslint-plugin.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.api.md
@@ -44,10 +44,10 @@ const plugin: {
         name: string;
     };
     rules: {
-        readonly "constraint-type-mismatch": TSESLint.RuleModule<"numericOnNonNumber" | "stringOnNonString", [], unknown, TSESLint.RuleListener> & {
+        readonly "constraint-type-mismatch": TSESLint.RuleModule<"numericOnNonNumber" | "stringOnNonString" | "arrayOnNonArray", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
-        readonly "consistent-constraints": TSESLint.RuleModule<"minimumGreaterThanMaximum" | "exclusiveMinGreaterOrEqualMax" | "minLengthGreaterThanMaxLength" | "conflictingMinimumBounds" | "conflictingMaximumBounds" | "exclusiveMaxLessOrEqualMin" | "maximumLessOrEqualExclusiveMin", [], unknown, TSESLint.RuleListener> & {
+        readonly "consistent-constraints": TSESLint.RuleModule<"minimumGreaterThanMaximum" | "exclusiveMinGreaterOrEqualMax" | "minLengthGreaterThanMaxLength" | "minItemsGreaterThanMaxItems" | "conflictingMinimumBounds" | "conflictingMaximumBounds" | "exclusiveMaxLessOrEqualMin" | "maximumLessOrEqualExclusiveMin", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
         readonly "constraints-allowed-field-types": TSESLint.RuleModule<"disallowedFieldType", Options, unknown, TSESLint.RuleListener> & {

--- a/packages/eslint-plugin/src/__tests__/rules/consistent-constraints.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/consistent-constraints.test.ts
@@ -123,6 +123,24 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         }
       `,
     },
+    // @minItems < @maxItems — valid
+    {
+      code: `
+        class Form {
+          /** @minItems 1 @maxItems 10 */
+          tags!: string[];
+        }
+      `,
+    },
+    // @minItems == @maxItems — valid (fixed-length array)
+    {
+      code: `
+        class Form {
+          /** @minItems 5 @maxItems 5 */
+          tags!: string[];
+        }
+      `,
+    },
   ],
   invalid: [
     // Negative values: @Minimum(-50) > @Maximum(-100) is invalid
@@ -234,6 +252,16 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         }
       `,
       errors: [{ messageId: "maximumLessOrEqualExclusiveMin" }],
+    },
+    // @minItems > @maxItems — invalid
+    {
+      code: `
+        class Form {
+          /** @minItems 10 @maxItems 1 */
+          tags!: string[];
+        }
+      `,
+      errors: [{ messageId: "minItemsGreaterThanMaxItems" }],
     },
   ],
 });

--- a/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
@@ -119,6 +119,33 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
         }
       `,
     },
+    // @multipleOf on number field — valid
+    {
+      code: `
+        class Form {
+          /** @multipleOf 0.01 */
+          price!: number;
+        }
+      `,
+    },
+    // @minItems on array field — valid
+    {
+      code: `
+        class Form {
+          /** @minItems 1 */
+          tags!: string[];
+        }
+      `,
+    },
+    // @maxItems on array field — valid
+    {
+      code: `
+        class Form {
+          /** @maxItems 10 */
+          items!: number[];
+        }
+      `,
+    },
   ],
   invalid: [
     // @Minimum on string field
@@ -210,6 +237,36 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
         }
       `,
       errors: [{ messageId: "numericOnNonNumber" }, { messageId: "numericOnNonNumber" }],
+    },
+    // @multipleOf on string field
+    {
+      code: `
+        class Form {
+          /** @multipleOf 0.01 */
+          name!: string;
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @minItems on string field
+    {
+      code: `
+        class Form {
+          /** @minItems 1 */
+          name!: string;
+        }
+      `,
+      errors: [{ messageId: "arrayOnNonArray" }],
+    },
+    // @maxItems on number field
+    {
+      code: `
+        class Form {
+          /** @maxItems 10 */
+          count!: number;
+        }
+      `,
+      errors: [{ messageId: "arrayOnNonArray" }],
     },
   ],
 });

--- a/packages/eslint-plugin/src/rules/consistent-constraints.ts
+++ b/packages/eslint-plugin/src/rules/consistent-constraints.ts
@@ -2,13 +2,14 @@
  * Rule: consistent-constraints
  *
  * Ensures JSDoc constraint pairs have valid ranges and don't conflict:
- * - @Minimum must be <= @Maximum
- * - @ExclusiveMinimum must be < @ExclusiveMaximum
- * - @MinLength must be <= @MaxLength
- * - @Minimum and @ExclusiveMinimum must not both be present
- * - @Maximum and @ExclusiveMaximum must not both be present
- * - @Maximum(n) where n < @Minimum(m) is invalid
- * - @ExclusiveMaximum(n) where n <= @Minimum(m) is invalid
+ * - @minimum must be <= @maximum
+ * - @exclusiveMinimum must be < @exclusiveMaximum
+ * - @minLength must be <= @maxLength
+ * - @minItems must be <= @maxItems
+ * - @minimum and @exclusiveMinimum must not both be present
+ * - @maximum and @exclusiveMaximum must not both be present
+ * - @maximum(n) where n < @minimum(m) is invalid
+ * - @exclusiveMaximum(n) where n <= @minimum(m) is invalid
  */
 
 import type { TSESTree } from "@typescript-eslint/utils";
@@ -23,6 +24,7 @@ type MessageIds =
   | "minimumGreaterThanMaximum"
   | "exclusiveMinGreaterOrEqualMax"
   | "minLengthGreaterThanMaxLength"
+  | "minItemsGreaterThanMaxItems"
   | "conflictingMinimumBounds"
   | "conflictingMaximumBounds"
   | "exclusiveMaxLessOrEqualMin"
@@ -47,19 +49,21 @@ export const consistentConstraints = createRule<[], MessageIds>({
     },
     messages: {
       minimumGreaterThanMaximum:
-        "@Minimum({{min}}) is greater than @Maximum({{max}}). Minimum must be less than or equal to Maximum.",
+        "@minimum({{min}}) is greater than @maximum({{max}}). minimum must be less than or equal to maximum.",
       exclusiveMinGreaterOrEqualMax:
-        "@ExclusiveMinimum({{min}}) must be less than @ExclusiveMaximum({{max}}).",
+        "@exclusiveMinimum({{min}}) must be less than @exclusiveMaximum({{max}}).",
       minLengthGreaterThanMaxLength:
-        "@MinLength({{min}}) is greater than @MaxLength({{max}}). MinLength must be less than or equal to MaxLength.",
+        "@minLength({{min}}) is greater than @maxLength({{max}}). minLength must be less than or equal to maxLength.",
+      minItemsGreaterThanMaxItems:
+        "@minItems({{min}}) is greater than @maxItems({{max}}). minItems must be less than or equal to maxItems.",
       conflictingMinimumBounds:
-        "Field has both @Minimum and @ExclusiveMinimum. Use only one lower bound constraint.",
+        "Field has both @minimum and @exclusiveMinimum. Use only one lower bound constraint.",
       conflictingMaximumBounds:
-        "Field has both @Maximum and @ExclusiveMaximum. Use only one upper bound constraint.",
+        "Field has both @maximum and @exclusiveMaximum. Use only one upper bound constraint.",
       exclusiveMaxLessOrEqualMin:
-        "@ExclusiveMaximum({{max}}) must be greater than @Minimum({{min}}).",
+        "@exclusiveMaximum({{max}}) must be greater than @minimum({{min}}).",
       maximumLessOrEqualExclusiveMin:
-        "@Maximum({{max}}) must be greater than @ExclusiveMinimum({{min}}).",
+        "@maximum({{max}}) must be greater than @exclusiveMinimum({{min}}).",
     },
     schema: [],
   },
@@ -98,9 +102,9 @@ export const consistentConstraints = createRule<[], MessageIds>({
           return { present: false, loc: null };
         }
 
-        // Check @Minimum/@Maximum range
-        const minimum = getConstraintValue("Minimum");
-        const maximum = getConstraintValue("Maximum");
+        // Check @minimum/@maximum range
+        const minimum = getConstraintValue("minimum");
+        const maximum = getConstraintValue("maximum");
 
         if (minimum && maximum && minimum.value > maximum.value) {
           context.report({
@@ -113,9 +117,9 @@ export const consistentConstraints = createRule<[], MessageIds>({
           });
         }
 
-        // Check @ExclusiveMinimum/@ExclusiveMaximum range
-        const exclusiveMin = getConstraintValue("ExclusiveMinimum");
-        const exclusiveMax = getConstraintValue("ExclusiveMaximum");
+        // Check @exclusiveMinimum/@exclusiveMaximum range
+        const exclusiveMin = getConstraintValue("exclusiveMinimum");
+        const exclusiveMax = getConstraintValue("exclusiveMaximum");
 
         if (exclusiveMin && exclusiveMax && exclusiveMin.value >= exclusiveMax.value) {
           context.report({
@@ -128,9 +132,9 @@ export const consistentConstraints = createRule<[], MessageIds>({
           });
         }
 
-        // Check @MinLength/@MaxLength range
-        const minLength = getConstraintValue("MinLength");
-        const maxLength = getConstraintValue("MaxLength");
+        // Check @minLength/@maxLength range
+        const minLength = getConstraintValue("minLength");
+        const maxLength = getConstraintValue("maxLength");
 
         if (minLength && maxLength && minLength.value > maxLength.value) {
           context.report({
@@ -143,9 +147,24 @@ export const consistentConstraints = createRule<[], MessageIds>({
           });
         }
 
-        // Check conflicting bound types: @Minimum + @ExclusiveMinimum
-        const hasMinimum = hasConstraint("Minimum");
-        const hasExclusiveMinimum = hasConstraint("ExclusiveMinimum");
+        // Check @minItems/@maxItems range
+        const minItems = getConstraintValue("minItems");
+        const maxItems = getConstraintValue("maxItems");
+
+        if (minItems && maxItems && minItems.value > maxItems.value) {
+          context.report({
+            loc: minItems.loc,
+            messageId: "minItemsGreaterThanMaxItems",
+            data: {
+              min: String(minItems.value),
+              max: String(maxItems.value),
+            },
+          });
+        }
+
+        // Check conflicting bound types: @minimum + @exclusiveMinimum
+        const hasMinimum = hasConstraint("minimum");
+        const hasExclusiveMinimum = hasConstraint("exclusiveMinimum");
 
         if (hasMinimum.present && hasExclusiveMinimum.present) {
           context.report({
@@ -154,9 +173,9 @@ export const consistentConstraints = createRule<[], MessageIds>({
           });
         }
 
-        // Check conflicting bound types: @Maximum + @ExclusiveMaximum
-        const hasMaximum = hasConstraint("Maximum");
-        const hasExclusiveMaximum = hasConstraint("ExclusiveMaximum");
+        // Check conflicting bound types: @maximum + @exclusiveMaximum
+        const hasMaximum = hasConstraint("maximum");
+        const hasExclusiveMaximum = hasConstraint("exclusiveMaximum");
 
         if (hasMaximum.present && hasExclusiveMaximum.present) {
           context.report({
@@ -165,7 +184,7 @@ export const consistentConstraints = createRule<[], MessageIds>({
           });
         }
 
-        // Check @ExclusiveMinimum(m) + @Maximum(n) where n <= m
+        // Check @exclusiveMinimum(m) + @maximum(n) where n <= m
         if (exclusiveMin && maximum && maximum.value <= exclusiveMin.value) {
           context.report({
             loc: maximum.loc,
@@ -177,7 +196,7 @@ export const consistentConstraints = createRule<[], MessageIds>({
           });
         }
 
-        // Check @ExclusiveMaximum(n) where n <= @Minimum(m)
+        // Check @exclusiveMaximum(n) where n <= @minimum(m)
         if (minimum && exclusiveMax && exclusiveMax.value <= minimum.value) {
           context.report({
             loc: exclusiveMax.loc,

--- a/packages/eslint-plugin/src/rules/constraint-type-mismatch.ts
+++ b/packages/eslint-plugin/src/rules/constraint-type-mismatch.ts
@@ -2,8 +2,8 @@
  * Rule: constraint-type-mismatch
  *
  * Ensures JSDoc constraints are applied to fields with compatible types:
- * - @Minimum/@Maximum/@ExclusiveMinimum/@ExclusiveMaximum only on number fields
- * - @MinLength/@MaxLength/@Pattern only on string fields
+ * - @minimum/@maximum/@exclusiveMinimum/@exclusiveMaximum/@multipleOf only on number fields
+ * - @minLength/@maxLength/@pattern only on string fields
  */
 
 import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
@@ -18,27 +18,33 @@ const createRule = ESLintUtils.RuleCreator(
   (name) => `https://formspec.dev/eslint-plugin/rules/${name}`
 );
 
-type MessageIds = "numericOnNonNumber" | "stringOnNonString";
+type MessageIds = "numericOnNonNumber" | "stringOnNonString" | "arrayOnNonArray";
 
 const EXPECTED_TYPES: Record<string, FieldTypeCategory[]> = {
-  Minimum: ["number"],
-  Maximum: ["number"],
-  ExclusiveMinimum: ["number"],
-  ExclusiveMaximum: ["number"],
-  MinLength: ["string"],
-  MaxLength: ["string"],
-  Pattern: ["string"],
-  EnumOptions: ["string", "union"],
+  minimum: ["number"],
+  maximum: ["number"],
+  exclusiveMinimum: ["number"],
+  exclusiveMaximum: ["number"],
+  multipleOf: ["number"],
+  minLength: ["string"],
+  maxLength: ["string"],
+  pattern: ["string"],
+  minItems: ["array"],
+  maxItems: ["array"],
+  enumOptions: ["string", "union"],
 };
 
 const CONSTRAINT_MESSAGE_IDS: Record<string, MessageIds | undefined> = {
-  Minimum: "numericOnNonNumber",
-  Maximum: "numericOnNonNumber",
-  ExclusiveMinimum: "numericOnNonNumber",
-  ExclusiveMaximum: "numericOnNonNumber",
-  MinLength: "stringOnNonString",
-  MaxLength: "stringOnNonString",
-  Pattern: "stringOnNonString",
+  minimum: "numericOnNonNumber",
+  maximum: "numericOnNonNumber",
+  exclusiveMinimum: "numericOnNonNumber",
+  exclusiveMaximum: "numericOnNonNumber",
+  multipleOf: "numericOnNonNumber",
+  minLength: "stringOnNonString",
+  maxLength: "stringOnNonString",
+  pattern: "stringOnNonString",
+  minItems: "arrayOnNonArray",
+  maxItems: "arrayOnNonArray",
 };
 
 export const constraintTypeMismatch = createRule<[], MessageIds>({
@@ -53,6 +59,8 @@ export const constraintTypeMismatch = createRule<[], MessageIds>({
         "@{{constraint}} can only be used on number fields, but field '{{field}}' has type '{{actualType}}'",
       stringOnNonString:
         "@{{constraint}} can only be used on string fields, but field '{{field}}' has type '{{actualType}}'",
+      arrayOnNonArray:
+        "@{{constraint}} can only be used on array fields, but field '{{field}}' has type '{{actualType}}'",
     },
     schema: [],
   },
@@ -77,7 +85,7 @@ export const constraintTypeMismatch = createRule<[], MessageIds>({
 
         for (const constraint of jsdocConstraints) {
           const constraintName = constraint.name;
-          if (constraintName === "EnumOptions") continue;
+          if (constraintName === "enumOptions") continue;
 
           const expectedTypes = EXPECTED_TYPES[constraintName];
           if (!expectedTypes) continue;

--- a/packages/eslint-plugin/src/utils/jsdoc-utils.ts
+++ b/packages/eslint-plugin/src/utils/jsdoc-utils.ts
@@ -4,11 +4,11 @@
 
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 import type { SourceCode } from "@typescript-eslint/utils/ts-eslint";
-import { BUILTIN_CONSTRAINT_DEFINITIONS } from "@formspec/core";
+import { BUILTIN_CONSTRAINT_DEFINITIONS, normalizeConstraintTagName } from "@formspec/core";
 
 /** A constraint extracted from a JSDoc comment tag. */
 export interface JSDocConstraint {
-  /** The constraint name (e.g., "Minimum", "Maximum") */
+  /** The constraint name (e.g., "minimum", "maximum") */
   name: string;
   /** The parsed value */
   value: number | string;
@@ -20,17 +20,22 @@ const NUMERIC_TAG_NAMES = Object.keys(BUILTIN_CONSTRAINT_DEFINITIONS).filter(
   (k) =>
     BUILTIN_CONSTRAINT_DEFINITIONS[k as keyof typeof BUILTIN_CONSTRAINT_DEFINITIONS] === "number"
 );
-const NUMERIC_TAGS_PATTERN = NUMERIC_TAG_NAMES.join("|");
 
-// Numeric tags: value stops at the next `@` tag, `*/`, or end-of-line
+// Build alternation that matches both PascalCase (@Minimum) and camelCase (@minimum)
+// by including the uppercased-first-letter variant for each camelCase tag name.
+const NUMERIC_TAGS_PATTERN = NUMERIC_TAG_NAMES.map(
+  (name) => `${name}|${name.charAt(0).toUpperCase()}${name.slice(1)}`
+).join("|");
+
+// Numeric tags: value stops at the next `@` tag, `*/`, or end-of-line.
 const NUMERIC_TAG_REGEX = new RegExp(
   `@(${NUMERIC_TAGS_PATTERN})\\s+(.+?)(?=\\s*@|\\s*\\*\\/|\\s*$)`,
   "gm"
 );
 
 // Pattern tag: value captures everything until `*/` or end-of-line,
-// because regex patterns can contain `@` (e.g., email validation)
-const PATTERN_TAG_REGEX = /@Pattern\s+(.+?)(?=\s*\*\/|\s*$)/gm;
+// because regex patterns can contain `@` (e.g., email validation).
+const PATTERN_TAG_REGEX = /@[Pp]attern\s+(.+?)(?=\s*\*\/|\s*$)/gm;
 
 /**
  * Extracts constraint tags from JSDoc comments preceding a node.
@@ -71,9 +76,11 @@ export function getJSDocConstraints(
     NUMERIC_TAG_REGEX.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = NUMERIC_TAG_REGEX.exec(comment.value)) !== null) {
-      const name = match[1];
+      const rawName = match[1];
       const rawValue = match[2];
-      if (!name || !rawValue) continue;
+      if (!rawName || !rawValue) continue;
+      // Normalize PascalCase → camelCase canonical form
+      const name = normalizeConstraintTagName(rawName);
 
       const cleanedValue = rawValue.replace(/^\s*\*\s*/gm, "").trim();
       const parsed = Number(cleanedValue);
@@ -89,7 +96,7 @@ export function getJSDocConstraints(
 
       const cleanedValue = rawValue.replace(/^\s*\*\s*/gm, "").trim();
       if (cleanedValue === "") continue;
-      results.push({ name: "Pattern", value: cleanedValue, comment });
+      results.push({ name: "pattern", value: cleanedValue, comment });
     }
   }
 

--- a/packages/formspec/README.md
+++ b/packages/formspec/README.md
@@ -147,14 +147,14 @@ You can import from the umbrella package for convenience, or from individual pac
 
 ## Related Packages
 
-| Package | Description |
-| --- | --- |
-| `@formspec/constraints` | Constraint definitions and validators |
-| `@formspec/validator` | JSON Schema validation for secure runtimes |
-| `@formspec/eslint-plugin` | ESLint rules for FormSpec |
-| `@formspec/language-server` | Language server for editor integration |
-| `@formspec/cli` | CLI tool for build-time schema generation |
-| `@formspec/playground` | Interactive browser editor (private) |
+| Package                     | Description                                |
+| --------------------------- | ------------------------------------------ |
+| `@formspec/constraints`     | Constraint definitions and validators      |
+| `@formspec/validator`       | JSON Schema validation for secure runtimes |
+| `@formspec/eslint-plugin`   | ESLint rules for FormSpec                  |
+| `@formspec/language-server` | Language server for editor integration     |
+| `@formspec/cli`             | CLI tool for build-time schema generation  |
+| `@formspec/playground`      | Interactive browser editor (private)       |
 
 ## License
 

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -39,17 +39,17 @@ This package provides language server features for FormSpec's JSDoc constraint t
 
 - **Completion** — Autocomplete for constraint tag names inside JSDoc comments
 - **Hover** — Documentation on hover for constraint tags
-- **Go to Definition** — Navigate to constraint definitions *(placeholder — not yet implemented)*
+- **Go to Definition** — Navigate to constraint definitions _(placeholder — not yet implemented)_
 
 ## API Reference
 
 ### Functions
 
-| Function | Description |
-| --- | --- |
-| `createServer()` | Create a full LSP server connection |
-| `getCompletionItems()` | Get completion items for constraint tags |
-| `getDefinition()` | Get definition location for a constraint tag |
+| Function                  | Description                                     |
+| ------------------------- | ----------------------------------------------- |
+| `createServer()`          | Create a full LSP server connection             |
+| `getCompletionItems()`    | Get completion items for constraint tags        |
+| `getDefinition()`         | Get definition location for a constraint tag    |
 | `getHoverForTag(tagName)` | Get hover information for a constraint tag name |
 
 ### `createServer()`

--- a/packages/language-server/src/__tests__/completion.test.ts
+++ b/packages/language-server/src/__tests__/completion.test.ts
@@ -40,23 +40,23 @@ describe("getCompletionItems", () => {
     }
   });
 
-  it("includes @Minimum completion", () => {
+  it("includes @minimum completion", () => {
     const items = getCompletionItems();
-    const minimum = items.find((item) => item.label === "@Minimum");
+    const minimum = items.find((item) => item.label === "@minimum");
     expect(minimum).toBeDefined();
     expect(minimum?.kind).toBe(CompletionItemKind.Keyword);
-    expect(minimum?.detail).toContain("Minimum");
+    expect(minimum?.detail).toContain("minimum");
   });
 
-  it("includes @Pattern completion", () => {
+  it("includes @pattern completion", () => {
     const items = getCompletionItems();
-    const pattern = items.find((item) => item.label === "@Pattern");
+    const pattern = items.find((item) => item.label === "@pattern");
     expect(pattern).toBeDefined();
   });
 
-  it("includes @EnumOptions completion", () => {
+  it("includes @enumOptions completion", () => {
     const items = getCompletionItems();
-    const enumOptions = items.find((item) => item.label === "@EnumOptions");
+    const enumOptions = items.find((item) => item.label === "@enumOptions");
     expect(enumOptions).toBeDefined();
   });
 });

--- a/packages/language-server/src/__tests__/hover.test.ts
+++ b/packages/language-server/src/__tests__/hover.test.ts
@@ -46,46 +46,51 @@ describe("getHoverForTag", () => {
     }
   });
 
-  it("returns markdown hover for @Minimum", () => {
-    const hover = getHoverForTag("Minimum");
+  it("returns markdown hover for @minimum (camelCase)", () => {
+    const hover = getHoverForTag("minimum");
     expect(hover).not.toBeNull();
     expect(isMarkupContent(hover?.contents)).toBe(true);
     if (hover !== null && isMarkupContent(hover.contents)) {
       expect(hover.contents.kind).toBe("markdown");
-      expect(hover.contents.value).toContain("@Minimum");
       expect(hover.contents.value).toContain("minimum");
     }
   });
 
-  it("returns markdown hover for @Minimum with @ prefix", () => {
-    const hover = getHoverForTag("@Minimum");
+  it("returns markdown hover for @minimum with @ prefix", () => {
+    const hover = getHoverForTag("@minimum");
     expect(hover).not.toBeNull();
     if (hover !== null && isMarkupContent(hover.contents)) {
-      expect(hover.contents.value).toContain("@Minimum");
+      expect(hover.contents.value).toContain("minimum");
     }
   });
 
-  it("returns markdown hover for @Pattern", () => {
-    const hover = getHoverForTag("Pattern");
+  it("returns markdown hover for @pattern (camelCase)", () => {
+    const hover = getHoverForTag("pattern");
     expect(hover).not.toBeNull();
     if (hover !== null && isMarkupContent(hover.contents)) {
-      expect(hover.contents.value).toContain("@Pattern");
       expect(hover.contents.value).toContain("pattern");
     }
   });
 
-  it("returns markdown hover for @EnumOptions", () => {
-    const hover = getHoverForTag("EnumOptions");
+  it("returns markdown hover for @enumOptions (camelCase)", () => {
+    const hover = getHoverForTag("enumOptions");
     expect(hover).not.toBeNull();
-    if (hover !== null && isMarkupContent(hover.contents)) {
-      expect(hover.contents.value).toContain("@EnumOptions");
-    }
   });
 
-  it("is case-sensitive — lowercase names return null", () => {
-    // The v2 hover provider uses canonical casing from BUILTIN_CONSTRAINT_DEFINITIONS
-    expect(getHoverForTag("minimum")).toBeNull();
-    expect(getHoverForTag("maximum")).toBeNull();
-    expect(getHoverForTag("pattern")).toBeNull();
+  it("accepts camelCase tag names", () => {
+    // Users write camelCase tags: @minimum, @maximum, @pattern
+    const minimumHover = getHoverForTag("minimum");
+    expect(minimumHover).not.toBeNull();
+    const maximumHover = getHoverForTag("maximum");
+    expect(maximumHover).not.toBeNull();
+    const patternHover = getHoverForTag("pattern");
+    expect(patternHover).not.toBeNull();
+  });
+
+  it("accepts PascalCase tag names via normalization", () => {
+    // PascalCase variants like @Minimum are normalized to camelCase
+    const pascalCase = getHoverForTag("Minimum");
+    const camelCase = getHoverForTag("minimum");
+    expect(pascalCase).toEqual(camelCase);
   });
 });

--- a/packages/language-server/src/providers/completion.ts
+++ b/packages/language-server/src/providers/completion.ts
@@ -2,7 +2,7 @@
  * Completion provider for FormSpec JSDoc constraint tags.
  *
  * Returns completion items for all recognized FormSpec JSDoc constraint tags
- * (e.g., `@Minimum`, `@Maximum`, `@Pattern`), derived from
+ * (e.g., `@minimum`, `@maximum`, `@pattern`), derived from
  * `BUILTIN_CONSTRAINT_DEFINITIONS`. This is a skeleton — context-aware
  * filtering will be added in a future phase.
  */
@@ -12,18 +12,21 @@ import { CompletionItem, CompletionItemKind } from "vscode-languageserver/node.j
 /**
  * Human-readable detail strings for each built-in constraint tag.
  *
- * Keys match the constraint name (matching keys in `BUILTIN_CONSTRAINT_DEFINITIONS`).
+ * Keys match the camelCase constraint names (matching keys in `BUILTIN_CONSTRAINT_DEFINITIONS`).
  * Values are shown as the detail string in completion items.
  */
 const CONSTRAINT_DETAIL: Record<string, string> = {
-  Minimum: "Minimum numeric value (inclusive). Example: `@Minimum 0`",
-  Maximum: "Maximum numeric value (inclusive). Example: `@Maximum 100`",
-  ExclusiveMinimum: "Minimum numeric value (exclusive). Example: `@ExclusiveMinimum 0`",
-  ExclusiveMaximum: "Maximum numeric value (exclusive). Example: `@ExclusiveMaximum 100`",
-  MinLength: "Minimum string length. Example: `@MinLength 1`",
-  MaxLength: "Maximum string length. Example: `@MaxLength 255`",
-  Pattern: "Regular expression pattern for string validation. Example: `@Pattern ^[a-z]+$`",
-  EnumOptions: 'Inline JSON array of allowed enum values. Example: `@EnumOptions ["a","b","c"]`',
+  minimum: "Minimum numeric value (inclusive). Example: `@minimum 0`",
+  maximum: "Maximum numeric value (inclusive). Example: `@maximum 100`",
+  exclusiveMinimum: "Minimum numeric value (exclusive). Example: `@exclusiveMinimum 0`",
+  exclusiveMaximum: "Maximum numeric value (exclusive). Example: `@exclusiveMaximum 100`",
+  multipleOf: "Value must be a multiple of this number. Example: `@multipleOf 0.01`",
+  minLength: "Minimum string length. Example: `@minLength 1`",
+  maxLength: "Maximum string length. Example: `@maxLength 255`",
+  minItems: "Minimum number of array items. Example: `@minItems 1`",
+  maxItems: "Maximum number of array items. Example: `@maxItems 10`",
+  pattern: "Regular expression pattern for string validation. Example: `@pattern ^[a-z]+$`",
+  enumOptions: 'Inline JSON array of allowed enum values. Example: `@enumOptions ["a","b","c"]`',
 };
 
 /**
@@ -39,7 +42,6 @@ const CONSTRAINT_DETAIL: Record<string, string> = {
  */
 export function getCompletionItems(): CompletionItem[] {
   return Object.entries(CONSTRAINT_DETAIL).map(([name, detail]) => ({
-
     label: `@${name}`,
     kind: CompletionItemKind.Keyword,
     detail,

--- a/packages/language-server/src/providers/hover.ts
+++ b/packages/language-server/src/providers/hover.ts
@@ -6,7 +6,11 @@
  * detection within JSDoc comment ranges will be added in a future phase.
  */
 
-import { BUILTIN_CONSTRAINT_DEFINITIONS, type BuiltinConstraintName } from "@formspec/core";
+import {
+  normalizeConstraintTagName,
+  isBuiltinConstraintName,
+  type BuiltinConstraintName,
+} from "@formspec/core";
 import type { Hover } from "vscode-languageserver/node.js";
 
 /**
@@ -16,8 +20,8 @@ import type { Hover } from "vscode-languageserver/node.js";
  * Values are Markdown strings suitable for LSP hover responses.
  */
 const CONSTRAINT_HOVER_DOCS: Record<BuiltinConstraintName, string> = {
-  Minimum: [
-    "**@Minimum** `<number>`",
+  minimum: [
+    "**@minimum** `<number>`",
     "",
     "Sets an inclusive lower bound on a numeric field.",
     "",
@@ -25,13 +29,13 @@ const CONSTRAINT_HOVER_DOCS: Record<BuiltinConstraintName, string> = {
     "",
     "**Example:**",
     "```typescript",
-    "/** @Minimum 0 */",
+    "/** @minimum 0 */",
     "amount: number;",
     "```",
   ].join("\n"),
 
-  Maximum: [
-    "**@Maximum** `<number>`",
+  maximum: [
+    "**@maximum** `<number>`",
     "",
     "Sets an inclusive upper bound on a numeric field.",
     "",
@@ -39,13 +43,13 @@ const CONSTRAINT_HOVER_DOCS: Record<BuiltinConstraintName, string> = {
     "",
     "**Example:**",
     "```typescript",
-    "/** @Maximum 100 */",
+    "/** @maximum 100 */",
     "percentage: number;",
     "```",
   ].join("\n"),
 
-  ExclusiveMinimum: [
-    "**@ExclusiveMinimum** `<number>`",
+  exclusiveMinimum: [
+    "**@exclusiveMinimum** `<number>`",
     "",
     "Sets an exclusive lower bound on a numeric field.",
     "",
@@ -53,13 +57,13 @@ const CONSTRAINT_HOVER_DOCS: Record<BuiltinConstraintName, string> = {
     "",
     "**Example:**",
     "```typescript",
-    "/** @ExclusiveMinimum 0 */",
+    "/** @exclusiveMinimum 0 */",
     "positiveAmount: number;",
     "```",
   ].join("\n"),
 
-  ExclusiveMaximum: [
-    "**@ExclusiveMaximum** `<number>`",
+  exclusiveMaximum: [
+    "**@exclusiveMaximum** `<number>`",
     "",
     "Sets an exclusive upper bound on a numeric field.",
     "",
@@ -67,13 +71,27 @@ const CONSTRAINT_HOVER_DOCS: Record<BuiltinConstraintName, string> = {
     "",
     "**Example:**",
     "```typescript",
-    "/** @ExclusiveMaximum 1 */",
+    "/** @exclusiveMaximum 1 */",
     "ratio: number;",
     "```",
   ].join("\n"),
 
-  MinLength: [
-    "**@MinLength** `<number>`",
+  multipleOf: [
+    "**@multipleOf** `<number>`",
+    "",
+    "Requires the numeric value to be a multiple of the given number.",
+    "",
+    "Maps to `multipleOf` in JSON Schema.",
+    "",
+    "**Example:**",
+    "```typescript",
+    "/** @multipleOf 0.01 */",
+    "price: number;",
+    "```",
+  ].join("\n"),
+
+  minLength: [
+    "**@minLength** `<number>`",
     "",
     "Sets a minimum character length on a string field.",
     "",
@@ -81,13 +99,13 @@ const CONSTRAINT_HOVER_DOCS: Record<BuiltinConstraintName, string> = {
     "",
     "**Example:**",
     "```typescript",
-    "/** @MinLength 1 */",
+    "/** @minLength 1 */",
     "name: string;",
     "```",
   ].join("\n"),
 
-  MaxLength: [
-    "**@MaxLength** `<number>`",
+  maxLength: [
+    "**@maxLength** `<number>`",
     "",
     "Sets a maximum character length on a string field.",
     "",
@@ -95,13 +113,41 @@ const CONSTRAINT_HOVER_DOCS: Record<BuiltinConstraintName, string> = {
     "",
     "**Example:**",
     "```typescript",
-    "/** @MaxLength 255 */",
+    "/** @maxLength 255 */",
     "description: string;",
     "```",
   ].join("\n"),
 
-  Pattern: [
-    "**@Pattern** `<regex>`",
+  minItems: [
+    "**@minItems** `<number>`",
+    "",
+    "Sets a minimum number of items in an array field.",
+    "",
+    "Maps to `minItems` in JSON Schema.",
+    "",
+    "**Example:**",
+    "```typescript",
+    "/** @minItems 1 */",
+    "tags: string[];",
+    "```",
+  ].join("\n"),
+
+  maxItems: [
+    "**@maxItems** `<number>`",
+    "",
+    "Sets a maximum number of items in an array field.",
+    "",
+    "Maps to `maxItems` in JSON Schema.",
+    "",
+    "**Example:**",
+    "```typescript",
+    "/** @maxItems 10 */",
+    "tags: string[];",
+    "```",
+  ].join("\n"),
+
+  pattern: [
+    "**@pattern** `<regex>`",
     "",
     "Sets a regular expression pattern that a string field must match.",
     "",
@@ -109,13 +155,13 @@ const CONSTRAINT_HOVER_DOCS: Record<BuiltinConstraintName, string> = {
     "",
     "**Example:**",
     "```typescript",
-    "/** @Pattern ^[a-z0-9]+$ */",
+    "/** @pattern ^[a-z0-9]+$ */",
     "slug: string;",
     "```",
   ].join("\n"),
 
-  EnumOptions: [
-    "**@EnumOptions** `<json-array>`",
+  enumOptions: [
+    "**@enumOptions** `<json-array>`",
     "",
     "Specifies the allowed values for an enum field as an inline JSON array.",
     "",
@@ -123,36 +169,26 @@ const CONSTRAINT_HOVER_DOCS: Record<BuiltinConstraintName, string> = {
     "",
     "**Example:**",
     "```typescript",
-    '/** @EnumOptions ["draft","sent","archived"] */',
+    '/** @enumOptions ["draft","sent","archived"] */',
     "status: string;",
     "```",
   ].join("\n"),
 } satisfies Record<BuiltinConstraintName, string>;
 
 /**
- * Checks whether a given string is a recognized built-in constraint name.
- *
- * @param name - The name to check
- * @returns `true` if `name` is a `BuiltinConstraintName`
- */
-function isBuiltinConstraintName(name: string): name is BuiltinConstraintName {
-  return Object.prototype.hasOwnProperty.call(BUILTIN_CONSTRAINT_DEFINITIONS, name);
-}
-
-/**
  * Returns hover documentation for a FormSpec JSDoc tag name.
  *
- * The tag name lookup is case-sensitive and matches the canonical casing used
- * in `BUILTIN_CONSTRAINT_DEFINITIONS` (e.g., `"Minimum"`, `"Pattern"`).
+ * Accepts both camelCase (`"minimum"`) and PascalCase (`"Minimum"`) forms.
  * The `@` prefix is stripped before lookup if present.
  * Returns `null` when the tag is not a recognized FormSpec constraint tag.
  *
- * @param tagName - The tag name to look up (e.g., `"Minimum"`, `"@Pattern"`)
+ * @param tagName - The tag name to look up (e.g., `"minimum"`, `"@pattern"`)
  * @returns An LSP `Hover` response, or `null` if the tag is not recognized
  */
 export function getHoverForTag(tagName: string): Hover | null {
   // Strip leading `@` prefix if present
-  const name = tagName.startsWith("@") ? tagName.slice(1) : tagName;
+  const raw = tagName.startsWith("@") ? tagName.slice(1) : tagName;
+  const name = normalizeConstraintTagName(raw);
 
   if (!isBuiltinConstraintName(name)) {
     return null;

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -37,10 +37,7 @@ This package is ESM-only and requires:
 import { createFormSpecValidator } from "@formspec/validator";
 import { buildFormSchemas, formspec, field } from "formspec";
 
-const form = formspec(
-  field.text("name", { required: true }),
-  field.number("age", { min: 0 })
-);
+const form = formspec(field.text("name", { required: true }), field.number("age", { min: 0 }));
 
 const { jsonSchema } = buildFormSchemas(form);
 
@@ -66,15 +63,15 @@ Standard JSON Schema validators like Ajv use `new Function()` internally, which 
 
 ### Functions
 
-| Function | Description |
-| --- | --- |
+| Function                                    | Description                                   |
+| ------------------------------------------- | --------------------------------------------- |
 | `createFormSpecValidator(schema, options?)` | Create a validator instance for a JSON Schema |
 
 ### Options
 
 ```typescript
 interface CreateValidatorOptions {
-  draft?: SchemaDraft;    // JSON Schema draft version (default: "2020-12")
+  draft?: SchemaDraft; // JSON Schema draft version (default: "2020-12")
   shortCircuit?: boolean; // Stop on first error (default: true)
 }
 ```
@@ -83,12 +80,12 @@ interface CreateValidatorOptions {
 
 This package re-exports key types from `@cfworker/json-schema`:
 
-| Export | Description |
-| --- | --- |
-| `Validator` | The validator class |
-| `ValidationResult` | Result of `validator.validate()` |
-| `OutputUnit` | Individual validation error detail |
-| `SchemaDraft` | Supported JSON Schema draft versions |
+| Export             | Description                          |
+| ------------------ | ------------------------------------ |
+| `Validator`        | The validator class                  |
+| `ValidationResult` | Result of `validator.validate()`     |
+| `OutputUnit`       | Individual validation error detail   |
+| `SchemaDraft`      | Supported JSON Schema draft versions |
 
 ## License
 

--- a/packages/validator/src/__tests__/validator.test.ts
+++ b/packages/validator/src/__tests__/validator.test.ts
@@ -238,7 +238,7 @@ describe("createFormSpecValidator", () => {
             age: { type: "number" },
           },
         },
-        { shortCircuit: false },
+        { shortCircuit: false }
       );
 
       const result = v.validate({});
@@ -321,7 +321,7 @@ describe("createFormSpecValidator", () => {
           definitions: { Str: { type: "string" } },
           $ref: "#/definitions/Str",
         },
-        { draft: "7" },
+        { draft: "7" }
       );
 
       expect(v.validate("hello").valid).toBe(true);

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -74,7 +74,7 @@ export interface CreateValidatorOptions {
  */
 export function createFormSpecValidator(
   schema: Record<string, unknown>,
-  options?: CreateValidatorOptions,
+  options?: CreateValidatorOptions
 ): Validator {
   const draft = options?.draft ?? "2020-12";
   const shortCircuit = options?.shortCircuit ?? true;

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -2,54 +2,72 @@
   "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
   "tagDefinitions": [
     {
-      "tagName": "@Minimum",
+      "tagName": "@minimum",
       "syntaxKind": "block",
       "allowMultiple": true
     },
     {
-      "tagName": "@Maximum",
+      "tagName": "@maximum",
       "syntaxKind": "block",
       "allowMultiple": true
     },
     {
-      "tagName": "@ExclusiveMinimum",
+      "tagName": "@exclusiveMinimum",
       "syntaxKind": "block",
       "allowMultiple": true
     },
     {
-      "tagName": "@ExclusiveMaximum",
+      "tagName": "@exclusiveMaximum",
       "syntaxKind": "block",
       "allowMultiple": true
     },
     {
-      "tagName": "@MinLength",
+      "tagName": "@multipleOf",
       "syntaxKind": "block",
       "allowMultiple": true
     },
     {
-      "tagName": "@MaxLength",
+      "tagName": "@minLength",
       "syntaxKind": "block",
       "allowMultiple": true
     },
     {
-      "tagName": "@Pattern",
+      "tagName": "@maxLength",
       "syntaxKind": "block",
       "allowMultiple": true
     },
     {
-      "tagName": "@EnumOptions",
+      "tagName": "@minItems",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@maxItems",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@pattern",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@enumOptions",
       "syntaxKind": "block",
       "allowMultiple": true
     }
   ],
   "supportForTags": {
-    "@Minimum": true,
-    "@Maximum": true,
-    "@ExclusiveMinimum": true,
-    "@ExclusiveMaximum": true,
-    "@MinLength": true,
-    "@MaxLength": true,
-    "@Pattern": true,
-    "@EnumOptions": true
+    "@minimum": true,
+    "@maximum": true,
+    "@exclusiveMinimum": true,
+    "@exclusiveMaximum": true,
+    "@multipleOf": true,
+    "@minLength": true,
+    "@maxLength": true,
+    "@minItems": true,
+    "@maxItems": true,
+    "@pattern": true,
+    "@enumOptions": true
   }
 }


### PR DESCRIPTION
## Summary

- **Path-target constraint syntax**: `:fieldName` modifier on constraint tags targets a specific subproperty of a complex-typed field (e.g., `@minimum :value 0` constrains the `value` subproperty of a named type)
- **Transitive type alias constraint propagation**: Constraints on type aliases now propagate through alias chains (e.g., `Integer → Percentage → field`), with a depth cap of 8
- **camelCase canonical form**: Flip `BUILTIN_CONSTRAINT_DEFINITIONS` keys from PascalCase to camelCase, matching JSON Schema property names. Both `@Minimum` and `@minimum` continue to work via normalization
- **Centralized normalization**: Consolidate duplicated `normalizeConstraintTagName` and `isBuiltinConstraintName` from 3 packages into `@formspec/core`
- **New constraints**: Add `multipleOf`, `minItems`, `maxItems` built-in constraints across all packages
- **ESLint rule coverage**: Extend `constraint-type-mismatch` with `arrayOnNonArray` message, extend `consistent-constraints` with `minItems`/`maxItems` range check
- **E2E test infrastructure**: Gold-master comparison tests for chain DSL and TSDoc pipelines (114 E2E tests)
- **Type guard soundness**: Fix `isBuiltinConstraintName` to only narrow values that are literally `BuiltinConstraintName` keys
- **TSDoc config**: Update `tsdoc.json` with camelCase tags and new constraint entries

## Test plan

- [x] `pnpm run build` — all packages build cleanly
- [x] `pnpm run test` — 965 unit tests + 114 E2E tests pass
- [x] `pnpm run typecheck` — clean across all packages
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run api-extractor:local` — API reports up to date
- [x] Both `@minimum` and `@Minimum` produce correct constraints (backward compat)
- [x] New ESLint rules flag `@multipleOf` on string, `@minItems` on non-array, `@minItems > @maxItems`