### PR TITLE
Tighten path-target constraint traversability check

### DIFF
--- a/packages/build/src/validate/constraint-validator.ts
+++ b/packages/build/src/validate/constraint-validator.ts
@@ -321,9 +321,12 @@ function checkTypeApplicability(
     // not the field itself. Skip type-applicability checks for these — the
     // constraint applies to the resolved sub-field type, not the declared field type.
     if (constraint.path) {
-      // However, when the declared field type cannot be traversed (primitives or
-      // enums), a path-targeted constraint is inherently invalid.
-      if (type.kind === "primitive" || type.kind === "enum") {
+      // Path-targeted constraints are only meaningful on traversable types
+      // (objects, arrays, references). All other kinds (primitives, enums,
+      // unions, dynamic, custom) cannot be traversed.
+      const isTraversable =
+        type.kind === "object" || type.kind === "array" || type.kind === "reference";
+      if (!isTraversable) {
         addTypeMismatch(
           ctx,
           `Field "${fieldName}": path-targeted constraint "${constraint.constraintKind}" is invalid because type "${label}" cannot be traversed`,


### PR DESCRIPTION
## Summary
- Invert path-target type check from blacklist (primitive, enum) to whitelist (object, array, reference)
- Previously `union`, `dynamic`, and `custom` types silently allowed path-targeted constraints that became no-ops in schema generation
- Now all non-traversable types emit TYPE_MISMATCH diagnostics

Addresses Copilot review feedback from PR #74.

## Test plan
- [x] Existing path-target tests pass (primitive/enum rejection, object/reference/array acceptance)
- [x] Build succeeds