### PR TITLE
Fix isBuiltinConstraintName prototype pollution

### DIFF
--- a/packages/build/src/__tests__/constraint-definitions.test.ts
+++ b/packages/build/src/__tests__/constraint-definitions.test.ts
@@ -68,4 +68,18 @@ describe("isBuiltinConstraintName", () => {
   it("returns false for all-caps input", () => {
     expect(isBuiltinConstraintName("MINIMUM")).toBe(false);
   });
+
+  it("returns false for 'toString' (prototype property — regression: in operator bug)", () => {
+    // The `in` operator matches inherited properties via the prototype chain.
+    // Object.hasOwn() prevents these false positives.
+    expect(isBuiltinConstraintName("toString")).toBe(false);
+  });
+
+  it("returns false for 'constructor' (prototype property — regression: in operator bug)", () => {
+    expect(isBuiltinConstraintName("constructor")).toBe(false);
+  });
+
+  it("returns false for 'hasOwnProperty' (prototype property)", () => {
+    expect(isBuiltinConstraintName("hasOwnProperty")).toBe(false);
+  });
 });

--- a/packages/build/src/analyzer/jsdoc-constraints.ts
+++ b/packages/build/src/analyzer/jsdoc-constraints.ts
@@ -18,8 +18,8 @@
 import * as ts from "typescript";
 import {
   BUILTIN_CONSTRAINT_DEFINITIONS,
+  isBuiltinConstraintName,
   normalizeConstraintTagName,
-  type BuiltinConstraintName,
   type ConstraintNode,
   type AnnotationNode,
   type JsonValue,
@@ -174,12 +174,11 @@ export function extractJSDocConstraints(node: ts.Node): ConstraintInfo[] {
     // Normalize to camelCase canonical form (e.g., "Minimum" → "minimum")
     const tagName = normalizeConstraintTagName(tag.tagName.text);
 
-    if (!(tagName in BUILTIN_CONSTRAINT_DEFINITIONS)) {
+    if (!isBuiltinConstraintName(tagName)) {
       continue;
     }
 
-    const constraintName = tagName as BuiltinConstraintName;
-    const expectedType = BUILTIN_CONSTRAINT_DEFINITIONS[constraintName];
+    const expectedType = BUILTIN_CONSTRAINT_DEFINITIONS[tagName];
 
     const commentText = getTagCommentText(tag);
     if (commentText === undefined || commentText === "") {
@@ -196,19 +195,19 @@ export function extractJSDocConstraints(node: ts.Node): ConstraintInfo[] {
       if (Number.isNaN(value)) {
         continue;
       }
-      results.push(createSyntheticDecorator(constraintName, value));
+      results.push(createSyntheticDecorator(tagName, value));
     } else if (expectedType === "json") {
       try {
         const parsed: unknown = JSON.parse(trimmed);
         if (!Array.isArray(parsed)) {
           continue;
         }
-        results.push(createSyntheticDecorator(constraintName, parsed as ConstraintArg));
+        results.push(createSyntheticDecorator(tagName, parsed as ConstraintArg));
       } catch {
         continue;
       }
     } else {
-      results.push(createSyntheticDecorator(constraintName, trimmed));
+      results.push(createSyntheticDecorator(tagName, trimmed));
     }
   }
 

--- a/packages/core/src/types/constraint-definitions.ts
+++ b/packages/core/src/types/constraint-definitions.ts
@@ -31,11 +31,15 @@ export const BUILTIN_CONSTRAINT_DEFINITIONS = {
 export type BuiltinConstraintName = keyof typeof BUILTIN_CONSTRAINT_DEFINITIONS;
 
 /**
- * Normalizes a constraint tag name to camelCase.
+ * Normalizes a constraint tag name from PascalCase to camelCase.
  *
- * Allows users to write either `@Minimum` or `@minimum` — both are
- * normalized to the camelCase canonical form `"minimum"` used as keys
- * in {@link BUILTIN_CONSTRAINT_DEFINITIONS}.
+ * Lowercases the first character so that e.g. `"Minimum"` becomes `"minimum"`.
+ * Callers must strip the `@` prefix before calling this function.
+ *
+ * @example
+ * normalizeConstraintTagName("Minimum")   // "minimum"
+ * normalizeConstraintTagName("MinLength") // "minLength"
+ * normalizeConstraintTagName("minimum")   // "minimum" (idempotent)
  */
 export function normalizeConstraintTagName(tagName: string): string {
   return tagName.charAt(0).toLowerCase() + tagName.slice(1);
@@ -44,9 +48,12 @@ export function normalizeConstraintTagName(tagName: string): string {
 /**
  * Type guard: checks whether a tag name is a known built-in constraint.
  *
+ * Uses `Object.hasOwn()` rather than `in` to prevent prototype-chain
+ * matches on names like `"toString"` or `"constructor"`.
+ *
  * Callers should normalize with {@link normalizeConstraintTagName} first
  * if the input may be PascalCase.
  */
 export function isBuiltinConstraintName(tagName: string): tagName is BuiltinConstraintName {
-  return tagName in BUILTIN_CONSTRAINT_DEFINITIONS;
+  return Object.hasOwn(BUILTIN_CONSTRAINT_DEFINITIONS, tagName);
 }


### PR DESCRIPTION
## Summary
- Use `Object.hasOwn()` instead of `in` operator in `isBuiltinConstraintName` to prevent prototype chain matches (e.g., `toString`, `constructor`)
- Clarify `normalizeConstraintTagName` docstring: callers must strip `@` prefix
- Use shared `isBuiltinConstraintName` guard in `jsdoc-constraints.ts` instead of raw `in` check, and remove the now-redundant `as BuiltinConstraintName` cast that the narrowed type makes unnecessary
- Add regression test for prototype property names (`toString`, `constructor`, `hasOwnProperty`)

Addresses Copilot review feedback from PR #74.

## Test plan
- [x] `isBuiltinConstraintName("toString")` returns `false`
- [x] `isBuiltinConstraintName("constructor")` returns `false`
- [x] All existing tests pass
- [x] Build succeeds