### PR TITLE
Skip path-targeted constraints in ESLint JSDoc regex

### DIFF
--- a/packages/eslint-plugin/src/__tests__/rules/consistent-constraints.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/consistent-constraints.test.ts
@@ -141,6 +141,15 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         }
       `,
     },
+    // Path-targeted constraints should be skipped
+    {
+      code: `
+        class Form {
+          /** @minimum :value 100 @maximum :value 50 */
+          amount!: { value: number };
+        }
+      `,
+    },
   ],
   invalid: [
     // Negative values: @Minimum(-50) > @Maximum(-100) is invalid

--- a/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
@@ -146,6 +146,24 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
         }
       `,
     },
+    // Path-targeted constraints should be skipped — @minimum targets a sub-property, not the field itself
+    {
+      code: `
+        class Form {
+          /** @minimum :value 0 */
+          amount!: { value: number; currency: string };
+        }
+      `,
+    },
+    // Path-targeted @pattern should be skipped
+    {
+      code: `
+        class Form {
+          /** @pattern :code ^[A-Z]{3}$ */
+          amount!: { value: number; code: string };
+        }
+      `,
+    },
   ],
   invalid: [
     // @Minimum on string field

--- a/packages/eslint-plugin/src/utils/jsdoc-utils.ts
+++ b/packages/eslint-plugin/src/utils/jsdoc-utils.ts
@@ -31,7 +31,7 @@ const NUMERIC_TAGS_PATTERN = NUMERIC_TAG_NAMES.map(
 // Skip path-targeted constraints (@minimum :value 0) — the leading
 // `:identifier` prefix indicates a sub-property target.
 const NUMERIC_TAG_REGEX = new RegExp(
-  `@(${NUMERIC_TAGS_PATTERN})\\s+(?!:[a-zA-Z])(.+?)(?=\\s*@|\\s*\\*\\/|\\s*$)`,
+  `@(${NUMERIC_TAGS_PATTERN})\\s+(?!:\\w+\\s)(.+?)(?=\\s*@|\\s*\\*\\/|\\s*$)`,
   "gm"
 );
 
@@ -39,7 +39,7 @@ const NUMERIC_TAG_REGEX = new RegExp(
 // because regex patterns can contain `@` (e.g., email validation).
 // Skip path-targeted constraints (@pattern :field value) — the leading
 // `:identifier` prefix indicates a sub-property target, not a regex pattern.
-const PATTERN_TAG_REGEX = /@[Pp]attern\s+(?!:[a-zA-Z])(.+?)(?=\s*\*\/|\s*$)/gm;
+const PATTERN_TAG_REGEX = /@[Pp]attern\s+(?!:\w+\s)(.+?)(?=\s*\*\/|\s*$)/gm;
 
 /**
  * Extracts constraint tags from JSDoc comments preceding a node.


### PR DESCRIPTION
## Summary
- Add negative lookahead `(?!:[a-zA-Z])` to NUMERIC_TAG_REGEX and PATTERN_TAG_REGEX
- Prevents `@pattern :currency ^[A-Z]{3}$` from being misinterpreted as a pattern constraint on the whole field
- Numeric tags already handled this gracefully (`:value 0` parses as NaN and is skipped), but pattern tags would capture the path prefix as part of the regex value

Addresses Copilot review feedback from PR #74.

## Test plan
- [x] All existing ESLint rule tests pass
- [x] Build succeeds