### PR TITLE
Add missing changesets for recent PRs

### DIFF
--- a/.changeset/fix-eslint-path-target-regex.md
+++ b/.changeset/fix-eslint-path-target-regex.md
@@ -1,0 +1,5 @@
+---
+"@formspec/eslint-plugin": patch
+---
+
+Fix ESLint JSDoc constraint regex: path-targeted constraint tags (e.g., `@minimum :value 0`) are now correctly parsed and no longer trigger false-positive rule violations

--- a/.changeset/fix-path-target-traversability.md
+++ b/.changeset/fix-path-target-traversability.md
@@ -1,0 +1,5 @@
+---
+"@formspec/build": patch
+---
+
+Fix path-target constraint traversability check: validation now correctly rejects constraints targeting non-traversable types (e.g., primitives) via the `:path` modifier

--- a/.changeset/fix-prototype-pollution-guard.md
+++ b/.changeset/fix-prototype-pollution-guard.md
@@ -1,0 +1,6 @@
+---
+"@formspec/core": patch
+"@formspec/build": patch
+---
+
+Fix prototype pollution vulnerability in `isBuiltinConstraintName`: guard now uses `Object.hasOwn()` instead of the `in` operator, preventing `__proto__` and inherited properties from being treated as valid constraint names

--- a/.changeset/refactor-build-type-safety.md
+++ b/.changeset/refactor-build-type-safety.md
@@ -1,0 +1,5 @@
+---
+"@formspec/build": patch
+---
+
+Internal: replace `as` casts with type guards and TypeScript narrowing in the TSDoc analyzer pipeline; extract `tryParseJson` utility to eliminate duplicated JSON parsing patterns


### PR DESCRIPTION
## Summary

Add changesets that were missing from PRs #75–#80:

- `@formspec/build` patch (#75): path-target traversability check now correctly rejects non-traversable types
- `@formspec/core` + `@formspec/build` patch (#76): `isBuiltinConstraintName` uses `Object.hasOwn()` to prevent prototype pollution
- `@formspec/eslint-plugin` patch (#78): JSDoc constraint regex correctly handles path-targeted tags (no changeset needed for #77 — test infrastructure only)
- `@formspec/build` patch (#79, #80): internal refactors — `as` cast removal and `tryParseJson` extraction

## Test plan
- [x] `pnpm changeset status` shows the new patch-level entries
- [x] No duplicate changesets for packages already covered by existing entries
- [x] `e2e` package excluded (private)