### PR TITLE
Emit @displayName as JSON Schema title and UI Schema label

### DIFF
--- a/e2e/expected/tsdoc-class/constrained-form.schema.json
+++ b/e2e/expected/tsdoc-class/constrained-form.schema.json
@@ -3,7 +3,8 @@
   "type": "object",
   "properties": {
     "name": {
-      "type": "string"
+      "type": "string",
+      "title": "Full Name"
     },
     "age": {
       "type": "number",

--- a/e2e/expected/tsdoc-class/constrained-form.uischema.json
+++ b/e2e/expected/tsdoc-class/constrained-form.uischema.json
@@ -3,7 +3,8 @@
   "elements": [
     {
       "type": "Control",
-      "scope": "#/properties/name"
+      "scope": "#/properties/name",
+      "label": "Full Name"
     },
     {
       "type": "Control",

--- a/e2e/tests/tsdoc-constrained-class.test.ts
+++ b/e2e/tests/tsdoc-constrained-class.test.ts
@@ -45,9 +45,13 @@ describe("TSDoc Constrained Class", () => {
     expect(schema).toHaveProperty("properties");
   });
 
-  describe("name field — @displayName annotation (no constraint assertions)", () => {
+  describe("name field — @displayName annotation", () => {
     it("has string type", () => {
       expect(properties["name"]?.["type"]).toBe("string");
+    });
+
+    it("emits title from @displayName", () => {
+      expect(properties["name"]?.["title"]).toBe("Full Name");
     });
   });
 

--- a/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
+++ b/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
@@ -460,4 +460,76 @@ describe("extractJSDocAnnotationNodes", () => {
       value: "Class Field",
     });
   });
+
+  // @displayName and @description — camelCase alternatives without underscore prefix
+  it("produces DisplayNameAnnotationNode for @displayName (camelCase form)", () => {
+    const prop = getInterfacePropertyFromSource(`
+      interface Foo {
+        /** @displayName Full Name */
+        name: string;
+      }
+    `);
+
+    const result = extractJSDocAnnotationNodes(prop, "/test.ts");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      kind: "annotation",
+      annotationKind: "displayName",
+      value: "Full Name",
+    });
+  });
+
+  it("produces DescriptionAnnotationNode for @description (camelCase form)", () => {
+    const prop = getInterfacePropertyFromSource(`
+      interface Foo {
+        /** @description Help text for this field */
+        name: string;
+      }
+    `);
+
+    const result = extractJSDocAnnotationNodes(prop);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      kind: "annotation",
+      annotationKind: "description",
+      value: "Help text for this field",
+    });
+  });
+
+  it("@Field_displayName takes precedence over @displayName when both present", () => {
+    const prop = getInterfacePropertyFromSource(`
+      interface Foo {
+        /**
+         * @displayName First
+         * @Field_displayName Second
+         */
+        name: string;
+      }
+    `);
+
+    const result = extractJSDocAnnotationNodes(prop);
+    const displayNames = result.filter((a) => a.annotationKind === "displayName");
+    // Only one displayName annotation, and it comes from @Field_displayName
+    expect(displayNames).toHaveLength(1);
+    expect(displayNames[0]).toMatchObject({
+      annotationKind: "displayName",
+      value: "Second",
+    });
+  });
+
+  it("@displayName works on class properties", () => {
+    const prop = getPropertyFromSource(`
+      class Foo {
+        /** @displayName My Label */
+        x!: string;
+      }
+    `);
+
+    const result = extractJSDocAnnotationNodes(prop);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      annotationKind: "displayName",
+      value: "My Label",
+    });
+  });
 });

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -226,9 +226,11 @@ export function parseTSDocTags(node: ts.Node, file = ""): TSDocParseResult {
     }
   }
 
-  // ----- Phase 2: TS compiler JSDoc API for underscore-containing annotation tags -----
+  // ----- Phase 2: TS compiler JSDoc API for annotation tags -----
   // @Field_displayName and @Field_description contain underscores which
-  // are invalid in TSDoc tag names. We extract them via the TS compiler API.
+  // are invalid in TSDoc tag names. @displayName and @description are
+  // TSDoc-compliant camelCase alternatives. Both forms are accepted; the
+  // underscore form (@Field_displayName) takes precedence when both appear.
   let displayName: string | undefined;
   let description: string | undefined;
   let displayNameTag: ts.JSDocTag | undefined;
@@ -243,10 +245,16 @@ export function parseTSDocTags(node: ts.Node, file = ""): TSDocParseResult {
 
     const trimmed = commentText.trim();
 
-    if (tagName === "Field_displayName") {
+    if (
+      tagName === "Field_displayName" ||
+      (tagName === "displayName" && displayName === undefined)
+    ) {
       displayName = trimmed;
       displayNameTag = tag;
-    } else if (tagName === "Field_description") {
+    } else if (
+      tagName === "Field_description" ||
+      (tagName === "description" && description === undefined)
+    ) {
       description = trimmed;
       descriptionTag = tag;
     }


### PR DESCRIPTION
## Summary
- Emit `@displayName` (TSDoc camelCase) as JSON Schema `"title"` per spec 003 §2.8
- Emit as UI Schema `"label"` per spec 002 §2.2
- Accept both `@displayName` and the legacy `@Field_displayName` form; the underscore form takes precedence when both appear

## Bug
`@displayName Full Name` on a field was silently dropped — neither JSON Schema `title` nor UI Schema `label` was emitted.

The TSDoc parser only recognized `@Field_displayName` (underscore-prefixed legacy form), but the `e2e/fixtures/tsdoc-class/constrained-form.ts` fixture used `@displayName` (camelCase, matching JSON Schema keyword naming convention).

Found by spec-compliance audit (BUG-2 and BUG-6).

## Test plan
- [x] Unit tests added for `@displayName` and `@description` camelCase forms in `ir-jsdoc-constraints.test.ts`
- [x] Unit test for precedence: `@Field_displayName` wins over `@displayName` when both present
- [x] `constrained-form` gold-master updated: `"title": "Full Name"` on the `name` JSON Schema property
- [x] `constrained-form` UI Schema gold-master updated: `"label": "Full Name"` on the name Control
- [x] E2E test assertion added: `properties["name"]["title"]` must equal `"Full Name"`
- [x] All existing tests pass (chain DSL `label` was already working)