### PR TITLE
test(eslint-plugin): expand lint rule coverage for all constraint × type combinations

### DIFF
--- a/packages/eslint-plugin/src/__tests__/rules/consistent-constraints.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/consistent-constraints.test.ts
@@ -25,6 +25,9 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("consistent-constraints", consistentConstraints, {
   valid: [
+    // -----------------------------------------------------------------------
+    // @minimum / @maximum — inclusive numeric bounds
+    // -----------------------------------------------------------------------
     // @Minimum < @Maximum
     {
       code: `
@@ -40,24 +43,6 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         class Form {
           /** @Minimum 50 @Maximum 50 */
           value!: number;
-        }
-      `,
-    },
-    // @ExclusiveMinimum < @ExclusiveMaximum
-    {
-      code: `
-        class Form {
-          /** @ExclusiveMinimum 0 @ExclusiveMaximum 100 */
-          value!: number;
-        }
-      `,
-    },
-    // @MinLength < @MaxLength
-    {
-      code: `
-        class Form {
-          /** @MinLength 1 @MaxLength 100 */
-          name!: string;
         }
       `,
     },
@@ -79,7 +64,40 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         }
       `,
     },
-    // @Minimum with @ExclusiveMaximum where exclusive max > min
+    // Negative values: @Minimum(-100) < @Maximum(-50) is valid
+    {
+      code: `
+        class Form {
+          /** @Minimum -100 @Maximum -50 */
+          value!: number;
+        }
+      `,
+    },
+    // Float bounds
+    {
+      code: `
+        class Form {
+          /** @Minimum 0.5 @Maximum 0.9 */
+          ratio!: number;
+        }
+      `,
+    },
+    // -----------------------------------------------------------------------
+    // @exclusiveMinimum / @exclusiveMaximum — exclusive numeric bounds
+    // -----------------------------------------------------------------------
+    // @ExclusiveMinimum < @ExclusiveMaximum
+    {
+      code: `
+        class Form {
+          /** @ExclusiveMinimum 0 @ExclusiveMaximum 100 */
+          value!: number;
+        }
+      `,
+    },
+    // -----------------------------------------------------------------------
+    // Mixed exclusive/inclusive bounds
+    // -----------------------------------------------------------------------
+    // @Minimum with @ExclusiveMaximum where exclusive max > min (valid)
     {
       code: `
         class Form {
@@ -97,6 +115,37 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         }
       `,
     },
+    // @Minimum equals @ExclusiveMaximum – still invalid (exclusiveMax must be > min)
+    // so we test the valid side: ExclusiveMaximum strictly greater than Minimum
+    {
+      code: `
+        class Form {
+          /** @Minimum 50 @ExclusiveMaximum 51 */
+          value!: number;
+        }
+      `,
+    },
+    // @ExclusiveMinimum strictly less than @Maximum (valid)
+    {
+      code: `
+        class Form {
+          /** @ExclusiveMinimum 49 @Maximum 50 */
+          value!: number;
+        }
+      `,
+    },
+    // -----------------------------------------------------------------------
+    // @minLength / @maxLength
+    // -----------------------------------------------------------------------
+    // @MinLength < @MaxLength
+    {
+      code: `
+        class Form {
+          /** @MinLength 1 @MaxLength 100 */
+          name!: string;
+        }
+      `,
+    },
     // @MinLength == @MaxLength (valid: fixed-length string)
     {
       code: `
@@ -106,23 +155,9 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         }
       `,
     },
-    // Negative values: @Minimum(-100) < @Maximum(-50) is valid
-    {
-      code: `
-        class Form {
-          /** @Minimum -100 @Maximum -50 */
-          value!: number;
-        }
-      `,
-    },
-    // No constraints at all
-    {
-      code: `
-        class Form {
-          value!: number;
-        }
-      `,
-    },
+    // -----------------------------------------------------------------------
+    // @minItems / @maxItems
+    // -----------------------------------------------------------------------
     // @minItems < @maxItems — valid
     {
       code: `
@@ -141,7 +176,20 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         }
       `,
     },
-    // Path-targeted constraints should be skipped
+    // -----------------------------------------------------------------------
+    // No constraints at all
+    // -----------------------------------------------------------------------
+    {
+      code: `
+        class Form {
+          value!: number;
+        }
+      `,
+    },
+    // -----------------------------------------------------------------------
+    // Path-targeted constraints — skipped entirely
+    // -----------------------------------------------------------------------
+    // Path-targeted contradicting bounds — skipped, no error
     {
       code: `
         class Form {
@@ -150,18 +198,29 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         }
       `,
     },
-  ],
-  invalid: [
-    // Negative values: @Minimum(-50) > @Maximum(-100) is invalid
+    // Path-targeted conflicting exclusive bounds — skipped
     {
       code: `
         class Form {
-          /** @Minimum -50 @Maximum -100 */
-          value!: number;
+          /** @exclusiveMinimum :value 50 @exclusiveMaximum :value 50 */
+          amount!: { value: number };
         }
       `,
-      errors: [{ messageId: "minimumGreaterThanMaximum" }],
     },
+    // Path-targeted conflicting bound types — skipped
+    {
+      code: `
+        class Form {
+          /** @minimum :value 0 @exclusiveMinimum :value 0 */
+          amount!: { value: number };
+        }
+      `,
+    },
+  ],
+  invalid: [
+    // -----------------------------------------------------------------------
+    // @minimum > @maximum
+    // -----------------------------------------------------------------------
     // @Minimum > @Maximum
     {
       code: `
@@ -172,7 +231,20 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
       `,
       errors: [{ messageId: "minimumGreaterThanMaximum" }],
     },
-    // @ExclusiveMinimum >= @ExclusiveMaximum (equal is invalid for exclusive bounds)
+    // Negative values: @Minimum(-50) > @Maximum(-100) is invalid
+    {
+      code: `
+        class Form {
+          /** @Minimum -50 @Maximum -100 */
+          value!: number;
+        }
+      `,
+      errors: [{ messageId: "minimumGreaterThanMaximum" }],
+    },
+    // -----------------------------------------------------------------------
+    // @exclusiveMinimum >= @exclusiveMaximum
+    // -----------------------------------------------------------------------
+    // @ExclusiveMinimum == @ExclusiveMaximum (equal is invalid for exclusive bounds)
     {
       code: `
         class Form {
@@ -192,7 +264,9 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
       `,
       errors: [{ messageId: "exclusiveMinGreaterOrEqualMax" }],
     },
-    // @MinLength > @MaxLength
+    // -----------------------------------------------------------------------
+    // @minLength > @maxLength
+    // -----------------------------------------------------------------------
     {
       code: `
         class Form {
@@ -202,7 +276,22 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
       `,
       errors: [{ messageId: "minLengthGreaterThanMaxLength" }],
     },
-    // Conflicting minimum bounds: @Minimum + @ExclusiveMinimum
+    // -----------------------------------------------------------------------
+    // @minItems > @maxItems
+    // -----------------------------------------------------------------------
+    {
+      code: `
+        class Form {
+          /** @minItems 10 @maxItems 1 */
+          tags!: string[];
+        }
+      `,
+      errors: [{ messageId: "minItemsGreaterThanMaxItems" }],
+    },
+    // -----------------------------------------------------------------------
+    // Conflicting bound types: both inclusive and exclusive on same side
+    // -----------------------------------------------------------------------
+    // @Minimum + @ExclusiveMinimum — conflicting lower bounds
     {
       code: `
         class Form {
@@ -212,7 +301,17 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
       `,
       errors: [{ messageId: "conflictingMinimumBounds" }],
     },
-    // Conflicting maximum bounds: @Maximum + @ExclusiveMaximum
+    // @Minimum + @ExclusiveMinimum with different values — still conflicting
+    {
+      code: `
+        class Form {
+          /** @Minimum 10 @ExclusiveMinimum 5 */
+          value!: number;
+        }
+      `,
+      errors: [{ messageId: "conflictingMinimumBounds" }],
+    },
+    // @Maximum + @ExclusiveMaximum — conflicting upper bounds
     {
       code: `
         class Form {
@@ -222,7 +321,20 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
       `,
       errors: [{ messageId: "conflictingMaximumBounds" }],
     },
-    // @ExclusiveMaximum(n) where n <= @Minimum(m)
+    // @Maximum + @ExclusiveMaximum with different values — still conflicting
+    {
+      code: `
+        class Form {
+          /** @Maximum 90 @ExclusiveMaximum 100 */
+          value!: number;
+        }
+      `,
+      errors: [{ messageId: "conflictingMaximumBounds" }],
+    },
+    // -----------------------------------------------------------------------
+    // Mixed exclusive/inclusive: impossible ranges
+    // -----------------------------------------------------------------------
+    // @exclusiveMaximum(n) <= @minimum(m): n == m is invalid
     {
       code: `
         class Form {
@@ -232,7 +344,7 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
       `,
       errors: [{ messageId: "exclusiveMaxLessOrEqualMin" }],
     },
-    // @ExclusiveMaximum(n) where n < @Minimum(m)
+    // @exclusiveMaximum(n) < @minimum(m)
     {
       code: `
         class Form {
@@ -242,7 +354,7 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
       `,
       errors: [{ messageId: "exclusiveMaxLessOrEqualMin" }],
     },
-    // @ExclusiveMinimum(m) + @Maximum(n) where n == m (invalid: no valid values)
+    // @maximum(n) <= @exclusiveMinimum(m): n == m is invalid (no valid values)
     {
       code: `
         class Form {
@@ -252,7 +364,7 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
       `,
       errors: [{ messageId: "maximumLessOrEqualExclusiveMin" }],
     },
-    // @ExclusiveMinimum(m) + @Maximum(n) where n < m (invalid)
+    // @maximum(n) < @exclusiveMinimum(m)
     {
       code: `
         class Form {
@@ -261,16 +373,6 @@ ruleTester.run("consistent-constraints", consistentConstraints, {
         }
       `,
       errors: [{ messageId: "maximumLessOrEqualExclusiveMin" }],
-    },
-    // @minItems > @maxItems — invalid
-    {
-      code: `
-        class Form {
-          /** @minItems 10 @maxItems 1 */
-          tags!: string[];
-        }
-      `,
-      errors: [{ messageId: "minItemsGreaterThanMaxItems" }],
     },
   ],
 });

--- a/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
@@ -29,6 +29,9 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
   valid: [
+    // -----------------------------------------------------------------------
+    // Numeric constraints on number fields
+    // -----------------------------------------------------------------------
     // @Minimum on number field — valid
     {
       code: `
@@ -65,6 +68,27 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
         }
       `,
     },
+    // @multipleOf on number field — valid
+    {
+      code: `
+        class Form {
+          /** @multipleOf 0.01 */
+          price!: number;
+        }
+      `,
+    },
+    // Edge values: zero, negative, float
+    {
+      code: `
+        class Form {
+          /** @Minimum -999.5 */
+          temperature!: number;
+        }
+      `,
+    },
+    // -----------------------------------------------------------------------
+    // String constraints on string fields
+    // -----------------------------------------------------------------------
     // @MinLength on string field — valid
     {
       code: `
@@ -92,42 +116,9 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
         }
       `,
     },
-    // @Minimum on optional number field — valid (string | undefined strips to number)
-    {
-      code: `
-        class Form {
-          /** @Minimum 0 */
-          count?: number;
-        }
-      `,
-    },
-    // No constraints at all — valid
-    {
-      code: `
-        class Form {
-          name!: string;
-          count!: number;
-        }
-      `,
-    },
-    // Multiple numeric constraints on number field — all valid
-    {
-      code: `
-        class Form {
-          /** @Minimum 0 @Maximum 100 */
-          score!: number;
-        }
-      `,
-    },
-    // @multipleOf on number field — valid
-    {
-      code: `
-        class Form {
-          /** @multipleOf 0.01 */
-          price!: number;
-        }
-      `,
-    },
+    // -----------------------------------------------------------------------
+    // Array constraints on array fields
+    // -----------------------------------------------------------------------
     // @minItems on array field — valid
     {
       code: `
@@ -146,7 +137,99 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
         }
       `,
     },
-    // Path-targeted constraints should be skipped — @minimum targets a sub-property, not the field itself
+    // -----------------------------------------------------------------------
+    // Optional fields (undefined stripped)
+    // -----------------------------------------------------------------------
+    // @Minimum on optional number field — valid (undefined stripped)
+    {
+      code: `
+        class Form {
+          /** @Minimum 0 */
+          count?: number;
+        }
+      `,
+    },
+    // -----------------------------------------------------------------------
+    // No constraints
+    // -----------------------------------------------------------------------
+    {
+      code: `
+        class Form {
+          name!: string;
+          count!: number;
+        }
+      `,
+    },
+    // Multiple numeric constraints on number field — all valid
+    {
+      code: `
+        class Form {
+          /** @Minimum 0 @Maximum 100 */
+          score!: number;
+        }
+      `,
+    },
+    // -----------------------------------------------------------------------
+    // Malformed / unrecognized tags — silently ignored, no errors
+    // -----------------------------------------------------------------------
+    // Bare @minimum with no value — ignored
+    {
+      code: `
+        class Form {
+          /** @minimum */
+          name!: string;
+        }
+      `,
+    },
+    // @minimum with non-numeric value — ignored
+    {
+      code: `
+        class Form {
+          /** @minimum abc */
+          name!: string;
+        }
+      `,
+    },
+    // @minimum with invalid number format — ignored
+    {
+      code: `
+        class Form {
+          /** @minimum 1.2.3 */
+          name!: string;
+        }
+      `,
+    },
+    // Unrecognized tag — ignored
+    {
+      code: `
+        class Form {
+          /** @unknownTag value */
+          count!: number;
+        }
+      `,
+    },
+    // PascalCase @Maximum on number field — identical behaviour to camelCase
+    {
+      code: `
+        class Form {
+          /** @Maximum 50 @Minimum 0 */
+          score!: number;
+        }
+      `,
+    },
+    // PascalCase @MaxLength on string field — identical behaviour to camelCase
+    {
+      code: `
+        class Form {
+          /** @MaxLength 64 */
+          slug!: string;
+        }
+      `,
+    },
+    // -----------------------------------------------------------------------
+    // Path-targeted constraints — skipped entirely (target sub-property)
+    // -----------------------------------------------------------------------
+    // @minimum :value on object field — skipped, no type-mismatch
     {
       code: `
         class Form {
@@ -155,7 +238,7 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
         }
       `,
     },
-    // Path-targeted @pattern should be skipped
+    // @pattern :code on object field — skipped
     {
       code: `
         class Form {
@@ -164,14 +247,47 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
         }
       `,
     },
+    // Path-targeted constraints with contradicting values — still skipped
+    {
+      code: `
+        class Form {
+          /** @minimum :value 100 @maximum :value 50 */
+          amount!: { value: number };
+        }
+      `,
+    },
   ],
   invalid: [
+    // -----------------------------------------------------------------------
+    // @minimum / @maximum / @exclusiveMinimum / @exclusiveMaximum / @multipleOf
+    // on non-number fields
+    // -----------------------------------------------------------------------
     // @Minimum on string field
     {
       code: `
         class Form {
           /** @Minimum 0 */
           name!: string;
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @Minimum on boolean field
+    {
+      code: `
+        class Form {
+          /** @Minimum 0 */
+          active!: boolean;
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @Minimum on array field
+    {
+      code: `
+        class Form {
+          /** @Minimum 0 */
+          tags!: string[];
         }
       `,
       errors: [{ messageId: "numericOnNonNumber" }],
@@ -186,11 +302,61 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
       `,
       errors: [{ messageId: "numericOnNonNumber" }],
     },
+    // @Maximum on boolean field
+    {
+      code: `
+        class Form {
+          /** @Maximum 1 */
+          active!: boolean;
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @Maximum on array field
+    {
+      code: `
+        class Form {
+          /** @Maximum 10 */
+          tags!: string[];
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
     // @ExclusiveMinimum on string field
     {
       code: `
         class Form {
           /** @ExclusiveMinimum 0 */
+          name!: string;
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @ExclusiveMinimum on boolean field
+    {
+      code: `
+        class Form {
+          /** @ExclusiveMinimum 0 */
+          active!: boolean;
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @ExclusiveMinimum on array field
+    {
+      code: `
+        class Form {
+          /** @ExclusiveMinimum 0 */
+          tags!: string[];
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @ExclusiveMaximum on string field
+    {
+      code: `
+        class Form {
+          /** @ExclusiveMaximum 100 */
           name!: string;
         }
       `,
@@ -206,31 +372,54 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
       `,
       errors: [{ messageId: "numericOnNonNumber" }],
     },
+    // @ExclusiveMaximum on array field
+    {
+      code: `
+        class Form {
+          /** @ExclusiveMaximum 10 */
+          tags!: string[];
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @multipleOf on string field
+    {
+      code: `
+        class Form {
+          /** @multipleOf 0.01 */
+          name!: string;
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @multipleOf on boolean field
+    {
+      code: `
+        class Form {
+          /** @multipleOf 1 */
+          active!: boolean;
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // @multipleOf on array field
+    {
+      code: `
+        class Form {
+          /** @multipleOf 2 */
+          tags!: string[];
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }],
+    },
+    // -----------------------------------------------------------------------
+    // @minLength / @maxLength / @pattern on non-string fields
+    // -----------------------------------------------------------------------
     // @MinLength on number field
     {
       code: `
         class Form {
           /** @MinLength 1 */
-          count!: number;
-        }
-      `,
-      errors: [{ messageId: "stringOnNonString" }],
-    },
-    // @MaxLength on number field
-    {
-      code: `
-        class Form {
-          /** @MaxLength 100 */
-          score!: number;
-        }
-      `,
-      errors: [{ messageId: "stringOnNonString" }],
-    },
-    // @Pattern on number field
-    {
-      code: `
-        class Form {
-          /** @Pattern ^[0-9]+$ */
           count!: number;
         }
       `,
@@ -246,31 +435,114 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
       `,
       errors: [{ messageId: "stringOnNonString" }],
     },
-    // Multiple wrong constraints produce multiple errors
+    // @MinLength on array field
     {
       code: `
         class Form {
-          /** @Minimum 0 @Maximum 100 */
-          label!: string;
+          /** @MinLength 1 */
+          tags!: string[];
         }
       `,
-      errors: [{ messageId: "numericOnNonNumber" }, { messageId: "numericOnNonNumber" }],
+      errors: [{ messageId: "stringOnNonString" }],
     },
-    // @multipleOf on string field
+    // @MaxLength on number field
     {
       code: `
         class Form {
-          /** @multipleOf 0.01 */
-          name!: string;
+          /** @MaxLength 100 */
+          score!: number;
         }
       `,
-      errors: [{ messageId: "numericOnNonNumber" }],
+      errors: [{ messageId: "stringOnNonString" }],
     },
+    // @MaxLength on boolean field
+    {
+      code: `
+        class Form {
+          /** @MaxLength 10 */
+          active!: boolean;
+        }
+      `,
+      errors: [{ messageId: "stringOnNonString" }],
+    },
+    // @MaxLength on array field
+    {
+      code: `
+        class Form {
+          /** @MaxLength 10 */
+          tags!: string[];
+        }
+      `,
+      errors: [{ messageId: "stringOnNonString" }],
+    },
+    // @Pattern on number field
+    {
+      code: `
+        class Form {
+          /** @Pattern ^[0-9]+$ */
+          count!: number;
+        }
+      `,
+      errors: [{ messageId: "stringOnNonString" }],
+    },
+    // @Pattern on boolean field
+    {
+      code: `
+        class Form {
+          /** @Pattern true|false */
+          active!: boolean;
+        }
+      `,
+      errors: [{ messageId: "stringOnNonString" }],
+    },
+    // @Pattern on array field
+    {
+      code: `
+        class Form {
+          /** @Pattern ^[a-z]+$ */
+          tags!: string[];
+        }
+      `,
+      errors: [{ messageId: "stringOnNonString" }],
+    },
+    // -----------------------------------------------------------------------
+    // @minItems / @maxItems on non-array fields
+    // -----------------------------------------------------------------------
     // @minItems on string field
     {
       code: `
         class Form {
           /** @minItems 1 */
+          name!: string;
+        }
+      `,
+      errors: [{ messageId: "arrayOnNonArray" }],
+    },
+    // @minItems on number field
+    {
+      code: `
+        class Form {
+          /** @minItems 1 */
+          count!: number;
+        }
+      `,
+      errors: [{ messageId: "arrayOnNonArray" }],
+    },
+    // @minItems on boolean field
+    {
+      code: `
+        class Form {
+          /** @minItems 1 */
+          active!: boolean;
+        }
+      `,
+      errors: [{ messageId: "arrayOnNonArray" }],
+    },
+    // @maxItems on string field
+    {
+      code: `
+        class Form {
+          /** @maxItems 10 */
           name!: string;
         }
       `,
@@ -285,6 +557,28 @@ ruleTester.run("constraint-type-mismatch", constraintTypeMismatch, {
         }
       `,
       errors: [{ messageId: "arrayOnNonArray" }],
+    },
+    // @maxItems on boolean field
+    {
+      code: `
+        class Form {
+          /** @maxItems 10 */
+          active!: boolean;
+        }
+      `,
+      errors: [{ messageId: "arrayOnNonArray" }],
+    },
+    // -----------------------------------------------------------------------
+    // Multiple constraints — all wrong types produce multiple errors
+    // -----------------------------------------------------------------------
+    {
+      code: `
+        class Form {
+          /** @Minimum 0 @Maximum 100 */
+          label!: string;
+        }
+      `,
+      errors: [{ messageId: "numericOnNonNumber" }, { messageId: "numericOnNonNumber" }],
     },
   ],
 });


### PR DESCRIPTION
## Summary

- Expands `constraint-type-mismatch` tests to cover every constraint × field type combination — each numeric, string, and array constraint now has invalid cases for all three incompatible types (e.g., `@minimum` on string, boolean, and array)
- Adds valid cases for malformed/ignored tag syntax: bare tags with no value, non-numeric values, invalid number formats, and unrecognized tag names are all silently ignored rather than erroring
- Adds valid cases for path-targeted constraints (`@minimum :value 0`) to confirm they are skipped entirely for type checking — including contradicting values that would be flagged on direct constraints
- Expands `consistent-constraints` tests with float bound values, mixed exclusive/inclusive boundary conditions, conflicting bounds with different values, and path-targeted constraints with contradicting or conflicting values (all skipped)

## Test plan

- [ ] `pnpm --filter @formspec/eslint-plugin run test` — 127 tests pass (up from 93)
- [ ] `pnpm run lint` — clean
- [ ] `pnpm run format:check` — clean