### PR TITLE
test(eslint-plugin): expand lint rule coverage for all constraint × type combinations

### DIFF
--- a/docs/000-principles.md
+++ b/docs/000-principles.md
@@ -70,7 +70,7 @@ The `:path` grammar is not specific to `@minimum` — it works across any tag wh
  * @displayName :sync Synchronous
  * @displayName :async Asynchronous
  */
-mode: 'sync' | 'async';
+mode: "sync" | "async";
 ```
 
 A new capability (like path targeting) should unlock expressiveness across many existing tags, not require inventing new ones.

--- a/docs/001-canonical-ir.md
+++ b/docs/001-canonical-ir.md
@@ -65,8 +65,8 @@ Primitives map directly to JSON Schema primitive types.
 
 ```typescript
 interface PrimitiveTypeNode {
-  readonly kind: 'primitive';
-  readonly primitiveKind: 'string' | 'number' | 'integer' | 'bigint' | 'boolean' | 'null';
+  readonly kind: "primitive";
+  readonly primitiveKind: "string" | "number" | "integer" | "bigint" | "boolean" | "null";
 }
 ```
 
@@ -89,7 +89,7 @@ interface EnumMember {
 }
 
 interface EnumTypeNode {
-  readonly kind: 'enum';
+  readonly kind: "enum";
   readonly members: readonly EnumMember[];
 }
 ```
@@ -100,7 +100,7 @@ interface EnumTypeNode {
 
 ```typescript
 interface ArrayTypeNode {
-  readonly kind: 'array';
+  readonly kind: "array";
   readonly items: TypeNode;
 }
 ```
@@ -111,7 +111,7 @@ Array-level constraints (`minItems`, `maxItems`) attach to the `FieldNode` that 
 
 ```typescript
 interface ObjectTypeNode {
-  readonly kind: 'object';
+  readonly kind: "object";
   /**
    * Named properties of this object. Order is preserved from the source
    * declaration (for deterministic D3 output).
@@ -168,7 +168,7 @@ Union types that are not all-string-literal or all-number-literal enums (those a
 
 ```typescript
 interface UnionTypeNode {
-  readonly kind: 'union';
+  readonly kind: "union";
   readonly members: readonly TypeNode[];
 }
 ```
@@ -181,7 +181,7 @@ Named types that appear as references in the source are preserved as references 
 
 ```typescript
 interface ReferenceTypeNode {
-  readonly kind: 'reference';
+  readonly kind: "reference";
   /**
    * The fully-qualified name of the referenced type.
    * For TypeScript interfaces/type aliases: `"<module>#<TypeName>"`.
@@ -206,8 +206,8 @@ Dynamic types are reserved for fields whose schema is discovered at runtime.
 
 ```typescript
 interface DynamicTypeNode {
-  readonly kind: 'dynamic';
-  readonly dynamicKind: 'schema';
+  readonly kind: "dynamic";
+  readonly dynamicKind: "schema";
   /**
    * Key identifying the runtime schema provider.
    */
@@ -223,7 +223,7 @@ Custom types registered by extensions (E1, E5) that do not map to any built-in k
 
 ```typescript
 interface CustomTypeNode {
-  readonly kind: 'custom';
+  readonly kind: "custom";
   /**
    * The extension-qualified type identifier.
    * Format: `"<vendor-prefix>/<extension-name>/<type-name>"`
@@ -270,13 +270,13 @@ Apply to `number`, `integer`, and `bigint` fields. `minimum` and `maximum` are i
 
 ```typescript
 interface NumericConstraintNode {
-  readonly kind: 'constraint';
+  readonly kind: "constraint";
   readonly constraintKind:
-    | 'minimum'
-    | 'maximum'
-    | 'exclusiveMinimum'
-    | 'exclusiveMaximum'
-    | 'multipleOf';
+    | "minimum"
+    | "maximum"
+    | "exclusiveMinimum"
+    | "exclusiveMaximum"
+    | "multipleOf";
   readonly value: number | string;
   readonly provenance: Provenance;
 }
@@ -292,8 +292,8 @@ Apply to `string` fields and `array` fields. `minLength`/`maxLength` apply to st
 
 ```typescript
 interface LengthConstraintNode {
-  readonly kind: 'constraint';
-  readonly constraintKind: 'minLength' | 'maxLength' | 'minItems' | 'maxItems';
+  readonly kind: "constraint";
+  readonly constraintKind: "minLength" | "maxLength" | "minItems" | "maxItems";
   readonly value: number;
   readonly provenance: Provenance;
 }
@@ -307,8 +307,8 @@ Apply to `string` fields only. Multiple `pattern` constraints on the same field 
 
 ```typescript
 interface PatternConstraintNode {
-  readonly kind: 'constraint';
-  readonly constraintKind: 'pattern';
+  readonly kind: "constraint";
+  readonly constraintKind: "pattern";
   /** ECMA-262 regular expression, without delimiters. */
   readonly pattern: string;
   readonly provenance: Provenance;
@@ -323,8 +323,8 @@ These are split from `LengthConstraintNode` above only if array cardinality need
 
 ```typescript
 interface ArrayCardinalityConstraintNode {
-  readonly kind: 'constraint';
-  readonly constraintKind: 'uniqueItems';
+  readonly kind: "constraint";
+  readonly constraintKind: "uniqueItems";
   readonly value: true;
   readonly provenance: Provenance;
 }
@@ -336,8 +336,8 @@ Allow restricting a field typed as a broader enum to a subset of its members at 
 
 ```typescript
 interface EnumMemberConstraintNode {
-  readonly kind: 'constraint';
-  readonly constraintKind: 'allowedMembers';
+  readonly kind: "constraint";
+  readonly constraintKind: "allowedMembers";
   readonly members: readonly (string | number)[];
   readonly provenance: Provenance;
 }
@@ -349,8 +349,8 @@ Extensions register custom constraints that carry an opaque payload. The `compos
 
 ```typescript
 interface CustomConstraintNode {
-  readonly kind: 'constraint';
-  readonly constraintKind: 'custom';
+  readonly kind: "constraint";
+  readonly constraintKind: "custom";
   /**
    * Extension-qualified constraint identifier.
    * Format: `"<vendor-prefix>/<extension-name>/<constraint-name>"`
@@ -369,7 +369,7 @@ interface CustomConstraintNode {
    * "override" — the most-specific instance wins (closest to point of use).
    *   Suitable for constraints that produce a single value (like a format hint).
    */
-  readonly compositionRule: 'intersect' | 'override';
+  readonly compositionRule: "intersect" | "override";
   readonly provenance: Provenance;
 }
 ```
@@ -417,29 +417,29 @@ type AnnotationNode =
 
 ```typescript
 interface DisplayNameAnnotationNode {
-  readonly kind: 'annotation';
-  readonly annotationKind: 'displayName';
+  readonly kind: "annotation";
+  readonly annotationKind: "displayName";
   readonly value: string;
   readonly provenance: Provenance;
 }
 
 interface DescriptionAnnotationNode {
-  readonly kind: 'annotation';
-  readonly annotationKind: 'description';
+  readonly kind: "annotation";
+  readonly annotationKind: "description";
   readonly value: string;
   readonly provenance: Provenance;
 }
 
 interface PlaceholderAnnotationNode {
-  readonly kind: 'annotation';
-  readonly annotationKind: 'placeholder';
+  readonly kind: "annotation";
+  readonly annotationKind: "placeholder";
   readonly value: string;
   readonly provenance: Provenance;
 }
 
 interface DefaultValueAnnotationNode {
-  readonly kind: 'annotation';
-  readonly annotationKind: 'defaultValue';
+  readonly kind: "annotation";
+  readonly annotationKind: "defaultValue";
   /**
    * The default value. Must be JSON-serializable and compatible with
    * the field's type. Type compatibility is verified during the Validate
@@ -450,8 +450,8 @@ interface DefaultValueAnnotationNode {
 }
 
 interface DeprecatedAnnotationNode {
-  readonly kind: 'annotation';
-  readonly annotationKind: 'deprecated';
+  readonly kind: "annotation";
+  readonly annotationKind: "deprecated";
   /** Optional deprecation message, sourced from `@deprecated <message>`. */
   readonly message?: string;
   readonly provenance: Provenance;
@@ -462,8 +462,8 @@ interface DeprecatedAnnotationNode {
  * This does not affect schema validation (B5).
  */
 interface FormatHintAnnotationNode {
-  readonly kind: 'annotation';
-  readonly annotationKind: 'formatHint';
+  readonly kind: "annotation";
+  readonly annotationKind: "formatHint";
   /**
    * Renderer-specific format identifier.
    * Examples: "textarea", "radio", "date", "color".
@@ -479,8 +479,8 @@ interface FormatHintAnnotationNode {
 
 ```typescript
 interface CustomAnnotationNode {
-  readonly kind: 'annotation';
-  readonly annotationKind: 'custom';
+  readonly kind: "annotation";
+  readonly annotationKind: "custom";
   /**
    * Extension-qualified annotation identifier.
    * Format: `"<vendor-prefix>/<extension-name>/<annotation-name>"`
@@ -518,7 +518,7 @@ interface Provenance {
    * Used to display meaningful diagnostic context and for surface-specific
    * filtering (e.g., "this error came from a TSDoc tag on line 42").
    */
-  readonly surface: 'tsdoc' | 'chain-dsl' | 'extension' | 'inferred';
+  readonly surface: "tsdoc" | "chain-dsl" | "extension" | "inferred";
   /**
    * Absolute path to the source file.
    */
@@ -556,7 +556,7 @@ When the contradiction detection algorithm (section 8) detects a contradiction b
 interface ContradictionDiagnostic {
   readonly code: string; // e.g., "CONTRADICTION" (prefixed per PP10)
   readonly message: string; // Human-readable, actionable (D4)
-  readonly severity: 'error'; // Contradictions are always errors (S2)
+  readonly severity: "error"; // Contradictions are always errors (S2)
   readonly primaryLocation: Provenance; // The constraint causing the contradiction
   readonly relatedLocations: readonly Provenance[]; // Prior constraints it conflicts with
 }
@@ -628,7 +628,7 @@ The same colon-based grammar applies to annotations. The per-member `@displayNam
  * @displayName :draft Draft
  * @displayName :paid Paid in Full
  */
-status: 'draft' | 'paid';
+status: "draft" | "paid";
 ```
 
 Here, `:draft` is syntactic sugar for targeting the `draft` member of the union. In the IR, the resolved member-level display-name metadata is stored on the individual `EnumMember` records within the `EnumTypeNode`, not as annotations on the parent field. The canonicalization phase (A5) resolves the member-target syntax into the correct IR placement.
@@ -754,11 +754,11 @@ Before contradiction checking, the Validate phase checks that each constraint is
 
 ```typescript
 type DiagnosticCode =
-  | 'CONTRADICTION'
-  | 'TYPE_MISMATCH' // Constraint applied to wrong type
-  | 'UNKNOWN_PATH_TARGET' // Path target does not exist in type
-  | 'INVALID_PATH_TARGET' // Path target type does not accept this constraint
-  | 'MISSING_REQUIRED' // Field that appears in a condition does not exist
+  | "CONTRADICTION"
+  | "TYPE_MISMATCH" // Constraint applied to wrong type
+  | "UNKNOWN_PATH_TARGET" // Path target does not exist in type
+  | "INVALID_PATH_TARGET" // Path target type does not accept this constraint
+  | "MISSING_REQUIRED" // Field that appears in a condition does not exist
   | string; // Extension-defined codes
 ```
 
@@ -873,13 +873,13 @@ interface CustomConstraintRegistration {
   /**
    * Composition rule declaration (E2 — must be explicit).
    */
-  readonly compositionRule: 'intersect' | 'override';
+  readonly compositionRule: "intersect" | "override";
 
   /**
    * Set of type kinds this constraint may be applied to.
    * Passing `null` means "any type" (rare — use only if truly type-agnostic).
    */
-  readonly applicableTypes: readonly TypeNode['kind'][] | null;
+  readonly applicableTypes: readonly TypeNode["kind"][] | null;
 
   /**
    * Generates the JSON Schema contribution for this constraint.
@@ -896,7 +896,7 @@ Per E3, all custom vocabulary keywords use a configurable vendor prefix. The pre
 
 ```yaml
 vendor:
-  prefix: 'x-stripe' # defaults to "x-formspec"
+  prefix: "x-stripe" # defaults to "x-formspec"
 ```
 
 The extension registration system substitutes the configured prefix at emit time. Extensions never hard-code their keyword prefix — they register keyword names without the prefix, and the generation context provides the effective prefix:
@@ -926,7 +926,7 @@ A `FieldNode` represents a single form field after canonicalization — its type
 
 ```typescript
 interface FieldNode {
-  readonly kind: 'field';
+  readonly kind: "field";
   /** The field's key in the data schema. */
   readonly name: string;
   /** The resolved type of this field. */
@@ -959,7 +959,7 @@ Layout nodes capture UI structure without affecting the data schema (C2). They a
 type LayoutNode = GroupLayoutNode | ConditionalLayoutNode;
 
 interface GroupLayoutNode {
-  readonly kind: 'group';
+  readonly kind: "group";
   readonly label: string;
   /** Elements contained in this group — may be fields or nested groups. */
   readonly elements: readonly FormIRElement[];
@@ -967,7 +967,7 @@ interface GroupLayoutNode {
 }
 
 interface ConditionalLayoutNode {
-  readonly kind: 'conditional';
+  readonly kind: "conditional";
   /**
    * The field whose value triggers visibility.
    * Must reference a field that exists at the same scope level.
@@ -1012,7 +1012,7 @@ interface TypeDefinition {
  * Serializable to JSON (A2). No live compiler objects.
  */
 interface FormIR {
-  readonly kind: 'form-ir';
+  readonly kind: "form-ir";
   /**
    * Schema version for the IR format itself. Allows tooling to detect
    * incompatible IR versions when IR artifacts are persisted.
@@ -1046,7 +1046,7 @@ Implementation-bridge and migration guidance has been moved out of this normativ
 
 ## Appendix: Open Decisions Summary
 
-| ID   | Section | Decision |
-| ---- | ------- | -------- |
+| ID  | Section | Decision |
+| --- | ------- | -------- |
 
 Open decisions are resolved before implementation begins on affected sections. Resolution is recorded by amending this document.

--- a/docs/002-tsdoc-grammar.md
+++ b/docs/002-tsdoc-grammar.md
@@ -34,21 +34,21 @@ Tags are organized into four categories: **constraint tags** (set-influencing, p
 
 Constraint tags narrow the set of valid values for a field. Per S1, constraints can only narrow — an attempt to broaden a constraint inherited from a base type is a static error. Per S4, each tag is only valid on fields whose type is compatible with the constraint. Per C1, multiple constraint tags on the same field compose by intersection.
 
-| Tag                                   | Applicable types                                        | IR node kind                 | JSON Schema validation keyword      |
-| ------------------------------------- | ------------------------------------------------------- | ---------------------------- | ----------------------------------- |
-| `@minimum`                            | `number`, `bigint` (extensible to custom numeric types) | `NumericBoundConstraint`     | `minimum`                           |
-| `@maximum`                            | `number`, `bigint` (extensible to custom numeric types) | `NumericBoundConstraint`     | `maximum`                           |
-| `@exclusiveMinimum`                   | `number`, `bigint` (extensible to custom numeric types) | `NumericBoundConstraint`     | `exclusiveMinimum`                  |
-| `@exclusiveMaximum`                   | `number`, `bigint` (extensible to custom numeric types) | `NumericBoundConstraint`     | `exclusiveMaximum`                  |
-| `@multipleOf`                         | `number`, `bigint` (extensible to custom numeric types) | `MultipleOfConstraint`       | `multipleOf`                        |
-| `@minLength`                          | `string`                                                | `StringLengthConstraint`     | `minLength`                         |
-| `@maxLength`                          | `string`                                                | `StringLengthConstraint`     | `maxLength`                         |
-| `@pattern`                            | `string`                                                | `PatternConstraint`          | `pattern`                           |
-| `@minItems`                           | `T[]`                                                   | `ArrayLengthConstraint`      | `minItems`                          |
-| `@maxItems`                           | `T[]`                                                   | `ArrayLengthConstraint`      | `maxItems`                          |
-| `@uniqueItems`                        | `T[]`                                                   | `UniquenessConstraint`       | `uniqueItems`                       |
-| `@maxSigFig` (example extension tag)  | extension-defined numeric-like types                    | `DecimalPrecisionConstraint` | `x-<vendor>-max-sig-fig` (see 003)  |
-| `@const`                              | any                                                     | `ConstConstraint`            | `const`                             |
+| Tag                                  | Applicable types                                        | IR node kind                 | JSON Schema validation keyword     |
+| ------------------------------------ | ------------------------------------------------------- | ---------------------------- | ---------------------------------- |
+| `@minimum`                           | `number`, `bigint` (extensible to custom numeric types) | `NumericBoundConstraint`     | `minimum`                          |
+| `@maximum`                           | `number`, `bigint` (extensible to custom numeric types) | `NumericBoundConstraint`     | `maximum`                          |
+| `@exclusiveMinimum`                  | `number`, `bigint` (extensible to custom numeric types) | `NumericBoundConstraint`     | `exclusiveMinimum`                 |
+| `@exclusiveMaximum`                  | `number`, `bigint` (extensible to custom numeric types) | `NumericBoundConstraint`     | `exclusiveMaximum`                 |
+| `@multipleOf`                        | `number`, `bigint` (extensible to custom numeric types) | `MultipleOfConstraint`       | `multipleOf`                       |
+| `@minLength`                         | `string`                                                | `StringLengthConstraint`     | `minLength`                        |
+| `@maxLength`                         | `string`                                                | `StringLengthConstraint`     | `maxLength`                        |
+| `@pattern`                           | `string`                                                | `PatternConstraint`          | `pattern`                          |
+| `@minItems`                          | `T[]`                                                   | `ArrayLengthConstraint`      | `minItems`                         |
+| `@maxItems`                          | `T[]`                                                   | `ArrayLengthConstraint`      | `maxItems`                         |
+| `@uniqueItems`                       | `T[]`                                                   | `UniquenessConstraint`       | `uniqueItems`                      |
+| `@maxSigFig` (example extension tag) | extension-defined numeric-like types                    | `DecimalPrecisionConstraint` | `x-<vendor>-max-sig-fig` (see 003) |
+| `@const`                             | any                                                     | `ConstConstraint`            | `const`                            |
 
 **Note on integer representation:** There is no `@integer` tag. FormSpec supports `integer` as a first-class data type in the canonical model and JSON Schema output, but TypeScript has no native integer type. On TSDoc-authored TypeScript surfaces, the common pattern is a `number` alias constrained with `@multipleOf 1`; the analyzer canonicalizes that pattern to integer semantics (see 003 §2.1 and 005 §2). Chain DSL may also author integer fields directly.
 
@@ -62,14 +62,14 @@ Constraint tags narrow the set of valid values for a field. Per S1, constraints 
 
 Annotation tags carry a single scalar value. Per C1, they compose via override — the most-specific declaration wins. Annotations do not affect the valid value set.
 
-| Tag            | IR node kind            | Primary schema/UI target                 | Notes                                                                                               |
-| -------------- | ----------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Tag            | IR node kind            | Primary schema/UI target                 | Notes                                                                                                          |
+| -------------- | ----------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `@displayName` | `DisplayNameAnnotation` | JSON Schema `title`, UI Schema label     | Per-field, per-member (`:member` syntax), singular-only on classes/interfaces, and per-variant on array fields |
-| `@apiName`     | `ApiNameAnnotation`     | JSON Schema property names, `$defs` keys | Controls JSON representation names. Per-variant (`:plural`, `:singular`) on classes; bare on fields |
-| `@description` | `DescriptionAnnotation` | JSON Schema `description`                | Longer prose; fallback to TSDoc `@remarks` if absent                                                |
-| `@placeholder` | `PlaceholderAnnotation` | UI Schema only (`options.placeholder`)   | Not a JSON Schema concept                                                                           |
-| `@format`      | `FormatAnnotation`      | JSON Schema `format`                     | Standard JSON Schema formats (`date`, `email`, `uri`, etc.) plus renderer hints                     |
-| `@order`       | `FieldOrderAnnotation`  | UI Schema element order                  | Integer; lower values appear first                                                                  |
+| `@apiName`     | `ApiNameAnnotation`     | JSON Schema property names, `$defs` keys | Controls JSON representation names. Per-variant (`:plural`, `:singular`) on classes; bare on fields            |
+| `@description` | `DescriptionAnnotation` | JSON Schema `description`                | Longer prose; fallback to TSDoc `@remarks` if absent                                                           |
+| `@placeholder` | `PlaceholderAnnotation` | UI Schema only (`options.placeholder`)   | Not a JSON Schema concept                                                                                      |
+| `@format`      | `FormatAnnotation`      | JSON Schema `format`                     | Standard JSON Schema formats (`date`, `email`, `uri`, etc.) plus renderer hints                                |
+| `@order`       | `FieldOrderAnnotation`  | UI Schema element order                  | Integer; lower values appear first                                                                             |
 
 ### 2.3 Ecosystem Tags (Reused Without Modification)
 
@@ -280,7 +280,7 @@ With member-target syntax (for string-literal union members):
  * @displayName :sync Synchronous
  * @displayName :async Asynchronous
  */
-mode: 'sync' | 'async';
+mode: "sync" | "async";
 ```
 
 **Variant qualifiers** — `:singular` and `:plural` — provide context-specific display names for array fields. Classes and interfaces do **not** support plural display names in this revision; they accept only the singular form, either bare or via `:singular`.
@@ -566,9 +566,9 @@ city?: string;  // only shown when both country AND state are selected
 
 **Valid combinations within the current spec revision:**
 
-| Combination                           | Semantics                      | Notes                        |
-| ------------------------------------- | ------------------------------ | ---------------------------- |
-| Multiple `@showWhen` on same field    | AND — all must be true to show | Compiles to `allOf` condition |
+| Combination                           | Semantics                         | Notes                         |
+| ------------------------------------- | --------------------------------- | ----------------------------- |
+| Multiple `@showWhen` on same field    | AND — all must be true to show    | Compiles to `allOf` condition |
 | Multiple `@disableWhen` on same field | AND — all must be true to disable | Compiles to `allOf` condition |
 
 **Cross-axis combinations are invalid in this revision.** A field may use at most one conditional rule axis. Combinations such as `@showWhen` + `@disableWhen` are deferred future work and should currently produce a static error rather than being treated as partially supported behavior.
@@ -791,7 +791,7 @@ Same as path-target — `:` followed by an identifier:
  * @displayName :sync Synchronous Processing
  * @displayName :async Asynchronous Processing
  */
-mode: 'sync' | 'async';
+mode: "sync" | "async";
 ```
 
 This syntax is not used for `enum` or `const enum`. Those types annotate members directly at the declaration site instead (see §9.4).
@@ -846,13 +846,13 @@ Diagnostic codes are symbolic machine-readable identifiers. The diagnostic struc
 
 The following categories group the symbolic codes conceptually:
 
-| Diagnostic category       | Meaning                                                                         |
-| ------------------------- | ------------------------------------------------------------------------------- |
-| Tag recognition           | Unknown tags, missing arguments, disabled tags                                  |
-| Value parsing             | Malformed numeric, regex, JSON, or date values                                  |
-| Type compatibility        | Tags applied to incompatible types                                              |
-| Target resolution         | Invalid path-target, member-target, or scope references                         |
-| Constraint validation     | Contradictions, duplicates, conflicts                                           |
+| Diagnostic category   | Meaning                                                 |
+| --------------------- | ------------------------------------------------------- |
+| Tag recognition       | Unknown tags, missing arguments, disabled tags          |
+| Value parsing         | Malformed numeric, regex, JSON, or date values          |
+| Type compatibility    | Tags applied to incompatible types                      |
+| Target resolution     | Invalid path-target, member-target, or scope references |
+| Constraint validation | Contradictions, duplicates, conflicts                   |
 
 ---
 
@@ -1007,7 +1007,7 @@ Each constraint tag instance produces one `ConstraintNode`:
 // Conceptual mapping (see 001 for authoritative IR types)
 interface ConstraintNode {
   kind: ConstraintKind; // e.g., "NumericBound", "StringLength", "Pattern"
-  bound?: 'minimum' | 'maximum' | 'exclusive-minimum' | 'exclusive-maximum';
+  bound?: "minimum" | "maximum" | "exclusive-minimum" | "exclusive-maximum";
   value: number | string | boolean | null;
   path?: string; // Present when path-target syntax used
   member?: string; // Present when member-target syntax used
@@ -1015,7 +1015,7 @@ interface ConstraintNode {
 }
 
 interface ProvenanceRecord {
-  surface: 'tsdoc'; // vs "chain-dsl"
+  surface: "tsdoc"; // vs "chain-dsl"
   file: string;
   line: number;
   column: number;
@@ -1080,7 +1080,7 @@ type Percent = Integer;
  * @displayName :suspended Suspended
  * @displayName :cancelled Cancelled
  */
-type PlanStatus = 'active' | 'suspended' | 'cancelled';
+type PlanStatus = "active" | "suspended" | "cancelled";
 ```
 
 These compose when used on fields — the field inherits all constraints from the type alias chain:
@@ -1172,25 +1172,25 @@ For `enum` and `const enum` types, display names are annotated directly on each 
 ```typescript
 enum PaymentCardBrand {
   /** @displayName Visa */
-  VISA = 'visa',
+  VISA = "visa",
   /** @displayName MasterCard */
-  MASTERCARD = 'mc',
+  MASTERCARD = "mc",
   /** @displayName American Express */
-  AMEX = 'amex',
+  AMEX = "amex",
 }
 
 const enum OrderStatus {
   /** @displayName Awaiting Processing */
-  Pending = 'pending',
+  Pending = "pending",
   /** @displayName In Progress */
-  Processing = 'processing',
+  Processing = "processing",
   /**
    * @displayName On Its Way
    * @deprecated Use Delivered instead
    */
-  Shipped = 'shipped',
+  Shipped = "shipped",
   /** @displayName Complete */
-  Delivered = 'delivered',
+  Delivered = "delivered",
 }
 ```
 
@@ -1208,7 +1208,7 @@ String literal unions don't have declaration sites for individual members, so th
  * @displayName :batch Batch Processing
  * @description :batch Batched nightly at 2am UTC.
  */
-mode: 'sync' | 'async' | 'batch';
+mode: "sync" | "async" | "batch";
 ```
 
 The `:member` syntax also works on type alias unions:
@@ -1219,7 +1219,7 @@ The `:member` syntax also works on type alias unions:
  * @displayName :suspended Suspended
  * @displayName :cancelled Cancelled
  */
-type PlanStatus = 'active' | 'suspended' | 'cancelled';
+type PlanStatus = "active" | "suspended" | "cancelled";
 ```
 
 **Summary:** For `enum`/`const enum`, annotate members directly at their declaration site — no `:member` syntax needed. The `:member` syntax exists specifically for string literal unions, which have no per-member declaration site. Both approaches produce the same IR.
@@ -1248,34 +1248,34 @@ tags: Tag[];
 
 ## Appendix A: Tag Quick Reference
 
-| Tag                 | Category   | Argument        | Path? | Member? |
-| ------------------- | ---------- | --------------- | ----- | ------- |
-| `@minimum`          | constraint | numeric literal | yes   | no      |
-| `@maximum`          | constraint | numeric literal | yes   | no      |
-| `@exclusiveMinimum` | constraint | numeric literal | yes   | no      |
-| `@exclusiveMaximum` | constraint | numeric literal | yes   | no      |
-| `@multipleOf`       | constraint | numeric literal | yes   | no      |
-| `@minLength`        | constraint | non-neg int     | yes   | no      |
-| `@maxLength`        | constraint | non-neg int     | yes   | no      |
-| `@pattern`          | constraint | regex string    | yes   | no      |
-| `@minItems`         | constraint | non-neg int     | yes   | no      |
-| `@maxItems`         | constraint | non-neg int     | yes   | no      |
-| `@uniqueItems`      | constraint | none (marker)   | yes   | no      |
-| `@maxSigFig` (example extension tag) | constraint | pos int | yes | no |
-| `@const`            | constraint | JSON value      | no    | no      |
-| `@displayName`      | annotation | text            | no    | yes     |
-| `@apiName`          | annotation | identifier      | no    | yes     |
-| `@description`      | annotation | text            | no    | yes     |
-| `@placeholder`      | annotation | text            | no    | no      |
-| `@format`           | annotation | identifier      | yes   | no      |
-| `@order`            | annotation | integer         | no    | no      |
-| `@defaultValue`     | ecosystem  | JSON/text       | yes   | no      |
-| `@deprecated`       | ecosystem  | text?           | no    | yes     |
-| `@example`          | ecosystem  | JSON/text       | no    | no      |
-| `@remarks`          | ecosystem  | text            | no    | no      |
-| `@see`              | ecosystem  | text            | no    | no      |
-| `@group`            | structure  | text            | no    | no      |
-| `@showWhen`         | structure  | field=value     | no    | no      |
-| `@hideWhen`         | structure  | field=value     | no    | no      |
-| `@enableWhen`       | structure  | field=value     | no    | no      |
-| `@disableWhen`      | structure  | field=value     | no    | no      |
+| Tag                                  | Category   | Argument        | Path? | Member? |
+| ------------------------------------ | ---------- | --------------- | ----- | ------- |
+| `@minimum`                           | constraint | numeric literal | yes   | no      |
+| `@maximum`                           | constraint | numeric literal | yes   | no      |
+| `@exclusiveMinimum`                  | constraint | numeric literal | yes   | no      |
+| `@exclusiveMaximum`                  | constraint | numeric literal | yes   | no      |
+| `@multipleOf`                        | constraint | numeric literal | yes   | no      |
+| `@minLength`                         | constraint | non-neg int     | yes   | no      |
+| `@maxLength`                         | constraint | non-neg int     | yes   | no      |
+| `@pattern`                           | constraint | regex string    | yes   | no      |
+| `@minItems`                          | constraint | non-neg int     | yes   | no      |
+| `@maxItems`                          | constraint | non-neg int     | yes   | no      |
+| `@uniqueItems`                       | constraint | none (marker)   | yes   | no      |
+| `@maxSigFig` (example extension tag) | constraint | pos int         | yes   | no      |
+| `@const`                             | constraint | JSON value      | no    | no      |
+| `@displayName`                       | annotation | text            | no    | yes     |
+| `@apiName`                           | annotation | identifier      | no    | yes     |
+| `@description`                       | annotation | text            | no    | yes     |
+| `@placeholder`                       | annotation | text            | no    | no      |
+| `@format`                            | annotation | identifier      | yes   | no      |
+| `@order`                             | annotation | integer         | no    | no      |
+| `@defaultValue`                      | ecosystem  | JSON/text       | yes   | no      |
+| `@deprecated`                        | ecosystem  | text?           | no    | yes     |
+| `@example`                           | ecosystem  | JSON/text       | no    | no      |
+| `@remarks`                           | ecosystem  | text            | no    | no      |
+| `@see`                               | ecosystem  | text            | no    | no      |
+| `@group`                             | structure  | text            | no    | no      |
+| `@showWhen`                          | structure  | field=value     | no    | no      |
+| `@hideWhen`                          | structure  | field=value     | no    | no      |
+| `@enableWhen`                        | structure  | field=value     | no    | no      |
+| `@disableWhen`                       | structure  | field=value     | no    | no      |

--- a/docs/003-json-schema-vocabulary.md
+++ b/docs/003-json-schema-vocabulary.md
@@ -8,17 +8,17 @@ This document specifies how FormSpec's canonical IR maps to JSON Schema 2020-12 
 
 ### Principles Satisfied
 
-| Principle                                          | How this document satisfies it                                                                                                                                              |
-| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **PP6** (JSON Schema as normative output)          | All generated output targets JSON Schema 2020-12. The meta-schema validates every generated document. Custom keywords are declared as a proper vocabulary                   |
-| **PP7** (High-fidelity JSON Schema output)         | Named types are emitted as `$defs` with `$ref`. Custom keywords are emitted as proper namespaced vocabulary members rather than undocumented metadata. The output works standalone   |
-| **E3** (Custom vocabulary keywords are namespaced) | All custom keywords use a configurable `x-<vendor>-` prefix (default `x-formspec-`). The vocabulary URI also includes the vendor prefix                                     |
-| **PP10** (White-labelable)                         | The vendor prefix, vocabulary URI, and `$schema` annotation are all configurable. No hard-coded "formspec" strings appear in generated output when the vendor is overridden |
-| **PP9** (Configurable surface area)                | Custom keywords that represent features disabled by project configuration are not emitted                                                                                   |
-| **B3** (Lossy transformations are configurable)    | Extension-defined precision keywords (e.g., `maxSigFig`) must support configurable precision-loss policies; the default should reject, not silently round                   |
-| **B4** (JSON Schema is the contract boundary)      | The IR is the source of truth; the JSON Schema is derived from it. If they disagree, fix the generator                                                                      |
-| **S1** (Specialization narrows)                    | `allOf` composition preserves and narrows constraints when types specialize                                                                                                 |
-| **PP2** (Inference over declaration)               | Standard JSON Schema keywords are inferred from TypeScript types without requiring author annotation where possible                                                         |
+| Principle                                          | How this document satisfies it                                                                                                                                                     |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PP6** (JSON Schema as normative output)          | All generated output targets JSON Schema 2020-12. The meta-schema validates every generated document. Custom keywords are declared as a proper vocabulary                          |
+| **PP7** (High-fidelity JSON Schema output)         | Named types are emitted as `$defs` with `$ref`. Custom keywords are emitted as proper namespaced vocabulary members rather than undocumented metadata. The output works standalone |
+| **E3** (Custom vocabulary keywords are namespaced) | All custom keywords use a configurable `x-<vendor>-` prefix (default `x-formspec-`). The vocabulary URI also includes the vendor prefix                                            |
+| **PP10** (White-labelable)                         | The vendor prefix, vocabulary URI, and `$schema` annotation are all configurable. No hard-coded "formspec" strings appear in generated output when the vendor is overridden        |
+| **PP9** (Configurable surface area)                | Custom keywords that represent features disabled by project configuration are not emitted                                                                                          |
+| **B3** (Lossy transformations are configurable)    | Extension-defined precision keywords (e.g., `maxSigFig`) must support configurable precision-loss policies; the default should reject, not silently round                          |
+| **B4** (JSON Schema is the contract boundary)      | The IR is the source of truth; the JSON Schema is derived from it. If they disagree, fix the generator                                                                             |
+| **S1** (Specialization narrows)                    | `allOf` composition preserves and narrows constraints when types specialize                                                                                                        |
+| **PP2** (Inference over declaration)               | Standard JSON Schema keywords are inferred from TypeScript types without requiring author annotation where possible                                                                |
 
 ### Relationship to 001 (Canonical IR)
 
@@ -36,18 +36,18 @@ FormSpec targets **JSON Schema 2020-12** (`https://json-schema.org/draft/2020-12
 
 ### 2.1 Primitive Types
 
-| IR type                                           | JSON Schema output                                                                                                                                                  |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `string`                                          | `{ "type": "string" }`                                                                                                                                              |
-| `number`                                          | `{ "type": "number" }`                                                                                                                                              |
-| `integer`                                         | `{ "type": "integer" }`                                                                                                                                             |
-| `bigint`                                          | `{ "type": "integer" }` (schema-level integer semantics; runtime transport/serialization is outside the JSON Schema contract)                                     |
+| IR type                                           | JSON Schema output                                                                                                                                                                        |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `string`                                          | `{ "type": "string" }`                                                                                                                                                                    |
+| `number`                                          | `{ "type": "number" }`                                                                                                                                                                    |
+| `integer`                                         | `{ "type": "integer" }`                                                                                                                                                                   |
+| `bigint`                                          | `{ "type": "integer" }` (schema-level integer semantics; runtime transport/serialization is outside the JSON Schema contract)                                                             |
 | `number` with `MultipleOfConstraint { value: 1 }` | `{ "type": "integer" }` (the canonicalization pipeline recognizes this common TypeScript authoring pattern and emits integer semantics; the redundant `multipleOf: 1` keyword is omitted) |
-| `boolean`                                         | `{ "type": "boolean" }`                                                                                                                                             |
-| `null`                                            | `{ "type": "null" }`                                                                                                                                                |
-| `undefined`                                       | Not emitted (optionality is expressed via `required`, per S8)                                                                                                       |
-| `unknown` / `any`                                 | `{}` (accepts any value)                                                                                                                                            |
-| `never`                                           | `{ "not": {} }`                                                                                                                                                     |
+| `boolean`                                         | `{ "type": "boolean" }`                                                                                                                                                                   |
+| `null`                                            | `{ "type": "null" }`                                                                                                                                                                      |
+| `undefined`                                       | Not emitted (optionality is expressed via `required`, per S8)                                                                                                                             |
+| `unknown` / `any`                                 | `{}` (accepts any value)                                                                                                                                                                  |
+| `never`                                           | `{ "not": {} }`                                                                                                                                                                           |
 
 ### 2.2 String Literal, Number Literal, Boolean Literal
 
@@ -93,17 +93,17 @@ When no per-member metadata exists, the flat `enum` form is preferred (simpler, 
 
 ### 2.5 Object Types
 
-| IR node                              | JSON Schema output                                             |
-| ------------------------------------ | -------------------------------------------------------------- |
-| Object with known properties         | `{ "type": "object", "properties": {...}, "required": [...] }` |
-| Required property                    | Listed in `"required"` array                                   |
-| Optional property                    | Absent from `"required"` array                                 |
-| Index signature `{ [k: string]: T }` | `{ "type": "object", "additionalProperties": <T schema> }`     |
-| `Record<string, T>` / unconstrained string key type | `{ "type": "object", "additionalProperties": <T schema> }` |
-| Finite constrained key set (e.g. `Record<'a' \| 'b', T>`, `Record<keyof SomeFiniteType, T>`) | Expanded to ordinary `"properties"` and `"required"` entries |
-| Pattern-shaped constrained key type (e.g. `Record<\`env_${string}\`, T>`) | `{ "type": "object", "patternProperties": { "<regex>": <T schema> } }` |
-| Mixed (known + index signature)      | `"properties"` + `"additionalProperties"` combined             |
-| Mixed (known + constrained key family) | `"properties"` + `"patternProperties"` combined             |
+| IR node                                                                                      | JSON Schema output                                                     |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Object with known properties                                                                 | `{ "type": "object", "properties": {...}, "required": [...] }`         |
+| Required property                                                                            | Listed in `"required"` array                                           |
+| Optional property                                                                            | Absent from `"required"` array                                         |
+| Index signature `{ [k: string]: T }`                                                         | `{ "type": "object", "additionalProperties": <T schema> }`             |
+| `Record<string, T>` / unconstrained string key type                                          | `{ "type": "object", "additionalProperties": <T schema> }`             |
+| Finite constrained key set (e.g. `Record<'a' \| 'b', T>`, `Record<keyof SomeFiniteType, T>`) | Expanded to ordinary `"properties"` and `"required"` entries           |
+| Pattern-shaped constrained key type (e.g. `Record<\`env\_${string}\`, T>`)                   | `{ "type": "object", "patternProperties": { "<regex>": <T schema> } }` |
+| Mixed (known + index signature)                                                              | `"properties"` + `"additionalProperties"` combined                     |
+| Mixed (known + constrained key family)                                                       | `"properties"` + `"patternProperties"` combined                        |
 
 **`additionalProperties` policy:** When a TypeScript type has only known properties and no index signature, `additionalProperties` is **not** set to `false` by default. Setting it to `false` would cause validation failures when form renderers add extra fields (e.g., `_id`, `_timestamp`). This is intentional and matches B4 (the JSON Schema represents the data contract, not the full TypeScript structural check).
 
@@ -119,35 +119,35 @@ FormSpec does **not** promise arbitrary regex-to-TypeScript or TypeScript-to-reg
 
 ### 2.6 Numeric Constraints
 
-| IR constraint                                           | JSON Schema validation keyword                                                                                                                              |
-| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NumericBoundConstraint { bound: "minimum" }`           | `"minimum"`                                                                                                                                                 |
-| `NumericBoundConstraint { bound: "maximum" }`           | `"maximum"`                                                                                                                                                 |
-| `NumericBoundConstraint { bound: "exclusive-minimum" }` | `"exclusiveMinimum"`                                                                                                                                        |
-| `NumericBoundConstraint { bound: "exclusive-maximum" }` | `"exclusiveMaximum"`                                                                                                                                        |
+| IR constraint                                           | JSON Schema validation keyword                                                                                                                                                                            |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NumericBoundConstraint { bound: "minimum" }`           | `"minimum"`                                                                                                                                                                                               |
+| `NumericBoundConstraint { bound: "maximum" }`           | `"maximum"`                                                                                                                                                                                               |
+| `NumericBoundConstraint { bound: "exclusive-minimum" }` | `"exclusiveMinimum"`                                                                                                                                                                                      |
+| `NumericBoundConstraint { bound: "exclusive-maximum" }` | `"exclusiveMaximum"`                                                                                                                                                                                      |
 | `MultipleOfConstraint`                                  | `"multipleOf"` (when the resolved type is integer and the only source of that integer semantic is `value = 1` on a `number`-derived alias, the redundant `"multipleOf": 1` keyword is omitted — see §2.1) |
 
 ### 2.7 String Constraints
 
 | IR constraint                                   | JSON Schema validation keyword |
-| ----------------------------------------------- | ------------------- |
-| `StringLengthConstraint { bound: "minLength" }` | `"minLength"`       |
-| `StringLengthConstraint { bound: "maxLength" }` | `"maxLength"`       |
-| `PatternConstraint`                             | `"pattern"`         |
-| `FormatAnnotation`                              | `"format"`          |
+| ----------------------------------------------- | ------------------------------ |
+| `StringLengthConstraint { bound: "minLength" }` | `"minLength"`                  |
+| `StringLengthConstraint { bound: "maxLength" }` | `"maxLength"`                  |
+| `PatternConstraint`                             | `"pattern"`                    |
+| `FormatAnnotation`                              | `"format"`                     |
 
 ### 2.8 Annotation → Metadata Keywords
 
-| IR annotation            | JSON Schema annotation key                         |
-| ------------------------ | -------------------------------------------------- |
-| `DisplayNameAnnotation`  | `"title"`                                          |
-| `DescriptionAnnotation`  | `"description"`                                    |
-| `DefaultValueAnnotation` | `"default"`                                        |
-| `ExampleAnnotation[]`    | `"examples"` (array)                               |
+| IR annotation            | JSON Schema annotation key                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------ |
+| `DisplayNameAnnotation`  | `"title"`                                                                                  |
+| `DescriptionAnnotation`  | `"description"`                                                                            |
+| `DefaultValueAnnotation` | `"default"`                                                                                |
+| `ExampleAnnotation[]`    | `"examples"` (array)                                                                       |
 | `DeprecatedAnnotation`   | `"deprecated": true` plus `"x-<vendor>-deprecation-description"` when a message is present |
-| `ReadOnlyAnnotation`     | `"readOnly"`                                       |
-| `WriteOnlyAnnotation`    | `"writeOnly"`                                      |
-| `ConstConstraint`        | `"const"`                                          |
+| `ReadOnlyAnnotation`     | `"readOnly"`                                                                               |
+| `WriteOnlyAnnotation`    | `"writeOnly"`                                                                              |
+| `ConstConstraint`        | `"const"`                                                                                  |
 
 ---
 
@@ -160,7 +160,7 @@ All FormSpec custom keywords use the shape `x-<vendor>-<local-name>`, where `<lo
 ```yaml
 # .formspec.yml
 schema:
-  vendorPrefix: 'x-stripe-' # Current config form; yields keywords like "x-stripe-option-source"
+  vendorPrefix: "x-stripe-" # Current config form; yields keywords like "x-stripe-option-source"
 ```
 
 Throughout this document, the placeholder `<vendor>` represents the vendor segment that appears between `x-` and the next dash. For example, `x-formspec-option-source` uses `<vendor> = formspec`, and `x-stripe-option-source` uses `<vendor> = stripe`.
@@ -455,7 +455,7 @@ The extension can register a configurable policy for precision-loss behavior (B3
 # Consumer's .formspec.yml
 extensions:
   decimal:
-    precisionLoss: 'error' # default: fail on any precision loss
+    precisionLoss: "error" # default: fail on any precision loss
     # precisionLoss: "warn"  # emit warning but continue
     # precisionLoss: "allow" # allow silently (not recommended for financial contexts)
 ```
@@ -510,8 +510,8 @@ Discriminated unions are emitted as `oneOf` with a `required` discriminant in ea
 
 ```typescript
 type Shape =
-  | { kind: 'circle'; radius: number }
-  | { kind: 'rectangle'; width: number; height: number };
+  | { kind: "circle"; radius: number }
+  | { kind: "rectangle"; width: number; height: number };
 ```
 
 ```json
@@ -688,7 +688,7 @@ interface InvoiceFormData {
    * @displayName :paid Paid in Full
    * @defaultValue draft
    */
-  status: 'draft' | 'sent' | 'paid';
+  status: "draft" | "sent" | "paid";
 
   /**
    * @displayName Total Amount
@@ -792,12 +792,12 @@ interface InvoiceFormData {
 
 ## Appendix A: Custom Keyword Summary
 
-| Keyword (default prefix)  | Type     | Validation?                         | Applies to                     |
-| ------------------------- | -------- | ----------------------------------- | ------------------------------ |
-| `x-formspec-option-source`        | string   | Annotation only                     | `type: "string"`                             |
+| Keyword (default prefix)          | Type     | Validation?                         | Applies to                                       |
+| --------------------------------- | -------- | ----------------------------------- | ------------------------------------------------ |
+| `x-formspec-option-source`        | string   | Annotation only                     | `type: "string"`                                 |
 | `x-formspec-option-source-params` | string[] | Annotation only                     | `type: "string"` with `x-formspec-option-source` |
-| `x-formspec-schema-source`        | string   | Annotation only                     | `type: "object"`                             |
-| `x-<vendor>-max-sig-fig`          | integer  | Yes — validates (extension-defined) | Extension-defined types                      |
+| `x-formspec-schema-source`        | string   | Annotation only                     | `type: "object"`                                 |
+| `x-<vendor>-max-sig-fig`          | integer  | Yes — validates (extension-defined) | Extension-defined types                          |
 
 Extension-specific keywords follow the pattern `x-<vendor>-<extension-name>` and are annotation-only unless the extension also provides validator/runtime support per E2.
 

--- a/docs/004-tooling.md
+++ b/docs/004-tooling.md
@@ -24,7 +24,7 @@ The tooling layer sits between the authoring surface (TSDoc tags, chain DSL) and
 | **D5** (auto-fixes when unambiguous)                | Rules offer auto-fixes only when intent is unambiguous. The confidence threshold is explicit: if more than one reasonable fix exists, the diagnostic describes the issue and defers to the author |
 | **D6** (machine-consumable diagnostics)             | The diagnostic format supports LSP, SARIF, and ESLint's RuleTester. Structured codes enable filtering and aggregation in CI                                                                       |
 | **PP9** (configurable surface area)                 | Every FormSpec diagnostic severity is overridable via project configuration. Rules can be set to `off`, `warn`, or `error` per project                                                            |
-| **PP10** (white-labelable)                          | Diagnostic presentation is configurable for downstream organizations, while canonical machine-readable diagnostic codes remain stable symbolic identifiers                                           |
+| **PP10** (white-labelable)                          | Diagnostic presentation is configurable for downstream organizations, while canonical machine-readable diagnostic codes remain stable symbolic identifiers                                        |
 | **PP11** (consumer-controlled messaging)            | Diagnostic message templates are overridable via project configuration. Organizations can substitute their own terminology, instructional text, and style                                         |
 | **E1** (built-in types use the same extension API)  | The ESLint rule infrastructure described here is the same API used by built-in rules. Extensions get tag-on-type validation, contradiction detection, and path-target resolution for free         |
 
@@ -123,8 +123,8 @@ Extension-registered constraints participate in contradiction detection by decla
  * Both surfaces supply their own TypeScript program and type checker.
  */
 interface TypeResolutionContext {
-  readonly program: import('typescript').Program;
-  readonly checker: import('typescript').TypeChecker;
+  readonly program: import("typescript").Program;
+  readonly checker: import("typescript").TypeChecker;
 }
 
 /**
@@ -138,7 +138,7 @@ interface AnalysisResult {
   /** Raw parsed tags, even if some produced errors. Used by the language server. */
   readonly parsedTags: readonly ParsedTag[];
   /** The resolved TypeScript type of the field, used by language server hover. */
-  readonly resolvedType: import('typescript').Type | undefined;
+  readonly resolvedType: import("typescript").Type | undefined;
 }
 
 /**
@@ -146,7 +146,7 @@ interface AnalysisResult {
  * Both ESLint rules and language server handlers call this function.
  */
 declare function analyzeDeclaration(
-  node: import('typescript').Declaration,
+  node: import("typescript").Declaration,
   context: TypeResolutionContext,
   config: FormSpecConfig
 ): AnalysisResult;
@@ -164,13 +164,13 @@ Per A7, ESLint owns all validation and auto-fix logic. The `@formspec/eslint-plu
 
 Each rule category maps directly to a diagnostic category from 002 §6:
 
-| Rule category           | Diagnostic families                                                  | Responsibility                                    |
-| ----------------------- | -------------------------------------------------------------------- | ------------------------------------------------- |
-| `tag-recognition`       | `UNKNOWN_TAG`, `MISSING_TAG_ARGUMENT`, `TAG_DISABLED`                | Unknown tags, missing arguments, disabled tags    |
-| `value-parsing`         | `INVALID_NUMERIC_VALUE`, `INVALID_NON_NEGATIVE_INTEGER`, related     | Malformed numeric, regex, JSON, and date values   |
-| `type-compatibility`    | `TYPE_MISMATCH`                                                      | Tags applied to incompatible field types          |
-| `target-resolution`     | `UNKNOWN_PATH_TARGET`, `UNKNOWN_MEMBER_TARGET`, related              | Invalid path-target and member-target references  |
-| `constraint-validation` | `CONSTRAINT_CONTRADICTION`, `DUPLICATE_TAG`, related                 | Contradictions, duplicates, rule effect conflicts |
+| Rule category           | Diagnostic families                                              | Responsibility                                    |
+| ----------------------- | ---------------------------------------------------------------- | ------------------------------------------------- |
+| `tag-recognition`       | `UNKNOWN_TAG`, `MISSING_TAG_ARGUMENT`, `TAG_DISABLED`            | Unknown tags, missing arguments, disabled tags    |
+| `value-parsing`         | `INVALID_NUMERIC_VALUE`, `INVALID_NON_NEGATIVE_INTEGER`, related | Malformed numeric, regex, JSON, and date values   |
+| `type-compatibility`    | `TYPE_MISMATCH`                                                  | Tags applied to incompatible field types          |
+| `target-resolution`     | `UNKNOWN_PATH_TARGET`, `UNKNOWN_MEMBER_TARGET`, related          | Invalid path-target and member-target references  |
+| `constraint-validation` | `CONSTRAINT_CONTRADICTION`, `DUPLICATE_TAG`, related             | Contradictions, duplicates, rule effect conflicts |
 
 Rules within each category are named `formspec/<category>/<specific-rule>`, for example:
 
@@ -185,8 +185,8 @@ Every FormSpec ESLint rule follows the same pattern: it registers an AST visitor
 Rules do not parse TSDoc themselves. They do not call the TypeScript compiler API directly for tag-related lookups. All of that lives in the shared pipeline — rules only interpret the `AnalysisResult`.
 
 ```typescript
-import type { Rule } from 'eslint';
-import { analyzeDeclaration } from '@formspec/build/analysis';
+import type { Rule } from "eslint";
+import { analyzeDeclaration } from "@formspec/build/analysis";
 
 /**
  * Example built-in rule: reports constraint contradictions (`CONSTRAINT_CONTRADICTION`).
@@ -194,10 +194,10 @@ import { analyzeDeclaration } from '@formspec/build/analysis';
  */
 const noContradictions: Rule.RuleModule = {
   meta: {
-    type: 'problem',
+    type: "problem",
     schema: [],
     messages: {
-      contradiction: '{{ message }}',
+      contradiction: "{{ message }}",
     },
   },
   create(context) {
@@ -209,16 +209,16 @@ const noContradictions: Rule.RuleModule = {
 
     return {
       // Visit all TypeScript property/member declarations
-      'PropertyDeclaration, PropertySignature'(node) {
+      "PropertyDeclaration, PropertySignature"(node) {
         const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
         const result = analyzeDeclaration(tsNode, tsContext, getConfig(context));
 
         for (const diag of result.diagnostics) {
-          if (diag.category !== 'constraint-validation') continue;
+          if (diag.category !== "constraint-validation") continue;
 
           context.report({
             node,
-            messageId: 'contradiction',
+            messageId: "contradiction",
             data: { message: diag.message },
             // Auto-fixes are attached by the diagnostic itself (see §7)
             fix: diag.fix ? (fixer) => applyFormSpecFix(fixer, diag.fix!) : undefined,
@@ -236,24 +236,24 @@ The built-in rules cover all diagnostic codes defined in 002 §6. They are group
 
 **`formspec/recommended` rule set:**
 
-| Rule                                            | Codes                                           | Default severity |
-| ----------------------------------------------- | ------- | ---------------- |
-| `tag-recognition/no-unknown-tags`               | `UNKNOWN_TAG`                                   | warn             |
-| `tag-recognition/require-tag-arguments`         | `MISSING_TAG_ARGUMENT`                          | error            |
-| `tag-recognition/no-disabled-tags`              | `TAG_DISABLED`                                  | warn             |
-| `value-parsing/valid-numeric-value`             | `INVALID_NUMERIC_VALUE`                         | error            |
-| `value-parsing/valid-integer-value`             | `INVALID_NON_NEGATIVE_INTEGER`                  | error            |
-| `value-parsing/valid-regex-pattern`             | `INVALID_REGEX_PATTERN`                         | error            |
-| `value-parsing/valid-json-value`                | `INVALID_JSON_VALUE`                            | error            |
-| `type-compatibility/tag-type-check`             | `TYPE_MISMATCH`                                 | error            |
-| `target-resolution/valid-path-target`           | `UNKNOWN_PATH_TARGET`                           | error            |
-| `target-resolution/valid-member-target`         | `UNKNOWN_MEMBER_TARGET`                         | error            |
-| `target-resolution/no-unsupported-targeting`    | `UNSUPPORTED_TARGETING_SYNTAX`                  | error            |
-| `target-resolution/no-member-target-on-object`  | `MEMBER_TARGET_ON_NON_UNION`                    | error            |
-| `constraint-validation/no-contradictions`       | `CONSTRAINT_CONTRADICTION`                      | error            |
-| `constraint-validation/no-duplicate-tags`       | `DUPLICATE_TAG`                                 | warn             |
-| `constraint-validation/no-description-conflict` | `DESCRIPTION_REMARKS_CONFLICT`                  | info             |
-| `constraint-validation/no-contradictory-rules`  | `CONTRADICTORY_RULES`                           | error            |
+| Rule                                            | Codes                          | Default severity |
+| ----------------------------------------------- | ------------------------------ | ---------------- |
+| `tag-recognition/no-unknown-tags`               | `UNKNOWN_TAG`                  | warn             |
+| `tag-recognition/require-tag-arguments`         | `MISSING_TAG_ARGUMENT`         | error            |
+| `tag-recognition/no-disabled-tags`              | `TAG_DISABLED`                 | warn             |
+| `value-parsing/valid-numeric-value`             | `INVALID_NUMERIC_VALUE`        | error            |
+| `value-parsing/valid-integer-value`             | `INVALID_NON_NEGATIVE_INTEGER` | error            |
+| `value-parsing/valid-regex-pattern`             | `INVALID_REGEX_PATTERN`        | error            |
+| `value-parsing/valid-json-value`                | `INVALID_JSON_VALUE`           | error            |
+| `type-compatibility/tag-type-check`             | `TYPE_MISMATCH`                | error            |
+| `target-resolution/valid-path-target`           | `UNKNOWN_PATH_TARGET`          | error            |
+| `target-resolution/valid-member-target`         | `UNKNOWN_MEMBER_TARGET`        | error            |
+| `target-resolution/no-unsupported-targeting`    | `UNSUPPORTED_TARGETING_SYNTAX` | error            |
+| `target-resolution/no-member-target-on-object`  | `MEMBER_TARGET_ON_NON_UNION`   | error            |
+| `constraint-validation/no-contradictions`       | `CONSTRAINT_CONTRADICTION`     | error            |
+| `constraint-validation/no-duplicate-tags`       | `DUPLICATE_TAG`                | warn             |
+| `constraint-validation/no-description-conflict` | `DESCRIPTION_REMARKS_CONFLICT` | info             |
+| `constraint-validation/no-contradictory-rules`  | `CONTRADICTORY_RULES`          | error            |
 
 ### 3.4 Rule Configuration Interface
 
@@ -263,7 +263,7 @@ Per PP9, every rule's severity is overridable in the project's ESLint configurat
 
 ```typescript
 // In the consumer's eslint.config.js — minimal setup using the recommended flat config
-import formspec from '@formspec/eslint-plugin';
+import formspec from "@formspec/eslint-plugin";
 
 export default [
   // Spread the recommended config to enable all built-in rules at their default severities
@@ -275,16 +275,16 @@ Rules can then be adjusted individually:
 
 ```typescript
 // In the consumer's eslint.config.js
-import formspec from '@formspec/eslint-plugin';
+import formspec from "@formspec/eslint-plugin";
 
 export default [
   ...formspec.configs.recommended,
   {
     rules: {
       // Override a specific rule's severity
-      'formspec/tag-recognition/no-unknown-tags': 'error',
+      "formspec/tag-recognition/no-unknown-tags": "error",
       // Disable a rule entirely
-      'formspec/constraint-validation/no-duplicate-tags': 'off',
+      "formspec/constraint-validation/no-duplicate-tags": "off",
     },
   },
 ];
@@ -297,7 +297,7 @@ For message template overrides (PP11), the consumer configures them in `.formspe
 diagnostics:
   messages:
     UNKNOWN_TAG: 'Unrecognized tag "@{tagName}". Valid tags: {validTags}.'
-    CONSTRAINT_CONTRADICTION: 'Conflicting constraints detected: {details}'
+    CONSTRAINT_CONTRADICTION: "Conflicting constraints detected: {details}"
 ```
 
 Message templates use `{placeholder}` syntax. The available placeholders for each code are documented in 002 §6 and are part of the stable public API.
@@ -328,14 +328,14 @@ For example, a `@maxSigFig` tag declared with `applicableTypes: ["Decimal"]` aut
 Extensions write ESLint rules only for domain logic that goes beyond what `defineConstraintTag` can express declaratively. The `createConstraintTagRule` factory from `@formspec/eslint-plugin/base` handles all the boilerplate (tag location extraction, type applicability, path-target resolution, provenance attachment, diagnostic emission per D1–D4); the extension provides only the domain-specific predicate:
 
 ```typescript
-import { createConstraintTagRule } from '@formspec/eslint-plugin/base';
+import { createConstraintTagRule } from "@formspec/eslint-plugin/base";
 
 // This rule validates @maxSigFig usage beyond what defineConstraintTag declares.
 // It does NOT need to re-implement type resolution, path-target syntax,
 // provenance tracking, or contradiction detection — the pipeline handles those.
 export const maxSigFigRule = createConstraintTagRule({
-  tag: '@maxSigFig',
-  applicableTypes: ['Decimal'],
+  tag: "@maxSigFig",
+  applicableTypes: ["Decimal"],
   valueParser: parsePositiveInt,
   contradictionCheck: (accumulated, proposed) =>
     proposed > accumulated
@@ -350,15 +350,15 @@ Extension rules receive an `AnalysisResult` from the shared pipeline. Tags that 
 
 By declaring a tag via `defineConstraintTag` (see 005 §4), an extension gets the following without writing any rule code:
 
-| Capability                                      | Mechanism                                                                       |
-| ----------------------------------------------- | ------------------------------------------------------------------------------- |
-| Parse error reporting (`INVALID_*`)                  | `valueParser` declaration → pipeline runs the right parser                           |
-| Type applicability checking (`TYPE_MISMATCH`)       | `applicableTypes` declaration → pipeline checks tag against field type               |
-| Path-target validation (`UNKNOWN_PATH_TARGET`, related) | Pipeline resolves `:subfield` modifiers; produces errors for unknown properties  |
-| Member-target validation (`UNKNOWN_MEMBER_TARGET`, related) | Pipeline validates `:member` references against string literal union members |
-| Contradiction detection (`CONSTRAINT_CONTRADICTION`) | `contradictionCheck` predicate → pipeline compares constraint pairs                  |
-| Duplicate detection (`DUPLICATE_TAG`)              | `composition: "intersection"` on same target → pipeline emits duplicate warning      |
-| Provenance tracking (S3, D2)                    | Pipeline records source location for every constraint node automatically        |
+| Capability                                                  | Mechanism                                                                       |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Parse error reporting (`INVALID_*`)                         | `valueParser` declaration → pipeline runs the right parser                      |
+| Type applicability checking (`TYPE_MISMATCH`)               | `applicableTypes` declaration → pipeline checks tag against field type          |
+| Path-target validation (`UNKNOWN_PATH_TARGET`, related)     | Pipeline resolves `:subfield` modifiers; produces errors for unknown properties |
+| Member-target validation (`UNKNOWN_MEMBER_TARGET`, related) | Pipeline validates `:member` references against string literal union members    |
+| Contradiction detection (`CONSTRAINT_CONTRADICTION`)        | `contradictionCheck` predicate → pipeline compares constraint pairs             |
+| Duplicate detection (`DUPLICATE_TAG`)                       | `composition: "intersection"` on same target → pipeline emits duplicate warning |
+| Provenance tracking (S3, D2)                                | Pipeline records source location for every constraint node automatically        |
 
 The extension rule only needs to express logic that is genuinely specific to its domain.
 
@@ -506,16 +506,16 @@ interface FormSpecDiagnostic {
    * The category string corresponding to the code prefix.
    */
   readonly category:
-    | 'tag-recognition'
-    | 'value-parsing'
-    | 'type-compatibility'
-    | 'target-resolution'
-    | 'constraint-validation';
+    | "tag-recognition"
+    | "value-parsing"
+    | "type-compatibility"
+    | "target-resolution"
+    | "constraint-validation";
 
   /**
    * The diagnostic severity. Configurable per PP9.
    */
-  readonly severity: 'error' | 'warning' | 'info';
+  readonly severity: "error" | "warning" | "info";
 
   /**
    * The human-readable message. Overridable via PP11.
@@ -599,12 +599,12 @@ For IDE display (D6), the language server maps `FormSpecDiagnostic` to the LSP `
 ```typescript
 function toLanguageServerDiagnostic(
   diag: FormSpecDiagnostic
-): import('vscode-languageclient').Diagnostic {
+): import("vscode-languageclient").Diagnostic {
   return {
     range: sourceLocationToRange(diag.location),
     severity: severityToLSP(diag.severity),
     code: diag.code,
-    source: 'formspec',
+    source: "formspec",
     message: diag.message,
     relatedInformation: diag.relatedLocations.map((loc, i) => ({
       location: { uri: fileUri(loc.file), range: sourceLocationToRange(loc) },
@@ -625,17 +625,17 @@ The `data` field carries the `fix` payload for use by LSP code action requests �
 
 Fixes are offered only when the intent is unambiguous and the transformation is purely mechanical (D5). The guiding question is: "Is there exactly one reasonable thing the author should do here?"
 
-| Scenario                                                  | Fix offered?                     | Rationale                                        |
-| --------------------------------------------------------- | -------------------------------- | ------------------------------------------------ |
-| Unknown tag with close match (edit distance ≤ 2)          | Yes — rename to the matched tag  | Only one plausible intent                        |
-| Disabled tag present                                      | Yes — remove the tag             | Only one valid action: remove it                 |
-| Float passed to integer-only tag (e.g., `@minLength 1.0`) | Yes — truncate to `1`            | Clearly a formatting mistake                     |
-| Duplicate tag (`DUPLICATE_TAG`) — second instance wins    | Yes — remove first               | Composition rule is clear (C1)                   |
-| `@description` + `@remarks` conflict (`DESCRIPTION_REMARKS_CONFLICT`) | Yes — remove `@remarks` | `@description` always wins per C1                |
-| Unknown path-target with close match (≤ 2 edits)          | Yes — rename to matched property | Only one plausible property                      |
-| Constraint contradiction (`CONSTRAINT_CONTRADICTION`)     | No                               | The author must decide which constraint is wrong |
-| Tag applied to wrong type (`TYPE_MISMATCH`)               | No                               | The author must change the field type or the tag |
-| Missing required argument (`MISSING_TAG_ARGUMENT`)        | No                               | The intent (which value?) is unknown             |
+| Scenario                                                              | Fix offered?                     | Rationale                                        |
+| --------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------ |
+| Unknown tag with close match (edit distance ≤ 2)                      | Yes — rename to the matched tag  | Only one plausible intent                        |
+| Disabled tag present                                                  | Yes — remove the tag             | Only one valid action: remove it                 |
+| Float passed to integer-only tag (e.g., `@minLength 1.0`)             | Yes — truncate to `1`            | Clearly a formatting mistake                     |
+| Duplicate tag (`DUPLICATE_TAG`) — second instance wins                | Yes — remove first               | Composition rule is clear (C1)                   |
+| `@description` + `@remarks` conflict (`DESCRIPTION_REMARKS_CONFLICT`) | Yes — remove `@remarks`          | `@description` always wins per C1                |
+| Unknown path-target with close match (≤ 2 edits)                      | Yes — rename to matched property | Only one plausible property                      |
+| Constraint contradiction (`CONSTRAINT_CONTRADICTION`)                 | No                               | The author must decide which constraint is wrong |
+| Tag applied to wrong type (`TYPE_MISMATCH`)                           | No                               | The author must change the field type or the tag |
+| Missing required argument (`MISSING_TAG_ARGUMENT`)                    | No                               | The intent (which value?) is unknown             |
 
 ### 7.2 ESLint Fixer
 
@@ -647,9 +647,9 @@ Auto-fixes that modify source code go through ESLint's `RuleFixer` API. This ens
  * Called from the rule's create() function when building the report.
  */
 function applyFormSpecFix(
-  fixer: import('eslint').Rule.RuleFixer,
+  fixer: import("eslint").Rule.RuleFixer,
   fix: DiagnosticFix
-): import('eslint').Rule.Fix | import('eslint').Rule.Fix[] {
+): import("eslint").Rule.Fix | import("eslint").Rule.Fix[] {
   return fix.changes.map((change) =>
     fixer.replaceTextRange([change.range.start, change.range.end], change.newText)
   );
@@ -666,10 +666,8 @@ The same `fix` payload from `FormSpecDiagnostic` is also surfaced as an LSP `Cod
 /**
  * Converts a DiagnosticFix into an LSP WorkspaceEdit for the code action response.
  */
-function toWorkspaceEdit(
-  fix: DiagnosticFix
-): import('vscode-languageserver').WorkspaceEdit {
-  const changes: Record<string, import('vscode-languageserver').TextEdit[]> = {};
+function toWorkspaceEdit(fix: DiagnosticFix): import("vscode-languageserver").WorkspaceEdit {
+  const changes: Record<string, import("vscode-languageserver").TextEdit[]> = {};
 
   for (const change of fix.changes) {
     const uri = fileUri(change.file);
@@ -714,13 +712,13 @@ export default [
       ...formspec.configs.recommended.rules,
 
       // Upgrade a warning to an error for this project
-      'formspec/tag-recognition/no-unknown-tags': 'error',
+      "formspec/tag-recognition/no-unknown-tags": "error",
 
       // Downgrade an error to a warning (e.g., during migration)
-      'formspec/type-compatibility/tag-type-check': 'warn',
+      "formspec/type-compatibility/tag-type-check": "warn",
 
       // Disable a rule entirely
-      'formspec/constraint-validation/no-duplicate-tags': 'off',
+      "formspec/constraint-validation/no-duplicate-tags": "off",
     },
   },
 ];
@@ -771,7 +769,7 @@ Extensions can declare configuration keys that appear under the `extensions:` na
 extensions:
   decimal:
     maxSigFigUpperLimit: 38 # Passed to the extension at initialization
-    precisionLoss: 'error' # B3 — configurable lossy transformation policy
+    precisionLoss: "error" # B3 — configurable lossy transformation policy
 ```
 
 This enables the Outcome 8 scenario from 003 §6.1 without requiring the extension to define its own configuration file or parsing logic.
@@ -780,13 +778,13 @@ This enables the Outcome 8 scenario from 003 §6.1 without requiring the extensi
 
 ## Appendix A: Diagnostic Category Quick Reference
 
-| Category              | Representative symbolic codes                               | Responsibility                                    |
-| --------------------- | ----------------------------------------------------------- | ------------------------------------------------- |
-| Tag recognition       | `UNKNOWN_TAG`, `MISSING_TAG_ARGUMENT`, `TAG_DISABLED`       | Unknown tags, missing arguments, disabled tags    |
-| Value parsing         | `INVALID_NUMERIC_VALUE`, `INVALID_REGEX_PATTERN`, related   | Malformed numeric, regex, JSON, and date values   |
-| Type compatibility    | `TYPE_MISMATCH`                                             | Tags applied to incompatible field types          |
-| Target resolution     | `UNKNOWN_PATH_TARGET`, `UNKNOWN_MEMBER_TARGET`, related     | Invalid path-target and member-target references  |
-| Constraint validation | `CONSTRAINT_CONTRADICTION`, `DUPLICATE_TAG`, related        | Contradictions, duplicates, rule effect conflicts |
+| Category              | Representative symbolic codes                             | Responsibility                                    |
+| --------------------- | --------------------------------------------------------- | ------------------------------------------------- |
+| Tag recognition       | `UNKNOWN_TAG`, `MISSING_TAG_ARGUMENT`, `TAG_DISABLED`     | Unknown tags, missing arguments, disabled tags    |
+| Value parsing         | `INVALID_NUMERIC_VALUE`, `INVALID_REGEX_PATTERN`, related | Malformed numeric, regex, JSON, and date values   |
+| Type compatibility    | `TYPE_MISMATCH`                                           | Tags applied to incompatible field types          |
+| Target resolution     | `UNKNOWN_PATH_TARGET`, `UNKNOWN_MEMBER_TARGET`, related   | Invalid path-target and member-target references  |
+| Constraint validation | `CONSTRAINT_CONTRADICTION`, `DUPLICATE_TAG`, related      | Contradictions, duplicates, rule effect conflicts |
 
 See 002 §6 for the individual diagnostic code definitions.
 
@@ -794,17 +792,17 @@ See 002 §6 for the individual diagnostic code definitions.
 
 ## Appendix B: ESLint vs. Language Server Responsibility Matrix
 
-| Capability                        | ESLint        | Language Server           | Notes                                                 |
-| --------------------------------- | ------------- | ------------------------- | ----------------------------------------------------- |
-| Parse error detection             | Yes           | No                        | ESLint only; surfaced in editor via vscode-eslint     |
-| Type applicability checking       | Yes           | No                        | ESLint rule `tag-type-check`                          |
-| Contradiction detection           | Yes           | No                        | ESLint only; surfaced in editor via vscode-eslint     |
-| Auto-fix application              | Yes (`--fix`) | Yes (code action)         | Same `DiagnosticFix` payload drives both              |
-| Tag name completions              | No            | Yes                       | LS-only authoring experience (A7)                     |
-| Path/member-target completions    | No            | Yes                       | LS-only authoring experience (A7)                     |
-| Hover (tag docs, provenance)      | No            | Yes                       | Requires cursor position                              |
-| Go-to-definition (`{@link}`)      | No            | Yes                       | TypeScript LS handles; FormSpec ensures participation |
-| Signature help                    | No            | Yes                       | Requires cursor position and incremental state        |
-| Bulk fix (fix-all)                | Yes           | Yes (delegates to ESLint) | LS `source.fixAll.formspec` action                    |
+| Capability                     | ESLint        | Language Server           | Notes                                                 |
+| ------------------------------ | ------------- | ------------------------- | ----------------------------------------------------- |
+| Parse error detection          | Yes           | No                        | ESLint only; surfaced in editor via vscode-eslint     |
+| Type applicability checking    | Yes           | No                        | ESLint rule `tag-type-check`                          |
+| Contradiction detection        | Yes           | No                        | ESLint only; surfaced in editor via vscode-eslint     |
+| Auto-fix application           | Yes (`--fix`) | Yes (code action)         | Same `DiagnosticFix` payload drives both              |
+| Tag name completions           | No            | Yes                       | LS-only authoring experience (A7)                     |
+| Path/member-target completions | No            | Yes                       | LS-only authoring experience (A7)                     |
+| Hover (tag docs, provenance)   | No            | Yes                       | Requires cursor position                              |
+| Go-to-definition (`{@link}`)   | No            | Yes                       | TypeScript LS handles; FormSpec ensures participation |
+| Signature help                 | No            | Yes                       | Requires cursor position and incremental state        |
+| Bulk fix (fix-all)             | Yes           | Yes (delegates to ESLint) | LS `source.fixAll.formspec` action                    |
 
 The asymmetry is intentional (A7): if a capability requires cursor position, incremental typing state, or live feedback during composition, it belongs in the language server. Everything else belongs in ESLint where it can run in CI without an editor.

--- a/docs/005-numeric-types.md
+++ b/docs/005-numeric-types.md
@@ -8,15 +8,15 @@ This document specifies how FormSpec handles built-in numeric types (`number`, `
 
 ### Principles Satisfied
 
-| Section                               | Principles              |
-| ------------------------------------- | ----------------------- |
-| Built-in numeric types                | PP2, PP3, S4, S7, B3    |
-| Integer semantics and derivation      | PP3, S1, S2, S4, C1     |
-| Extension numeric types               | E1, E2, E3, E4, E5, PP3 |
-| Type alias chains                     | PP3, S1, C1             |
-| Extension case study: DateOnly        | E1, E5, S5              |
-| Extension case study: MonetaryAmount  | S5, PP3, C1, B4         |
-| Constraint composition                | S1, S2, C1              |
+| Section                              | Principles              |
+| ------------------------------------ | ----------------------- |
+| Built-in numeric types               | PP2, PP3, S4, S7, B3    |
+| Integer semantics and derivation     | PP3, S1, S2, S4, C1     |
+| Extension numeric types              | E1, E2, E3, E4, E5, PP3 |
+| Type alias chains                    | PP3, S1, C1             |
+| Extension case study: DateOnly       | E1, E5, S5              |
+| Extension case study: MonetaryAmount | S5, PP3, C1, B4         |
+| Constraint composition               | S1, S2, C1              |
 
 ### Scope and Relationship to Other Documents
 
@@ -284,7 +284,7 @@ interface CustomTypeConfig<T extends string> {
   /** Base JSON Schema emitted for bare fields of this type (no constraints). */
   jsonSchemaBase: Record<string, unknown>;
   /** IR node emitted for fields of this type. */
-  irNode: { kind: 'custom'; typeId: string; payload: Record<string, unknown> };
+  irNode: { kind: "custom"; typeId: string; payload: Record<string, unknown> };
 }
 
 declare function defineCustomType<T extends string>(
@@ -296,27 +296,25 @@ declare function defineCustomType<T extends string>(
 interface ConstraintTagConfig {
   tag: `@${string}`;
   /** "set-influencing" narrows the valid value set; "annotation" is metadata-only. */
-  kind: 'set-influencing' | 'annotation';
+  kind: "set-influencing" | "annotation";
   /** How multiple occurrences compose. "intersection" = tightest wins (C1). */
-  composition: 'intersection' | 'override';
+  composition: "intersection" | "override";
   /** Returns an error descriptor if `proposed` broadens `inherited`, else null. */
   contradictionCheck: (
     inherited: unknown,
     proposed: unknown
-  ) => { kind: 'error'; message: string } | null;
+  ) => { kind: "error"; message: string } | null;
   applicableTypes: string[];
   valueParser: (raw: string) => unknown;
   irNode: (value: unknown) => {
-    kind: 'constraint';
-    constraintKind: 'custom';
+    kind: "constraint";
+    constraintKind: "custom";
     extensionId: string;
     value: unknown;
   };
 }
 
-declare function defineConstraintTag(
-  config: ConstraintTagConfig
-): ConstraintTagRegistration;
+declare function defineConstraintTag(config: ConstraintTagConfig): ConstraintTagRegistration;
 
 // --- Broadening an existing built-in constraint tag ---
 
@@ -337,9 +335,9 @@ interface VocabularyKeywordConfig {
   /** The logical keyword name (vendor prefix is injected at registration time). */
   logicalName: string;
   /** "validation" affects whether a value is accepted; "annotation" is metadata only. */
-  kind: 'validation' | 'annotation';
+  kind: "validation" | "annotation";
   /** The JSON Schema type of the keyword's schema value. */
-  schemaType: 'integer' | 'number' | 'string' | 'boolean' | 'array' | 'object';
+  schemaType: "integer" | "number" | "string" | "boolean" | "array" | "object";
   /** The IR constraint extensionId that triggers emission of this keyword. */
   emitFrom: string;
 }
@@ -366,21 +364,21 @@ export type Decimal = string & { readonly [_decimal]: true };
 
 // Extension registration (see E5 — extensions are npm packages with
 // the "formspec-extension" keyword in their package.json)
-import { defineExtension, defineCustomType } from '@formspec/core';
+import { defineExtension, defineCustomType } from "@formspec/core";
 
 export default defineExtension({
-  name: 'decimal',
+  name: "decimal",
   types: [
     defineCustomType({
-      typeName: 'Decimal',
+      typeName: "Decimal",
       // The module path where the TypeScript type is declared.
       // The analyzer uses this to recognize `Decimal` fields in user code.
-      typeModule: '@myorg/formspec-decimal',
+      typeModule: "@myorg/formspec-decimal",
       // How to emit this type in JSON Schema.
       // For string-backed decimal, the JSON Schema type is "string".
-      jsonSchemaBase: { type: 'string' },
+      jsonSchemaBase: { type: "string" },
       // The IR node to use for this type.
-      irNode: { kind: 'custom', typeId: 'x-myorg/decimal/Decimal', payload: {} },
+      irNode: { kind: "custom", typeId: "x-myorg/decimal/Decimal", payload: {} },
     }),
   ],
 });
@@ -393,37 +391,37 @@ After registration, the analyzer recognizes fields typed as `Decimal` and includ
 The extension declares that `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, and `@multipleOf` are valid on `Decimal` fields. The extension provides a parser for decimal-literal tag values (since the built-in parser works with `number` precision; decimals may exceed this):
 
 ```typescript
-import { defineExtension, broadenConstraintTag } from '@formspec/core';
+import { defineExtension, broadenConstraintTag } from "@formspec/core";
 
 export default defineExtension({
-  name: 'decimal',
+  name: "decimal",
   // ...
   constraintTagBroadening: [
     broadenConstraintTag({
-      tag: '@minimum',
-      additionalTypes: ['Decimal'],
+      tag: "@minimum",
+      additionalTypes: ["Decimal"],
       // The extension provides its own value parser for decimal literals.
       // The built-in parser would use Number() and lose precision.
       valueParser: parseDecimalLiteral,
     }),
     broadenConstraintTag({
-      tag: '@maximum',
-      additionalTypes: ['Decimal'],
+      tag: "@maximum",
+      additionalTypes: ["Decimal"],
       valueParser: parseDecimalLiteral,
     }),
     broadenConstraintTag({
-      tag: '@exclusiveMinimum',
-      additionalTypes: ['Decimal'],
+      tag: "@exclusiveMinimum",
+      additionalTypes: ["Decimal"],
       valueParser: parseDecimalLiteral,
     }),
     broadenConstraintTag({
-      tag: '@exclusiveMaximum',
-      additionalTypes: ['Decimal'],
+      tag: "@exclusiveMaximum",
+      additionalTypes: ["Decimal"],
       valueParser: parseDecimalLiteral,
     }),
     broadenConstraintTag({
-      tag: '@multipleOf',
-      additionalTypes: ['Decimal'],
+      tag: "@multipleOf",
+      additionalTypes: ["Decimal"],
       valueParser: parseDecimalLiteral,
     }),
   ],
@@ -437,36 +435,36 @@ After this registration, applying `@minimum 0.01` to a `Decimal` field is valid,
 The consumer introduces `@maxSigFig` — a new constraint tag that limits the number of significant figures a decimal value may carry:
 
 ```typescript
-import { defineExtension, defineConstraintTag } from '@formspec/core';
+import { defineExtension, defineConstraintTag } from "@formspec/core";
 
 export default defineExtension({
-  name: 'decimal',
+  name: "decimal",
   // ...
   constraintTags: [
     defineConstraintTag({
-      tag: '@maxSigFig',
+      tag: "@maxSigFig",
       // Set-influencing: narrows the valid value set (C1)
-      kind: 'set-influencing',
+      kind: "set-influencing",
       // Composition rule: intersection — lower maxSigFig wins (S1, C1)
-      composition: 'intersection',
+      composition: "intersection",
       // Contradiction check: if inherited maxSigFig < proposed maxSigFig, error (S2)
       contradictionCheck: (inherited, proposed) =>
         proposed > inherited
           ? {
-              kind: 'error',
+              kind: "error",
               message: `@maxSigFig ${proposed} is broader than inherited @maxSigFig ${inherited}`,
             }
           : null,
-      applicableTypes: ['Decimal'],
+      applicableTypes: ["Decimal"],
       valueParser: (raw) => {
         const n = parseInt(raw, 10);
-        if (isNaN(n) || n <= 0) throw new Error('@maxSigFig requires a positive integer');
+        if (isNaN(n) || n <= 0) throw new Error("@maxSigFig requires a positive integer");
         return n;
       },
       irNode: (value) => ({
-        kind: 'constraint',
-        constraintKind: 'custom',
-        extensionId: 'x-myorg/decimal/maxSigFig',
+        kind: "constraint",
+        constraintKind: "custom",
+        extensionId: "x-myorg/decimal/maxSigFig",
         value,
       }),
     }),
@@ -489,15 +487,15 @@ Rule code is only needed when an extension wants authoring-time checks that go b
 
 ```typescript
 // In the extension's ESLint plugin
-import { createConstraintTagRule } from '@formspec/eslint-plugin/base';
+import { createConstraintTagRule } from "@formspec/eslint-plugin/base";
 
 // Optional: only needed for richer, domain-specific authoring checks
 // beyond what defineConstraintTag already declares.
 export const decimalWarningRule = createConstraintTagRule({
-  tag: '@maxSigFig',
+  tag: "@maxSigFig",
   customValidate: ({ value }) => {
     if (value > 18) {
-      return 'Values above 18 significant figures may be impractical for this renderer.';
+      return "Values above 18 significant figures may be impractical for this renderer.";
     }
     return null;
   },
@@ -511,22 +509,22 @@ The `createConstraintTagRule` factory handles the boilerplate for these optional
 The extension registers a custom JSON Schema keyword for `@maxSigFig`. The generator emits it when the constraint is present:
 
 ```typescript
-import { defineExtension, defineVocabularyKeyword } from '@formspec/core';
+import { defineExtension, defineVocabularyKeyword } from "@formspec/core";
 
 export default defineExtension({
-  name: 'decimal',
+  name: "decimal",
   // ...
   vocabularyKeywords: [
     defineVocabularyKeyword({
       // The keyword name uses the configured vendor prefix (E3).
       // At registration time the vendor prefix from .formspec.yml is
       // substituted; the extension sees the logical name.
-      logicalName: 'maxSigFig',
+      logicalName: "maxSigFig",
       // This keyword validates — it affects whether a value is accepted.
-      kind: 'validation',
-      schemaType: 'integer',
+      kind: "validation",
+      schemaType: "integer",
       // The IR constraint kind that triggers emission of this keyword.
-      emitFrom: 'x-myorg/decimal/maxSigFig',
+      emitFrom: "x-myorg/decimal/maxSigFig",
     }),
   ],
 });
@@ -556,7 +554,7 @@ interface DecimalKeywordDefinition {
 }
 
 export const maxSigFigKeyword: DecimalKeywordDefinition = {
-  keyword: 'x-myorg-maxSigFig',
+  keyword: "x-myorg-maxSigFig",
   validate: function validateMaxSigFig(schema: number, data: string): boolean {
     // Consumer provides their own precision library here.
     // FormSpec provides no opinion on how to count sig figs.
@@ -567,7 +565,7 @@ export const maxSigFigKeyword: DecimalKeywordDefinition = {
 };
 
 export const minimumDecimalKeyword: DecimalKeywordDefinition = {
-  keyword: 'x-myorg-minimum',
+  keyword: "x-myorg-minimum",
   validate: function validateDecimalMinimum(schema: string, data: string): boolean {
     return compareDecimal(data, schema) >= 0;
   },
@@ -619,7 +617,7 @@ The extension supports the B3 configurable-lossy-transformation requirement:
 # Consumer's .formspec.yml
 extensions:
   decimal:
-    precisionLoss: 'error' # default: fail on precision loss
+    precisionLoss: "error" # default: fail on precision loss
     # precisionLoss: "warn"   # allow with diagnostic
     # precisionLoss: "allow"  # allow silently (not recommended for financial use)
 ```
@@ -782,9 +780,9 @@ This composition is performed in the Validate phase of the pipeline (A5), after 
 
 ## Appendix: Open Decisions Summary
 
-| #    | Section | Question                                                                                                                                                             | Status                                                                                                    |
-| ---- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| OD-1 | §3.1    | Should type alias resolution be eager (at analysis time) or lazy (at generation time)?                                                                               | Eager — resolved at Canonicalize phase to enable Validate phase contradiction detection                   |
+| #    | Section | Question                                                                                                                                                             | Status                                                                                                                                                            |
+| ---- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OD-1 | §3.1    | Should type alias resolution be eager (at analysis time) or lazy (at generation time)?                                                                               | Eager — resolved at Canonicalize phase to enable Validate phase contradiction detection                                                                           |
 | OD-2 | §3.3    | Should the generator emit `{ "type": "integer" }` or `{ "type": "number", "multipleOf": 1 }` for aliases with `MultipleOfConstraint(1)`?                             | **DECIDED:** `{ "type": "integer" }`. Integer is a first-class FormSpec numeric kind; `number + @multipleOf 1` is a TSDoc authoring path that canonicalizes to it |
-| OD-3 | §4.3    | Should `broadenConstraintTag` be a compile-time registration or a runtime registration?                                                                              | Compile-time, via extension npm package loaded at build time (E5)                                         |
-| OD-4 | §6      | When a type alias inherits subfield constraints, should the generator always emit `allOf` + `$ref`, or inline when the alias adds only a single subfield constraint? | Always `allOf` + `$ref` for consistency and high-fidelity output (PP7)                                    |
+| OD-3 | §4.3    | Should `broadenConstraintTag` be a compile-time registration or a runtime registration?                                                                              | Compile-time, via extension npm package loaded at build time (E5)                                                                                                 |
+| OD-4 | §6      | When a type alias inherits subfield constraints, should the generator always emit `allOf` + `$ref`, or inline when the alias adds only a single subfield constraint? | Always `allOf` + `$ref` for consistency and high-fidelity output (PP7)                                                                                            |

--- a/docs/006-parity-testing.md
+++ b/docs/006-parity-testing.md
@@ -144,7 +144,7 @@ interface Promotion {
  * @displayName :cancelled Cancelled
  * @defaultValue active
  */
-type PlanStatus = 'active' | 'paused' | 'cancelled';
+type PlanStatus = "active" | "paused" | "cancelled";
 
 interface Subscription {
   status: PlanStatus;
@@ -287,7 +287,7 @@ interface LineItem {
 **Chain DSL surface (`usd-cents/chain-dsl.ts`):**
 
 ```typescript
-import { field, formspec } from '@formspec/dsl';
+import { field, formspec } from "@formspec/dsl";
 
 // The chain DSL expresses constraint inheritance through type references.
 // The DSL consumer names the type and the build pipeline resolves it to
@@ -296,10 +296,10 @@ import { field, formspec } from '@formspec/dsl';
 // the "Integer" $defs entry resolves to JSON Schema type "integer".
 
 const lineItemForm = formspec(
-  field.number('unitPrice', { displayName: 'Unit Price', type: 'USDCents' }),
-  field.number('quantity', {
-    displayName: 'Quantity',
-    type: 'USDCents',
+  field.number("unitPrice", { displayName: "Unit Price", type: "USDCents" }),
+  field.number("quantity", {
+    displayName: "Quantity",
+    type: "USDCents",
     minimum: 1,
     maximum: 9999,
   })
@@ -321,7 +321,7 @@ export { lineItemForm };
  * @displayName :paused Paused
  * @displayName :cancelled Cancelled
  */
-type PlanStatus = 'active' | 'paused' | 'cancelled';
+type PlanStatus = "active" | "paused" | "cancelled";
 
 interface Subscription {
   /** @defaultValue active */
@@ -332,16 +332,16 @@ interface Subscription {
 **Chain DSL surface (`plan-status/chain-dsl.ts`):**
 
 ```typescript
-import { field, formspec } from '@formspec/dsl';
+import { field, formspec } from "@formspec/dsl";
 
 const subscriptionForm = formspec(
-  field.enum('status', ['active', 'paused', 'cancelled'] as const, {
-    displayName: 'Plan Status',
-    defaultValue: 'active',
+  field.enum("status", ["active", "paused", "cancelled"] as const, {
+    displayName: "Plan Status",
+    defaultValue: "active",
     memberDisplayNames: {
-      active: 'Active',
-      paused: 'Paused',
-      cancelled: 'Cancelled',
+      active: "Active",
+      paused: "Paused",
+      cancelled: "Cancelled",
     },
   })
 );
@@ -356,19 +356,19 @@ export { subscriptionForm };
 **Chain DSL surface (`monetary-amount/chain-dsl.ts`):**
 
 ```typescript
-import { field, formspec } from '@formspec/dsl';
+import { field, formspec } from "@formspec/dsl";
 
 const invoiceForm = formspec(
-  field.object('total', {
-    displayName: 'Total Amount',
-    type: 'MonetaryAmount',
+  field.object("total", {
+    displayName: "Total Amount",
+    type: "MonetaryAmount",
     subfieldConstraints: {
       value: { minimum: 0.01, maximum: 9999999.99, multipleOf: 0.01 },
-      currency: { pattern: '^[A-Z]{3}$' },
+      currency: { pattern: "^[A-Z]{3}$" },
     },
   }),
-  field.object('discount', {
-    type: 'MonetaryAmount',
+  field.object("discount", {
+    type: "MonetaryAmount",
     optional: true,
     subfieldConstraints: {
       value: { minimum: 0 },
@@ -385,26 +385,26 @@ Each parity test follows the same structure:
 
 ```typescript
 // monetary-amount.test.ts
-import { describe, it, expect } from 'vitest';
-import { extractFormIR } from '@formspec/build/internals';
-import { canonicalizeDSL } from '@formspec/build/internals';
-import { compareIR } from '../helpers/ir-comparison';
-import { invoiceForm } from './fixtures/monetary-amount/chain-dsl';
-import { expectedIR } from './fixtures/monetary-amount/expected-ir';
+import { describe, it, expect } from "vitest";
+import { extractFormIR } from "@formspec/build/internals";
+import { canonicalizeDSL } from "@formspec/build/internals";
+import { compareIR } from "../helpers/ir-comparison";
+import { invoiceForm } from "./fixtures/monetary-amount/chain-dsl";
+import { expectedIR } from "./fixtures/monetary-amount/expected-ir";
 
-describe('parity: MonetaryAmount', () => {
-  it('TSDoc surface produces expected IR', async () => {
-    const ir = await extractFormIR('./fixtures/monetary-amount/tsdoc.ts');
+describe("parity: MonetaryAmount", () => {
+  it("TSDoc surface produces expected IR", async () => {
+    const ir = await extractFormIR("./fixtures/monetary-amount/tsdoc.ts");
     expect(compareIR(ir, expectedIR)).toEqual({ equivalent: true, differences: [] });
   });
 
-  it('Chain DSL surface produces expected IR', () => {
+  it("Chain DSL surface produces expected IR", () => {
     const ir = canonicalizeDSL(invoiceForm);
     expect(compareIR(ir, expectedIR)).toEqual({ equivalent: true, differences: [] });
   });
 
-  it('Both surfaces produce identical IR', async () => {
-    const tsdocIR = await extractFormIR('./fixtures/monetary-amount/tsdoc.ts');
+  it("Both surfaces produce identical IR", async () => {
+    const tsdocIR = await extractFormIR("./fixtures/monetary-amount/tsdoc.ts");
     const chainIR = canonicalizeDSL(invoiceForm);
     expect(compareIR(tsdocIR, chainIR)).toEqual({ equivalent: true, differences: [] });
   });
@@ -529,20 +529,17 @@ Testing A3 requires:
 
 ```typescript
 // monetary-amount.test.ts (continued)
-import fs from 'node:fs';
-import path from 'node:path';
-import { generateJsonSchema } from '@formspec/build';
+import fs from "node:fs";
+import path from "node:path";
+import { generateJsonSchema } from "@formspec/build";
 
 const expectedSchema = JSON.parse(
-  fs.readFileSync(
-    path.join(__dirname, 'fixtures/monetary-amount/expected-schema.json'),
-    'utf-8'
-  )
+  fs.readFileSync(path.join(__dirname, "fixtures/monetary-amount/expected-schema.json"), "utf-8")
 );
 
-describe('A3 parity: MonetaryAmount', () => {
-  it('both surfaces produce identical JSON Schema', async () => {
-    const tsdocIR = await extractFormIR('./fixtures/monetary-amount/tsdoc.ts');
+describe("A3 parity: MonetaryAmount", () => {
+  it("both surfaces produce identical JSON Schema", async () => {
+    const tsdocIR = await extractFormIR("./fixtures/monetary-amount/tsdoc.ts");
     const chainIR = canonicalizeDSL(invoiceForm);
 
     const tsdocSchema = generateJsonSchema(tsdocIR);
@@ -555,7 +552,7 @@ describe('A3 parity: MonetaryAmount', () => {
     expect(tsdocSchema).toEqual(expectedSchema);
   });
 
-  it('generator is pure: same IR produces same output on repeated calls', () => {
+  it("generator is pure: same IR produces same output on repeated calls", () => {
     const ir = canonicalizeDSL(invoiceForm);
 
     const output1 = generateJsonSchema(ir);
@@ -580,7 +577,7 @@ The generator must produce deterministic output (D3). This means:
 JSON Schema output tests use `toEqual` (deep structural equality), which for plain objects in JavaScript treats key order as insignificant. This is correct for semantic equivalence. However, the generator's determinism test additionally checks that serialized output (via `JSON.stringify`) is identical between runs:
 
 ```typescript
-it('serialized output is deterministic across runs', () => {
+it("serialized output is deterministic across runs", () => {
   const ir1 = canonicalizeDSL(invoiceForm);
   const ir2 = canonicalizeDSL(invoiceForm);
 
@@ -612,21 +609,21 @@ Extension types (`Decimal`, `DateOnly`) are included in the parity test suite as
 **Chain DSL surface (`decimal/chain-dsl.ts`):**
 
 ```typescript
-import { field, formspec } from '@formspec/dsl';
+import { field, formspec } from "@formspec/dsl";
 
 const pricingRuleForm = formspec(
-  field.custom('baseRate', {
-    typeName: 'PositiveDecimal8',
-    displayName: 'Base Rate',
-    minimum: '0.01',
-    maximum: '999999.99',
+  field.custom("baseRate", {
+    typeName: "PositiveDecimal8",
+    displayName: "Base Rate",
+    minimum: "0.01",
+    maximum: "999999.99",
   }),
-  field.custom('overrideRate', {
-    typeName: 'PositiveDecimal8',
+  field.custom("overrideRate", {
+    typeName: "PositiveDecimal8",
     optional: true,
-    displayName: 'Override Rate',
-    minimum: '0',
-    maximum: '999999.99',
+    displayName: "Override Rate",
+    minimum: "0",
+    maximum: "999999.99",
     maxSigFig: 4,
   })
 );
@@ -658,7 +655,7 @@ Both the TSDoc extractor and the chain DSL canonicalizer must produce equivalent
 **TSDoc surface (`date-only/tsdoc.ts`):**
 
 ```typescript
-import type { DateOnly } from '@myorg/formspec-date-only';
+import type { DateOnly } from "@myorg/formspec-date-only";
 
 interface AuditPeriod {
   /**
@@ -685,25 +682,25 @@ interface AuditPeriod {
 **Chain DSL surface (`date-only/chain-dsl.ts`):**
 
 ```typescript
-import { field, formspec } from '@formspec/dsl';
+import { field, formspec } from "@formspec/dsl";
 
 const auditPeriodForm = formspec(
-  field.custom('startDate', {
-    typeName: 'DateOnly',
-    displayName: 'Period Start',
-    after: '2000-01-01',
+  field.custom("startDate", {
+    typeName: "DateOnly",
+    displayName: "Period Start",
+    after: "2000-01-01",
   }),
-  field.custom('endDate', {
-    typeName: 'DateOnly',
-    displayName: 'Period End',
-    after: '2000-01-01',
-    before: '2099-12-31',
+  field.custom("endDate", {
+    typeName: "DateOnly",
+    displayName: "Period End",
+    after: "2000-01-01",
+    before: "2099-12-31",
   }),
-  field.custom('reviewedOn', {
-    typeName: 'DateOnly',
+  field.custom("reviewedOn", {
+    typeName: "DateOnly",
     optional: true,
-    displayName: 'Reviewed On',
-    after: '2000-01-01',
+    displayName: "Reviewed On",
+    after: "2000-01-01",
   })
 );
 
@@ -750,16 +747,16 @@ Two diagnostic sets are equivalent when:
 ```typescript
 // packages/build/src/__tests__/parity/diagnostics.test.ts
 
-import { describe, it, expect } from 'vitest';
-import { extractWithDiagnostics } from '@formspec/build/internals';
-import { canonicalizeWithDiagnostics } from '@formspec/build/internals';
-import { compareDiagnostics } from '../helpers/diagnostic-comparison';
+import { describe, it, expect } from "vitest";
+import { extractWithDiagnostics } from "@formspec/build/internals";
+import { canonicalizeWithDiagnostics } from "@formspec/build/internals";
+import { compareDiagnostics } from "../helpers/diagnostic-comparison";
 
-describe('diagnostic parity: constraint broadening', () => {
-  it('inverted numeric bounds', async () => {
+describe("diagnostic parity: constraint broadening", () => {
+  it("inverted numeric bounds", async () => {
     // TSDoc: @minimum 10 @maximum 5 on the same number field
     const tsdocDiagnostics = await extractWithDiagnostics(
-      './fixtures/diagnostics/inverted-bounds-tsdoc.ts'
+      "./fixtures/diagnostics/inverted-bounds-tsdoc.ts"
     );
 
     // Chain DSL: field.number("x", { minimum: 10, maximum: 5 })
@@ -771,11 +768,11 @@ describe('diagnostic parity: constraint broadening', () => {
     });
   });
 
-  it('@maxSigFig broadening through alias chain (Decimal extension)', async () => {
+  it("@maxSigFig broadening through alias chain (Decimal extension)", async () => {
     // Both surfaces should produce CONSTRAINT_BROADENING with
     // severity: "error" and reference both constraint locations
     const tsdocDiagnostics = await extractWithDiagnostics(
-      './fixtures/diagnostics/decimal-maxsigfig-broadening-tsdoc.ts'
+      "./fixtures/diagnostics/decimal-maxsigfig-broadening-tsdoc.ts"
     );
     const chainDiagnostics = canonicalizeWithDiagnostics(decimalBroadeningDSLForm);
 
@@ -787,8 +784,8 @@ describe('diagnostic parity: constraint broadening', () => {
     // Also verify the diagnostic code and severity directly
     expect(tsdocDiagnostics).toHaveLength(1);
     expect(tsdocDiagnostics[0]).toMatchObject({
-      code: 'CONSTRAINT_BROADENING',
-      severity: 'error',
+      code: "CONSTRAINT_BROADENING",
+      severity: "error",
     });
   });
 });
@@ -931,6 +928,6 @@ The `expected-ir.ts` and `expected-schema.json` files are the specification. Cha
 | #    | Section  | Question                                                                                                                                           | Status                                                                                                                                                                                                                                                                                                                                                   |
 | ---- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | OD-1 | §3.2     | How does the chain DSL express type alias constraint inheritance — by name reference resolved at build time, or by explicit constraint repetition? | By name reference — `type: "USDCents"` loads the alias chain from the project's type registry                                                                                                                                                                                                                                                            |
-| OD-2 | §4.3     | Should snapshot tests be part of parity validation?                                                                                                 | **DECIDED:** No — snapshots are not part of the normative parity strategy; parity uses hand-authored expectations and structural assertions only                                                                                                                                                                                                          |
+| OD-2 | §4.3     | Should snapshot tests be part of parity validation?                                                                                                | **DECIDED:** No — snapshots are not part of the normative parity strategy; parity uses hand-authored expectations and structural assertions only                                                                                                                                                                                                         |
 | OD-3 | §6, §8.2 | Should extension fixture packages (`@formspec/test-fixtures`) be in `packages/` or alongside the tests?                                            | **DECIDED:** In `packages/test-fixtures/` as a private, unpublished workspace package. This allows the fixture extensions to have their own `package.json`, `tsconfig.json`, and build step, while remaining clearly separated from distributable code. Tests in `packages/build/src/__tests__/` reference the fixture package via workspace dependency. |
 | OD-4 | §7.1     | Should diagnostic message text be compared character-for-character, or only code + severity?                                                       | Code + severity in parity comparison; message text is verified separately against expected values                                                                                                                                                                                                                                                        |

--- a/docs/e2e-test-matrix.md
+++ b/docs/e2e-test-matrix.md
@@ -8,6 +8,7 @@
 ## Coverage Gap Summary
 
 ### Already covered by existing fixtures
+
 - Basic primitive types: string, number, boolean (product-form, constrained-form)
 - String literal union → `enum` (product-form, nullable-types)
 - `T | null` → `anyOf` [BUG: spec says `oneOf`, existing output uses `anyOf`] (nullable-types)
@@ -27,6 +28,7 @@
 - Chain DSL: groups, conditionals, labeled enums, dynamic enums, objects, arrays (chain-dsl fixtures)
 
 ### NOT yet covered (this matrix adds these)
+
 - `@displayName` (all variants: bare, `:singular`/`:plural`, `:member`, absence/inference)
 - `@description` / `@remarks` fallback
 - `@placeholder`
@@ -57,6 +59,7 @@
 ### Fixture: annotations-display-name
 
 #### File: e2e/fixtures/tsdoc-class/annotations-display-name.ts
+
 ```typescript
 /**
  * @displayName User Profile Form
@@ -76,16 +79,17 @@ export class UserProfileForm {
    * @displayName :suspended Suspended
    * @displayName :closed Permanently Closed
    */
-  status!: 'active' | 'suspended' | 'closed';
+  status!: "active" | "suspended" | "closed";
 
   /**
    * @displayName Preferred Language
    */
-  language!: 'en' | 'fr' | 'de';
+  language!: "en" | "fr" | "de";
 }
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -120,6 +124,7 @@ export class UserProfileForm {
 ```
 
 #### Test assertions (e2e/tests/annotations-display-name.test.ts)
+
 - [ ] Root schema has `"title": "User Profile Form"` from class-level `@displayName` (spec 002 §3.2, 003 §2.8)
 - [ ] `fullName` has `"title": "Full Legal Name"` (spec 002 §3.2)
 - [ ] `email` has `"title": "Email Address"` (spec 002 §3.2)
@@ -137,6 +142,7 @@ export class UserProfileForm {
 ### Fixture: annotations-description
 
 #### File: e2e/fixtures/tsdoc-class/annotations-description.ts
+
 ```typescript
 /**
  * Form for collecting user feedback.
@@ -164,6 +170,7 @@ export class FeedbackForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -191,6 +198,7 @@ export class FeedbackForm {
 ```
 
 #### Test assertions (e2e/tests/annotations-description.test.ts)
+
 - [ ] Root schema has `"description"` from class-level `@description` (spec 002 §3.2)
 - [ ] `name` has `"description"` from field-level `@description` (spec 002 §3.2)
 - [ ] `comments` has `"description"` derived from `@remarks` fallback (spec 002 §2.3 — `@remarks` treated as `@description` when no explicit `@description`)
@@ -202,6 +210,7 @@ export class FeedbackForm {
 ### Fixture: annotations-metadata
 
 #### File: e2e/fixtures/tsdoc-class/annotations-metadata.ts
+
 ```typescript
 export class MetadataForm {
   /**
@@ -249,6 +258,7 @@ export class MetadataForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -282,10 +292,7 @@ export class MetadataForm {
       "default": false
     },
     "nickname": {
-      "oneOf": [
-        { "type": "string" },
-        { "type": "null" }
-      ],
+      "oneOf": [{ "type": "string" }, { "type": "null" }],
       "default": null
     },
     "requiredField": {
@@ -297,6 +304,7 @@ export class MetadataForm {
 ```
 
 #### Expected UI Schema
+
 ```json
 {
   "type": "VerticalLayout",
@@ -323,6 +331,7 @@ export class MetadataForm {
 ```
 
 #### Test assertions (e2e/tests/annotations-metadata.test.ts)
+
 - [ ] `@placeholder` does NOT appear in JSON Schema — it's UI-only (spec 002 §2.2, 003 — no `placeholder` mapping)
 - [ ] `@placeholder` appears in UI Schema `options.placeholder` (spec 002 §2.2)
 - [ ] `@deprecated` with message emits `"deprecated": true` and `"x-<vendor>-deprecation-description"` in JSON Schema (spec 003 §2.8, 003 §3)
@@ -348,6 +357,7 @@ This fixture verifies that class-based schema extraction works when the fixture 
 - fixture-local `tsconfig.json` with `"strictPropertyInitialization": false`
 
 #### File: e2e/fixtures/tsdoc-class/class-fields-without-definite-assignment.ts
+
 ```typescript
 /**
  * @displayName Customer Profile
@@ -360,11 +370,12 @@ export class CustomerProfile {
   email: string;
 
   /** @displayName Loyalty Tier */
-  tier?: 'bronze' | 'silver' | 'gold';
+  tier?: "bronze" | "silver" | "gold";
 }
 ```
 
 #### Expected structure
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -389,6 +400,7 @@ export class CustomerProfile {
 ```
 
 #### Test assertions (e2e/tests/class-fields-without-definite-assignment.test.ts)
+
 - [ ] Fixture compiles and schema generation succeeds with `strictPropertyInitialization: false`
 - [ ] Class fields declared without `!` are still recognized as fields in the generated schema
 - [ ] Requiredness is determined by `?` optionality, not by definite-assignment syntax
@@ -405,6 +417,7 @@ export class CustomerProfile {
 ### Fixture: numeric-constraints-comprehensive
 
 #### File: e2e/fixtures/tsdoc-class/numeric-constraints-comprehensive.ts
+
 ```typescript
 export class NumericConstraintsForm {
   /** @minimum 0 */
@@ -448,6 +461,7 @@ export class NumericConstraintsForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -513,15 +527,25 @@ export class NumericConstraintsForm {
     }
   },
   "required": [
-    "nonNegative", "allowsNegative", "exactlyZero", "floatBounds",
-    "strictlyPositive", "strictlyBelow100", "openInterval",
-    "mixedBounds", "mixedBoundsReverse", "currency", "steppedBy5",
-    "percentStepped", "unconstrained"
+    "nonNegative",
+    "allowsNegative",
+    "exactlyZero",
+    "floatBounds",
+    "strictlyPositive",
+    "strictlyBelow100",
+    "openInterval",
+    "mixedBounds",
+    "mixedBoundsReverse",
+    "currency",
+    "steppedBy5",
+    "percentStepped",
+    "unconstrained"
   ]
 }
 ```
 
 #### Test assertions (e2e/tests/numeric-constraints-comprehensive.test.ts)
+
 - [ ] `@minimum 0` → `"minimum": 0` (spec 003 §2.6)
 - [ ] `@minimum -100` → `"minimum": -100` — negative values allowed (spec 002 §3.2)
 - [ ] `@minimum 0 @maximum 0` → both keywords emitted, valid (spec 003 §2.6)
@@ -543,6 +567,7 @@ export class NumericConstraintsForm {
 ### Fixture: string-constraints-comprehensive
 
 #### File: e2e/fixtures/tsdoc-class/string-constraints-comprehensive.ts
+
 ```typescript
 export class StringConstraintsForm {
   /** @minLength 1 */
@@ -586,6 +611,7 @@ export class StringConstraintsForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -648,14 +674,25 @@ export class StringConstraintsForm {
     }
   },
   "required": [
-    "nonEmpty", "bounded", "allowsEmpty", "exactLength", "combinedBounds",
-    "lowercaseOnly", "emailPattern", "ssnPattern", "constrainedEmail",
-    "emailFormat", "dateFormat", "uriFormat", "unconstrained"
+    "nonEmpty",
+    "bounded",
+    "allowsEmpty",
+    "exactLength",
+    "combinedBounds",
+    "lowercaseOnly",
+    "emailPattern",
+    "ssnPattern",
+    "constrainedEmail",
+    "emailFormat",
+    "dateFormat",
+    "uriFormat",
+    "unconstrained"
   ]
 }
 ```
 
 #### Test assertions
+
 - [ ] `@minLength 1` → `"minLength": 1` (spec 003 §2.7)
 - [ ] `@maxLength 255` → `"maxLength": 255` (spec 003 §2.7)
 - [ ] `@minLength 0` is valid — emits `"minLength": 0` (spec 002 §3.2 — non-negative integer)
@@ -673,6 +710,7 @@ export class StringConstraintsForm {
 ### Fixture: array-constraints-comprehensive
 
 #### File: e2e/fixtures/tsdoc-class/array-constraints-comprehensive.ts
+
 ```typescript
 export class ArrayConstraintsForm {
   /** @minItems 1 */
@@ -701,6 +739,7 @@ export class ArrayConstraintsForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -749,13 +788,20 @@ export class ArrayConstraintsForm {
     }
   },
   "required": [
-    "nonEmpty", "bounded", "allowsEmpty", "combinedBounds",
-    "uniqueTags", "allConstraints", "itemConstrained", "unconstrained"
+    "nonEmpty",
+    "bounded",
+    "allowsEmpty",
+    "combinedBounds",
+    "uniqueTags",
+    "allConstraints",
+    "itemConstrained",
+    "unconstrained"
   ]
 }
 ```
 
 #### Test assertions
+
 - [ ] `@minItems 1` → `"minItems": 1` (spec 003 §2.4)
 - [ ] `@maxItems 100` → `"maxItems": 100` (spec 003 §2.4)
 - [ ] `@minItems 0` is valid (spec 002 §3.2)
@@ -772,6 +818,7 @@ export class ArrayConstraintsForm {
 ### Fixture: type-mappings-comprehensive
 
 #### File: e2e/fixtures/tsdoc-class/type-mappings-comprehensive.ts
+
 ```typescript
 interface Address {
   street: string;
@@ -790,7 +837,7 @@ export class TypeMappingsForm {
   optionalString?: string;
   optionalNumber?: number;
 
-  stringLiteralUnion!: 'a' | 'b' | 'c';
+  stringLiteralUnion!: "a" | "b" | "c";
   numberArray!: number[];
   stringArray!: string[];
 
@@ -804,6 +851,7 @@ export class TypeMappingsForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -813,16 +861,10 @@ export class TypeMappingsForm {
     "numberField": { "type": "number" },
     "booleanField": { "type": "boolean" },
     "nullableString": {
-      "oneOf": [
-        { "type": "string" },
-        { "type": "null" }
-      ]
+      "oneOf": [{ "type": "string" }, { "type": "null" }]
     },
     "nullableNumber": {
-      "oneOf": [
-        { "type": "number" },
-        { "type": "null" }
-      ]
+      "oneOf": [{ "type": "number" }, { "type": "null" }]
     },
     "optionalString": { "type": "string" },
     "optionalNumber": { "type": "number" },
@@ -855,10 +897,17 @@ export class TypeMappingsForm {
     }
   },
   "required": [
-    "stringField", "numberField", "booleanField",
-    "nullableString", "nullableNumber",
-    "stringLiteralUnion", "numberArray", "stringArray",
-    "inlineObject", "namedType", "recordType"
+    "stringField",
+    "numberField",
+    "booleanField",
+    "nullableString",
+    "nullableNumber",
+    "stringLiteralUnion",
+    "numberArray",
+    "stringArray",
+    "inlineObject",
+    "namedType",
+    "recordType"
   ],
   "$defs": {
     "Address": {
@@ -875,6 +924,7 @@ export class TypeMappingsForm {
 ```
 
 #### Test assertions
+
 - [ ] `string` → `{ "type": "string" }` (spec 003 §2.1)
 - [ ] `number` → `{ "type": "number" }` (spec 003 §2.1)
 - [ ] `boolean` → `{ "type": "boolean" }` (spec 003 §2.1)
@@ -896,6 +946,7 @@ export class TypeMappingsForm {
 ### Fixture: alias-chain-3-level
 
 #### File: e2e/fixtures/tsdoc-class/alias-chain-3-level.ts
+
 ```typescript
 /** @multipleOf 1 */
 type Integer = number;
@@ -917,6 +968,7 @@ export class NetworkForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -941,6 +993,7 @@ export class NetworkForm {
 ```
 
 #### Test assertions (e2e/tests/alias-chain-3-level.test.ts)
+
 - [ ] 3-level chain: Integer → NonNegativeInteger → PortNumber propagates all constraints (spec 005 §3, PP3)
 - [ ] `@multipleOf 1` from `Integer` promotes to `"type": "integer"` throughout (spec 005 §2.2, 003 §2.1)
 - [ ] `multipleOf` keyword is suppressed when value is 1 (spec 003 §2.1, 005 §2.2)
@@ -972,6 +1025,7 @@ export class NetworkForm {
 ### Fixture: alias-chain-multipleOf-composition
 
 #### File: e2e/fixtures/tsdoc-class/alias-chain-multipleOf.ts
+
 ```typescript
 /** @multipleOf 1 */
 type Integer = number;
@@ -996,6 +1050,7 @@ export class PromotionForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1020,6 +1075,7 @@ export class PromotionForm {
 ```
 
 #### Test assertions
+
 - [ ] `discountPercent`: integer promotion from `@multipleOf 1` inherited via `Percent` → `Integer` (spec 005 §2.2)
 - [ ] `discountPercent`: field-level `@multipleOf 5` is emitted in addition to integer promotion (spec 006 §2.3 — `multipleOf: 1` from Integer and `multipleOf: 5` compose; every multiple of 5 is also a multiple of 1, so the effective constraint is `multipleOf: 5`)
 - [ ] `discountPercent`: inherits `@minimum 0 @maximum 100` from `Percent` (spec 005 §7.3)
@@ -1033,6 +1089,7 @@ export class PromotionForm {
 ### Fixture: path-target-expanded
 
 #### File: e2e/fixtures/tsdoc-class/path-target-expanded.ts
+
 ```typescript
 interface Dimensions {
   width: number;
@@ -1091,6 +1148,7 @@ export class PathTargetExpandedForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1205,6 +1263,7 @@ export class PathTargetExpandedForm {
 ```
 
 #### Test assertions
+
 - [ ] Multiple path targets on same field (`size` has constraints on `:width`, `:height`, `:unit`) (spec 002 §4.4)
 - [ ] Multiple constraint types on same subfield (`:width` has both `@minimum` and `@maximum`) (spec 002 §4.4, C1)
 - [ ] Mixed constraint types across subfields: numeric on `:value`, string on `:currency` (spec 002 §4.3, S4)
@@ -1222,13 +1281,14 @@ export class PathTargetExpandedForm {
 ### Fixture: enum-display-names
 
 #### File: e2e/fixtures/tsdoc-class/enum-display-names.ts
+
 ```typescript
 /**
  * @displayName :draft Draft Invoice
  * @displayName :sent Sent to Customer
  * @displayName :paid Paid in Full
  */
-type InvoiceStatus = 'draft' | 'sent' | 'paid';
+type InvoiceStatus = "draft" | "sent" | "paid";
 
 export class InvoiceForm {
   /**
@@ -1244,14 +1304,15 @@ export class InvoiceForm {
    * @displayName :high High Priority
    * @displayName :critical Critical - Immediate Action
    */
-  priority!: 'low' | 'medium' | 'high' | 'critical';
+  priority!: "low" | "medium" | "high" | "critical";
 
   /** No per-member display names */
-  simpleEnum!: 'a' | 'b' | 'c';
+  simpleEnum!: "a" | "b" | "c";
 }
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1289,6 +1350,7 @@ export class InvoiceForm {
 ```
 
 #### Test assertions
+
 - [ ] Named type alias with `:member` display names → `$defs` entry with `oneOf`/`const`/`title` (spec 003 §2.3, 003 §5.2)
 - [ ] `status` references `InvoiceStatus` via `$ref` (spec 003 §5.1, PP7)
 - [ ] `status` has `"title"` and `"default"` as sibling keywords to `$ref` (spec 003 §7 — 2020-12 allows siblings)
@@ -1310,6 +1372,7 @@ Both surfaces must produce identical JSON Schema. The chain-dsl fixture already 
 **Existing chain DSL fixture:** `e2e/fixtures/chain-dsl/contact-form.ts` (already covered)
 
 #### File: e2e/fixtures/tsdoc-class/parity-contact-form.ts
+
 ```typescript
 export class ParityContactForm {
   /** @displayName First Name */
@@ -1322,7 +1385,7 @@ export class ParityContactForm {
   email?: string;
 
   /** @displayName Preferred Contact Method */
-  contactMethod!: 'email' | 'phone' | 'mail';
+  contactMethod!: "email" | "phone" | "mail";
 
   /** @displayName Phone Number */
   phoneNumber?: string;
@@ -1336,6 +1399,7 @@ export class ParityContactForm {
 ```
 
 #### Test assertions (e2e/tests/parity-contact-form.test.ts)
+
 - [ ] TSDoc-generated JSON Schema matches chain-DSL-generated JSON Schema (spec PP5, A3)
 - [ ] Both have identical `properties` keys and types
 - [ ] Both have identical `required` arrays
@@ -1349,6 +1413,7 @@ export class ParityContactForm {
 ### Fixture: parity-constrained-fields
 
 #### File: e2e/fixtures/chain-dsl/parity-constrained-fields.ts
+
 ```typescript
 import { formspec, field } from "@formspec/dsl";
 
@@ -1360,13 +1425,13 @@ export const ParityConstrainedForm = formspec(
     required: true,
     minLength: 5,
     maxLength: 100,
-    pattern: "^[^@]+@[^@]+$"
+    pattern: "^[^@]+@[^@]+$",
   }),
   field.array("tags", field.text("tag"), {
     label: "Tags",
     required: true,
     minItems: 1,
-    maxItems: 10
+    maxItems: 10,
   }),
   field.text("legacyField", { label: "Legacy", deprecated: true })
 );
@@ -1375,6 +1440,7 @@ export const ParityConstrainedForm = formspec(
 **Counterpart TSDoc fixture:** `e2e/fixtures/tsdoc-class/constrained-form.ts` (already exists)
 
 #### Test assertions
+
 - [ ] Chain DSL output matches the TSDoc counterpart structurally using hand-authored normative expectations (spec PP5, A3)
 - [ ] Both surfaces produce identical constraint keywords (spec A1)
 
@@ -1528,6 +1594,7 @@ These fixtures verify that the build pipeline produces errors (non-zero exit cod
 ### Fixture: error-contradicting-constraints
 
 #### File: e2e/fixtures/tsdoc-class/error-contradicting-constraints.ts
+
 ```typescript
 export class ContradictingForm {
   /** @minimum 10 @maximum 5 */
@@ -1536,6 +1603,7 @@ export class ContradictingForm {
 ```
 
 #### Test assertions (e2e/tests/error-contradicting-constraints.test.ts)
+
 - [ ] CLI exits with non-zero exit code OR produces a diagnostic (spec S2, 002 §6 `CONSTRAINT_CONTRADICTION`)
 - [ ] Diagnostic references both `@minimum 10` and `@maximum 5` (spec D2)
 - [ ] Diagnostic message is actionable (spec D4)
@@ -1545,6 +1613,7 @@ export class ContradictingForm {
 ### Fixture: error-type-mismatch
 
 #### File: e2e/fixtures/tsdoc-class/error-type-mismatch.ts
+
 ```typescript
 export class TypeMismatchForm {
   /** @minimum 0 */
@@ -1559,6 +1628,7 @@ export class TypeMismatchForm {
 ```
 
 #### Test assertions (e2e/tests/error-type-mismatch.test.ts)
+
 - [ ] `@minimum` on string field produces diagnostic `TYPE_MISMATCH` (spec S4, 002 §6)
 - [ ] `@minLength` on number field produces diagnostic `TYPE_MISMATCH` (spec S4, 002 §6)
 - [ ] `@minItems` on non-array field produces diagnostic `TYPE_MISMATCH` (spec S4, 002 §6)
@@ -1568,6 +1638,7 @@ export class TypeMismatchForm {
 ### Fixture: error-invalid-path-target
 
 #### File: e2e/fixtures/tsdoc-class/error-invalid-path-target.ts
+
 ```typescript
 interface SimpleObj {
   name: string;
@@ -1584,6 +1655,7 @@ export class InvalidPathTargetForm {
 ```
 
 #### Test assertions (e2e/tests/error-invalid-path-target.test.ts)
+
 - [ ] Path target `:nonexistent` on unknown subfield → diagnostic `UNKNOWN_PATH_TARGET` (spec 002 §6)
 - [ ] `@minimum` on string subfield `:name` → diagnostic `TYPE_MISMATCH` (spec S4 — type checked against subfield)
 
@@ -1592,6 +1664,7 @@ export class InvalidPathTargetForm {
 ### Fixture: error-broadening-constraint
 
 #### File: e2e/fixtures/tsdoc-class/error-broadening-constraint.ts
+
 ```typescript
 /** @minimum 0 */
 type NonNegative = number;
@@ -1603,6 +1676,7 @@ export class BroadeningForm {
 ```
 
 #### Test assertions (e2e/tests/error-broadening-constraint.test.ts)
+
 - [ ] `@minimum -10` on `NonNegative` (which has `@minimum 0`) → error diagnostic (spec S1, 005 §3.4)
 - [ ] Diagnostic is `CONSTRAINT_BROADENING` type (spec 005 §3.4)
 
@@ -1615,6 +1689,7 @@ export class BroadeningForm {
 ### Fixture: const-constraints
 
 #### File: e2e/fixtures/tsdoc-class/const-constraints.ts
+
 ```typescript
 interface MonetaryAmount {
   value: number;
@@ -1634,6 +1709,7 @@ export class ConstForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1657,6 +1733,7 @@ export class ConstForm {
 ```
 
 #### Test assertions
+
 - [ ] `@const "USD"` → `"const": "USD"` (spec 002 §2.1, 003 §2.8)
 - [ ] `@const 42` → `"const": 42` (spec 002 §3.2)
 - [ ] `@const true` → `"const": true` (spec 002 §3.2)
@@ -1668,6 +1745,7 @@ export class ConstForm {
 ### Fixture: parity-usd-cents (from spec 006 §2.2, §3.2)
 
 #### File: e2e/fixtures/tsdoc-class/parity-usd-cents.ts
+
 ```typescript
 /** @multipleOf 1 @maximum 99999999999999 */
 type Integer = number;
@@ -1700,9 +1778,7 @@ export class LineItem {
       "title": "Unit Price"
     },
     "quantity": {
-      "allOf": [
-        { "$ref": "#/$defs/USDCents" }
-      ],
+      "allOf": [{ "$ref": "#/$defs/USDCents" }],
       "minimum": 1,
       "maximum": 9999,
       "title": "Quantity"
@@ -1715,16 +1791,14 @@ export class LineItem {
       "maximum": 99999999999999
     },
     "USDCents": {
-      "allOf": [
-        { "$ref": "#/$defs/Integer" },
-        { "minimum": 0 }
-      ]
+      "allOf": [{ "$ref": "#/$defs/Integer" }, { "minimum": 0 }]
     }
   }
 }
 ```
 
 #### Test assertions
+
 - [ ] `unitPrice`: inherits `@minimum 0` from USDCents, `@maximum 99999999999999` and `@multipleOf 1` from Integer (spec 005 §7.3, 006 §2.2)
 - [ ] `quantity`: field-level `@minimum 1` narrows USDCents' `@minimum 0` (spec S1, 005 §7.1)
 - [ ] `quantity`: field-level `@maximum 9999` narrows Integer's `@maximum 99999999999999` (spec S1, 005 §7.1)
@@ -1736,6 +1810,7 @@ export class LineItem {
 ### Fixture: parity-plan-status (from spec 006 §2.4, §3.3)
 
 #### File: e2e/fixtures/tsdoc-class/parity-plan-status.ts
+
 ```typescript
 /**
  * @displayName Plan Status
@@ -1743,7 +1818,7 @@ export class LineItem {
  * @displayName :paused Paused
  * @displayName :cancelled Cancelled
  */
-type PlanStatus = 'active' | 'paused' | 'cancelled';
+type PlanStatus = "active" | "paused" | "cancelled";
 
 export class Subscription {
   /** @defaultValue "active" */
@@ -1752,6 +1827,7 @@ export class Subscription {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1777,6 +1853,7 @@ export class Subscription {
 ```
 
 #### Test assertions
+
 - [ ] Named type `PlanStatus` appears in `$defs` with `oneOf` (spec 003 §5.2, 003 §2.3)
 - [ ] Per-member display names → `const`/`title` per member (spec 003 §2.3)
 - [ ] Type-level `@displayName Plan Status` → `$defs.PlanStatus.title` (spec 003 §2.8)
@@ -1788,6 +1865,7 @@ export class Subscription {
 ### Fixture: parity-address (from spec 006 §2.5)
 
 #### File: e2e/fixtures/tsdoc-class/parity-address.ts
+
 ```typescript
 interface Address {
   /**
@@ -1822,6 +1900,7 @@ export class CustomerForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1870,6 +1949,7 @@ export class CustomerForm {
 ```
 
 #### Test assertions
+
 - [ ] `Address` appears once in `$defs`, referenced twice via `$ref` (spec PP7, 003 §5.1)
 - [ ] `billing` is required, `shipping` is not (spec S8)
 - [ ] Constraints on `Address` fields are in the `$defs` entry, not at the use site (spec 003 §5.3)
@@ -1884,6 +1964,7 @@ export class CustomerForm {
 ### Fixture: exclusive-bound-edge-cases
 
 #### File: e2e/fixtures/tsdoc-class/exclusive-bound-edge-cases.ts
+
 ```typescript
 export class ExclusiveBoundsForm {
   /** @exclusiveMinimum 0 @exclusiveMaximum 1 */
@@ -1901,6 +1982,7 @@ export class ExclusiveBoundsForm {
 ```
 
 #### Expected JSON Schema
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1931,6 +2013,7 @@ export class ExclusiveBoundsForm {
 ```
 
 #### Test assertions
+
 - [ ] Both exclusive bounds on same field (spec 003 §2.6)
 - [ ] Negative float exclusive minimum (spec 002 §3.2)
 - [ ] Mixed exclusive min + inclusive max (spec 003 §2.6)
@@ -1941,49 +2024,54 @@ export class ExclusiveBoundsForm {
 
 ## Known Bugs Summary
 
-| Bug | Fixture | Spec Reference | Description |
-|-----|---------|----------------|-------------|
-| BUG-1 | nullable-types | 003 §2.3 | `T \| null` emits `anyOf` instead of `oneOf` |
-| BUG-2 | product-form | 003 §2.5 | `Record<string, T>` emits `$ref` to empty Record def instead of `additionalProperties: <T>` |
-| BUG-3 | inherited-constraints, alias-chain-3-level | 003 §5.2, 005 §3.3 | Named type aliases are inlined instead of using `$defs` + `$ref` |
-| BUG-4 | (not yet tested) | 003 §2.3 | `:member` display names on type aliases may not produce `$defs` entry with `oneOf` |
+| Bug   | Fixture                                    | Spec Reference     | Description                                                                                 |
+| ----- | ------------------------------------------ | ------------------ | ------------------------------------------------------------------------------------------- |
+| BUG-1 | nullable-types                             | 003 §2.3           | `T \| null` emits `anyOf` instead of `oneOf`                                                |
+| BUG-2 | product-form                               | 003 §2.5           | `Record<string, T>` emits `$ref` to empty Record def instead of `additionalProperties: <T>` |
+| BUG-3 | inherited-constraints, alias-chain-3-level | 003 §5.2, 005 §3.3 | Named type aliases are inlined instead of using `$defs` + `$ref`                            |
+| BUG-4 | (not yet tested)                           | 003 §2.3           | `:member` display names on type aliases may not produce `$defs` entry with `oneOf`          |
 
 ---
 
 ## Ambiguous Areas Summary
 
-| Area | Fixture | Question | Recommendation |
-|------|---------|----------|----------------|
-| AMB-1 | annotations-display-name | Class-level `@displayName` → root `title`? | Yes, per 003 §9 full example |
-| AMB-2 | annotations-metadata | `@deprecated` message in JSON Schema? | Emit standard `"deprecated": true` plus `x-<vendor>-deprecation-description` when message text exists |
-| AMB-3 | enum-display-names | `@defaultValue draft` vs `@defaultValue "draft"`? | Both produce string "draft" per 002 §3.2 fallback |
-| AMB-4 | parity-contact-form | Conditional behavior parity? | Rewrite the TSDoc surface toward the chain DSL fixture first; until then, treat this as blocked on surface alignment rather than unconditional parity |
-| AMB-5 | alias-chain-3-level | Inline vs `$defs` for type aliases? | Spec says `$defs` (PP7); current impl inlines |
+| Area  | Fixture                  | Question                                          | Recommendation                                                                                                                                        |
+| ----- | ------------------------ | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AMB-1 | annotations-display-name | Class-level `@displayName` → root `title`?        | Yes, per 003 §9 full example                                                                                                                          |
+| AMB-2 | annotations-metadata     | `@deprecated` message in JSON Schema?             | Emit standard `"deprecated": true` plus `x-<vendor>-deprecation-description` when message text exists                                                 |
+| AMB-3 | enum-display-names       | `@defaultValue draft` vs `@defaultValue "draft"`? | Both produce string "draft" per 002 §3.2 fallback                                                                                                     |
+| AMB-4 | parity-contact-form      | Conditional behavior parity?                      | Rewrite the TSDoc surface toward the chain DSL fixture first; until then, treat this as blocked on surface alignment rather than unconditional parity |
+| AMB-5 | alias-chain-3-level      | Inline vs `$defs` for type aliases?               | Spec says `$defs` (PP7); current impl inlines                                                                                                         |
 
 ---
 
 ## Test Infrastructure Notes
 
 All TSDoc fixtures use the pattern:
+
 1. Run CLI: `formspec generate <fixture> <className> -o <tempDir>`
 2. Parse output schema JSON
 3. Assert structure against hand-authored expectations
 
 All chain DSL fixtures use the pattern:
+
 1. Import `buildFormSchemas` from `@formspec/build`
 2. Call with the DSL form definition
 3. Assert structure against hand-authored expectations
 
 Parity tests should:
+
 1. Generate from both surfaces
 2. Assert `jsonSchema` output is `toEqual` between them (spec PP5, A3)
 
 Mixed-authoring composition tests should:
+
 1. Generate the composed form from the static type-derived model plus ChainDSL overlays
 2. Assert the resulting JSON Schema and UI Schema are correct for the composed form
 3. Assert against hand-authored normative expectations derived from the spec
 
 User-authored confidence tests should be split by concern:
+
 1. Data-model conformance tests validate example payloads against generated JSON Schema
 2. Dynamic-option tests exercise resolver behavior and verify returned options match the field's stored type
 3. Dynamic-schema tests exercise resolver logic that turns source data into JSON Schema and JSON Forms UI schema

--- a/docs/maintainer-migration-notes.md
+++ b/docs/maintainer-migration-notes.md
@@ -10,18 +10,18 @@ It is intentionally separate from the spec because it discusses current implemen
 
 The current `FormElement` discriminated union maps to the target IR roughly as follows:
 
-| Current Type                  | Target IR shape                                                          |
-| ----------------------------- | ------------------------------------------------------------------------ |
-| `TextField<N>`                | `FieldNode` with `PrimitiveTypeNode("string")`                           |
-| `NumberField<N>`              | `FieldNode` with `PrimitiveTypeNode("number")`                           |
-| `BooleanField<N>`             | `FieldNode` with `PrimitiveTypeNode("boolean")`                          |
-| `StaticEnumField<N, O>`       | `FieldNode` with `EnumTypeNode` (members from `options`)                 |
+| Current Type                  | Target IR shape                                                           |
+| ----------------------------- | ------------------------------------------------------------------------- |
+| `TextField<N>`                | `FieldNode` with `PrimitiveTypeNode("string")`                            |
+| `NumberField<N>`              | `FieldNode` with `PrimitiveTypeNode("number")`                            |
+| `BooleanField<N>`             | `FieldNode` with `PrimitiveTypeNode("boolean")`                           |
+| `StaticEnumField<N, O>`       | `FieldNode` with `EnumTypeNode` (members from `options`)                  |
 | `DynamicEnumField<N, Source>` | `FieldNode` with statically known value type plus runtime option metadata |
-| `DynamicSchemaField<N>`       | `FieldNode` with `DynamicTypeNode("schema", schemaSource)`               |
-| `ArrayField<N, Items>`        | `FieldNode` with `ArrayTypeNode` (items from elements)                   |
-| `ObjectField<N, Props>`       | `FieldNode` with `ObjectTypeNode` (properties from elements)             |
-| `Group<Elements>`             | `GroupLayoutNode`                                                        |
-| `Conditional<K, V, Elements>` | `ConditionalLayoutNode`                                                  |
+| `DynamicSchemaField<N>`       | `FieldNode` with `DynamicTypeNode("schema", schemaSource)`                |
+| `ArrayField<N, Items>`        | `FieldNode` with `ArrayTypeNode` (items from elements)                    |
+| `ObjectField<N, Props>`       | `FieldNode` with `ObjectTypeNode` (properties from elements)              |
+| `Group<Elements>`             | `GroupLayoutNode`                                                         |
+| `Conditional<K, V, Elements>` | `ConditionalLayoutNode`                                                   |
 
 The chain DSL canonicalizer walks the `FormSpec<Elements>` structure and produces `FormIR`. Inline options on chain DSL fields (`label`, `min`, `max`, `required`, etc.) become `AnnotationNode` and `ConstraintNode` entries with `surface: "chain-dsl"` provenance.
 
@@ -39,31 +39,31 @@ The current TSDoc/type-analysis path produces `FieldInfo[]` via static analysis.
 
 Approximate mapping:
 
-| Current `FieldInfo` property                    | Target IR                                          |
-| ----------------------------------------------- | -------------------------------------------------- |
-| `name`                                          | `FieldNode.name`                                   |
+| Current `FieldInfo` property                    | Target IR                                            |
+| ----------------------------------------------- | ---------------------------------------------------- |
+| `name`                                          | `FieldNode.name`                                     |
 | `type` (ts.Type)                                | Resolved to a `TypeNode` by the type-to-IR converter |
-| `optional`                                      | `FieldNode.required = !optional`                   |
-| `deprecated`                                    | `DeprecatedAnnotationNode`                         |
-| `defaultValue`                                  | `DefaultValueAnnotationNode`                       |
-| legacy extracted tag/decorator metadata carrier | Normalized to `ConstraintNode` and `AnnotationNode` |
+| `optional`                                      | `FieldNode.required = !optional`                     |
+| `deprecated`                                    | `DeprecatedAnnotationNode`                           |
+| `defaultValue`                                  | `DefaultValueAnnotationNode`                         |
+| legacy extracted tag/decorator metadata carrier | Normalized to `ConstraintNode` and `AnnotationNode`  |
 
 Historically, some implementations used `DecoratorInfo`-shaped carriers, including for synthetic JSDoc-derived metadata. Those are transitional implementation details only.
 
 Approximate historical mapping examples:
 
-| Legacy metadata shape      | Target IR                                     |
-| -------------------------- | ---------------------------------------------- |
-| `Minimum(n)`               | `NumericConstraintNode("minimum", n)`          |
-| `Maximum(n)`               | `NumericConstraintNode("maximum", n)`          |
-| `ExclusiveMinimum(n)`      | `NumericConstraintNode("exclusiveMinimum", n)` |
-| `ExclusiveMaximum(n)`      | `NumericConstraintNode("exclusiveMaximum", n)` |
-| `MinLength(n)`             | `LengthConstraintNode("minLength", n)`         |
-| `MaxLength(n)`             | `LengthConstraintNode("maxLength", n)`         |
-| `Pattern(s)`               | `PatternConstraintNode(s)`                     |
-| `Field({ displayName })`   | `DisplayNameAnnotationNode(displayName)`       |
-| `Field({ description })`   | `DescriptionAnnotationNode(description)`       |
-| `Field({ placeholder })`   | `PlaceholderAnnotationNode(placeholder)`       |
+| Legacy metadata shape    | Target IR                                      |
+| ------------------------ | ---------------------------------------------- |
+| `Minimum(n)`             | `NumericConstraintNode("minimum", n)`          |
+| `Maximum(n)`             | `NumericConstraintNode("maximum", n)`          |
+| `ExclusiveMinimum(n)`    | `NumericConstraintNode("exclusiveMinimum", n)` |
+| `ExclusiveMaximum(n)`    | `NumericConstraintNode("exclusiveMaximum", n)` |
+| `MinLength(n)`           | `LengthConstraintNode("minLength", n)`         |
+| `MaxLength(n)`           | `LengthConstraintNode("maxLength", n)`         |
+| `Pattern(s)`             | `PatternConstraintNode(s)`                     |
+| `Field({ displayName })` | `DisplayNameAnnotationNode(displayName)`       |
+| `Field({ description })` | `DescriptionAnnotationNode(description)`       |
+| `Field({ placeholder })` | `PlaceholderAnnotationNode(placeholder)`       |
 
 Legacy decorator-specific resolution logic should be deleted, not preserved. The target system is TSDoc plus ChainDSL only.
 
@@ -84,12 +84,12 @@ The current `ConstraintConfig` type in `@formspec/constraints` can be reinterpre
 
 Approximate mapping examples:
 
-| Current `ConstraintConfig` key       | Target enforcement idea                                |
-| ------------------------------------ | ------------------------------------------------------ |
-| `fieldTypes.dynamicEnum: "error"`    | Error on runtime option-capable fields when disabled   |
-| `fieldTypes.dynamicSchema: "error"`  | Error on `DynamicTypeNode("schema")` when disabled     |
-| `layout.group: "off"`                | Restrict `GroupLayoutNode` usage                       |
-| `layout.conditionals: "warn"`        | Warn on `ConditionalLayoutNode` usage                  |
-| `layout.maxNestingDepth: N`          | Error when nesting depth exceeds `N`                   |
+| Current `ConstraintConfig` key      | Target enforcement idea                              |
+| ----------------------------------- | ---------------------------------------------------- |
+| `fieldTypes.dynamicEnum: "error"`   | Error on runtime option-capable fields when disabled |
+| `fieldTypes.dynamicSchema: "error"` | Error on `DynamicTypeNode("schema")` when disabled   |
+| `layout.group: "off"`               | Restrict `GroupLayoutNode` usage                     |
+| `layout.conditionals: "warn"`       | Warn on `ConditionalLayoutNode` usage                |
+| `layout.maxNestingDepth: N`         | Error when nesting depth exceeds `N`                 |
 
 This enforcement belongs in validation of the IR, not in canonicalization and not in the generators.

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -136,6 +136,7 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
 - Added user-authored confidence test tracks.
   - The matrix now distinguishes data-model conformance tests from dynamic-option tests and dynamic-schema resolver tests.
   - These are explicitly framed as user integration-confidence tests rather than parity tests.
+
 # 2026-03-25
 
 ## 001-canonical-ir

--- a/packages/eslint-plugin/src/__tests__/rules/consistent-constraints.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/consistent-constraints.test.ts
@@ -9,6 +9,8 @@
  * - Path-targeted constraints skipped entirely
  * - Edge values (negative, float, zero)
  *
+ * @see docs/002-tsdoc-grammar.md §2.1 (constraint contradiction detection)
+ * @see docs/005-numeric-types.md §7.2 (numeric bound consistency)
  * @see https://json-schema.org/understanding-json-schema/reference/numeric#range
  */
 

--- a/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
@@ -11,6 +11,8 @@
  * - PascalCase tag equivalence (@Minimum identical to @minimum)
  * - Path-targeted constraints (@minimum :prop value) skipped entirely
  *
+ * @see docs/002-tsdoc-grammar.md §2.1 (constraint tag type applicability)
+ * @see docs/003-json-schema-vocabulary.md §2.6-§2.7 (constraint → keyword mapping)
  * @see https://json-schema.org/understanding-json-schema/reference/numeric#range
  * @see https://json-schema.org/understanding-json-schema/reference/string#length
  * @see https://json-schema.org/understanding-json-schema/reference/array#length


### PR DESCRIPTION
## Summary

- Expands `constraint-type-mismatch` tests from 13 to 59 cases, adding every constraint × incompatible type combination: each numeric constraint (`@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, `@multipleOf`) is now tested on string, boolean, and array; each string constraint (`@minLength`, `@maxLength`, `@pattern`) on number, boolean, and array; each array constraint (`@minItems`, `@maxItems`) on string, number, and boolean
- Adds positive cases for camelCase/PascalCase equivalence (both `@minimum` and `@Minimum` tested on number fields) and for malformed tag syntax that must be silently ignored: bare tags with no value, non-numeric values, invalid number formats (`1.2.3`), unrecognized tag names, and all path-targeted constraint forms including bad path-target syntax variants
- Expands `consistent-constraints` tests from 26 to 33 cases, adding valid cases for float bounds, close-boundary mixed exclusive/inclusive ranges (`@Minimum 50 @ExclusiveMaximum 51`), and three path-targeted scenarios that must all be skipped; adds invalid cases for conflicting same-side bounds with differing values

## Test plan

- [ ] `pnpm --filter @formspec/eslint-plugin run test` — 132 tests pass (up from 93 on main)
- [ ] `pnpm exec eslint packages/eslint-plugin/src/__tests__/rules/` — clean
- [ ] `pnpm exec prettier --check packages/eslint-plugin/src/__tests__/rules/` — clean