### PR TITLE
docs(cli): align UI schema output contract (#26)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -243,7 +243,7 @@
   ├── instance_methods/
   │   └── methodName/
   │       ├── params.schema.json
-  │       ├── params.ui_schema.json
+  │       ├── params.ui_schema.json     # emitted when FormSpec-based params UI schema is available
   │       └── return_type.schema.json
   └── static_methods/
       └── ...

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -202,7 +202,7 @@ generated/
 │   ├── instance_methods/
 │   │   └── methodName/
 │   │       ├── params.schema.json
-│   │       ├── params.ui_schema.json
+│   │       ├── params.ui_schema.json (if FormSpec-based)
 │   │       └── return_type.schema.json
 │   └── static_methods/
 │       └── methodName/

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -164,7 +164,7 @@ OPTIONS:
 
 OUTPUT FILES:
   - Class outputs include schema.json and ui_schema.json
-  - Method parameter UI schemas are written as params.ui_schema.json
+  - When available, method parameter UI schemas are written as params.ui_schema.json
   - FormSpec export UI schemas are written as ui_schema.json
 
 EXAMPLES:


### PR DESCRIPTION
## Summary
Aligns the CLI docs and help output to the current UI schema file contract.

## Includes
- help text now refers to JSON Forms UI Schema output
- docs use ui_schema.json and params.ui_schema.json consistently
- stale ux_spec.json framing removed from the CLI package docs/changelog

## Verification
- pnpm run build
- pnpm --filter @formspec/cli run test
- pnpm run typecheck
- pnpm run lint
