### PR TITLE
test(e2e): add UI schema completeness coverage (#90)

### DIFF
--- a/.changeset/ui-schema-completeness-placeholder.md
+++ b/.changeset/ui-schema-completeness-placeholder.md
@@ -1,0 +1,6 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+---
+
+Add UI Schema placeholder support for TSDoc and ChainDSL fields, and cover UI Schema completeness with direct spec-driven E2E tests.

--- a/e2e/fixtures/chain-dsl/ui-schema-completeness.ts
+++ b/e2e/fixtures/chain-dsl/ui-schema-completeness.ts
@@ -1,0 +1,25 @@
+import { formspec, field, group, when, is } from "@formspec/dsl";
+
+export const UiSchemaCompletenessForm = formspec(
+  group(
+    "Profile",
+    field.text("firstName", {
+      label: "First Name",
+      placeholder: "Enter your first name",
+      required: true,
+    }),
+    field.text("lastName", { required: true }),
+    field.text("emailAddress")
+  ),
+  field.enum("contactMethod", ["email", "phone"] as const, {
+    label: "Preferred Contact Method",
+    required: true,
+  }),
+  when(is("contactMethod", "phone"), field.text("phoneNumber", { label: "Phone Number" })),
+  field.objectWithConfig(
+    "billingAddress",
+    { label: "Billing Address" },
+    field.text("street", { label: "Street", required: true }),
+    field.text("city", { label: "City", required: true })
+  )
+);

--- a/e2e/fixtures/tsdoc-class/ui-schema-completeness.ts
+++ b/e2e/fixtures/tsdoc-class/ui-schema-completeness.ts
@@ -1,0 +1,18 @@
+export interface BillingAddress {
+  street: string;
+  city: string;
+}
+
+export class UiSchemaCompletenessForm {
+  accountId!: string;
+
+  /**
+   * @displayName Full Name
+   * @placeholder Enter your full name
+   */
+  fullName!: string;
+
+  emailAddress!: string;
+
+  billingAddress!: BillingAddress;
+}

--- a/e2e/tests/ui-schema-completeness.test.ts
+++ b/e2e/tests/ui-schema-completeness.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildFormSchemas } from "@formspec/build";
+import { UiSchemaCompletenessForm as ChainUiSchemaCompletenessForm } from "../fixtures/chain-dsl/ui-schema-completeness.js";
+import {
+  assertUiSchemaRule,
+  findSchemaFile,
+  findUiElement,
+  resolveFixture,
+  runCli,
+} from "../helpers/schema-assertions.js";
+
+describe("UI Schema Completeness", () => {
+  describe("TSDoc pipeline", () => {
+    let tempDir: string;
+    let uiSchema: Record<string, unknown>;
+    let elements: Record<string, unknown>[];
+
+    beforeAll(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-e2e-ui-tsdoc-"));
+      const fixturePath = resolveFixture("tsdoc-class", "ui-schema-completeness.ts");
+      const result = runCli(["generate", fixturePath, "UiSchemaCompletenessForm", "-o", tempDir]);
+      expect(result.exitCode).toBe(0);
+
+      const uiSchemaFile = findSchemaFile(tempDir, "ui_schema.json");
+      expect(uiSchemaFile).toBeDefined();
+      if (!uiSchemaFile) throw new Error("UI schema file not found");
+      uiSchema = JSON.parse(fs.readFileSync(uiSchemaFile, "utf-8")) as Record<string, unknown>;
+      elements = uiSchema["elements"] as Record<string, unknown>[];
+    });
+
+    afterAll(() => {
+      if (tempDir && fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true });
+      }
+    });
+
+    it("renders a VerticalLayout root with controls in source order", () => {
+      expect(uiSchema["type"]).toBe("VerticalLayout");
+      expect(elements).toHaveLength(4);
+      expect(elements.map(scopeOf)).toEqual([
+        "#/properties/accountId",
+        "#/properties/fullName",
+        "#/properties/emailAddress",
+        "#/properties/billingAddress",
+      ]);
+    });
+
+    it("maps displayName to label and placeholder to options.placeholder", () => {
+      const fullName = findUiElement(uiSchema, "#/properties/fullName");
+      expect(fullName).toMatchObject({
+        type: "Control",
+        scope: "#/properties/fullName",
+        label: "Full Name",
+        options: { placeholder: "Enter your full name" },
+      });
+    });
+
+    it("keeps nested object fields scoped to the object property", () => {
+      const address = findUiElement(uiSchema, "#/properties/billingAddress");
+      expect(address).toMatchObject({
+        type: "Control",
+        scope: "#/properties/billingAddress",
+        label: "Billing Address",
+      });
+    });
+
+    it("infers labels when displayName is absent", () => {
+      const accountId = findUiElement(uiSchema, "#/properties/accountId");
+      const emailAddress = findUiElement(uiSchema, "#/properties/emailAddress");
+      const billingAddress = findUiElement(uiSchema, "#/properties/billingAddress");
+
+      expect(accountId).toMatchObject({
+        type: "Control",
+        scope: "#/properties/accountId",
+        label: "Account Id",
+      });
+      expect(emailAddress).toMatchObject({
+        type: "Control",
+        scope: "#/properties/emailAddress",
+        label: "Email Address",
+      });
+      expect(billingAddress).toMatchObject({
+        type: "Control",
+        scope: "#/properties/billingAddress",
+        label: "Billing Address",
+      });
+    });
+  });
+
+  describe("Chain DSL pipeline", () => {
+    const { uiSchema } = buildFormSchemas(ChainUiSchemaCompletenessForm);
+    const elements = uiSchema.elements as Record<string, unknown>[];
+
+    it("renders the group and root controls in source order", () => {
+      expect(uiSchema.type).toBe("VerticalLayout");
+      expect(elements).toHaveLength(4);
+      expect(elements[0]).toMatchObject({ type: "Group", label: "Profile" });
+      expect(elements[1]).toMatchObject({
+        type: "Control",
+        scope: "#/properties/contactMethod",
+        label: "Preferred Contact Method",
+      });
+      expect(elements[2]).toMatchObject({
+        type: "Control",
+        scope: "#/properties/phoneNumber",
+        label: "Phone Number",
+      });
+      expect(elements[3]).toMatchObject({
+        type: "Control",
+        scope: "#/properties/billingAddress",
+        label: "Billing Address",
+      });
+    });
+
+    it("maps group children and placeholder options", () => {
+      const group = elements[0];
+      expect(group).toBeDefined();
+      if (!group) {
+        throw new Error("Expected group element at index 0");
+      }
+      const groupElements = group["elements"] as Record<string, unknown>[];
+
+      expect(groupElements).toHaveLength(3);
+      expect(groupElements[0]).toMatchObject({
+        type: "Control",
+        scope: "#/properties/firstName",
+        label: "First Name",
+        options: { placeholder: "Enter your first name" },
+      });
+      expect(groupElements[1]).toMatchObject({
+        type: "Control",
+        scope: "#/properties/lastName",
+        label: "Last Name",
+      });
+      expect(groupElements[2]).toMatchObject({
+        type: "Control",
+        scope: "#/properties/emailAddress",
+        label: "Email Address",
+      });
+    });
+
+    it("attaches a SHOW rule to the conditional field", () => {
+      assertUiSchemaRule(uiSchema, "#/properties/phoneNumber", "SHOW", {
+        scope: "#/properties/contactMethod",
+        schema: { const: "phone" },
+      });
+    });
+
+    it("keeps the nested object field as a scoped Control", () => {
+      const address = findUiElement(uiSchema, "#/properties/billingAddress");
+      expect(address).toMatchObject({
+        type: "Control",
+        scope: "#/properties/billingAddress",
+        label: "Billing Address",
+      });
+    });
+  });
+});
+
+function scopeOf(element: Record<string, unknown>): string | undefined {
+  return typeof element["scope"] === "string" ? element["scope"] : undefined;
+}

--- a/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
+++ b/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
@@ -378,6 +378,23 @@ describe("extractJSDocAnnotationNodes", () => {
     });
   });
 
+  it("produces PlaceholderAnnotationNode for @placeholder", () => {
+    const prop = getInterfacePropertyFromSource(`
+      interface Foo {
+        /** @placeholder Enter your email address */
+        email: string;
+      }
+    `);
+
+    const result = extractJSDocAnnotationNodes(prop);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      kind: "annotation",
+      annotationKind: "placeholder",
+      value: "Enter your email address",
+    });
+  });
+
   it("produces DeprecatedAnnotationNode for @deprecated", () => {
     const prop = getInterfacePropertyFromSource(`
       interface Foo {

--- a/packages/build/src/__tests__/ir-ui-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-ui-schema-generator.test.ts
@@ -118,6 +118,21 @@ function labelledFieldNode(name: string, label: string): FieldNode {
   };
 }
 
+/** Build a FieldNode with a placeholder annotation. */
+function placeholderFieldNode(name: string, placeholder: string): FieldNode {
+  return {
+    ...simpleFieldNode(name),
+    annotations: [
+      {
+        kind: "annotation",
+        annotationKind: "placeholder",
+        value: placeholder,
+        provenance: CHAIN_DSL_PROVENANCE,
+      },
+    ],
+  };
+}
+
 /** Build a GroupLayoutNode wrapping the given elements. */
 function groupNode(label: string, elements: FormIR["elements"]): GroupLayoutNode {
   return {
@@ -174,14 +189,15 @@ describe("generateUiSchemaFromIR", () => {
 
       const control = expectControl(result.elements, 0);
       expect(control.scope).toBe("#/properties/name");
+      expect(control.label).toBe("Name");
     });
 
-    it("should not include a label when no displayName annotation is present", () => {
+    it("should infer a label when no displayName annotation is present", () => {
       const ir = formIRFromElements([simpleFieldNode("email")]);
       const result = generateUiSchemaFromIR(ir);
 
       const control = expectControl(result.elements, 0);
-      expect(control.label).toBeUndefined();
+      expect(control.label).toBe("Email");
     });
 
     it("should not include a rule on an unconditional field", () => {
@@ -228,6 +244,14 @@ describe("generateUiSchemaFromIR", () => {
       expect(control.label).toBe("Full Name");
     });
 
+    it("should infer a label when displayName is absent", () => {
+      const ir = formIRFromElements([simpleFieldNode("emailAddress")]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.label).toBe("Email Address");
+    });
+
     it("should use the first displayName annotation when multiple annotations are present", () => {
       const fieldNode: FieldNode = {
         ...simpleFieldNode("field"),
@@ -253,7 +277,7 @@ describe("generateUiSchemaFromIR", () => {
       expect(control.label).toBe("First Label");
     });
 
-    it("should not produce a label when only non-displayName annotations are present", () => {
+    it("should infer a label when only non-displayName annotations are present", () => {
       const fieldNode: FieldNode = {
         ...simpleFieldNode("field"),
         annotations: [
@@ -269,7 +293,15 @@ describe("generateUiSchemaFromIR", () => {
       const result = generateUiSchemaFromIR(ir);
 
       const control = expectControl(result.elements, 0);
-      expect(control.label).toBeUndefined();
+      expect(control.label).toBe("Field");
+    });
+
+    it("should map placeholder annotations to Control options", () => {
+      const ir = formIRFromElements([placeholderFieldNode("emailAddress", "name@example.com")]);
+      const result = generateUiSchemaFromIR(ir);
+
+      const control = expectControl(result.elements, 0);
+      expect(control.options).toEqual({ placeholder: "name@example.com" });
     });
   });
 

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -14,9 +14,9 @@
  *    — Parsed via TSDocParser as custom block tags.
  *    Both camelCase and PascalCase forms are accepted (e.g., `@Minimum`).
  *
- * 2. **Annotation tags** (`@displayName`, `@description`):
- *    These are parsed as structured custom block tags and mapped directly
- *    onto annotation IR nodes.
+ * 2. **Annotation tags** (`@displayName`, `@description`, `@placeholder`):
+ *    Canonical tags are emitted as annotation IR nodes and parsed
+ *    structurally via the TSDoc custom block-tag pipeline.
  *
  * The `@deprecated` tag is a standard TSDoc block tag, parsed structurally.
  *
@@ -110,7 +110,7 @@ function createFormSpecTSDocConfig(): TSDocConfiguration {
   }
 
   // Register annotation tags that participate in the canonical IR.
-  for (const tagName of ["displayName", "description"]) {
+  for (const tagName of ["displayName", "description", "placeholder"]) {
     config.addTagDefinition(
       new TSDocTagDefinition({
         tagName: "@" + tagName,
@@ -154,8 +154,9 @@ export interface TSDocParseResult {
  * nodes.
  *
  * For constraint tags (`@minimum`, `@pattern`, `@enumOptions`, etc.),
- * the structured TSDoc parser is used. Canonical annotation tags
- * (`@displayName`, `@description`) are also parsed structurally.
+ * the structured TSDoc parser is used. Canonical `@displayName`,
+ * `@description`, and `@placeholder` annotations are also parsed
+ * structurally.
  *
  * @param node - The TS AST node to inspect (PropertyDeclaration, PropertySignature, etc.)
  * @param file - Absolute source file path for provenance
@@ -166,8 +167,10 @@ export function parseTSDocTags(node: ts.Node, file = ""): TSDocParseResult {
   const annotations: AnnotationNode[] = [];
   let displayName: string | undefined;
   let description: string | undefined;
+  let placeholder: string | undefined;
   let displayNameProvenance: Provenance | undefined;
   let descriptionProvenance: Provenance | undefined;
+  let placeholderProvenance: Provenance | undefined;
 
   // ----- Phase 1: TSDoc structural parse for constraint tags -----
   const sourceFile = node.getSourceFile();
@@ -196,7 +199,11 @@ export function parseTSDocTags(node: ts.Node, file = ""): TSDocParseResult {
       // TS compiler API in Phase 1b below.
       for (const block of docComment.customBlocks) {
         const tagName = normalizeConstraintTagName(block.blockTag.tagName.substring(1)); // Remove leading @ and normalize to camelCase
-        if (tagName === "displayName" || tagName === "description") {
+        if (
+          tagName === "displayName" ||
+          tagName === "description" ||
+          tagName === "placeholder"
+        ) {
           const text = extractBlockText(block).trim();
           if (text === "") continue;
 
@@ -204,9 +211,12 @@ export function parseTSDocTags(node: ts.Node, file = ""): TSDocParseResult {
           if (tagName === "displayName") {
             displayName = text;
             displayNameProvenance = provenance;
-          } else {
+          } else if (tagName === "description") {
             description = text;
             descriptionProvenance = provenance;
+          } else {
+            placeholder = text;
+            placeholderProvenance = provenance;
           }
           continue;
         }
@@ -249,6 +259,14 @@ export function parseTSDocTags(node: ts.Node, file = ""): TSDocParseResult {
       annotationKind: "description",
       value: description,
       provenance: descriptionProvenance,
+    });
+  }
+  if (placeholder !== undefined && placeholderProvenance !== undefined) {
+    annotations.push({
+      kind: "annotation",
+      annotationKind: "placeholder",
+      value: placeholder,
+      provenance: placeholderProvenance,
     });
   }
 

--- a/packages/build/src/ui-schema/ir-generator.ts
+++ b/packages/build/src/ui-schema/ir-generator.ts
@@ -40,6 +40,30 @@ function fieldToScope(fieldName: string): string {
 }
 
 /**
+ * Converts a property name into a human-friendly UI label.
+ *
+ * Examples:
+ * - `fullName` -> `Full Name`
+ * - `billing_address` -> `Billing Address`
+ * - `account-id` -> `Account Id`
+ */
+function inferLabelFromFieldName(fieldName: string): string {
+  const withSpaces = fieldName
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .trim();
+
+  if (withSpaces === "") {
+    return fieldName;
+  }
+
+  return withSpaces
+    .split(/\s+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+/**
  * Creates a SHOW rule for a single conditional field/value pair.
  */
 function createShowRule(fieldName: string, value: unknown): Rule {
@@ -99,11 +123,16 @@ function combineRules(parentRule: Rule, childRule: Rule): Rule {
  */
 function fieldNodeToControl(field: FieldNode, parentRule?: Rule): ControlElement {
   const displayNameAnnotation = field.annotations.find((a) => a.annotationKind === "displayName");
+  const placeholderAnnotation = field.annotations.find((a) => a.annotationKind === "placeholder");
+  const label = displayNameAnnotation?.value ?? inferLabelFromFieldName(field.name);
 
   const control: ControlElement = {
     type: "Control",
     scope: fieldToScope(field.name),
-    ...(displayNameAnnotation !== undefined && { label: displayNameAnnotation.value }),
+    label,
+    ...(placeholderAnnotation !== undefined && {
+      options: { placeholder: placeholderAnnotation.value },
+    }),
     ...(parentRule !== undefined && { rule: parentRule }),
   };
 


### PR DESCRIPTION
## Summary
Adds focused UI schema completeness coverage and the minimal parser/UI-generator changes needed to support the revised spec.

## Includes
- label inference when @displayName is absent
- @placeholder mapped to Control.options.placeholder
- focused build tests for parser and UI schema generation
- focused E2E coverage for TSDoc and Chain DSL UI schema output

## Verification
- pnpm --filter @formspec/build run test -- --run src/__tests__/ir-jsdoc-constraints.test.ts src/__tests__/ir-ui-schema-generator.test.ts
- pnpm --filter @formspec/e2e exec vitest run tests/ui-schema-completeness.test.ts

## Notes
- Gold-master expected-file updates were intentionally reverted; the new targeted normative tests are the source of truth for this PR.
