### PR TITLE
feat(build,cli): adopt semantic diagnostics (#92)

### DIFF
--- a/.changeset/semantic-diagnostics-cli-format.md
+++ b/.changeset/semantic-diagnostics-cli-format.md
@@ -1,0 +1,8 @@
+---
+"@formspec/build": minor
+"@formspec/cli": minor
+---
+
+Switch constraint validation to semantic diagnostic codes such as `CONTRADICTING_CONSTRAINTS`, `TYPE_MISMATCH`, and `UNKNOWN_EXTENSION`.
+
+The CLI now prints those codes with repo-relative source locations so validation output is stable and reviewable in tests and downstream tooling.

--- a/e2e/fixtures/tsdoc-class/error-broadening-constraint.ts
+++ b/e2e/fixtures/tsdoc-class/error-broadening-constraint.ts
@@ -1,0 +1,11 @@
+/**
+ * @minimum 10
+ */
+type MinimumTen = number;
+
+export class BroadeningConstraintForm {
+  /**
+   * @minimum 0
+   */
+  quantity!: MinimumTen;
+}

--- a/e2e/fixtures/tsdoc-class/error-contradicting-constraints.ts
+++ b/e2e/fixtures/tsdoc-class/error-contradicting-constraints.ts
@@ -1,0 +1,13 @@
+export class ContradictingConstraintsForm {
+  /**
+   * @minimum 10
+   * @maximum 5
+   */
+  count!: number;
+
+  /**
+   * @minLength 5
+   * @maxLength 2
+   */
+  code!: string;
+}

--- a/e2e/fixtures/tsdoc-class/error-invalid-path-target.ts
+++ b/e2e/fixtures/tsdoc-class/error-invalid-path-target.ts
@@ -1,0 +1,11 @@
+interface Address {
+  street: string;
+  city: string;
+}
+
+export class InvalidPathTargetForm {
+  /**
+   * @minLength :zip 5
+   */
+  address!: Address;
+}

--- a/e2e/fixtures/tsdoc-class/error-type-mismatch.ts
+++ b/e2e/fixtures/tsdoc-class/error-type-mismatch.ts
@@ -1,0 +1,11 @@
+export class TypeMismatchDiagnosticsForm {
+  /**
+   * @minimum 0
+   */
+  name!: string;
+
+  /**
+   * @minItems 1
+   */
+  total!: number;
+}

--- a/e2e/tests/diagnostics-supported.test.ts
+++ b/e2e/tests/diagnostics-supported.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { resolveFixture, runCli } from "../helpers/schema-assertions.js";
+
+describe("Supported diagnostics", () => {
+  it("reports semantic contradiction diagnostics with field names, constraint names, and locations", () => {
+    const fixturePath = resolveFixture("tsdoc-class", "error-contradicting-constraints.ts");
+    const result = runCli([
+      "generate",
+      fixturePath,
+      "ContradictingConstraintsForm",
+      "--validate-only",
+    ]);
+    const output = result.stdout + result.stderr;
+
+    expect(result.exitCode).toBe(1);
+    expect(output).toContain('Class "ContradictingConstraintsForm": 2 diagnostic(s)');
+    expect(output).toContain("[ERROR] CONTRADICTING_CONSTRAINTS");
+    expect(output).toContain('Field "count"');
+    expect(output).toContain("minimum");
+    expect(output).toContain("maximum");
+    expect(output).toContain('Field "code"');
+    expect(output).toContain("minLength");
+    expect(output).toContain("maxLength");
+    expect(output).toContain("fixtures/tsdoc-class/error-contradicting-constraints.ts:2:");
+    expect(output).toContain("fixtures/tsdoc-class/error-contradicting-constraints.ts:8:");
+    expect(output).toContain(
+      "related: fixtures/tsdoc-class/error-contradicting-constraints.ts:2:"
+    );
+    expect(output).toContain(
+      "related: fixtures/tsdoc-class/error-contradicting-constraints.ts:8:"
+    );
+  });
+
+  it("reports semantic type-mismatch diagnostics with field names, constraint names, and locations", () => {
+    const fixturePath = resolveFixture("tsdoc-class", "error-type-mismatch.ts");
+    const result = runCli([
+      "generate",
+      fixturePath,
+      "TypeMismatchDiagnosticsForm",
+      "--validate-only",
+    ]);
+    const output = result.stdout + result.stderr;
+
+    expect(result.exitCode).toBe(1);
+    expect(output).toContain('Class "TypeMismatchDiagnosticsForm": 2 diagnostic(s)');
+    expect(output).toContain("[ERROR] TYPE_MISMATCH");
+    expect(output).toContain('Field "name"');
+    expect(output).toContain('constraint "minimum"');
+    expect(output).toContain('Field "total"');
+    expect(output).toContain('constraint "minItems"');
+    expect(output).toContain("fixtures/tsdoc-class/error-type-mismatch.ts:2:");
+    expect(output).toContain("fixtures/tsdoc-class/error-type-mismatch.ts:7:");
+  });
+
+  it.skip("BUG: invalid path targets should produce UNKNOWN_PATH_TARGET with the unresolved segment", () => {
+    const fixturePath = resolveFixture("tsdoc-class", "error-invalid-path-target.ts");
+    const result = runCli(["generate", fixturePath, "InvalidPathTargetForm", "--validate-only"]);
+    const output = result.stdout + result.stderr;
+
+    expect(result.exitCode).toBe(1);
+    expect(output).toContain("[ERROR] UNKNOWN_PATH_TARGET");
+    expect(output).toContain('Field "address"');
+    expect(output).toContain("zip");
+  });
+
+  it.skip("BUG: field-level broadening should produce CONSTRAINT_BROADENING", () => {
+    const fixturePath = resolveFixture("tsdoc-class", "error-broadening-constraint.ts");
+    const result = runCli(["generate", fixturePath, "BroadeningConstraintForm", "--validate-only"]);
+    const output = result.stdout + result.stderr;
+
+    expect(result.exitCode).toBe(1);
+    expect(output).toContain("[ERROR] CONSTRAINT_BROADENING");
+    expect(output).toContain('Field "quantity"');
+    expect(output).toContain("@minimum");
+  });
+});

--- a/packages/build/src/__tests__/constraint-validator.test.ts
+++ b/packages/build/src/__tests__/constraint-validator.test.ts
@@ -207,12 +207,12 @@ function makeIR(fields: readonly FieldNode[]): FormIR {
   };
 }
 
-/** Extract diagnostics matching a code prefix (e.g. "FORMSPEC-CONTRADICTION"). */
+/** Extract diagnostics matching an exact semantic code. */
 function byCode(
   diagnostics: readonly ValidationDiagnostic[],
-  prefix: string
+  code: string
 ): readonly ValidationDiagnostic[] {
-  return diagnostics.filter((d) => d.code.startsWith(prefix));
+  return diagnostics.filter((d) => d.code === code);
 }
 
 // =============================================================================
@@ -255,7 +255,7 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("minimum > maximum", () => {
-    it("emits CONTRADICTION-001 when minimum > maximum", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when minimum > maximum", () => {
       const ir = makeIR([
         makeField("count", NUMBER_TYPE, [minConstraint(10, 1), maxConstraint(5, 2)]),
       ]);
@@ -264,7 +264,7 @@ describe("validateIR", () => {
       expect(result.valid).toBe(false);
       expect(result.diagnostics).toHaveLength(1);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(diag?.code).toBe("CONTRADICTING_CONSTRAINTS");
       expect(diag?.message).toContain("minimum");
       expect(diag?.message).toContain("maximum");
       expect(diag?.message).toContain("count");
@@ -286,7 +286,7 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("exclusiveMinimum >= maximum", () => {
-    it("emits CONTRADICTION-001 when exclusiveMinimum === maximum", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when exclusiveMinimum === maximum", () => {
       const ir = makeIR([
         makeField("val", NUMBER_TYPE, [exMinConstraint(5, 1), maxConstraint(5, 2)]),
       ]);
@@ -294,11 +294,11 @@ describe("validateIR", () => {
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(diag?.code).toBe("CONTRADICTING_CONSTRAINTS");
       expect(diag?.message).toContain("exclusiveMinimum");
     });
 
-    it("emits CONTRADICTION-001 when exclusiveMinimum > maximum", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when exclusiveMinimum > maximum", () => {
       const ir = makeIR([
         makeField("val", NUMBER_TYPE, [exMinConstraint(10, 1), maxConstraint(5, 2)]),
       ]);
@@ -320,7 +320,7 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("minimum >= exclusiveMaximum", () => {
-    it("emits CONTRADICTION-001 when minimum === exclusiveMaximum", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when minimum === exclusiveMaximum", () => {
       const ir = makeIR([
         makeField("val", NUMBER_TYPE, [minConstraint(5, 1), exMaxConstraint(5, 2)]),
       ]);
@@ -328,11 +328,11 @@ describe("validateIR", () => {
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(diag?.code).toBe("CONTRADICTING_CONSTRAINTS");
       expect(diag?.message).toContain("exclusiveMaximum");
     });
 
-    it("emits CONTRADICTION-001 when minimum > exclusiveMaximum", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when minimum > exclusiveMaximum", () => {
       const ir = makeIR([
         makeField("val", NUMBER_TYPE, [minConstraint(10, 1), exMaxConstraint(5, 2)]),
       ]);
@@ -352,7 +352,7 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("exclusiveMinimum >= exclusiveMaximum", () => {
-    it("emits CONTRADICTION-001 when exclusiveMinimum === exclusiveMaximum", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when exclusiveMinimum === exclusiveMaximum", () => {
       const ir = makeIR([
         makeField("val", NUMBER_TYPE, [exMinConstraint(5, 1), exMaxConstraint(5, 2)]),
       ]);
@@ -360,10 +360,10 @@ describe("validateIR", () => {
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(diag?.code).toBe("CONTRADICTING_CONSTRAINTS");
     });
 
-    it("emits CONTRADICTION-001 when exclusiveMinimum > exclusiveMaximum", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when exclusiveMinimum > exclusiveMaximum", () => {
       const ir = makeIR([
         makeField("val", NUMBER_TYPE, [exMinConstraint(6, 1), exMaxConstraint(5, 2)]),
       ]);
@@ -383,7 +383,7 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("minLength > maxLength", () => {
-    it("emits CONTRADICTION-001 when minLength > maxLength", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when minLength > maxLength", () => {
       const ir = makeIR([
         makeField("code", STRING_TYPE, [minLenConstraint(10, 1), maxLenConstraint(5, 2)]),
       ]);
@@ -391,7 +391,7 @@ describe("validateIR", () => {
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(diag?.code).toBe("CONTRADICTING_CONSTRAINTS");
       expect(diag?.message).toContain("minLength");
       expect(diag?.message).toContain("maxLength");
     });
@@ -409,7 +409,7 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("minItems > maxItems", () => {
-    it("emits CONTRADICTION-001 when minItems > maxItems", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when minItems > maxItems", () => {
       const ir = makeIR([
         makeField("tags", ARRAY_TYPE, [minItemsConstraint(5, 1), maxItemsConstraint(2, 2)]),
       ]);
@@ -417,7 +417,7 @@ describe("validateIR", () => {
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(diag?.code).toBe("CONTRADICTING_CONSTRAINTS");
       expect(diag?.message).toContain("minItems");
       expect(diag?.message).toContain("maxItems");
     });
@@ -435,7 +435,7 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("allowedMembers empty intersection", () => {
-    it("emits CONTRADICTION-001 when two allowedMembers sets are disjoint", () => {
+    it("emits CONTRADICTING_CONSTRAINTS when two allowedMembers sets are disjoint", () => {
       const ir = makeIR([
         makeField("status", enumType(["a", "b", "c"]), [
           allowedMembersConstraint(["a", "b"], 1),
@@ -446,7 +446,7 @@ describe("validateIR", () => {
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(diag?.code).toBe("CONTRADICTING_CONSTRAINTS");
       expect(diag?.message).toContain("allowedMembers");
     });
 
@@ -473,35 +473,35 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("numeric constraints on non-number fields", () => {
-    it("emits TYPE_MISMATCH-001 for minimum on a string field", () => {
+    it("emits TYPE_MISMATCH for minimum on a string field", () => {
       const ir = makeIR([makeField("name", STRING_TYPE, [minConstraint(5, 1)])]);
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(diag?.code).toBe("TYPE_MISMATCH");
       expect(diag?.message).toContain("minimum");
       expect(diag?.message).toContain("number");
       expect(diag?.message).toContain("string");
     });
 
-    it("emits TYPE_MISMATCH-001 for maximum on a string field", () => {
+    it("emits TYPE_MISMATCH for maximum on a string field", () => {
       const ir = makeIR([makeField("name", STRING_TYPE, [maxConstraint(10, 1)])]);
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     });
 
-    it("emits TYPE_MISMATCH-001 for exclusiveMinimum on a boolean field", () => {
+    it("emits TYPE_MISMATCH for exclusiveMinimum on a boolean field", () => {
       const ir = makeIR([makeField("flag", BOOL_TYPE, [exMinConstraint(0, 1)])]);
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     });
 
-    it("emits TYPE_MISMATCH-001 for multipleOf on a string field", () => {
+    it("emits TYPE_MISMATCH for multipleOf on a string field", () => {
       const multipleOf: NumericConstraintNode = {
         kind: "constraint",
         constraintKind: "multipleOf",
@@ -510,7 +510,7 @@ describe("validateIR", () => {
       };
       const ir = makeIR([makeField("name", STRING_TYPE, [multipleOf])]);
       expect(validateIR(ir).valid).toBe(false);
-      expect(validateIR(ir).diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(validateIR(ir).diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     });
   });
 
@@ -519,31 +519,31 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("string constraints on non-string fields", () => {
-    it("emits TYPE_MISMATCH-001 for minLength on a number field", () => {
+    it("emits TYPE_MISMATCH for minLength on a number field", () => {
       const ir = makeIR([makeField("age", NUMBER_TYPE, [minLenConstraint(1, 1)])]);
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(diag?.code).toBe("TYPE_MISMATCH");
       expect(diag?.message).toContain("minLength");
       expect(diag?.message).toContain("string");
     });
 
-    it("emits TYPE_MISMATCH-001 for maxLength on a boolean field", () => {
+    it("emits TYPE_MISMATCH for maxLength on a boolean field", () => {
       const ir = makeIR([makeField("flag", BOOL_TYPE, [maxLenConstraint(5, 1)])]);
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     });
 
-    it("emits TYPE_MISMATCH-001 for pattern on an array field", () => {
+    it("emits TYPE_MISMATCH for pattern on an array field", () => {
       const ir = makeIR([makeField("tags", ARRAY_TYPE, [patternConstraint("^[a-z]+$", 1)])]);
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     });
   });
 
@@ -552,31 +552,31 @@ describe("validateIR", () => {
   // ---------------------------------------------------------------------------
 
   describe("array constraints on non-array fields", () => {
-    it("emits TYPE_MISMATCH-001 for minItems on a string field", () => {
+    it("emits TYPE_MISMATCH for minItems on a string field", () => {
       const ir = makeIR([makeField("name", STRING_TYPE, [minItemsConstraint(1, 1)])]);
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(diag?.code).toBe("TYPE_MISMATCH");
       expect(diag?.message).toContain("minItems");
       expect(diag?.message).toContain("array");
     });
 
-    it("emits TYPE_MISMATCH-001 for maxItems on a number field", () => {
+    it("emits TYPE_MISMATCH for maxItems on a number field", () => {
       const ir = makeIR([makeField("count", NUMBER_TYPE, [maxItemsConstraint(5, 1)])]);
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     });
 
-    it("emits TYPE_MISMATCH-001 for uniqueItems on a string field", () => {
+    it("emits TYPE_MISMATCH for uniqueItems on a string field", () => {
       const ir = makeIR([makeField("name", STRING_TYPE, [uniqueItemsConstraint(1)])]);
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     });
 
     it("does not emit for uniqueItems on an array field", () => {
@@ -600,7 +600,7 @@ describe("validateIR", () => {
       const result = validateIR(ir);
 
       // Type-check passes (both patterns are on a string field), no contradiction
-      const contradictions = byCode(result.diagnostics, "FORMSPEC-CONTRADICTION");
+      const contradictions = byCode(result.diagnostics, "CONTRADICTING_CONSTRAINTS");
       expect(contradictions).toHaveLength(0);
     });
   });
@@ -671,7 +671,7 @@ describe("validateIR", () => {
 
       expect(result.valid).toBe(false);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(diag?.code).toBe("CONTRADICTING_CONSTRAINTS");
       // Qualified name should appear in the message
       expect(diag?.message).toContain("details.score");
     });
@@ -696,7 +696,7 @@ describe("validateIR", () => {
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
       expect(result.diagnostics[0]?.message).toContain("address.label");
     });
   });
@@ -752,26 +752,26 @@ describe("validateIR", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // 16. Custom vendor prefix
+  // 16. Semantic diagnostic codes
   // ---------------------------------------------------------------------------
 
-  describe("custom vendor prefix", () => {
-    it("uses the provided vendorPrefix in diagnostic codes", () => {
-      const ir = makeIR([
-        makeField("count", NUMBER_TYPE, [minConstraint(10, 1), maxConstraint(5, 2)]),
-      ]);
-      const result = validateIR(ir, { vendorPrefix: "ACME" });
-
-      expect(result.diagnostics[0]?.code).toBe("ACME-CONTRADICTION-001");
-    });
-
-    it("uses FORMSPEC as the default prefix when none is provided", () => {
+  describe("semantic diagnostic codes", () => {
+    it("uses semantic codes for contradictions", () => {
       const ir = makeIR([
         makeField("count", NUMBER_TYPE, [minConstraint(10, 1), maxConstraint(5, 2)]),
       ]);
       const result = validateIR(ir);
 
-      expect(result.diagnostics[0]?.code).toMatch(/^FORMSPEC-/);
+      expect(result.diagnostics[0]?.code).toBe("CONTRADICTING_CONSTRAINTS");
+    });
+
+    it("ignores vendorPrefix and keeps semantic codes stable", () => {
+      const ir = makeIR([
+        makeField("count", NUMBER_TYPE, [minConstraint(10, 1), maxConstraint(5, 2)]),
+      ]);
+      const result = validateIR(ir, { vendorPrefix: "ACME" });
+
+      expect(result.diagnostics[0]?.code).toBe("CONTRADICTING_CONSTRAINTS");
     });
   });
 
@@ -800,7 +800,7 @@ describe("validateIR", () => {
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(result.diagnostics[0]?.code).toBe("CONTRADICTING_CONSTRAINTS");
     });
 
     it("detects contradictions inside a conditional layout node", () => {
@@ -824,7 +824,7 @@ describe("validateIR", () => {
       const result = validateIR(ir);
 
       expect(result.valid).toBe(false);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-CONTRADICTION-001");
+      expect(result.diagnostics[0]?.code).toBe("CONTRADICTING_CONSTRAINTS");
     });
   });
 
@@ -905,7 +905,7 @@ describe("validateIR", () => {
       expect(result.valid).toBe(true); // warning, not error
       expect(result.diagnostics).toHaveLength(1);
       const diag = result.diagnostics[0];
-      expect(diag?.code).toBe("FORMSPEC-UNKNOWN_EXTENSION-001");
+      expect(diag?.code).toBe("UNKNOWN_EXTENSION");
       expect(diag?.severity).toBe("warning");
       expect(diag?.message).toContain("x-stripe/monetary/unknown-thing");
     });
@@ -938,7 +938,7 @@ describe("validateIR", () => {
       ]);
       const result = validateIR(ir, { vendorPrefix: "MYCO", extensionRegistry: registry });
 
-      expect(result.diagnostics[0]?.code).toBe("MYCO-UNKNOWN_EXTENSION-001");
+      expect(result.diagnostics[0]?.code).toBe("UNKNOWN_EXTENSION");
     });
 
     it("emits warning for each unknown custom constraint on different fields", () => {
@@ -969,7 +969,7 @@ describe("validateIR", () => {
 
       expect(result.valid).toBe(false);
       expect(result.diagnostics).toHaveLength(1);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
       expect(result.diagnostics[0]?.message).toContain("cannot be traversed");
     });
 

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -405,7 +405,7 @@ describe("Extension API", () => {
 
       expect(result.valid).toBe(false);
       expect(result.diagnostics).toHaveLength(1);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-TYPE_MISMATCH-001");
+      expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
       expect(result.diagnostics[0]?.message).toContain("ArrayOnly");
       expect(result.diagnostics[0]?.message).toContain("string");
     });
@@ -453,7 +453,7 @@ describe("Extension API", () => {
 
       expect(result.valid).toBe(true); // warning, not error
       expect(result.diagnostics).toHaveLength(1);
-      expect(result.diagnostics[0]?.code).toBe("FORMSPEC-UNKNOWN_EXTENSION-001");
+      expect(result.diagnostics[0]?.code).toBe("UNKNOWN_EXTENSION");
       expect(result.diagnostics[0]?.severity).toBe("warning");
     });
 

--- a/packages/build/src/validate/constraint-validator.ts
+++ b/packages/build/src/validate/constraint-validator.ts
@@ -31,9 +31,8 @@ import type { ExtensionRegistry } from "../extensions/index.js";
 /**
  * A structured diagnostic produced by constraint validation.
  *
- * The `code` follows the format: `{VENDOR}-{CATEGORY}-{NNN}`.
- * - VENDOR defaults to "FORMSPEC" (configurable via `vendorPrefix`).
- * - Categories: CONTRADICTION, TYPE_MISMATCH, UNKNOWN_EXTENSION
+ * The `code` is a stable, machine-readable semantic identifier.
+ * Examples: `CONTRADICTING_CONSTRAINTS`, `TYPE_MISMATCH`, `UNKNOWN_EXTENSION`.
  */
 export interface ValidationDiagnostic {
   readonly code: string;
@@ -54,10 +53,7 @@ export interface ValidationResult {
 
 /** Options for constraint validation. */
 export interface ValidateIROptions {
-  /**
-   * Vendor prefix used when constructing diagnostic codes.
-   * @defaultValue "FORMSPEC"
-   */
+  /** @deprecated Ignored. Diagnostic codes are semantic identifiers only. */
   readonly vendorPrefix?: string;
   /**
    * Extension registry for resolving custom constraint type applicability.
@@ -76,19 +72,12 @@ export interface ValidateIROptions {
 /** Mutable accumulator threaded through the validation walk. */
 interface ValidationContext {
   readonly diagnostics: ValidationDiagnostic[];
-  readonly vendorPrefix: string;
   readonly extensionRegistry: ExtensionRegistry | undefined;
 }
 
 // =============================================================================
 // DIAGNOSTIC FACTORIES
 // =============================================================================
-
-type DiagnosticCategory = "CONTRADICTION" | "TYPE_MISMATCH" | "UNKNOWN_EXTENSION";
-
-function makeCode(ctx: ValidationContext, category: DiagnosticCategory, number: number): string {
-  return `${ctx.vendorPrefix}-${category}-${String(number).padStart(3, "0")}`;
-}
 
 function addContradiction(
   ctx: ValidationContext,
@@ -97,7 +86,7 @@ function addContradiction(
   related: Provenance
 ): void {
   ctx.diagnostics.push({
-    code: makeCode(ctx, "CONTRADICTION", 1),
+    code: "CONTRADICTING_CONSTRAINTS",
     message,
     severity: "error",
     primaryLocation: primary,
@@ -107,7 +96,7 @@ function addContradiction(
 
 function addTypeMismatch(ctx: ValidationContext, message: string, primary: Provenance): void {
   ctx.diagnostics.push({
-    code: makeCode(ctx, "TYPE_MISMATCH", 1),
+    code: "TYPE_MISMATCH",
     message,
     severity: "error",
     primaryLocation: primary,
@@ -117,7 +106,7 @@ function addTypeMismatch(ctx: ValidationContext, message: string, primary: Prove
 
 function addUnknownExtension(ctx: ValidationContext, message: string, primary: Provenance): void {
   ctx.diagnostics.push({
-    code: makeCode(ctx, "UNKNOWN_EXTENSION", 1),
+    code: "UNKNOWN_EXTENSION",
     message,
     severity: "warning",
     primaryLocation: primary,
@@ -534,7 +523,6 @@ function validateElement(ctx: ValidationContext, element: FormIRElement): void {
 export function validateIR(ir: FormIR, options?: ValidateIROptions): ValidationResult {
   const ctx: ValidationContext = {
     diagnostics: [],
-    vendorPrefix: options?.vendorPrefix ?? "FORMSPEC",
     extensionRegistry: options?.extensionRegistry,
   };
 

--- a/packages/cli/src/__tests__/emit-ir-validate-only.test.ts
+++ b/packages/cli/src/__tests__/emit-ir-validate-only.test.ts
@@ -266,7 +266,7 @@ describe("validateIR: constraint violations", () => {
     expect(result.valid).toBe(false);
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.severity).toBe("error");
-    expect(result.diagnostics[0]?.code).toMatch(/CONTRADICTION/);
+    expect(result.diagnostics[0]?.code).toBe("CONTRADICTING_CONSTRAINTS");
     expect(result.diagnostics[0]?.message).toContain("minimum");
     expect(result.diagnostics[0]?.message).toContain("maximum");
   });
@@ -303,7 +303,7 @@ describe("validateIR: constraint violations", () => {
     expect(result.valid).toBe(false);
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.severity).toBe("error");
-    expect(result.diagnostics[0]?.code).toMatch(/TYPE_MISMATCH/);
+    expect(result.diagnostics[0]?.code).toBe("TYPE_MISMATCH");
   });
 
   it("returns valid=true for an empty IR with no elements", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -235,6 +235,14 @@ function writeIrFile(ir: FormIR, name: string, outDir: string): void {
   console.log(`✓ Wrote IR: ${filePath}`);
 }
 
+function formatDiagnosticLocation(file: string, line: number, column: number): string {
+  if (file.length === 0) {
+    return `${String(line)}:${String(column + 1)}`;
+  }
+
+  return `${path.relative(process.cwd(), file)}:${String(line)}:${String(column + 1)}`;
+}
+
 /**
  * Prints validation results and returns true if any error-severity diagnostics
  * were found (which should cause the CLI to exit non-zero).
@@ -253,7 +261,17 @@ function printValidationResult(result: ValidationResult, label: string): boolean
   console.warn(`⚠️  ${label}: ${String(diagnostics.length)} diagnostic(s)`);
   for (const diag of diagnostics) {
     const severity = diag.severity === "error" ? "ERROR" : "WARN";
-    console.warn(`  [${severity}] ${diag.message}`);
+    const location = formatDiagnosticLocation(
+      diag.primaryLocation.file,
+      diag.primaryLocation.line,
+      diag.primaryLocation.column
+    );
+    console.warn(`  [${severity}] ${diag.code} ${location} ${diag.message}`);
+    for (const related of diag.relatedLocations) {
+      console.warn(
+        `    related: ${formatDiagnosticLocation(related.file, related.line, related.column)}`
+      );
+    }
   }
   return diagnostics.some((d) => d.severity === "error");
 }


### PR DESCRIPTION
## Summary
- switch build validation diagnostics to semantic codes only
- print CLI validation diagnostics with stable repo-relative locations
- add spec-driven E2E coverage for supported diagnostics and skipped `BUG:` coverage for unsupported ones

## Changes
- replace vendor-prefixed numeric-style diagnostic codes with semantic identifiers
- update CLI validation output to print `[SEVERITY] CODE location message`
- add E2E fixtures/tests for contradicting constraints and type mismatch diagnostics
- add skipped spec coverage for invalid path targets and constraint broadening
- add a changeset for the runtime behavior change

## Verification
- `pnpm run build`
- `pnpm --filter @formspec/build exec vitest run src/__tests__/constraint-validator.test.ts src/__tests__/extension-api.test.ts`
- `pnpm --filter @formspec/cli exec vitest run src/__tests__/emit-ir-validate-only.test.ts`
- `pnpm --filter @formspec/e2e exec vitest run tests/diagnostics-supported.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`

## Review
- `ai_review`: APPROVE
