### PR TITLE
test(e2e): cover annotation fixtures (#89)

### DIFF
--- a/e2e/fixtures/tsdoc-class/const-constraints.ts
+++ b/e2e/fixtures/tsdoc-class/const-constraints.ts
@@ -1,0 +1,10 @@
+export class ConstForm {
+  /** @const "USD" */
+  currency!: string;
+
+  /** @const 42 */
+  magicNumber!: number;
+
+  /** @const true */
+  alwaysTrue!: boolean;
+}

--- a/e2e/fixtures/tsdoc-class/parity-plan-status.ts
+++ b/e2e/fixtures/tsdoc-class/parity-plan-status.ts
@@ -1,0 +1,12 @@
+/**
+ * @displayName Plan Status
+ * @displayName :active Active
+ * @displayName :paused Paused
+ * @displayName :cancelled Cancelled
+ */
+type PlanStatus = "active" | "paused" | "cancelled";
+
+export class Subscription {
+  /** @defaultValue "active" */
+  status!: PlanStatus;
+}

--- a/e2e/tests/annotations-display-name.test.ts
+++ b/e2e/tests/annotations-display-name.test.ts
@@ -77,10 +77,10 @@ describe("Annotation: @displayName", () => {
   });
 
   // @see 003-json-schema-vocabulary.md §2.3: "no per-member metadata → flat enum"
-  it("language without :member display names → flat enum (no title without @displayName support)", () => {
+  it("language without :member display names → flat enum", () => {
     const language = properties["language"];
     // No per-member display names → flat enum array
-    expect(language["enum"]).toEqual(expect.arrayContaining(["en", "fr", "de"]));
+    expect(language["enum"]).toEqual(["en", "fr", "de"]);
     // Must NOT use oneOf when flat enum suffices
     expect(language["oneOf"]).toBeUndefined();
   });

--- a/e2e/tests/annotations-metadata.test.ts
+++ b/e2e/tests/annotations-metadata.test.ts
@@ -65,6 +65,17 @@ describe("Annotation: @placeholder / @deprecated / @defaultValue", () => {
       expect(options).toBeDefined();
       expect(options?.["placeholder"]).toBe("Enter your email address");
     });
+
+    it.skip("BUG: quantity @placeholder appears in UI Schema options.placeholder", () => {
+      if (!uischema) throw new Error("UI schema not loaded");
+      const elements = uischema["elements"] as Record<string, unknown>[];
+      const quantityControl = elements.find((el) => el["scope"] === "#/properties/quantity");
+      expect(quantityControl).toBeDefined();
+      if (!quantityControl) return;
+      const options = quantityControl["options"] as Record<string, unknown> | undefined;
+      expect(options).toBeDefined();
+      expect(options?.["placeholder"]).toBe("0");
+    });
   });
 
   describe("@deprecated — JSON Schema deprecated: true", () => {
@@ -77,6 +88,12 @@ describe("Annotation: @placeholder / @deprecated / @defaultValue", () => {
     it("oldField: @deprecated with message emits deprecated: true", () => {
       // The message text "Use newField instead" is IR-only — not a JSON Schema keyword
       expect(properties["oldField"]["deprecated"]).toBe(true);
+    });
+
+    it.skip("BUG: oldField deprecation message is preserved in the JSON Schema extension keyword", () => {
+      expect(properties["oldField"]["x-formspec-deprecation-description"]).toBe(
+        "Use newField instead"
+      );
     });
   });
 

--- a/e2e/tests/const-constraints.test.ts
+++ b/e2e/tests/const-constraints.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @see 002-tsdoc-grammar.md §4.1: "@const parses a JSON value"
+ * @see 003-json-schema-vocabulary.md §2.2: literals map to const
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { runCli, resolveFixture, findSchemaFile } from "../helpers/schema-assertions.js";
+
+describe("Annotation: @const", () => {
+  let tempDir: string;
+  let schema: Record<string, unknown>;
+  let properties: Record<string, Record<string, unknown>>;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-e2e-const-"));
+    const fixturePath = resolveFixture("tsdoc-class", "const-constraints.ts");
+    const result = runCli(["generate", fixturePath, "ConstForm", "-o", tempDir]);
+    expect(result.exitCode).toBe(0);
+
+    const schemaFile = findSchemaFile(tempDir, "schema.json");
+    expect(schemaFile).toBeDefined();
+    if (!schemaFile) throw new Error("Schema file not found");
+    schema = JSON.parse(fs.readFileSync(schemaFile, "utf-8")) as Record<string, unknown>;
+    properties = schema["properties"] as Record<string, Record<string, unknown>>;
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true });
+    }
+  });
+
+  it("keeps the object schema shape", () => {
+    expect(schema).toHaveProperty("type", "object");
+    expect(properties).toHaveProperty("currency");
+    expect(properties).toHaveProperty("magicNumber");
+    expect(properties).toHaveProperty("alwaysTrue");
+  });
+
+  it.skip('BUG: currency @const "USD" emits const: "USD"', () => {
+    const currency = properties["currency"];
+    expect(currency).toBeDefined();
+    if (!currency) return;
+    expect(currency["const"]).toBe("USD");
+  });
+
+  it.skip("BUG: magicNumber @const 42 emits const: 42", () => {
+    const magicNumber = properties["magicNumber"];
+    expect(magicNumber).toBeDefined();
+    if (!magicNumber) return;
+    expect(magicNumber["const"]).toBe(42);
+  });
+
+  it.skip("BUG: alwaysTrue @const true emits const: true", () => {
+    const alwaysTrue = properties["alwaysTrue"];
+    expect(alwaysTrue).toBeDefined();
+    if (!alwaysTrue) return;
+    expect(alwaysTrue["const"]).toBe(true);
+  });
+
+  it("keeps all fields required", () => {
+    const required = schema["required"] as string[];
+    expect(required).toContain("currency");
+    expect(required).toContain("magicNumber");
+    expect(required).toContain("alwaysTrue");
+  });
+});

--- a/e2e/tests/parity-plan-status.test.ts
+++ b/e2e/tests/parity-plan-status.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @see 003-json-schema-vocabulary.md §2.3: enum member metadata uses oneOf/const/title
+ * @see 003-json-schema-vocabulary.md §2.8: class/type-level display names and default values
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { runCli, resolveFixture, findSchemaFile } from "../helpers/schema-assertions.js";
+
+describe("Parity: plan status annotations", () => {
+  let tempDir: string;
+  let schema: Record<string, unknown>;
+  let properties: Record<string, Record<string, unknown>>;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-e2e-plan-status-"));
+    const fixturePath = resolveFixture("tsdoc-class", "parity-plan-status.ts");
+    const result = runCli(["generate", fixturePath, "Subscription", "-o", tempDir]);
+    expect(result.exitCode).toBe(0);
+
+    const schemaFile = findSchemaFile(tempDir, "schema.json");
+    expect(schemaFile).toBeDefined();
+    if (!schemaFile) throw new Error("Schema file not found");
+    schema = JSON.parse(fs.readFileSync(schemaFile, "utf-8")) as Record<string, unknown>;
+    properties = schema["properties"] as Record<string, Record<string, unknown>>;
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true });
+    }
+  });
+
+  it("keeps the field in the object schema", () => {
+    expect(properties).toHaveProperty("status");
+    const required = schema["required"] as string[];
+    expect(required).toContain("status");
+  });
+
+  it.skip("BUG: PlanStatus type-level @displayName emits a root title in $defs", () => {
+    const defs = schema["$defs"] as Record<string, Record<string, unknown>> | undefined;
+    expect(defs?.["PlanStatus"]?.["title"]).toBe("Plan Status");
+  });
+
+  it.skip("BUG: PlanStatus member labels emit oneOf with const/title entries", () => {
+    const defs = schema["$defs"] as Record<string, Record<string, unknown>> | undefined;
+    expect(defs?.["PlanStatus"]?.["oneOf"]).toEqual([
+        { const: "active", title: "Active" },
+        { const: "paused", title: "Paused" },
+        { const: "cancelled", title: "Cancelled" },
+      ]);
+  });
+
+  it.skip("BUG: status @defaultValue emits default: \"active\"", () => {
+    const status = properties["status"];
+    expect(status).toBeDefined();
+    if (!status) return;
+    expect(status["default"]).toBe("active");
+  });
+});


### PR DESCRIPTION
## Summary
- add spec-driven E2E coverage for the annotation slice of `#89`
- add new fixtures for `@const` and plan-status parity coverage
- tighten existing annotation expectations without reverting to gold-master assertions

## Changes
- add `const-constraints` fixture/test
- add `parity-plan-status` fixture/test
- tighten `annotations-display-name` and `annotations-metadata` assertions
- keep current spec-vs-implementation gaps as explicit `BUG:` skips

## Verification
- `pnpm run build`
- `pnpm --filter @formspec/e2e exec vitest run tests/annotations-display-name.test.ts tests/annotations-description.test.ts tests/annotations-metadata.test.ts tests/const-constraints.test.ts tests/parity-plan-status.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`

## Review
- `ai_review`: REQUEST_CHANGES on skipped tests, triaged as non-blocking because these are intentional spec-first `BUG:` skips rather than dead coverage
