### PR TITLE
fix: repair malformed changeset frontmatter

### DIFF
--- a/.changeset/issue-100-remove-legacy-field-tags.md
+++ b/.changeset/issue-100-remove-legacy-field-tags.md
@@ -1,3 +1,4 @@
+---
 "@formspec/build": minor
 "@formspec/cli": minor
 ---

--- a/.changeset/issue-89-type-mappings.md
+++ b/.changeset/issue-89-type-mappings.md
@@ -1,3 +1,4 @@
+---
 "@formspec/build": minor
 "@formspec/cli": minor
 ---


### PR DESCRIPTION
## Summary
- restore missing opening frontmatter delimiters in two existing changeset files
- unblock the main release workflow, which currently fails while parsing changesets

## Verification
- 
> formspec-workspace@0.0.0 changeset /Users/mnorth/Development/formspec
> changeset status

🦋  info NO packages to be bumped at patch
🦋  ---
🦋  info Packages to be bumped at minor:
🦋  info 
🦋  - @formspec/build
🦋  - @formspec/cli
🦋  - @formspec/e2e
🦋  - formspec
🦋  - @formspec/playground
🦋  ---
🦋  info NO packages to be bumped at major
- scanned  for malformed frontmatter starts
