### PR TITLE
docs: refresh post-merge stabilization tracking

### DIFF
--- a/docs/execution-board.md
+++ b/docs/execution-board.md
@@ -31,12 +31,12 @@
 - `#130` Diagnostics and CLI harness cleanup
 - `#102` Cross-axis conditional rule flattening
 - `#104` Mixed-authoring overlays
-- `#105` Circular references
+- `#105` Recursive circular-reference support
 
 ## Integration-Ready Surfaces
 
 - `buildMixedAuthoringSchemas(...)`
-- recursive named-type emission in canonical IR and JSON Schema
+- recursive named-type emission in canonical IR and JSON Schema via recursive `$defs` / `$ref`
 - flattened cross-axis JSON Forms rule generation
 - public extension/runtime generation surfaces landed in the readiness wave
 

--- a/docs/skip-report.md
+++ b/docs/skip-report.md
@@ -15,7 +15,7 @@ The following formerly skipped/non-normative areas are now implemented on `main`
 - supported diagnostics (`UNKNOWN_PATH_TARGET`, `CONSTRAINT_BROADENING`)
 - CLI compiled-fixture harness cleanup
 - mixed-authoring overlays
-- circular references
+- recursive circular-reference support via emitted `$defs` / `$ref`
 - cross-axis conditional flattening
 
 ## No Longer Present

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -137,6 +137,20 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
   - The matrix now distinguishes data-model conformance tests from dynamic-option tests and dynamic-schema resolver tests.
   - These are explicitly framed as user integration-confidence tests rather than parity tests.
 
+# 2026-03-26
+
+## 001-canonical-ir
+
+- Superseded the prior circular-reference decision from 2026-03-25.
+  - Circular references are now supported in the canonical IR and downstream JSON Schema emission.
+  - Recursive named types emit stable `$defs` / `$ref` structures instead of failing with a diagnostic.
+
+## 003-json-schema-vocabulary
+
+- Superseded the prior circular-reference note from 2026-03-25.
+  - Recursive named-type graphs are now supported through recursive `$defs` / `$ref` emission.
+  - Circular references are no longer treated as a diagnostic-only gap in the current product revision.
+
 # 2026-03-25
 
 ## 001-canonical-ir


### PR DESCRIPTION
## Summary
- refresh the execution board to reflect the merged stabilization work on main
- refresh the skip report from current main and record that the active test tree has no skips left
- close the remaining merged issues (#102, #104, #105) that GitHub did not auto-close

## Verification
- pnpm run build
- pnpm run test
- pnpm run lint
- pnpm run typecheck
- pnpm run api-extractor
- rg -n \"it\\.skip\\(|describe\\.skip\\(|test\\.skip\\(|skipIf\\(|BUG:\" e2e packages --glob '!**/dist/**'

## Notes
- no changeset: docs/tracking-only cleanup with no public behavior change
- review sub-agent: no findings on the cleanup diff