### PR TITLE
fix(eslint-plugin): parse inline pattern tags correctly

### DIFF
--- a/.changeset/eslint-plugin-tag-parsing-fixes.md
+++ b/.changeset/eslint-plugin-tag-parsing-fixes.md
@@ -1,0 +1,5 @@
+---
+"@formspec/eslint-plugin": patch
+---
+
+Fix ESLint FormSpec tag parsing so `@pattern` values containing inline `@...` text are handled correctly, and allow `:singular` / `:plural` display-name targets without false-positive member-target errors.

--- a/packages/eslint-plugin/src/__tests__/rules/tag-recognition.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/tag-recognition.test.ts
@@ -32,7 +32,15 @@ ruleTester.run("no-unknown-tags", noUnknownTags, {
     {
       code: String.raw`
         class Form {
-          /** @pattern ^[^@]+@example\.org$ */
+          /** @pattern ^[^@]+@example\\.org$ */
+          email!: string;
+        }
+      `,
+    },
+    {
+      code: String.raw`
+        class Form {
+          /** @pattern ^\\S+ @example.org$ */
           email!: string;
         }
       `,

--- a/packages/eslint-plugin/src/__tests__/rules/target-resolution.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/target-resolution.test.ts
@@ -95,6 +95,17 @@ ruleTester.run("no-unsupported-targeting", noUnsupportedTargeting, {
         }
       `,
     },
+    {
+      code: `
+        interface Form {
+          /**
+           * @displayName :singular Line item
+           * @displayName :plural Line items
+           */
+          items: string[];
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -116,6 +127,17 @@ ruleTester.run("no-member-target-on-object", noMemberTargetOnObject, {
         interface Form {
           /** @displayName :draft Draft status */
           status: "draft" | "published";
+        }
+      `,
+    },
+    {
+      code: `
+        interface Form {
+          /**
+           * @displayName :singular Line item
+           * @displayName :plural Line items
+           */
+          items: string[];
         }
       `,
     },

--- a/packages/eslint-plugin/src/__tests__/rules/value-parsing.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/value-parsing.test.ts
@@ -47,7 +47,10 @@ ruleTester.run("valid-regex-pattern", validRegexPattern, {
   valid: [
     { code: String.raw`class Form { /** @pattern ^[a-z]+$ */ name!: string; }` },
     {
-      code: String.raw`class Form { /** @pattern ^[^@]+@example\.org$ */ email!: string; }`,
+      code: String.raw`class Form { /** @pattern ^[^@]+@example\\.org$ */ email!: string; }`,
+    },
+    {
+      code: String.raw`class Form { /** @pattern ^\\S+ @example.org$ */ email!: string; }`,
     },
   ],
   invalid: [
@@ -56,7 +59,7 @@ ruleTester.run("valid-regex-pattern", validRegexPattern, {
       errors: [{ messageId: "invalidRegexPattern" }],
     },
     {
-      code: String.raw`class Form { /** @pattern ^[^@]+@example\.org)$ */ email!: string; }`,
+      code: String.raw`class Form { /** @pattern ^[^@]+@example\\.org)$ */ email!: string; }`,
       errors: [{ messageId: "invalidRegexPattern" }],
     },
   ],

--- a/packages/eslint-plugin/src/utils/rule-helpers.ts
+++ b/packages/eslint-plugin/src/utils/rule-helpers.ts
@@ -63,6 +63,10 @@ export function resolveTagTarget(
     return { valid: true, reason: "none", type: declarationType };
   }
 
+  if (tag.target.kind === "variant") {
+    return { valid: true, reason: "none", type: declarationType };
+  }
+
   const checker = getTypeChecker(services);
   if (tag.target.kind === "path") {
     let currentType: ts.Type = declarationType;

--- a/packages/eslint-plugin/src/utils/tag-metadata.ts
+++ b/packages/eslint-plugin/src/utils/tag-metadata.ts
@@ -13,7 +13,7 @@ export type FormSpecValueKind =
   | "json"
   | "boolean"
   | "condition";
-export type FormSpecTargetKind = "none" | "path" | "member";
+export type FormSpecTargetKind = "none" | "path" | "member" | "variant";
 
 export interface FormSpecTagMetadata {
   readonly canonicalName: string;
@@ -48,7 +48,7 @@ const CONDITION_VALUE_TAGS = new Set(["showWhen", "hideWhen", "enableWhen", "dis
 const EXTRA_TAGS = {
   displayName: {
     requiresArgument: true,
-    supportedTargets: ["none", "member"] as const,
+    supportedTargets: ["none", "member", "variant"] as const,
     allowDuplicates: false,
     category: "annotation" as const,
   },
@@ -84,7 +84,7 @@ const EXTRA_TAGS = {
   },
   apiName: {
     requiresArgument: true,
-    supportedTargets: ["none", "member"] as const,
+    supportedTargets: ["none", "member", "variant"] as const,
     allowDuplicates: false,
     category: "annotation" as const,
   },

--- a/packages/eslint-plugin/src/utils/tag-scanner.ts
+++ b/packages/eslint-plugin/src/utils/tag-scanner.ts
@@ -38,7 +38,7 @@ function scanComment(comment: TSESTree.Comment): ScannedTag[] {
 
   for (const line of lines) {
     const cleaned = line.replace(/^\s*\*\s?/, "");
-    const tagStartRegex = /(^|\s)@([A-Za-z][A-Za-z0-9]*)/g;
+    const tagStartRegex = /(^|\s)@([A-Za-z][A-Za-z0-9]*)(?=\s|$)/g;
     const starts: { rawName: string; start: number; end: number }[] = [];
     let startMatch: RegExpExecArray | null;
     while ((startMatch = tagStartRegex.exec(cleaned)) !== null) {
@@ -49,18 +49,16 @@ function scanComment(comment: TSESTree.Comment): ScannedTag[] {
       starts.push({ rawName, start, end: start + rawName.length + 1 });
     }
 
-    for (let index = 0; index < starts.length; index += 1) {
+    for (let index = 0; index < starts.length; ) {
       const current = starts[index];
-      if (!current) continue;
+      if (!current) {
+        index += 1;
+        continue;
+      }
+
       const next = starts[index + 1];
       const metadata = getTagMetadata(current.rawName);
-      const nextMetadata = next ? getTagMetadata(next.rawName) : null;
-      const nextBoundary =
-        next && (metadata?.valueKind === "string" || metadata?.valueKind === "condition" || metadata?.valueKind === null)
-          ? nextMetadata
-            ? next.start
-            : cleaned.length
-          : (next?.start ?? cleaned.length);
+      const nextBoundary = next?.start ?? cleaned.length;
       const rawSegment = cleaned.slice(current.start, nextBoundary);
       const rawText = rawSegment.trimEnd();
       const rawArgument = rawText.slice(current.end - current.start).trim();
@@ -76,11 +74,14 @@ function scanComment(comment: TSESTree.Comment): ScannedTag[] {
         const rawTarget = targetMatch[1];
         const targetValue = rawTarget.replace(/^['"]|['"]$/g, "");
         const inferredKind =
-          metadata?.supportedTargets.includes("member") && !metadata.supportedTargets.includes("path")
-            ? "member"
-            : metadata?.supportedTargets.includes("path") && !metadata.supportedTargets.includes("member")
-              ? "path"
-              : "path";
+          metadata?.supportedTargets.includes("variant") &&
+          (targetValue === "singular" || targetValue === "plural")
+            ? "variant"
+            : metadata?.supportedTargets.includes("member") && !metadata.supportedTargets.includes("path")
+              ? "member"
+              : metadata?.supportedTargets.includes("path") && !metadata.supportedTargets.includes("member")
+                ? "path"
+                : "path";
         target = {
           kind: inferredKind,
           raw: rawTarget,
@@ -98,6 +99,11 @@ function scanComment(comment: TSESTree.Comment): ScannedTag[] {
         target,
         comment,
       });
+
+      index += 1;
+      while (index < starts.length && (starts[index]?.start ?? cleaned.length) < nextBoundary) {
+        index += 1;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- fix tag scanning so `@pattern` values containing inline `@...` text do not get split into phantom tags
- allow `:singular` and `:plural` display-name targets without triggering member-target validation errors
- add a patch changeset and regression coverage for the scanner and target-resolution cases

## Test plan
- `pnpm --filter @formspec/eslint-plugin run build`
- `pnpm --filter @formspec/eslint-plugin exec vitest run src/__tests__/rules/tag-recognition.test.ts src/__tests__/rules/value-parsing.test.ts src/__tests__/rules/target-resolution.test.ts src/__tests__/rules/constraint-type-mismatch.test.ts src/__tests__/rules/constraint-validation-extra.test.ts`