### PR TITLE
Refresh package docs and automate ESLint rule docs

### DIFF
--- a/.changeset/release-unpublished-followups.md
+++ b/.changeset/release-unpublished-followups.md
@@ -1,0 +1,10 @@
+"@formspec/build": patch
+"@formspec/core": patch
+"@formspec/eslint-plugin": patch
+---
+
+Release the unpublished follow-up fixes from the spec-parity work.
+
+- `@formspec/build`: restore generation-time IR validation, respect vendor-prefixed deprecation metadata, and keep custom constraint validation working for nullable and array-backed extension types.
+- `@formspec/core`: include the extension and constraint-definition fixes required by the updated build pipeline.
+- `@formspec/eslint-plugin`: fix boolean tag handling so `@uniqueItems` does not require an argument and still participates in type checking.

--- a/README.md
+++ b/README.md
@@ -1,514 +1,130 @@
 # FormSpec
 
-Type-safe form specifications that compile to JSON Schema and JSON Forms UI Schema.
+Type-safe form definitions that compile to JSON Schema 2020-12 and JSON Forms UI Schema.
 
-## Overview
+## What It Covers
 
-FormSpec is a TypeScript library that lets you define forms using a declarative DSL, then compile them to standard JSON Schema and JSON Forms UI Schema. The key benefits are:
+FormSpec supports two authoring styles:
 
-- **Type Safety**: Full TypeScript inference from form definition to schema type
-- **Single Source of Truth**: One form definition generates both data schema and UI layout
-- **Conditional Logic**: Built-in support for showing/hiding fields based on other field values
-- **Dynamic Data**: Support for dynamic enums (fetched at runtime) and dynamic schemas
-- **Nested Structures**: Full support for objects, arrays, and deeply nested compositions
+- Chain DSL for programmatic form definitions
+- Static analysis of TypeScript classes, interfaces, and type aliases annotated with TSDoc tags
 
-## Installation
+Both paths compile into the same canonical IR before JSON Schema and UI Schema generation.
+
+## Install
 
 ```bash
-npm install formspec
-# or
 pnpm add formspec
-# or
-yarn add formspec
 ```
+
+Use the umbrella package when you want the common runtime-facing APIs in one import. Tooling packages such as the CLI, ESLint plugin, and language server are published separately.
 
 ## Quick Start
 
-```typescript
-import { formspec, field, group, when, is, buildFormSchemas } from "formspec";
+### Chain DSL
+
+```ts
+import { buildFormSchemas, field, formspec, group, is, when } from "formspec";
 import type { InferFormSchema } from "formspec";
 
-// Define your form
 const ContactForm = formspec(
   group(
-    "Personal Info",
-    field.text("name", { label: "Full Name", required: true }),
+    "Contact",
+    field.text("name", { label: "Name", required: true }),
     field.text("email", { label: "Email", required: true })
   ),
-  group(
-    "Preferences",
-    field.enum("contactMethod", ["email", "phone", "mail"], {
-      label: "Preferred Contact Method",
-    }),
-    when(is("contactMethod", "phone"), field.text("phoneNumber", { label: "Phone Number" }))
-  )
+  field.enum("preferredChannel", ["email", "phone"] as const, {
+    label: "Preferred Channel",
+    required: true,
+  }),
+  when(is("preferredChannel", "phone"), field.text("phoneNumber", { label: "Phone Number" }))
 );
 
-// Infer the TypeScript type
-type ContactSchema = InferFormSchema<typeof ContactForm>;
-// { name: string; email: string; contactMethod: "email" | "phone" | "mail"; phoneNumber: string }
+type ContactData = InferFormSchema<typeof ContactForm>;
 
-// Generate JSON Schema and UI Schema
 const { jsonSchema, uiSchema } = buildFormSchemas(ContactForm);
 ```
 
-## Field Types
+### Runtime Resolvers
 
-### Basic Fields
+```ts
+import { defineResolvers, field, formspec } from "formspec";
 
-```typescript
-// Text input
-field.text("name", { label: "Name", placeholder: "Enter name", required: true });
+const Form = formspec(field.dynamicEnum("country", "countries", { label: "Country" }));
 
-// Number input
-field.number("age", { label: "Age", min: 0, max: 150 });
-
-// Boolean checkbox
-field.boolean("subscribe", { label: "Subscribe to newsletter" });
-
-// Static enum (dropdown/radio)
-field.enum("status", ["draft", "published", "archived"], { label: "Status" });
-```
-
-### Dynamic Fields
-
-```typescript
-// Dynamic enum - options fetched at runtime
-// Second argument is the resolver identifier (maps to a resolver defined with defineResolvers)
-field.dynamicEnum("country", "fetch_countries", { label: "Country" });
-
-// Dynamic enum with dependencies
-field.dynamicEnum("city", "fetch_cities", {
-  label: "City",
-  params: ["country"], // city options depend on selected country
-});
-```
-
-### Complex Fields
-
-```typescript
-// Object field - nested properties under a single key
-field.object(
-  "address",
-  field.text("street", { label: "Street" }),
-  field.text("city", { label: "City" }),
-  field.text("zip", { label: "ZIP Code" })
-);
-
-// Array field - repeating items
-field.array(
-  "contacts",
-  field.text("name", { label: "Contact Name" }),
-  field.text("email", { label: "Email" })
-);
-
-// Array with constraints
-field.arrayWithConfig(
-  "lineItems",
-  { label: "Line Items", minItems: 1, maxItems: 20 },
-  field.text("description"),
-  field.number("quantity", { min: 1 }),
-  field.number("price", { min: 0 })
-);
-```
-
-## Structure Elements
-
-### Groups
-
-Groups provide visual organization without affecting the schema structure:
-
-```typescript
-const form = formspec(
-  group("Customer Information", field.text("name"), field.text("email")),
-  group("Order Details", field.number("quantity"), field.number("total"))
-);
-```
-
-### Conditionals
-
-Show/hide fields based on other field values:
-
-```typescript
-const form = formspec(
-  field.enum("paymentMethod", ["card", "bank", "crypto"]),
-
-  when(
-    is("paymentMethod", "card"),
-    field.text("cardNumber", { label: "Card Number" }),
-    field.text("cvv", { label: "CVV" })
-  ),
-
-  when(
-    is("paymentMethod", "bank"),
-    field.text("accountNumber", { label: "Account Number" }),
-    field.text("routingNumber", { label: "Routing Number" })
-  )
-);
-```
-
-Conditionals can be nested for complex logic:
-
-```typescript
-when(
-  is("country", "US"),
-  field.text("ssn", { label: "SSN" }),
-  when(is("paymentMethod", "bank"), field.text("routingNumber", { label: "Routing Number" }))
-);
-```
-
-## Dynamic Data with Resolvers
-
-Define resolvers for dynamic enum fields:
-
-```typescript
-import { defineResolvers } from "formspec";
-
-const resolvers = defineResolvers(ContactForm, {
-  fetch_countries: async () => ({
+const resolvers = defineResolvers(Form, {
+  countries: async () => ({
     options: [
       { value: "us", label: "United States" },
       { value: "ca", label: "Canada" },
-      { value: "gb", label: "United Kingdom" },
     ],
     validity: "valid",
   }),
-
-  fetch_cities: async (params) => {
-    const country = params.country;
-    const cities = await fetchCitiesForCountry(country);
-    return {
-      options: cities.map((c) => ({ value: c.id, label: c.name })),
-      validity: "valid",
-    };
-  },
 });
 ```
 
-## Type Inference
+### Static Type Analysis
 
-FormSpec provides full type inference:
+Static schema generation lives in `@formspec/build` and `@formspec/cli`.
 
-```typescript
-import type { InferSchema, InferFormSchema } from "formspec";
+```ts
+import { generateSchemas } from "@formspec/build";
 
-const form = formspec(
-  field.text("name"),
-  field.number("age"),
-  field.enum("role", ["admin", "user"]),
-  field.object("address", field.text("city"), field.text("country")),
-  field.array("tags", field.text("tag"))
-);
-
-// Infer from elements
-type Schema = InferSchema<typeof form.elements>;
-
-// Or infer from entire form
-type Schema2 = InferFormSchema<typeof form>;
-
-// Both produce:
-// {
-//   name: string;
-//   age: number;
-//   role: "admin" | "user";
-//   address: { city: string; country: string };
-//   tags: { tag: string }[];
-// }
-```
-
-## Using the DSL
-
-FormSpec uses a builder-based DSL for defining forms:
-
-```typescript
-import { formspec, field, group, buildFormSchemas } from "formspec";
-
-const form = formspec(
-  field.text("name", { label: "Full Name" }),
-  field.enum("country", ["us", "ca"], { label: "Country" })
-);
-
-// Works at build-time
-const { jsonSchema, uiSchema } = buildFormSchemas(form);
-
-// Also works at runtime - no codegen needed
-```
-
-The DSL works directly at both build-time and runtime without any code generation step. It provides full TypeScript type inference and supports dynamic data through resolvers.
-
-## JSON Schema Extensions
-
-FormSpec adds custom extensions to JSON Schema for dynamic fields. These use the `x-formspec-` prefix following JSON Schema extension conventions.
-
-### `x-formspec-source`
-
-Added to dynamic enum fields. Indicates the data source key for fetching options at runtime.
-
-```json
-{
-  "type": "string",
-  "x-formspec-source": "fetch_countries"
-}
-```
-
-### `x-formspec-params`
-
-Added to dynamic enum fields with dependencies. Lists field names whose values are needed to fetch options.
-
-```json
-{
-  "type": "string",
-  "x-formspec-source": "fetch_cities",
-  "x-formspec-params": ["country", "state"]
-}
-```
-
-## Package Structure
-
-FormSpec is organized as a monorepo with the following packages:
-
-| Package                     | Description                                          |
-| --------------------------- | ---------------------------------------------------- |
-| `formspec`                  | Main package with all re-exports (recommended)       |
-| `@formspec/core`            | Core type definitions                                |
-| `@formspec/dsl`             | DSL functions (`field`, `group`, `when`, `formspec`) |
-| `@formspec/build`           | Schema generators                                    |
-| `@formspec/runtime`         | Resolver helpers                                     |
-| `@formspec/constraints`     | Constraint definitions and validators                |
-| `@formspec/validator`       | JSON Schema validation for secure runtimes           |
-| `@formspec/eslint-plugin`   | ESLint rules for FormSpec                            |
-| `@formspec/language-server` | Language server for editor integration               |
-| `@formspec/playground`      | Interactive browser editor (private)                 |
-
-For most use cases, just import from `formspec`:
-
-```typescript
-import { formspec, field, group, when, is, buildFormSchemas, defineResolvers } from "formspec";
-```
-
-## API Reference
-
-### DSL Functions
-
-- `formspec(...elements)` - Create a form specification
-- `field.text(name, config?)` - Text input field
-- `field.number(name, config?)` - Number input field
-- `field.boolean(name, config?)` - Boolean checkbox field
-- `field.enum(name, options, config?)` - Static enum field
-- `field.dynamicEnum(name, source, config?)` - Dynamic enum field (source is the resolver identifier)
-- `field.array(name, ...items)` - Array field
-- `field.arrayWithConfig(name, config, ...items)` - Array field with constraints
-- `field.object(name, ...properties)` - Object field
-- `field.objectWithConfig(name, config, ...properties)` - Object field with config
-- `group(label, ...elements)` - Visual grouping
-- `is(fieldName, value)` - Create an equality predicate
-- `when(predicate, ...elements)` - Conditional visibility based on predicate
-
-### Build Functions
-
-- `buildFormSchemas(form)` - Generate both JSON Schema and UI Schema
-- `generateJsonSchema(form)` - Generate only JSON Schema
-- `generateUiSchema(form)` - Generate only UI Schema
-- `writeSchemas(form, options)` - Build and write schemas to disk
-
-### Runtime Functions
-
-- `defineResolvers(form, resolvers)` - Define resolvers for dynamic fields
-
-### Validation Functions
-
-- `formspecWithValidation(options, ...elements)` - Create form with validation
-- `validateForm(elements)` - Validate form elements and return issues
-
-```typescript
-import { formspecWithValidation, validateForm } from "formspec";
-
-// Validate during creation (logs to console)
-const form = formspecWithValidation(
-  { validate: true, name: "MyForm" },
-  field.text("name"),
-  when(is("status", "draft"), field.text("notes")) // Error: "status" doesn't exist
-);
-
-// Or validate separately
-const result = validateForm(form.elements);
-if (!result.valid) {
-  console.log(result.issues); // Array of { severity, message, path }
-}
-```
-
-### Type Utilities
-
-- `InferSchema<Elements>` - Infer schema type from form elements
-- `InferFormSchema<Form>` - Infer schema type from FormSpec
-- `InferFieldValue<Field>` - Infer value type from a single field
-
-## Constraints
-
-FormSpec supports constraining which DSL features are allowed in your project. This is useful for enforcing consistency, restricting to renderer-supported features, or keeping forms simple.
-
-### Configuration
-
-Create a `.formspec.yml` file in your project root:
-
-```yaml
-constraints:
-  fieldTypes:
-    text: off # Allow (default)
-    dynamicSchema: error # Disallow
-    array: warn # Allow with warning
-
-  layout:
-    conditionals: off # Allow when() conditionals
-    maxNestingDepth: 2 # Max nesting depth for objects/arrays
-
-  fieldOptions:
-    placeholder: off # Allow placeholder option
-    minItems: warn # Warn on array length constraints
-```
-
-### Severity Levels
-
-| Severity  | Behavior                     |
-| --------- | ---------------------------- |
-| `"off"`   | Feature is allowed (default) |
-| `"warn"`  | Emit warning but allow       |
-| `"error"` | Disallow - fail validation   |
-
-### Available Constraints
-
-**Field Types** (`fieldTypes`): `text`, `number`, `boolean`, `staticEnum`, `dynamicEnum`, `dynamicSchema`, `array`, `object`
-
-**Layout** (`layout`): `group`, `conditionals`, `maxNestingDepth`
-
-**Field Options** (`fieldOptions`): `label`, `placeholder`, `required`, `minValue`, `maxValue`, `minItems`, `maxItems`
-
-### ESLint Integration
-
-Use `@formspec/eslint-plugin` to catch constraint violations during development:
-
-```javascript
-// eslint.config.js
-import formspec from "@formspec/eslint-plugin";
-
-export default [
-  {
-    plugins: { formspec },
-    rules: {
-      "formspec/constraints-allowed-field-types": "error",
-      "formspec/constraints-allowed-layouts": "error",
-    },
-  },
-];
-```
-
-See [@formspec/constraints](./packages/constraints/README.md) for full documentation.
-
-## Build Integration
-
-FormSpec can generate JSON Schema and UI Schema artifacts as part of your build process.
-
-### Using writeSchemas()
-
-The simplest approach is using the `writeSchemas()` helper:
-
-```typescript
-// scripts/generate-schemas.ts
-import { formspec, field, group, writeSchemas } from "formspec";
-
-const ProductForm = formspec(
-  group(
-    "Product",
-    field.text("name", { required: true }),
-    field.enum("status", ["draft", "active", "archived"]),
-    field.number("price", { min: 0 })
-  )
-);
-
-// Write schemas to ./generated/product-schema.json and ./generated/product-uischema.json
-writeSchemas(ProductForm, {
-  outDir: "./generated",
-  name: "product",
+const { jsonSchema, uiSchema } = generateSchemas({
+  filePath: "./src/forms.ts",
+  typeName: "UserRegistration",
 });
 ```
 
-### Adding to package.json
+```ts
+export interface UserRegistration {
+  /** @displayName Full Name @minLength 1 */
+  name: string;
 
-Add a script to generate schemas during build:
+  /** @format email */
+  email: string;
 
-```json
-{
-  "scripts": {
-    "generate:schemas": "npx tsx scripts/generate-schemas.ts",
-    "build": "npm run generate:schemas && your-build-command"
-  }
+  /** @minimum 18 @maximum 120 */
+  age?: number;
 }
 ```
 
-### Multiple Forms
+## Generated Schema Extensions
 
-For multiple forms, create a generation script:
+Generated schemas may include vendor keywords such as:
 
-```typescript
-// scripts/generate-schemas.ts
-import { writeSchemas } from "formspec";
-import { ProductForm } from "../src/forms/product.js";
-import { CustomerForm } from "../src/forms/customer.js";
-import { OrderForm } from "../src/forms/order.js";
+- `x-formspec-source`
+- `x-formspec-params`
+- `x-formspec-deprecation-description`
 
-const forms = [
-  { form: ProductForm, name: "product" },
-  { form: CustomerForm, name: "customer" },
-  { form: OrderForm, name: "order" },
-];
+The default vendor prefix is `x-formspec`. `@formspec/build` also supports custom vendor prefixes for extension-generated JSON Schema keywords.
 
-for (const { form, name } of forms) {
-  const { jsonSchemaPath, uiSchemaPath } = writeSchemas(form, {
-    outDir: "./generated",
-    name,
-  });
-  console.log(`Generated: ${jsonSchemaPath}, ${uiSchemaPath}`);
-}
-```
+## Package Guide
 
-### Using the CLI
+| Package | Purpose |
+| --- | --- |
+| `formspec` | Umbrella package re-exporting the common `core`, `dsl`, `build`, and `runtime` APIs |
+| `@formspec/core` | Shared types, IR nodes, and extension registration APIs |
+| `@formspec/dsl` | Chain DSL authoring surface |
+| `@formspec/build` | JSON Schema / UI Schema generation and static TypeScript analysis |
+| `@formspec/runtime` | Resolver helpers for dynamic data |
+| `@formspec/constraints` | `.formspec.yml` configuration and DSL capability validation |
+| `@formspec/validator` | Runtime JSON Schema validation for secure environments |
+| `@formspec/eslint-plugin` | ESLint rules for FormSpec tags and DSL usage |
+| `@formspec/language-server` | Completion, hover, and definition support for FormSpec tags |
+| `@formspec/cli` | Build-time CLI for schema and IR generation |
+| `@formspec/playground` | Private monorepo playground app |
 
-For quick generation without writing a script, use the CLI:
+## Monorepo Development
 
 ```bash
-# Install the CLI
-npm install -D @formspec/cli
-
-# Generate schemas from all FormSpec exports in a file (requires compiled JS)
-tsc && npx formspec generate src/forms/product.ts -o ./schemas
+pnpm install
+pnpm run build
+pnpm run test
+pnpm run lint
 ```
 
-The CLI detects all named `FormSpec` exports from the compiled module:
-
-```typescript
-// src/forms/product.ts
-import { formspec, field } from "formspec";
-
-export const ProductForm = formspec(
-  field.text("name", { required: true }),
-  field.enum("status", ["draft", "active"])
-);
-```
-
-### Programmatic Control
-
-For more control, use `buildFormSchemas()` directly:
-
-```typescript
-import { buildFormSchemas } from "formspec";
-import * as fs from "node:fs";
-
-const { jsonSchema, uiSchema } = buildFormSchemas(ProductForm);
-
-// Custom file naming or additional processing
-fs.writeFileSync("schemas/product.schema.json", JSON.stringify(jsonSchema, null, 2));
-fs.writeFileSync("schemas/product.ui.json", JSON.stringify(uiSchema, null, 2));
-```
+The root build runs packages in dependency order. `@formspec/build` must be built before its tests.
 
 ## License
 

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -1,173 +1,119 @@
 # @formspec/build
 
-Build tools to compile FormSpec forms into JSON Schema and JSON Forms UI Schema.
+Build-time schema generation for FormSpec.
 
-## Installation
+This package covers:
+
+- Chain DSL to JSON Schema / UI Schema compilation
+- Static analysis of TypeScript classes, interfaces, and type aliases with TSDoc tags
+- Canonical IR generation and validation
+- Extension-aware schema generation with custom vendor keywords
+
+## Install
 
 ```bash
-npm install @formspec/build
-# or
 pnpm add @formspec/build
 ```
 
-> **Note:** Most users should install the `formspec` umbrella package instead, which re-exports everything from this package.
+Most app code can use `formspec`, but use `@formspec/build` directly when you need static analysis or lower-level generation APIs.
 
-## Requirements
+## Public Entry Points
 
-This package is ESM-only and requires:
+| Entry point | Purpose |
+| --- | --- |
+| `@formspec/build` | Public build APIs |
+| `@formspec/build/browser` | Browser-safe schema generation surface |
+| `@formspec/build/internals` | Unstable internal APIs used by the CLI |
 
-```json
-// package.json
-{
-  "type": "module"
-}
-```
+## Chain DSL Generation
 
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}
-```
-
-## Usage
-
-### Generate Schemas in Memory
-
-```typescript
+```ts
 import { buildFormSchemas } from "@formspec/build";
-import { formspec, field, group } from "@formspec/dsl";
+import { field, formspec } from "@formspec/dsl";
 
-const ContactForm = formspec(
-  field.text("name", { label: "Name", required: true }),
-  field.text("email", { label: "Email", required: true }),
-  field.enum("subject", ["General", "Support", "Sales"])
+const form = formspec(
+  field.text("name", { required: true }),
+  field.enum("status", ["draft", "published"] as const)
 );
 
-const { jsonSchema, uiSchema } = buildFormSchemas(ContactForm);
-
-// Use with JSON Forms renderer
-// <JsonForms schema={jsonSchema} uischema={uiSchema} data={formData} />
+const { jsonSchema, uiSchema } = buildFormSchemas(form);
 ```
 
-### Write Schemas to Disk
+## Static Analysis
 
-```typescript
-import { writeSchemas } from "@formspec/build";
+`generateSchemas()` is the main entry point for TSDoc-backed generation.
 
-const result = writeSchemas(ContactForm, {
-  outDir: "./generated",
-  name: "contact-form",
-  indent: 2,
+```ts
+import { generateSchemas } from "@formspec/build";
+
+const { jsonSchema, uiSchema } = generateSchemas({
+  filePath: "./src/forms.ts",
+  typeName: "ProductConfig",
 });
-
-console.log(`JSON Schema: ${result.jsonSchemaPath}`);
-console.log(`UI Schema: ${result.uiSchemaPath}`);
-// JSON Schema: ./generated/contact-form-schema.json
-// UI Schema: ./generated/contact-form-uischema.json
 ```
 
-### Use Individual Generators
+`generateSchemasFromClass()` remains available when the input is definitely a class declaration.
 
-```typescript
-import { generateJsonSchema, generateUiSchema } from "@formspec/build";
-
-const jsonSchema = generateJsonSchema(ContactForm);
-const uiSchema = generateUiSchema(ContactForm);
-```
-
-### Canonical IR Pipeline
-
-The build pipeline now flows through a Canonical Intermediate Representation (IR). When you call `buildFormSchemas()`, the form definition is first converted to IR, then the IR is compiled to JSON Schema and UI Schema:
-
-```
-FormSpec definition → Canonical IR → JSON Schema + UI Schema
-```
-
-This enables consistent processing regardless of whether forms are defined via the Chain DSL or analyzed from TypeScript source files.
-
-### Generate from TypeScript Classes
-
-Generate schemas from TypeScript class definitions using static analysis of JSDoc constraint tags:
-
-```typescript
+```ts
 import { generateSchemasFromClass } from "@formspec/build";
 
-const { jsonSchema, uiSchema } = generateSchemasFromClass({
+const result = generateSchemasFromClass({
   filePath: "./src/forms.ts",
-  className: "UserForm",
+  className: "ProductConfig",
 });
 ```
 
-The analyzer extracts type information and JSDoc constraint tags (e.g., `/** @Minimum 0 @Maximum 100 */`) from class properties to generate schemas.
+### Supported TSDoc Examples
 
-### Entry Points
+```ts
+export interface ProductConfig {
+  /** @displayName Product Name @minLength 1 */
+  name: string;
 
-| Entry Point                 | Audience             | Description                                                                       |
-| --------------------------- | -------------------- | --------------------------------------------------------------------------------- |
-| `@formspec/build`           | Public API           | `buildFormSchemas`, `writeSchemas`, `generateSchemasFromClass`, schema generators |
-| `@formspec/build/browser`   | Browser (playground) | Schema generators without Node.js `fs`/`path` — safe for bundlers                 |
-| `@formspec/build/internals` | CLI (unstable)       | Internal APIs: `createProgramContext`, `analyzeClass`, `generateClassSchemas`     |
+  /** @format email */
+  supportEmail?: string;
 
-## Generated Output
+  /** @placeholder Search products */
+  query?: string;
 
-### JSON Schema (2020-12)
+  /** @minimum 0 @maximum 9999.99 */
+  price: number;
 
-```json
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "properties": {
-    "name": { "type": "string", "title": "Name" },
-    "email": { "type": "string", "title": "Email" },
-    "subject": {
-      "type": "string",
-      "enum": ["General", "Support", "Sales"]
-    }
-  },
-  "required": ["name", "email"]
+  /** @uniqueItems */
+  tags: string[];
 }
 ```
 
-### JSON Forms UI Schema
+## Extension-Aware Generation
 
-```json
-{
-  "type": "VerticalLayout",
-  "elements": [
-    { "type": "Control", "scope": "#/properties/name", "label": "Name" },
-    { "type": "Control", "scope": "#/properties/email", "label": "Email" },
-    { "type": "Control", "scope": "#/properties/subject" }
-  ]
-}
+Both chain and static generation APIs accept `extensionRegistry` and `vendorPrefix` where relevant.
+
+```ts
+import { createExtensionRegistry, generateSchemas } from "@formspec/build";
+
+const registry = createExtensionRegistry([myExtension]);
+
+const result = generateSchemas({
+  filePath: "./src/forms.ts",
+  typeName: "Invoice",
+  extensionRegistry: registry,
+  vendorPrefix: "x-acme",
+});
 ```
 
-## API Reference
+Generation validates canonical IR before emitting schemas. Invalid inputs now fail generation with structured diagnostic codes surfaced in the thrown error.
 
-### Functions
+## Main Exports
 
-| Function                            | Description                                                  |
-| ----------------------------------- | ------------------------------------------------------------ |
-| `buildFormSchemas(form)`            | Generate both JSON Schema and UI Schema                      |
-| `generateJsonSchema(form)`          | Generate only JSON Schema                                    |
-| `generateUiSchema(form)`            | Generate only UI Schema                                      |
-| `writeSchemas(form, options)`       | Build and write schemas to disk                              |
-| `generateSchemasFromClass(options)` | Generate schemas from a TypeScript class via static analysis |
-| `generateSchemas(options)`          | Generate schemas from a TypeScript type via static analysis  |
-
-### Types
-
-| Type                       | Description                            |
-| -------------------------- | -------------------------------------- |
-| `BuildResult`              | Return type of `buildFormSchemas`      |
-| `WriteSchemasOptions`      | Options for `writeSchemas`             |
-| `WriteSchemasResult`       | Return type of `writeSchemas`          |
-| `JsonSchema2020`           | JSON Schema 2020-12 type               |
-| `GenerateFromClassOptions` | Options for `generateSchemasFromClass` |
-| `UISchema`                 | JSON Forms UI Schema type              |
+- `buildFormSchemas(form, options?)`
+- `generateJsonSchema(form, options?)`
+- `generateUiSchema(form)`
+- `writeSchemas(form, options)`
+- `generateSchemas(options)`
+- `generateSchemasFromClass(options)`
+- `generateJsonSchemaFromIR(ir, options?)`
+- `buildMixedAuthoringSchemas(options)`
+- `createExtensionRegistry(extensions)`
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,237 +1,50 @@
 # @formspec/cli
 
-CLI tool for generating JSON Schema and JSON Forms UI Schema from TypeScript source files.
+CLI for generating schemas and canonical IR from TypeScript source files.
 
-## Installation
+## Install
 
 ```bash
-npm install -D @formspec/cli
-# or
 pnpm add -D @formspec/cli
-```
-
-## Requirements
-
-**Package configuration** (package.json):
-
-```json
-{
-  "type": "module"
-}
-```
-
-**TypeScript configuration** (tsconfig.json):
-
-```json
-{
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}
-```
-
-## Quick Start
-
-```bash
-# Generate schemas from a TypeScript class with JSDoc constraints
-formspec generate ./src/forms.ts UserForm -o ./generated
-
-# Generate schemas from chain DSL exports
-formspec generate ./src/forms.ts -o ./generated
-
-# Also emit Canonical IR alongside schemas
-formspec generate ./src/forms.ts UserForm --emit-ir -o ./generated
-
-# Validate without writing files
-formspec generate ./src/forms.ts UserForm --validate-only
-
-# Preview output paths without writing files
-formspec generate ./src/forms.ts UserForm --dry-run -o ./generated
 ```
 
 ## Commands
 
-### `generate` — Build-time Schema Generation
-
-Generate JSON Schema and UI Schema files from TypeScript source files.
-
-```
-formspec generate <file> [className] [options]
-```
-
-**Arguments:**
-
-- `<file>` — Path to TypeScript source file
-- `[className]` — Optional class or type name to analyze
-
-**Options:**
-
-| Option                  | Description                                           | Default       |
-| ----------------------- | ----------------------------------------------------- | ------------- |
-| `-o, --output <dir>`    | Output directory                                      | `./generated` |
-| `-c, --compiled <path>` | Path to compiled JS file                              | auto-detected |
-| `--emit-ir`             | Emit Canonical IR as JSON alongside generated schemas |               |
-| `--validate-only`       | Validate input without writing files                  |               |
-| `--dry-run`             | Show planned output paths without writing files       |               |
-| `-h, --help`            | Show help message                                     |               |
-
-**Examples:**
+### Generate Schemas
 
 ```bash
-# Generate from a class with JSDoc constraint tags
 formspec generate ./src/forms.ts UserForm -o ./generated
-
-# Generate from chain DSL exports (requires compiled JS)
-tsc && formspec generate ./src/forms.ts -o ./generated
-
-# Generate schemas and also emit Canonical IR
-formspec generate ./src/forms.ts UserForm --emit-ir
-
-# Validate only (no file output)
-formspec generate ./src/forms.ts UserForm --validate-only
-
-# Preview class and FormSpec output paths without writing files
-formspec generate ./src/forms.ts UserForm --dry-run -o ./generated
 ```
 
-## JSDoc Constraint Tags
-
-The CLI performs static analysis of TypeScript source files. It reads type information directly from the TypeScript compiler and extracts constraint metadata from JSDoc tags:
-
-```typescript
-class UserRegistration {
-  /** @DisplayName Full Name */
-  name!: string;
-
-  /** @DisplayName Email Address */
-  email!: string;
-
-  /**
-   * @DisplayName Age
-   * @minimum 18
-   * @maximum 120
-   */
-  age?: number;
-
-  /** @DisplayName Country */
-  country!: "us" | "ca" | "uk";
-}
-```
-
-```bash
-formspec generate ./src/user-registration.ts UserRegistration -o ./generated
-```
-
-### Supported Tags
-
-| Tag                 | Purpose                   | Example                                          |
-| ------------------- | ------------------------- | ------------------------------------------------ |
-| `@DisplayName`      | Set field label           | `/** @DisplayName Full Name */`                  |
-| `@Description`      | Set field description     | `/** @Description Your legal name */`            |
-| `@Placeholder`      | Set placeholder text      | `/** @Placeholder Enter name... */`              |
-| `@minimum`          | Set minimum value         | `/** @minimum 0 */`                              |
-| `@maximum`          | Set maximum value         | `/** @maximum 100 */`                            |
-| `@exclusiveMinimum` | Set exclusive minimum     | `/** @exclusiveMinimum 0 */`                     |
-| `@exclusiveMaximum` | Set exclusive maximum     | `/** @exclusiveMaximum 100 */`                   |
-| `@multipleOf`       | Set numeric step          | `/** @multipleOf 0.01 */`                        |
-| `@minLength`        | Set minimum string length | `/** @minLength 1 */`                            |
-| `@maxLength`        | Set maximum string length | `/** @maxLength 255 */`                          |
-| `@minItems`         | Set minimum array length  | `/** @minItems 1 */`                             |
-| `@maxItems`         | Set maximum array length  | `/** @maxItems 10 */`                            |
-| `@pattern`          | Set validation regex      | `/** @pattern ^[a-z]+$ */`                       |
-| `@enumOptions`      | Override enum display     | `/** @enumOptions [{"id":"us","label":"US"}] */` |
-
-### Type Inference
-
-The CLI automatically infers JSON Schema types from TypeScript:
-
-| TypeScript Type | JSON Schema                                 | FormSpec Field |
-| --------------- | ------------------------------------------- | -------------- |
-| `string`        | `{ "type": "string" }`                      | text           |
-| `number`        | `{ "type": "number" }`                      | number         |
-| `boolean`       | `{ "type": "boolean" }`                     | boolean        |
-| `"a" \| "b"`    | `{ "enum": ["a", "b"] }`                    | enum           |
-| `string[]`      | `{ "type": "array", "items": {...} }`       | array          |
-| `{ a: string }` | `{ "type": "object", "properties": {...} }` | object         |
-| `field?: T`     | not in `required` array                     | optional       |
-
-## Chain DSL Support
-
-The CLI also supports FormSpec chain DSL exports:
-
-```typescript
-// forms.ts
-import { formspec, field } from "@formspec/dsl";
-
-export const ContactForm = formspec(
-  field.text("name", { label: "Name", required: true }),
-  field.text("email", { label: "Email", required: true }),
-  field.text("message", { label: "Message" })
-);
-```
+### Generate From Chain DSL Exports
 
 ```bash
 formspec generate ./src/forms.ts -o ./generated
 ```
 
-### Method Parameter Analysis
-
-The CLI detects `InferSchema<typeof X>` or `InferFormSchema<typeof X>` patterns in method parameters:
-
-```typescript
-import { formspec, field, type InferFormSchema } from "@formspec/dsl";
-
-export const ActivateParams = formspec(
-  field.number("amount", { label: "Amount", min: 100 }),
-  field.number("installments", { min: 2, max: 12 })
-);
-
-class PaymentPlan {
-  status!: "active" | "paused" | "canceled";
-
-  activate(params: InferFormSchema<typeof ActivateParams>): boolean {
-    // ...
-  }
-}
-```
-
-## Output Structure
-
-The CLI writes JSON Schema plus JSON Forms UI Schema files using the current
-contract:
-
-```
-generated/
-├── ClassName/
-│   ├── schema.json
-│   ├── ui_schema.json
-│   ├── instance_methods/
-│   │   └── methodName/
-│   │       ├── params.schema.json
-│   │       ├── params.ui_schema.json (if FormSpec-based)
-│   │       └── return_type.schema.json
-│   └── static_methods/
-│       └── methodName/
-│           └── ...
-└── formspecs/
-    └── ExportName/
-        ├── schema.json
-        └── ui_schema.json
-```
-
-## Troubleshooting
-
-### "Could not load compiled module" Warning
-
-This warning appears when the CLI cannot find a compiled JavaScript version of your TypeScript file. The CLI still works — it uses static TypeScript analysis which doesn't require compiled output.
-
-To suppress the warning, compile your TypeScript first:
+### Emit Canonical IR
 
 ```bash
-tsc
-formspec generate ./src/forms.ts MyClass -o ./generated
+formspec generate ./src/forms.ts UserForm --emit-ir -o ./generated
 ```
+
+### Validate Only
+
+```bash
+formspec generate ./src/forms.ts UserForm --validate-only
+```
+
+### Dry Run
+
+```bash
+formspec generate ./src/forms.ts UserForm --dry-run -o ./generated
+```
+
+## Notes
+
+- Class and interface analysis uses the TypeScript compiler directly.
+- Chain DSL export generation requires compiled JavaScript that the CLI can load.
+- `--validate-only` exercises the same validation path used by schema generation.
 
 ## License
 

--- a/packages/constraints/README.md
+++ b/packages/constraints/README.md
@@ -1,263 +1,60 @@
 # @formspec/constraints
 
-Define and enforce constraints on which FormSpec DSL features are allowed in your project.
+Constraint configuration and validation for FormSpec DSL usage.
 
-## Overview
+Use this package when you want project-level rules such as:
 
-The constraints package lets you restrict which parts of the FormSpec DSL can be used. This is useful for:
+- disallowing certain field types
+- limiting layout nesting
+- restricting selected field options
+- validating `.formspec.yml`-driven capability policies
 
-- **Standardization**: Enforce consistent form patterns across a team
-- **Compatibility**: Restrict to features your renderer supports
-- **Simplicity**: Keep forms simple by disallowing complex nesting or conditionals
-- **Linting**: Catch constraint violations at development time via ESLint
-
-## Installation
+## Install
 
 ```bash
-npm install @formspec/constraints
-# or
 pnpm add @formspec/constraints
 ```
 
-## Configuration
-
-Create a `.formspec.yml` file in your project root:
-
-```yaml
-constraints:
-  fieldTypes:
-    text: off # Allow text fields
-    number: off # Allow number fields
-    boolean: off # Allow boolean fields
-    staticEnum: off # Allow static enums
-    dynamicEnum: warn # Warn on dynamic enums
-    dynamicSchema: error # Disallow dynamic schemas
-    array: off # Allow arrays
-    object: off # Allow objects
-
-  layout:
-    group: off # Allow groups
-    conditionals: off # Allow when() conditionals
-    maxNestingDepth: 3 # Max nesting depth (0 = flat only)
-
-  fieldOptions:
-    label: off
-    placeholder: off
-    required: off
-    minValue: off
-    maxValue: off
-    minItems: off
-    maxItems: off
-```
-
-### Severity Levels
-
-Each constraint can be set to:
-
-| Severity  | Behavior                     |
-| --------- | ---------------------------- |
-| `"off"`   | Feature is allowed (default) |
-| `"warn"`  | Emit warning but allow       |
-| `"error"` | Disallow - fail validation   |
-
-## Constraint Categories
-
-### Field Types (`fieldTypes`)
-
-Control which DSL field builders are allowed:
-
-| Constraint      | DSL Function                                 |
-| --------------- | -------------------------------------------- |
-| `text`          | `field.text()`                               |
-| `number`        | `field.number()`                             |
-| `boolean`       | `field.boolean()`                            |
-| `staticEnum`    | `field.enum()`                               |
-| `dynamicEnum`   | `field.dynamicEnum()`                        |
-| `dynamicSchema` | `field.dynamicSchema()`                      |
-| `array`         | `field.array()`, `field.arrayWithConfig()`   |
-| `object`        | `field.object()`, `field.objectWithConfig()` |
-
-### Layout (`layout`)
-
-Control structure and nesting:
-
-| Constraint        | Description                             |
-| ----------------- | --------------------------------------- |
-| `group`           | `group()` visual grouping               |
-| `conditionals`    | `when()` conditional visibility         |
-| `maxNestingDepth` | Maximum depth for nested objects/arrays |
-
-### Field Options (`fieldOptions`)
-
-Control which field configuration options are allowed:
-
-| Constraint             | Description               |
-| ---------------------- | ------------------------- |
-| `label`                | Field label text          |
-| `placeholder`          | Input placeholder         |
-| `required`             | Required field validation |
-| `minValue`, `maxValue` | Number field constraints  |
-| `minItems`, `maxItems` | Array length constraints  |
-
-### UI Schema (`uiSchema`)
-
-Control JSON Forms-specific features:
-
-```yaml
-constraints:
-  uiSchema:
-    layouts:
-      VerticalLayout: off
-      HorizontalLayout: off
-      Group: off
-      Categorization: error # Disallow tabbed interfaces
-      Category: error
-    rules:
-      enabled: off
-      effects:
-        SHOW: off
-        HIDE: off
-        ENABLE: warn
-        DISABLE: warn
-```
-
-## Programmatic Usage
-
-### Loading Configuration
-
-```typescript
-import { loadConfig, mergeWithDefaults } from "@formspec/constraints";
-
-// Load from .formspec.yml (searches up directory tree)
-const config = await loadConfig();
-
-// Or load from specific path
-const config = await loadConfig("/path/to/.formspec.yml");
-
-// Merge with defaults to get fully resolved config
-const resolved = mergeWithDefaults(config.constraints);
-```
-
-### Validating Forms
-
-```typescript
-import { validateFormSpec } from "@formspec/constraints";
-import { formspec, field, when, is } from "@formspec/dsl";
-
-const form = formspec(
-  field.text("name"),
-  field.dynamicEnum("country", "fetch_countries"),
-  when(is("country", "US"), field.text("state"))
-);
-
-const result = validateFormSpec(form, resolved);
-
-if (!result.valid) {
-  for (const issue of result.issues) {
-    console.log(`${issue.severity}: ${issue.message}`);
-  }
-}
-```
-
-### Validation Result
-
-```typescript
-interface ValidationResult {
-  valid: boolean; // true if no errors (warnings OK)
-  issues: ValidationIssue[];
-}
-
-interface ValidationIssue {
-  code: string; // e.g., "FIELD_TYPE_NOT_ALLOWED"
-  message: string; // Human-readable description
-  severity: "error" | "warning";
-  category: "fieldTypes" | "layout" | "uiSchema" | "fieldOptions" | "controlOptions";
-  path?: string; // JSON pointer to issue location
-  fieldName?: string; // Affected field name
-  fieldType?: string; // Affected field type
-}
-```
-
-## ESLint Integration
-
-Use `@formspec/eslint-plugin` to catch constraint violations at development time:
-
-```javascript
-// eslint.config.js
-import formspec from "@formspec/eslint-plugin";
-
-export default [
-  {
-    plugins: { formspec },
-    rules: {
-      // Enforce allowed field types from .formspec.yml
-      "formspec/constraints-allowed-field-types": "error",
-      // Enforce allowed layouts from .formspec.yml
-      "formspec/constraints-allowed-layouts": "error",
-    },
-  },
-];
-```
-
-The ESLint rules automatically load constraints from your `.formspec.yml` file.
-
-## Example Configurations
-
-### Simple Forms Only
-
-Restrict to flat forms with basic field types:
-
-```yaml
-constraints:
-  fieldTypes:
-    array: error
-    object: error
-    dynamicEnum: error
-    dynamicSchema: error
-  layout:
-    conditionals: error
-    maxNestingDepth: 0
-```
-
-### JSON Forms Compatible
-
-Restrict to features supported by standard JSON Forms renderers:
-
-```yaml
-constraints:
-  fieldTypes:
-    dynamicSchema: error # Not supported by JSON Forms
-  uiSchema:
-    layouts:
-      Categorization: warn # May not be supported by all renderers
-```
-
-### Warn on Advanced Features
-
-Allow all features but warn on complex ones:
+## `.formspec.yml`
 
 ```yaml
 constraints:
   fieldTypes:
     dynamicEnum: warn
-    dynamicSchema: warn
-    array: warn
-    object: warn
+    dynamicSchema: error
+
   layout:
-    conditionals: warn
+    conditionals: off
     maxNestingDepth: 2
+
+  fieldOptions:
+    placeholder: off
+    minItems: warn
 ```
 
-## JSON Schema
+## Programmatic Use
 
-A JSON Schema for `.formspec.yml` is available for editor autocompletion:
+```ts
+import { loadConfig, mergeWithDefaults, validateFormSpecElements } from "@formspec/constraints";
+import { field, formspec } from "@formspec/dsl";
 
-```yaml
-# .formspec.yml
-# yaml-language-server: $schema=node_modules/@formspec/constraints/formspec.schema.json
+const { config } = await loadConfig();
+const resolved = mergeWithDefaults(config.constraints);
 
-constraints:
-  fieldTypes:
-    text: off
-    # ... autocomplete available
+const form = formspec(field.text("name"), field.dynamicEnum("country", "countries"));
+const result = validateFormSpecElements(form.elements, { constraints: resolved });
+void result;
 ```
+
+## Main Exports
+
+- `loadConfig`
+- `loadConfigFromString`
+- `defineConstraints`
+- `mergeWithDefaults`
+- `validateFormSpecElements`
+- `validateFormSpec`
+
+## License
+
+UNLICENSED

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,160 +1,88 @@
 # @formspec/core
 
-Core type definitions for the FormSpec library.
+Shared types, canonical IR nodes, and extension registration APIs for FormSpec.
 
-## Installation
+## Install
 
 ```bash
-npm install @formspec/core
-# or
 pnpm add @formspec/core
 ```
 
-> **Note:** Most users should install the `formspec` umbrella package instead, which re-exports everything from this package.
+Most app code should prefer `formspec` unless you are building tooling, extensions, or lower-level integrations.
 
-## Requirements
+## Main Responsibilities
 
-This package is ESM-only and requires:
+- Form element and state types
+- Canonical IR types used by the build pipeline
+- Constraint-definition metadata
+- Extension registration helpers for custom types, constraints, and annotations
+- Shared type guards
 
-```json
-// package.json
-{
-  "type": "module"
-}
-```
+## Example
 
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}
-```
+```ts
+import type { FormElement, FormIR } from "@formspec/core";
+import { defineConstraint, defineCustomType, defineExtension } from "@formspec/core";
 
-## Overview
-
-This package provides the foundational types used throughout the FormSpec ecosystem:
-
-- **Form element types**: `TextField`, `NumberField`, `BooleanField`, `StaticEnumField`, `DynamicEnumField`, `ArrayField`, `ObjectField`
-- **Structural types**: `Group`, `Conditional`, `FormElement`, `FormSpec`
-- **State types**: `FieldState`, `FormState`, `Validity`
-- **Data source types**: `DataSourceRegistry`, `DataSourceOption`, `FetchOptionsResponse`
-- **Predicate types**: `EqualsPredicate`, `Predicate`
-- **IR types**: `FormIR`, `FormIRElement`, `FieldNode`, `LayoutNode`, `TypeNode`, `ConstraintNode`, `AnnotationNode`, `Provenance`, `IR_VERSION`
-- **Extension API**: `defineExtension`, `defineConstraint`, `defineAnnotation`, `defineCustomType`
-
-## Usage
-
-```typescript
-import type {
-  FormSpec,
-  FormElement,
-  TextField,
-  NumberField,
-  AnyField,
-  Group,
-  Conditional,
-} from "@formspec/core";
-
-// Type guard for field elements
-function isField(element: FormElement): element is AnyField {
+function isFieldElement(element: FormElement): boolean {
   return element._type === "field";
 }
 
-// Process form elements
-function processForm(form: FormSpec<readonly FormElement[]>) {
-  for (const element of form.elements) {
-    if (isField(element)) {
-      console.log(`Field: ${element.name} (${element._field})`);
-    } else if (element._type === "group") {
-      console.log(`Group: ${element.label}`);
-    }
-  }
-}
+const decimalType = defineCustomType({
+  typeName: "Decimal",
+  tsTypeNames: ["Decimal"],
+  toJsonSchema: (_payload, vendorPrefix) => ({
+    type: "string",
+    [`${vendorPrefix}-decimal`]: true,
+  }),
+});
+
+const extension = defineExtension({
+  extensionId: "x-example/decimal",
+  types: [decimalType],
+  constraints: [],
+  annotations: [],
+});
+
+void extension;
+void ({} as FormIR);
+void isFieldElement;
 ```
 
-## Type Reference
+## Key Exports
 
-### Field Types
+### Form Types
 
-| Type                 | Description                                 |
-| -------------------- | ------------------------------------------- |
-| `TextField`          | Text input field                            |
-| `NumberField`        | Numeric input field                         |
-| `BooleanField`       | Boolean/checkbox field                      |
-| `StaticEnumField`    | Dropdown with static options                |
-| `DynamicEnumField`   | Dropdown with dynamic options from resolver |
-| `DynamicSchemaField` | Field with dynamic schema from resolver     |
-| `ArrayField`         | Array of nested elements                    |
-| `ObjectField`        | Nested object with child fields             |
-| `AnyField`           | Union of all field types                    |
-
-### Structural Types
-
-| Type          | Description                                 |
-| ------------- | ------------------------------------------- |
-| `Group`       | Groups related fields with a label          |
-| `Conditional` | Shows fields based on predicate             |
-| `FormElement` | Union of `AnyField`, `Group`, `Conditional` |
-| `FormSpec<E>` | Complete form specification                 |
-
-### State Types
-
-| Type            | Description                         |
-| --------------- | ----------------------------------- |
-| `Validity`      | `"valid"`, `"invalid"`, `"unknown"` |
-| `FieldState<T>` | Runtime state of a single field     |
-| `FormState<S>`  | Runtime state of entire form        |
+- `FormSpec`
+- `FormElement`
+- `AnyField`
+- `Group`
+- `Conditional`
+- `FieldState`
+- `FormState`
 
 ### IR Types
 
-| Type             | Description                                                                                                                                                                                                |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FormIR`         | Root IR node — contains elements, type registry, IR version                                                                                                                                                |
-| `FormIRElement`  | Union of `FieldNode` and `LayoutNode`                                                                                                                                                                      |
-| `FieldNode`      | IR field with name, type, constraints, annotations                                                                                                                                                         |
-| `LayoutNode`     | Union of `GroupLayoutNode` and `ConditionalLayoutNode`                                                                                                                                                     |
-| `TypeNode`       | Union: `PrimitiveTypeNode`, `EnumTypeNode`, `ArrayTypeNode`, `ObjectTypeNode`, `UnionTypeNode`, `ReferenceTypeNode`, `DynamicTypeNode`, `CustomTypeNode`                                                   |
-| `ConstraintNode` | Union: `NumericConstraintNode`, `LengthConstraintNode`, `PatternConstraintNode`, `ArrayCardinalityConstraintNode`, `EnumMemberConstraintNode`, `CustomConstraintNode`                                      |
-| `AnnotationNode` | Union: `DisplayNameAnnotationNode`, `DescriptionAnnotationNode`, `PlaceholderAnnotationNode`, `DefaultValueAnnotationNode`, `DeprecatedAnnotationNode`, `FormatHintAnnotationNode`, `CustomAnnotationNode` |
-| `Provenance`     | Source location tracking — file, line, column, surface                                                                                                                                                     |
-| `IR_VERSION`     | Current IR version (`"0.1.0"`)                                                                                                                                                                             |
+- `FormIR`
+- `FieldNode`
+- `LayoutNode`
+- `TypeNode`
+- `ConstraintNode`
+- `AnnotationNode`
+- `Provenance`
 
 ### Extension API
 
-FormSpec's type system is extensible via registration functions:
+- `defineExtension`
+- `defineConstraint`
+- `defineConstraintTag`
+- `defineAnnotation`
+- `defineCustomType`
 
-| Function                | Description                                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------------- |
-| `defineExtension(def)`  | Register a complete extension with constraints, annotations, types, and vocabulary keywords |
-| `defineConstraint(reg)` | Register a custom constraint (e.g., `multipleOf`, `uniqueItems`)                            |
-| `defineAnnotation(reg)` | Register a custom annotation (e.g., tooltip, help URL)                                      |
-| `defineCustomType(reg)` | Register a custom type node for JSON Schema generation                                      |
+### Utilities
 
-```typescript
-import { defineExtension, defineConstraint, defineAnnotation } from "@formspec/core";
-
-// Register a complete extension
-const myExtension = defineExtension({
-  extensionId: "my-ext",
-  constraints: [
-    {
-      constraintName: "Precision",
-      applicableTypes: ["primitive"],
-      compositionRule: "override",
-      toJsonSchema: (payload, vendorPrefix) => ({ [`${vendorPrefix}-precision`]: payload }),
-    },
-  ],
-  annotations: [
-    {
-      annotationName: "HelpUrl",
-      toJsonSchema: (value, vendorPrefix) => ({ [`${vendorPrefix}-help-url`]: value }),
-    },
-  ],
-});
-```
+- `normalizeConstraintTagName`
+- field and layout type guards
 
 ## License
 

--- a/packages/dsl/README.md
+++ b/packages/dsl/README.md
@@ -1,336 +1,62 @@
 # @formspec/dsl
 
-Type-safe form definition using a fluent builder API. This is the recommended approach for defining forms programmatically, especially when you need runtime form construction or dynamic forms.
+Chain DSL for defining FormSpec forms with TypeScript inference.
 
-## Installation
+## Install
 
 ```bash
-npm install @formspec/dsl @formspec/build
-# Or use the umbrella package:
-npm install formspec
+pnpm add @formspec/dsl @formspec/build
 ```
 
-## Requirements
+Or use the umbrella package:
 
-This package is ESM-only and requires:
-
-```json
-// package.json
-{
-  "type": "module"
-}
-```
-
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}
+```bash
+pnpm add formspec
 ```
 
 ## Quick Start
 
-```typescript
-import { formspec, field, group, when, is, type InferFormSchema } from "@formspec/dsl";
+```ts
+import { field, formspec, group, is, type InferFormSchema, when } from "@formspec/dsl";
 import { buildFormSchemas } from "@formspec/build";
 
-// Define a form with full type safety
-const ContactForm = formspec(
-  field.text("name", { label: "Name", required: true }),
-  field.text("email", { label: "Email", required: true }),
-  field.enum("subject", ["general", "support", "sales"] as const, {
-    label: "Subject",
-    required: true,
-  }),
-  field.text("message", { label: "Message", required: true }),
-  field.boolean("subscribe", { label: "Subscribe to newsletter" })
-);
-
-// Infer TypeScript types from the form definition
-type ContactData = InferFormSchema<typeof ContactForm>;
-// Result: { name: string; email: string; subject: "general" | "support" | "sales"; message: string; subscribe: boolean }
-
-// Generate JSON Schema and UI Schema
-const { jsonSchema, uiSchema } = buildFormSchemas(ContactForm);
-```
-
-## Field Types
-
-### Text Field
-
-```typescript
-field.text("fieldName", {
-  label: "Display Label",
-  description: "Help text",
-  required: true,
-  minLength: 1,
-  maxLength: 100,
-  pattern: "^[a-zA-Z]+$", // Regex pattern
-});
-```
-
-### Number Field
-
-```typescript
-field.number("age", {
-  label: "Age",
-  required: true,
-  min: 0,
-  max: 120,
-});
-```
-
-### Boolean Field
-
-```typescript
-field.boolean("acceptTerms", {
-  label: "I accept the terms and conditions",
-  required: true,
-});
-```
-
-### Enum Field (Dropdown/Select)
-
-Use `as const` to preserve literal types for type inference:
-
-```typescript
-// Simple string options
-field.enum("status", ["draft", "published", "archived"] as const, {
-  label: "Status",
-  required: true,
-});
-
-// Options with separate IDs and labels
-field.enum(
-  "country",
-  [
-    { id: "us", label: "United States" },
-    { id: "ca", label: "Canada" },
-    { id: "uk", label: "United Kingdom" },
-  ] as const,
-  {
-    label: "Country",
-  }
-);
-```
-
-**Note:** Use `as const` when passing enum options from a variable. For inline array literals, the `const` type parameter preserves literal types automatically.
-
-### Dynamic Enum Field
-
-For dropdowns populated at runtime from an API:
-
-```typescript
-field.dynamicEnum("customerId", "fetch_customers", {
-  label: "Customer",
-  required: true,
-});
-```
-
-The second argument is a source identifier used with `@formspec/runtime` resolvers.
-
-### Array Field
-
-For repeatable field groups:
-
-```typescript
-field.array(
-  "lineItems",
-  field.text("description", { label: "Description", required: true }),
-  field.number("quantity", { label: "Quantity", min: 1 }),
-  field.number("price", { label: "Unit Price", min: 0 })
-);
-
-// With configuration
-field.arrayWithConfig(
-  "contacts",
-  { label: "Contact List", minItems: 1, maxItems: 5 },
-  field.text("name", { label: "Name" }),
-  field.text("phone", { label: "Phone" })
-);
-```
-
-### Object Field
-
-For nested field groups:
-
-```typescript
-field.object(
-  "address",
-  field.text("street", { label: "Street", required: true }),
-  field.text("city", { label: "City", required: true }),
-  field.text("zipCode", { label: "ZIP Code", required: true })
-);
-```
-
-## Grouping
-
-Use `group()` to visually organize fields:
-
-```typescript
-const UserForm = formspec(
+const ProfileForm = formspec(
   group(
-    "Personal Information",
-    field.text("firstName", { label: "First Name", required: true }),
-    field.text("lastName", { label: "Last Name", required: true }),
-    field.text("email", { label: "Email", required: true })
+    "Profile",
+    field.text("displayName", { required: true }),
+    field.enum("role", ["admin", "member"] as const, { required: true })
   ),
-  group(
-    "Preferences",
-    field.enum("theme", ["light", "dark", "system"] as const, { label: "Theme" }),
-    field.boolean("notifications", { label: "Enable notifications" })
-  )
-);
-```
-
-## Conditional Fields
-
-Use `when()` and `is()` to show/hide fields based on other field values:
-
-```typescript
-const OrderForm = formspec(
-  field.enum("shippingMethod", ["standard", "express", "pickup"] as const, {
-    label: "Shipping Method",
-    required: true,
-  }),
-
-  // Only show address fields when shipping method is not "pickup"
-  when(
-    is("shippingMethod", "standard"),
-    field.text("address", { label: "Shipping Address", required: true }),
-    field.text("city", { label: "City", required: true })
-  ),
-  when(
-    is("shippingMethod", "express"),
-    field.text("address", { label: "Shipping Address", required: true }),
-    field.text("city", { label: "City", required: true }),
-    field.text("phone", { label: "Phone for courier", required: true })
-  )
-);
-```
-
-## Type Inference
-
-The library provides powerful type inference utilities:
-
-```typescript
-import { type InferFormSchema, type InferFieldValue } from "@formspec/dsl";
-
-const MyForm = formspec(
-  field.text("name"),
-  field.number("age"),
-  field.enum("role", ["admin", "user", "guest"] as const)
+  when(is("role", "admin"), field.boolean("superUser"))
 );
 
-// Infer the complete form data type
-type FormData = InferFormSchema<typeof MyForm>;
-// { name: string; age: number; role: "admin" | "user" | "guest" }
+type ProfileData = InferFormSchema<typeof ProfileForm>;
 
-// Access form elements at runtime
-for (const element of MyForm.elements) {
-  if (element._type === "field") {
-    console.log(element.name, element._field);
-  }
-}
+const { jsonSchema, uiSchema } = buildFormSchemas(ProfileForm);
+void jsonSchema;
+void uiSchema;
 ```
 
-## Validation
+## Main Builders
 
-Validate form definitions at runtime:
+- `formspec(...elements)`
+- `field.text(name, config?)`
+- `field.number(name, config?)`
+- `field.boolean(name, config?)`
+- `field.enum(name, options, config?)`
+- `field.dynamicEnum(name, source, config?)`
+- `field.array(name, ...elements)`
+- `field.arrayWithConfig(name, config, ...elements)`
+- `field.object(name, ...elements)`
+- `field.objectWithConfig(name, config, ...elements)`
+- `group(label, ...elements)`
+- `when(predicate, ...elements)`
+- `is(fieldName, value)`
 
-```typescript
-import { formspec, field, validateForm, logValidationIssues } from "@formspec/dsl";
+## Notes
 
-const form = formspec(
-  field.text("email"),
-  field.text("email") // Duplicate field name!
-);
-
-const result = validateForm(form.elements);
-if (!result.valid) {
-  logValidationIssues(result, "MyForm");
-  // Logs: [MyForm] ERROR at email: Duplicate field name "email"
-}
-
-// Or use formspecWithValidation for automatic checking
-import { formspecWithValidation } from "@formspec/dsl";
-
-const validatedForm = formspecWithValidation(
-  { name: "MyForm", validate: "throw" },
-  field.text("email"),
-  field.text("email") // Throws error!
-);
-```
-
-## Schema Generation
-
-Use `@formspec/build` to generate JSON Schema and UI Schema:
-
-```typescript
-import { buildFormSchemas, writeSchemas } from "@formspec/build";
-
-// Get schema objects
-const { jsonSchema, uiSchema } = buildFormSchemas(MyForm);
-
-// Or write to files
-writeSchemas(MyForm, {
-  outDir: "./generated",
-  name: "MyForm",
-});
-// Creates:
-//   ./generated/MyForm-schema.json
-//   ./generated/MyForm-uischema.json
-```
-
-## When to Use This Package
-
-Use `@formspec/dsl` when:
-
-- **Forms are defined programmatically** - Building forms from configuration or code
-- **Runtime form construction** - Creating forms dynamically based on user input or API data
-- **Full type inference needed** - Deriving TypeScript types from form definitions
-- **No build step preferred** - Works directly at runtime without CLI codegen
-
-## API Reference
-
-### Functions
-
-| Function                                       | Description                      |
-| ---------------------------------------------- | -------------------------------- |
-| `formspec(...elements)`                        | Create a form specification      |
-| `formspecWithValidation(options, ...elements)` | Create a form with validation    |
-| `group(label, ...elements)`                    | Create a visual field group      |
-| `when(predicate, ...elements)`                 | Create conditional fields        |
-| `is(fieldName, value)`                         | Create an equality predicate     |
-| `validateForm(elements)`                       | Validate form elements           |
-| `logValidationIssues(result)`                  | Log validation issues to console |
-
-### Field Builders
-
-| Builder                                               | Description               |
-| ----------------------------------------------------- | ------------------------- |
-| `field.text(name, config?)`                           | Text input field          |
-| `field.number(name, config?)`                         | Numeric input field       |
-| `field.boolean(name, config?)`                        | Checkbox/toggle field     |
-| `field.enum(name, options, config?)`                  | Dropdown/select field     |
-| `field.dynamicEnum(name, source, config?)`            | API-populated dropdown    |
-| `field.dynamicSchema(name, source, config?)`          | Dynamic nested schema     |
-| `field.array(name, ...items)`                         | Repeatable field array    |
-| `field.arrayWithConfig(name, config, ...items)`       | Array with configuration  |
-| `field.object(name, ...properties)`                   | Nested object field       |
-| `field.objectWithConfig(name, config, ...properties)` | Object with configuration |
-
-### Type Utilities
-
-| Type                    | Description                          |
-| ----------------------- | ------------------------------------ |
-| `InferFormSchema<F>`    | Infer data type from FormSpec        |
-| `InferSchema<Elements>` | Infer data type from element array   |
-| `InferFieldValue<F>`    | Infer value type from a single field |
-| `ExtractFields<E>`      | Extract all fields from an element   |
+- Use `as const` for enum option arrays when you want literal inference from variables.
+- `group()` is layout-only; it does not change the data shape.
+- `when()` affects UI behavior, not whether a field exists in the JSON Schema.
 
 ## License
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,34 +1,34 @@
 # @formspec/eslint-plugin
 
-ESLint plugin for validating FormSpec usage in TypeScript projects. Catches constraint mismatches, invalid ranges, and enforces project-level restrictions from `.formspec.yml`.
+ESLint rules for FormSpec TSDoc tags and Chain DSL usage.
 
-## Installation
+## Install
 
 ```bash
-npm install --save-dev @formspec/eslint-plugin
-# or
-pnpm add -D @formspec/eslint-plugin
+pnpm add -D @formspec/eslint-plugin @typescript-eslint/parser eslint
 ```
 
-## Requirements
+## Flat Config
 
-- ESLint v9+ (flat config)
-- TypeScript v5+
-- `@typescript-eslint/parser`
+### Recommended
 
-## Usage
-
-### Recommended Configuration
-
-```javascript
+```js
 import formspec from "@formspec/eslint-plugin";
 
 export default [...formspec.configs.recommended];
 ```
 
-### Manual Configuration
+### Strict
 
-```javascript
+```js
+import formspec from "@formspec/eslint-plugin";
+
+export default [...formspec.configs.strict];
+```
+
+### Manual
+
+```js
 import formspec from "@formspec/eslint-plugin";
 
 export default [
@@ -39,170 +39,105 @@ export default [
     rules: {
       "@formspec/tag-recognition/no-unknown-tags": "warn",
       "@formspec/tag-recognition/require-tag-arguments": "error",
-      "@formspec/tag-recognition/no-disabled-tags": "warn",
       "@formspec/value-parsing/valid-numeric-value": "error",
-      "@formspec/value-parsing/valid-integer-value": "error",
-      "@formspec/value-parsing/valid-regex-pattern": "error",
-      "@formspec/value-parsing/valid-json-value": "error",
       "@formspec/type-compatibility/tag-type-check": "error",
       "@formspec/target-resolution/valid-path-target": "error",
-      "@formspec/target-resolution/valid-member-target": "error",
-      "@formspec/target-resolution/no-unsupported-targeting": "error",
-      "@formspec/target-resolution/no-member-target-on-object": "error",
       "@formspec/constraint-validation/no-contradictions": "error",
-      "@formspec/constraint-validation/no-duplicate-tags": "warn",
-      "@formspec/constraint-validation/no-description-conflict": "warn",
-      "@formspec/constraint-validation/no-contradictory-rules": "error",
-      "@formspec/constraints-allowed-field-types": "error",
-      "@formspec/constraints-allowed-layouts": "error",
     },
   },
 ];
 ```
 
+## Keeping Docs Current
+
+```bash
+pnpm --filter @formspec/eslint-plugin run fix:eslint-docs
+pnpm --filter @formspec/eslint-plugin run check:eslint-docs
+```
+
+## Rule Groups
+
+### Tag Recognition
+
+- `tag-recognition/no-unknown-tags`
+- `tag-recognition/require-tag-arguments`
+- `tag-recognition/no-disabled-tags`
+
+### Value Parsing
+
+- `value-parsing/valid-numeric-value`
+- `value-parsing/valid-integer-value`
+- `value-parsing/valid-regex-pattern`
+- `value-parsing/valid-json-value`
+
+### Type Compatibility
+
+- `type-compatibility/tag-type-check`
+
+### Target Resolution
+
+- `target-resolution/valid-path-target`
+- `target-resolution/valid-member-target`
+- `target-resolution/no-unsupported-targeting`
+- `target-resolution/no-member-target-on-object`
+
+### Constraint Validation
+
+- `constraint-validation/no-contradictions`
+- `constraint-validation/no-duplicate-tags`
+- `constraint-validation/no-description-conflict`
+- `constraint-validation/no-contradictory-rules`
+
+### `.formspec.yml` Capability Rules
+
+- `constraints-allowed-field-types`
+- `constraints-allowed-layouts`
+
 ## Rules
 
-| Rule                                                                                             | Description                                       | Recommended | Strict |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- | ----------- | ------ |
-| [`tag-recognition/no-unknown-tags`](#tag-recognitionno-unknown-tags)                             | Reject unknown FormSpec tags                      | warn        | error  |
-| [`tag-recognition/require-tag-arguments`](#tag-recognitionrequire-tag-arguments)                 | Require arguments for tags that need values       | error       | error  |
-| [`tag-recognition/no-disabled-tags`](#tag-recognitionno-disabled-tags)                           | Reject project-disabled tags                      | warn        | error  |
-| [`value-parsing/valid-numeric-value`](#value-parsingvalid-numeric-value)                         | Validate numeric-valued tags                      | error       | error  |
-| [`value-parsing/valid-integer-value`](#value-parsingvalid-integer-value)                         | Validate non-negative integer-valued tags         | error       | error  |
-| [`value-parsing/valid-regex-pattern`](#value-parsingvalid-regex-pattern)                         | Validate `@pattern` values                        | error       | error  |
-| [`value-parsing/valid-json-value`](#value-parsingvalid-json-value)                               | Validate JSON-valued tags                         | error       | error  |
-| [`type-compatibility/tag-type-check`](#type-compatibilitytag-type-check)                         | FormSpec tags must match field type               | error       | error  |
-| [`target-resolution/valid-path-target`](#target-resolutionvalid-path-target)                     | Validate `:path` target references                | error       | error  |
-| [`target-resolution/valid-member-target`](#target-resolutionvalid-member-target)                 | Validate `:member` target references              | error       | error  |
-| [`target-resolution/no-unsupported-targeting`](#target-resolutionno-unsupported-targeting)       | Reject target syntax on unsupported tags          | error       | error  |
-| [`target-resolution/no-member-target-on-object`](#target-resolutionno-member-target-on-object)   | Restrict member targets to string-literal unions  | error       | error  |
-| [`constraint-validation/no-contradictions`](#constraint-validationno-contradictions)             | Constraint ranges must be valid                   | error       | error  |
-| [`constraint-validation/no-duplicate-tags`](#constraint-validationno-duplicate-tags)             | Reject duplicate single-instance tags             | warn        | error  |
-| [`constraint-validation/no-description-conflict`](#constraint-validationno-description-conflict) | Report `@description`/`@remarks` conflicts        | warn        | error  |
-| [`constraint-validation/no-contradictory-rules`](#constraint-validationno-contradictory-rules)   | Reject conflicting conditional effects            | error       | error  |
-| [`constraints-allowed-field-types`](#constraints-allowed-field-types)                            | Field types validated against `.formspec.yml`     | —           | —      |
-| [`constraints-allowed-layouts`](#constraints-allowed-layouts)                                    | Layout elements validated against `.formspec.yml` | —           | —      |
+<!-- begin auto-generated rules list -->
 
-### tag-recognition/no-unknown-tags
+💼 Configurations enabled in.\
+⚠️ Configurations set to warn in.\
+✅ Set in the `recommended` configuration.\
+🔒 Set in the `strict` configuration.
 
-Rejects tags outside the FormSpec specification.
+| Name                                                                                                                                                                                 | Description                                                                                     | 💼   | ⚠️ |
+| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- | :--- | :- |
+| [constraint-validation/no-contradictions](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictions.md)             | Reports contradictory FormSpec constraint combinations                                          | ✅ 🔒 |    |
+| [constraint-validation/no-contradictory-rules](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictory-rules.md)   | Reports contradictory FormSpec conditional rules on the same behavioral axis                    | ✅ 🔒 |    |
+| [constraint-validation/no-description-conflict](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-description-conflict.md) | Reports conflicting @description and @remarks tags on the same field                            | 🔒   | ✅  |
+| [constraint-validation/no-duplicate-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-duplicate-tags.md)             | Reports duplicate FormSpec tags on the same field target                                        | 🔒   | ✅  |
+| [constraints-allowed-field-types](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraints-allowed-field-types.md)                             | Validates that field types are allowed by the project's constraints                             |      |    |
+| [constraints-allowed-layouts](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraints-allowed-layouts.md)                                     | Validates that layout constructs (group, conditionals) are allowed by the project's constraints |      |    |
+| [tag-recognition/no-disabled-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-disabled-tags.md)                           | Reports FormSpec tags disabled by project configuration                                         | 🔒   | ✅  |
+| [tag-recognition/no-unknown-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-unknown-tags.md)                             | Reports FormSpec tags that are not part of the specification                                    | 🔒   | ✅  |
+| [tag-recognition/require-tag-arguments](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/require-tag-arguments.md)                 | Requires arguments for FormSpec tags that need values                                           | ✅ 🔒 |    |
+| [target-resolution/no-member-target-on-object](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/no-member-target-on-object.md)   | Disallows member-target syntax on non-string-literal-union fields                               | ✅ 🔒 |    |
+| [target-resolution/no-unsupported-targeting](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/no-unsupported-targeting.md)       | Disallows path or member target syntax on tags that do not support it                           | ✅ 🔒 |    |
+| [target-resolution/valid-member-target](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/valid-member-target.md)                 | Validates member-target references against string literal union fields                          | ✅ 🔒 |    |
+| [target-resolution/valid-path-target](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/valid-path-target.md)                     | Validates path-target references against the resolved field type                                | ✅ 🔒 |    |
+| [type-compatibility/tag-type-check](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/type-compatibility/tag-type-check.md)                         | Ensures FormSpec tags are applied to compatible field types                                     | ✅ 🔒 |    |
+| [value-parsing/valid-integer-value](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-integer-value.md)                         | Validates integer-valued FormSpec tags                                                          | ✅ 🔒 |    |
+| [value-parsing/valid-json-value](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-json-value.md)                               | Validates JSON-valued FormSpec tags                                                             | ✅ 🔒 |    |
+| [value-parsing/valid-numeric-value](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-numeric-value.md)                         | Validates numeric-valued FormSpec tags                                                          | ✅ 🔒 |    |
+| [value-parsing/valid-regex-pattern](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-regex-pattern.md)                         | Validates @pattern tag values as regular expressions                                            | ✅ 🔒 |    |
 
-### tag-recognition/require-tag-arguments
+<!-- end auto-generated rules list -->
 
-Requires values for tags like `@minimum`, `@description`, and `@showWhen`.
+## Example
 
-### tag-recognition/no-disabled-tags
+```ts
+class Example {
+  /** @minimum 0 */
+  age!: number;
 
-Rejects tags disabled by project-specific configuration.
-
-### value-parsing/valid-numeric-value
-
-Ensures numeric tags such as `@minimum` and `@multipleOf` contain valid numbers.
-
-### value-parsing/valid-integer-value
-
-Ensures integer-only tags such as `@minLength` and `@maxItems` contain non-negative integers.
-
-### value-parsing/valid-regex-pattern
-
-Ensures `@pattern` contains a valid JavaScript regular expression body.
-
-### value-parsing/valid-json-value
-
-Ensures JSON-valued tags such as `@const` and `@enumOptions` contain valid JSON.
-
-### type-compatibility/tag-type-check
-
-Ensures JSDoc constraint tags are applied to fields with compatible types.
-
-```typescript
-// Valid — @Minimum on a number field
-/** @Minimum 0 */
-age!: number;
-
-/** @MinLength 1 */
-name!: string;
-
-// Invalid — @Minimum requires a number field
-/** @Minimum 0 */
-name!: string; // Error: @Minimum can only be used on number fields
+  /** @uniqueItems */
+  tags!: string[];
+}
 ```
 
-### constraint-validation/no-contradictions
-
-Ensures constraint values form valid ranges.
-
-```typescript
-// Valid
-/** @Minimum 0 @Maximum 100 */
-value!: number;
-
-// Invalid — minimum > maximum
-/** @Minimum 100 @Maximum 50 */
-value!: number; // Error: @Minimum(100) > @Maximum(50)
-```
-
-### target-resolution/valid-path-target
-
-Validates `:path` target references against object field types.
-
-### target-resolution/valid-member-target
-
-Validates `:member` target references against string literal union fields.
-
-### target-resolution/no-unsupported-targeting
-
-Rejects `:path` or `:member` syntax on tags that do not support targeting.
-
-### target-resolution/no-member-target-on-object
-
-Restricts member-target syntax to string literal union fields.
-
-### constraint-validation/no-duplicate-tags
-
-Rejects duplicate single-instance tags on the same field target.
-
-### constraint-validation/no-description-conflict
-
-Reports when both `@description` and `@remarks` are present on the same field.
-
-### constraint-validation/no-contradictory-rules
-
-Rejects conflicting conditional rules on the same axis, such as `@showWhen` plus `@hideWhen`.
-
-### constraints-allowed-field-types
-
-Validates chain DSL field types against your `.formspec.yml` configuration.
-
-```typescript
-// With .formspec.yml: fieldTypes: { dynamicEnum: error }
-field.dynamicEnum("country", "fetch_countries"); // Error: dynamicEnum fields are not allowed
-```
-
-### constraints-allowed-layouts
-
-Validates layout elements against your `.formspec.yml` configuration.
-
-```typescript
-// With .formspec.yml: layout: { conditionals: error }
-when(is("type", "a"), field.text("extra")); // Error: conditionals are not allowed
-```
-
-## Configurations
-
-### Recommended
-
-Enables the spec-defined built-in rules with recommended severities. The `constraints-allowed-*` rules must be enabled manually when using `.formspec.yml` constraints.
-
-### Strict
-
-Same rule set as Recommended, but all built-in rules are promoted to errors. The `constraints-allowed-*` rules must be enabled manually when using `.formspec.yml` constraints.
-
-```javascript
-import formspec from "@formspec/eslint-plugin";
-
-export default [...formspec.configs.strict];
-```
+The plugin validates tag names, argument syntax, target paths, and type compatibility before your build gets to static schema generation.
 
 ## License
 

--- a/packages/eslint-plugin/api-report/eslint-plugin.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.api.md
@@ -24,6 +24,17 @@ export const allowedLayouts: ESLintUtils.RuleModule<MessageIds_2, Options_2, unk
     name: string;
 };
 
+// @public
+export const configs: {
+    readonly recommended: TSESLint.FlatConfig.ConfigArray;
+    readonly strict: TSESLint.FlatConfig.ConfigArray;
+};
+
+// @public
+export const meta: {
+    name: string;
+};
+
 // Warning: (ae-forgotten-export) The symbol "MessageIds" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -68,7 +79,7 @@ export const noUnsupportedTargeting: ESLintUtils.RuleModule<"unsupportedTargetin
     name: string;
 };
 
-// @public
+// @public (undocumented)
 const plugin: {
     meta: {
         name: string;
@@ -132,16 +143,82 @@ const plugin: {
         };
     };
     configs: {
-        recommended: TSESLint.FlatConfig.ConfigArray;
-        strict: TSESLint.FlatConfig.ConfigArray;
+        readonly recommended: TSESLint.FlatConfig.ConfigArray;
+        readonly strict: TSESLint.FlatConfig.ConfigArray;
     };
 };
 export default plugin;
+
+// @public
+export const recommendedConfig: TSESLint.FlatConfig.ConfigArray;
 
 // @public (undocumented)
 export const requireTagArguments: ESLintUtils.RuleModule<"missingTagArgument", [], unknown, ESLintUtils.RuleListener> & {
     name: string;
 };
+
+// @public
+export const rules: {
+    readonly "tag-recognition/no-unknown-tags": TSESLint.RuleModule<"unknownTag", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "tag-recognition/require-tag-arguments": TSESLint.RuleModule<"missingTagArgument", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "tag-recognition/no-disabled-tags": TSESLint.RuleModule<"disabledTag", [{
+        tags?: string[];
+    }], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "value-parsing/valid-numeric-value": TSESLint.RuleModule<"invalidNumericValue", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "value-parsing/valid-integer-value": TSESLint.RuleModule<"invalidIntegerValue", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "value-parsing/valid-regex-pattern": TSESLint.RuleModule<"invalidRegexPattern", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "value-parsing/valid-json-value": TSESLint.RuleModule<"invalidJsonValue", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "type-compatibility/tag-type-check": TSESLint.RuleModule<"typeMismatch", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "target-resolution/valid-path-target": TSESLint.RuleModule<"unknownPathTarget", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "target-resolution/valid-member-target": TSESLint.RuleModule<"unknownMemberTarget", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "target-resolution/no-unsupported-targeting": TSESLint.RuleModule<"unsupportedTargetingSyntax", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "target-resolution/no-member-target-on-object": TSESLint.RuleModule<"memberTargetOnNonUnion", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "constraint-validation/no-contradictions": TSESLint.RuleModule<"minimumGreaterThanMaximum" | "exclusiveMinGreaterOrEqualMax" | "minLengthGreaterThanMaxLength" | "minItemsGreaterThanMaxItems" | "conflictingMinimumBounds" | "conflictingMaximumBounds" | "exclusiveMaxLessOrEqualMin" | "maximumLessOrEqualExclusiveMin", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "constraint-validation/no-duplicate-tags": TSESLint.RuleModule<"duplicateTag", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "constraint-validation/no-description-conflict": TSESLint.RuleModule<"descriptionRemarksConflict", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "constraint-validation/no-contradictory-rules": TSESLint.RuleModule<"contradictoryRuleEffects", [], unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "constraints-allowed-field-types": TSESLint.RuleModule<"disallowedFieldType", Options, unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+    readonly "constraints-allowed-layouts": TSESLint.RuleModule<"disallowedGroup" | "disallowedConditional", Options_2, unknown, TSESLint.RuleListener> & {
+        name: string;
+    };
+};
+
+// @public
+export const strictConfig: TSESLint.FlatConfig.ConfigArray;
 
 // @public (undocumented)
 export const tagTypeCheck: ESLintUtils.RuleModule<"typeMismatch", [], unknown, ESLintUtils.RuleListener> & {

--- a/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictions.md
+++ b/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictions.md
@@ -1,0 +1,7 @@
+# @formspec/constraint-validation/no-contradictions
+
+📝 Reports contradictory FormSpec constraint combinations.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictory-rules.md
+++ b/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictory-rules.md
@@ -1,0 +1,7 @@
+# @formspec/constraint-validation/no-contradictory-rules
+
+📝 Reports contradictory FormSpec conditional rules on the same behavioral axis.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/constraint-validation/no-description-conflict.md
+++ b/packages/eslint-plugin/docs/rules/constraint-validation/no-description-conflict.md
@@ -1,0 +1,7 @@
+# @formspec/constraint-validation/no-description-conflict
+
+📝 Reports conflicting @description and @remarks tags on the same field.
+
+💼⚠️ This rule is enabled in the 🔒 `strict` config. This rule _warns_ in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/constraint-validation/no-duplicate-tags.md
+++ b/packages/eslint-plugin/docs/rules/constraint-validation/no-duplicate-tags.md
@@ -1,0 +1,7 @@
+# @formspec/constraint-validation/no-duplicate-tags
+
+📝 Reports duplicate FormSpec tags on the same field target.
+
+💼⚠️ This rule is enabled in the 🔒 `strict` config. This rule _warns_ in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/constraints-allowed-field-types.md
+++ b/packages/eslint-plugin/docs/rules/constraints-allowed-field-types.md
@@ -1,0 +1,22 @@
+# @formspec/constraints-allowed-field-types
+
+📝 Validates that field types are allowed by the project's constraints.
+
+<!-- end auto-generated rule header -->
+
+## Options
+
+<!-- begin auto-generated rule options list -->
+
+| Name            | Type   | Choices                |
+| :-------------- | :----- | :--------------------- |
+| `array`         | String | `error`, `warn`, `off` |
+| `boolean`       | String | `error`, `warn`, `off` |
+| `dynamicEnum`   | String | `error`, `warn`, `off` |
+| `dynamicSchema` | String | `error`, `warn`, `off` |
+| `number`        | String | `error`, `warn`, `off` |
+| `object`        | String | `error`, `warn`, `off` |
+| `staticEnum`    | String | `error`, `warn`, `off` |
+| `text`          | String | `error`, `warn`, `off` |
+
+<!-- end auto-generated rule options list -->

--- a/packages/eslint-plugin/docs/rules/constraints-allowed-layouts.md
+++ b/packages/eslint-plugin/docs/rules/constraints-allowed-layouts.md
@@ -1,0 +1,17 @@
+# @formspec/constraints-allowed-layouts
+
+📝 Validates that layout constructs (group, conditionals) are allowed by the project's constraints.
+
+<!-- end auto-generated rule header -->
+
+## Options
+
+<!-- begin auto-generated rule options list -->
+
+| Name              | Type   | Choices                |
+| :---------------- | :----- | :--------------------- |
+| `conditionals`    | String | `error`, `warn`, `off` |
+| `group`           | String | `error`, `warn`, `off` |
+| `maxNestingDepth` | Number |                        |
+
+<!-- end auto-generated rule options list -->

--- a/packages/eslint-plugin/docs/rules/tag-recognition/no-disabled-tags.md
+++ b/packages/eslint-plugin/docs/rules/tag-recognition/no-disabled-tags.md
@@ -1,0 +1,17 @@
+# @formspec/tag-recognition/no-disabled-tags
+
+📝 Reports FormSpec tags disabled by project configuration.
+
+💼⚠️ This rule is enabled in the 🔒 `strict` config. This rule _warns_ in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+## Options
+
+<!-- begin auto-generated rule options list -->
+
+| Name   | Type     |
+| :----- | :------- |
+| `tags` | String[] |
+
+<!-- end auto-generated rule options list -->

--- a/packages/eslint-plugin/docs/rules/tag-recognition/no-unknown-tags.md
+++ b/packages/eslint-plugin/docs/rules/tag-recognition/no-unknown-tags.md
@@ -1,0 +1,7 @@
+# @formspec/tag-recognition/no-unknown-tags
+
+📝 Reports FormSpec tags that are not part of the specification.
+
+💼⚠️ This rule is enabled in the 🔒 `strict` config. This rule _warns_ in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/tag-recognition/require-tag-arguments.md
+++ b/packages/eslint-plugin/docs/rules/tag-recognition/require-tag-arguments.md
@@ -1,0 +1,7 @@
+# @formspec/tag-recognition/require-tag-arguments
+
+📝 Requires arguments for FormSpec tags that need values.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/target-resolution/no-member-target-on-object.md
+++ b/packages/eslint-plugin/docs/rules/target-resolution/no-member-target-on-object.md
@@ -1,0 +1,7 @@
+# @formspec/target-resolution/no-member-target-on-object
+
+📝 Disallows member-target syntax on non-string-literal-union fields.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/target-resolution/no-unsupported-targeting.md
+++ b/packages/eslint-plugin/docs/rules/target-resolution/no-unsupported-targeting.md
@@ -1,0 +1,7 @@
+# @formspec/target-resolution/no-unsupported-targeting
+
+📝 Disallows path or member target syntax on tags that do not support it.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/target-resolution/valid-member-target.md
+++ b/packages/eslint-plugin/docs/rules/target-resolution/valid-member-target.md
@@ -1,0 +1,7 @@
+# @formspec/target-resolution/valid-member-target
+
+📝 Validates member-target references against string literal union fields.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/target-resolution/valid-path-target.md
+++ b/packages/eslint-plugin/docs/rules/target-resolution/valid-path-target.md
@@ -1,0 +1,7 @@
+# @formspec/target-resolution/valid-path-target
+
+📝 Validates path-target references against the resolved field type.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/type-compatibility/tag-type-check.md
+++ b/packages/eslint-plugin/docs/rules/type-compatibility/tag-type-check.md
@@ -1,0 +1,7 @@
+# @formspec/type-compatibility/tag-type-check
+
+📝 Ensures FormSpec tags are applied to compatible field types.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/value-parsing/valid-integer-value.md
+++ b/packages/eslint-plugin/docs/rules/value-parsing/valid-integer-value.md
@@ -1,0 +1,7 @@
+# @formspec/value-parsing/valid-integer-value
+
+📝 Validates integer-valued FormSpec tags.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/value-parsing/valid-json-value.md
+++ b/packages/eslint-plugin/docs/rules/value-parsing/valid-json-value.md
@@ -1,0 +1,7 @@
+# @formspec/value-parsing/valid-json-value
+
+📝 Validates JSON-valued FormSpec tags.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/value-parsing/valid-numeric-value.md
+++ b/packages/eslint-plugin/docs/rules/value-parsing/valid-numeric-value.md
@@ -1,0 +1,7 @@
+# @formspec/value-parsing/valid-numeric-value
+
+📝 Validates numeric-valued FormSpec tags.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/value-parsing/valid-regex-pattern.md
+++ b/packages/eslint-plugin/docs/rules/value-parsing/valid-regex-pattern.md
@@ -1,0 +1,7 @@
+# @formspec/value-parsing/valid-regex-pattern
+
+📝 Validates @pattern tag values as regular expressions.
+
+💼 This rule is enabled in the following configs: ✅ `recommended`, 🔒 `strict`.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -23,7 +23,9 @@
   ],
   "scripts": {
     "build": "tsup && tsc --emitDeclarationOnly && api-extractor run --local",
+    "check:eslint-docs": "eslint-doc-generator --check --path-rule-list README.md --url-rule-doc \"https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/{name}.md\"",
     "clean": "rm -rf dist temp",
+    "fix:eslint-docs": "eslint-doc-generator --path-rule-list README.md --url-rule-doc \"https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/{name}.md\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "api-extractor": "api-extractor run",
@@ -41,6 +43,7 @@
   },
   "devDependencies": {
     "@typescript-eslint/rule-tester": "^8.0.0",
+    "eslint-doc-generator": "^3.3.2",
     "vitest": "^3.0.0"
   },
   "publishConfig": {

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -35,7 +35,7 @@ import { allowedFieldTypes, allowedLayouts } from "./rules/constraints/index.js"
 /**
  * All rules provided by this plugin.
  */
-const rules = {
+export const rules = {
   // Spec built-in rules
   "tag-recognition/no-unknown-tags": noUnknownTags,
   "tag-recognition/require-tag-arguments": requireTagArguments,
@@ -62,7 +62,7 @@ const rules = {
 /**
  * Plugin metadata.
  */
-const meta = {
+export const meta = {
   name: "@formspec/eslint-plugin",
 };
 
@@ -78,7 +78,7 @@ const meta = {
  * ];
  * ```
  */
-const recommendedConfig: TSESLint.FlatConfig.ConfigArray = [
+export const recommendedConfig: TSESLint.FlatConfig.ConfigArray = [
   {
     plugins: {
       "@formspec": {
@@ -110,7 +110,7 @@ const recommendedConfig: TSESLint.FlatConfig.ConfigArray = [
 /**
  * Strict configuration - all rules as errors.
  */
-const strictConfig: TSESLint.FlatConfig.ConfigArray = [
+export const strictConfig: TSESLint.FlatConfig.ConfigArray = [
   {
     plugins: {
       "@formspec": {
@@ -142,13 +142,15 @@ const strictConfig: TSESLint.FlatConfig.ConfigArray = [
 /**
  * The FormSpec ESLint plugin.
  */
+export const configs = {
+  recommended: recommendedConfig,
+  strict: strictConfig,
+} as const;
+
 const plugin = {
   meta,
   rules,
-  configs: {
-    recommended: recommendedConfig,
-    strict: strictConfig,
-  },
+  configs,
 };
 
 export default plugin;

--- a/packages/formspec/README.md
+++ b/packages/formspec/README.md
@@ -1,160 +1,91 @@
 # formspec
 
-Type-safe form specifications that compile to JSON Schema and JSON Forms UI Schema.
+Umbrella package for the common FormSpec authoring and runtime APIs.
 
-## Installation
+It re-exports the most commonly used pieces from:
+
+- `@formspec/core`
+- `@formspec/dsl`
+- `@formspec/build`
+- `@formspec/runtime`
+
+It does not include the CLI, ESLint plugin, language server, or playground app.
+
+## Install
 
 ```bash
-npm install formspec
-# or
 pnpm add formspec
-```
-
-## Requirements
-
-This package is ESM-only and requires:
-
-```json
-// package.json
-{
-  "type": "module"
-}
-```
-
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}
 ```
 
 ## Quick Start
 
-```typescript
-import { formspec, field, group, when, is, buildFormSchemas, type InferFormSchema } from "formspec";
+```ts
+import {
+  buildFormSchemas,
+  defineResolvers,
+  field,
+  formspec,
+  group,
+  is,
+  type InferFormSchema,
+  when,
+} from "formspec";
 
-// Define a form
-const ContactForm = formspec(
-  field.text("name", { label: "Name", required: true }),
-  field.text("email", { label: "Email", required: true }),
-  field.enum("subject", ["General", "Support", "Sales"], { label: "Subject" }),
-  field.text("message", { label: "Message", required: true }),
-  field.boolean("subscribe", { label: "Subscribe to newsletter" })
+const OrderForm = formspec(
+  group(
+    "Order",
+    field.text("customerName", { required: true }),
+    field.enum("status", ["draft", "submitted"] as const, { required: true })
+  ),
+  when(is("status", "submitted"), field.text("submittedBy"))
 );
 
-// Infer TypeScript type from the form
-type ContactData = InferFormSchema<typeof ContactForm>;
-// { name: string; email: string; subject: "General" | "Support" | "Sales" | undefined; ... }
+type OrderData = InferFormSchema<typeof OrderForm>;
 
-// Generate JSON Schema and UI Schema
-const { jsonSchema, uiSchema } = buildFormSchemas(ContactForm);
+const { jsonSchema, uiSchema } = buildFormSchemas(OrderForm);
+
+const resolvers = defineResolvers(OrderForm, {});
+void jsonSchema;
+void uiSchema;
+void resolvers;
 ```
 
-## Features
+## What You Get
 
-### Field Types
+### DSL
 
-```typescript
-field.text("name", { label: "Name", required: true });
-field.number("age", { label: "Age", min: 0, max: 120 });
-field.boolean("active", { label: "Active" });
-field.enum("status", ["draft", "published"], { label: "Status" });
-field.dynamicEnum("country", "fetch_countries", { label: "Country" });
-field.array("tags", field.text("tag"));
-field.object("address", field.text("street"), field.text("city"));
-```
+- `formspec`
+- `field`
+- `group`
+- `when`
+- `is`
+- `formspecWithValidation`
+- `validateForm`
 
-### Grouping
+### Build
 
-```typescript
-const Form = formspec(
-  group("Personal Info", field.text("firstName"), field.text("lastName")),
-  group("Contact", field.text("email"), field.text("phone"))
-);
-```
+- `buildFormSchemas`
+- `generateJsonSchema`
+- `generateUiSchema`
+- `writeSchemas`
+- `buildMixedAuthoringSchemas`
 
-### Conditional Fields
+### Runtime
 
-```typescript
-const Form = formspec(
-  field.enum("type", ["personal", "business"]),
-  when(
-    is("type", "business"),
-    field.text("companyName", { label: "Company Name" }),
-    field.text("taxId", { label: "Tax ID" })
-  )
-);
-```
+- `defineResolvers`
 
-### Type Inference
+### Types
 
-```typescript
-// Infer the form data type
-type FormData = InferFormSchema<typeof MyForm>;
+- `InferSchema`
+- `InferFormSchema`
+- core field, layout, and state types
 
-// Use with form libraries
-const handleSubmit = (data: FormData) => {
-  // data is fully typed
-};
-```
+## When To Use Individual Packages
 
-### Dynamic Enums with Resolvers
-
-```typescript
-import { defineResolvers } from "formspec";
-
-const Form = formspec(field.dynamicEnum("country", "fetch_countries", { label: "Country" }));
-
-const resolvers = defineResolvers(Form, {
-  fetch_countries: async () => ({
-    options: [
-      { value: "us", label: "United States" },
-      { value: "ca", label: "Canada" },
-    ],
-    validity: "valid",
-  }),
-});
-```
-
-### Write Schemas to Disk
-
-```typescript
-import { writeSchemas } from "formspec";
-
-writeSchemas(ContactForm, {
-  outDir: "./generated",
-  name: "contact-form",
-});
-// Creates: ./generated/contact-form-schema.json
-//          ./generated/contact-form-uischema.json
-```
-
-## Package Structure
-
-This umbrella package re-exports from several focused packages:
-
-| Package             | Description                                                |
-| ------------------- | ---------------------------------------------------------- |
-| `@formspec/core`    | Core type definitions                                      |
-| `@formspec/dsl`     | DSL functions (`formspec`, `field`, `group`, `when`, `is`) |
-| `@formspec/build`   | Schema generators (`buildFormSchemas`, `writeSchemas`)     |
-| `@formspec/runtime` | Runtime helpers (`defineResolvers`)                        |
-
-You can import from the umbrella package for convenience, or from individual packages for smaller bundle sizes.
-
-## Related Packages
-
-| Package                     | Description                                |
-| --------------------------- | ------------------------------------------ |
-| `@formspec/constraints`     | Constraint definitions and validators      |
-| `@formspec/validator`       | JSON Schema validation for secure runtimes |
-| `@formspec/eslint-plugin`   | ESLint rules for FormSpec                  |
-| `@formspec/language-server` | Language server for editor integration     |
-| `@formspec/cli`             | CLI tool for build-time schema generation  |
-| `@formspec/playground`      | Interactive browser editor (private)       |
+- Use `@formspec/build` directly for `generateSchemas()` and static TypeScript analysis.
+- Use `@formspec/eslint-plugin` for lint rules.
+- Use `@formspec/cli` for build-time artifact generation from files.
+- Use `@formspec/validator` for runtime JSON Schema validation.
 
 ## License
 

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -1,95 +1,34 @@
 # @formspec/language-server
 
-Language server protocol (LSP) features for FormSpec, providing editor intelligence for JSDoc constraint tags.
+Language-server support for FormSpec TSDoc tags.
 
-## Installation
+## Install
 
 ```bash
-npm install @formspec/language-server
-# or
 pnpm add @formspec/language-server
 ```
 
-## Requirements
+## Features
 
-This package is ESM-only and requires:
+- completion items for FormSpec tags
+- hover documentation for recognized tags
+- go-to-definition support for known tags
 
-```json
-// package.json
-{
-  "type": "module"
-}
+Diagnostics are intentionally handled elsewhere; this package focuses on editor assistance.
+
+## Usage
+
+```ts
+import { createServer, getCompletionItems, getHoverForTag } from "@formspec/language-server";
+
+const server = createServer();
+const completions = getCompletionItems();
+const hover = getHoverForTag("minimum");
+
+void server;
+void completions;
+void hover;
 ```
-
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}
-```
-
-## Overview
-
-This package provides language server features for FormSpec's JSDoc constraint tags (`@Minimum`, `@Maximum`, `@Pattern`, etc.). It can be integrated into any LSP-compatible editor.
-
-### Features
-
-- **Completion** — Autocomplete for constraint tag names inside JSDoc comments
-- **Hover** — Documentation on hover for constraint tags
-- **Go to Definition** — Navigate to constraint definitions _(placeholder — not yet implemented)_
-
-## API Reference
-
-### Functions
-
-| Function                  | Description                                     |
-| ------------------------- | ----------------------------------------------- |
-| `createServer()`          | Create a full LSP server connection             |
-| `getCompletionItems()`    | Get completion items for constraint tags        |
-| `getDefinition()`         | Get definition location for a constraint tag    |
-| `getHoverForTag(tagName)` | Get hover information for a constraint tag name |
-
-### `createServer()`
-
-Creates a Language Server Protocol connection that handles `initialize`, `textDocument/completion`, `textDocument/hover`, and `textDocument/definition` requests.
-
-```typescript
-import { createServer } from "@formspec/language-server";
-
-const connection = createServer();
-connection.listen();
-```
-
-### `getCompletionItems()`
-
-Returns completion items for all known FormSpec constraint tags.
-
-```typescript
-import { getCompletionItems } from "@formspec/language-server";
-
-const items = getCompletionItems();
-// [{ label: "@Minimum", kind: CompletionItemKind.Keyword, ... }, ...]
-```
-
-### `getHoverForTag(tagName)`
-
-Returns hover documentation for a given tag name, or `null` if the tag is not recognized.
-
-```typescript
-import { getHoverForTag } from "@formspec/language-server";
-
-const hover = getHoverForTag("Minimum");
-// { contents: { kind: "markdown", value: "..." } }
-```
-
-## Editor Integration
-
-### VS Code
-
-Use with a VS Code extension that connects to the language server. The server communicates over the standard LSP protocol via `vscode-languageserver/node.js`.
 
 ## License
 

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -1,101 +1,26 @@
 # @formspec/playground
 
-Interactive playground for FormSpec - write forms and see generated schemas live.
+Private playground app for interactive FormSpec development inside this monorepo.
 
-## Features
+## What It Includes
 
-- **Real-time compilation** - TypeScript transpilation and FormSpec validation as you type
-- **Live schema generation** - See JSON Schema and UI Schema output instantly
-- **Canonical IR viewer** - Inspect the intermediate representation of your form
-- **Validation panel** - See validation results and constraint issues
-- **Interactive form preview** - Rendered forms using JSON Forms + Material UI
-- **Monaco editor** - Full TypeScript support with FormSpec type definitions
-- **ESLint integration** - Constraint violations shown as editor markers
-- **Configurable constraints** - UI for restricting which DSL features are allowed
+- Monaco editor with FormSpec-aware TypeScript support
+- live JSON Schema and UI Schema generation
+- canonical IR inspection
+- browser-based ESLint integration
+- JSON Forms preview
 
-## Running Locally
+## Run Locally
 
 ```bash
-# From the monorepo root
 pnpm install
 pnpm run build
 cd packages/playground
 pnpm run dev
 ```
 
-The playground will be available at `http://localhost:5173/formspec/`.
+The default dev URL is `http://localhost:5173/formspec/`.
 
-## Architecture
+## License
 
-```
-User Code (Monaco) ──► TypeScript Compile ──► Execute ──► FormSpec Object
-                                                              │
-Constraints Config ─────────────────────────────────────────►│
-                                                              ▼
-                                              ┌───────────────────────────┐
-                                              │    canonicalizeChainDSL() │
-                                              │    generateJsonSchema()   │
-                                              │    generateUiSchema()     │
-                                              │    validateFormSpec()     │
-                                              └───────────────────────────┘
-                                                              │
-                    ┌────────────┬─────────────┬──────────────┼───────────────────┐
-                    ▼            ▼             ▼              ▼                   ▼
-              Canonical IR  JSON Schema   UI Schema     Lint Issues          Form Preview
-                Panel         Panel        Panel          Panel              (JSON Forms)
-```
-
-### Key Components
-
-- **Editor** (`src/components/Editor/`) - Monaco editor wrapper with FormSpec types
-- **Compiler** (`src/lib/compiler.ts`) - TypeScript transpilation + sandboxed execution + schema generation
-- **Linter** (`src/lib/linter.ts`) - Browser-based ESLint with `@formspec/eslint-plugin` rules
-- **Preview** (`src/components/Preview/`) - Live form rendering with JSON Forms
-- **Constraints** (`src/components/Constraints/`) - UI for configuring DSL restrictions
-
-### Browser Entry Points
-
-The playground uses browser-safe entry points that exclude Node.js APIs:
-
-- `@formspec/build/browser` - Schema generation without `node:fs`
-- `@formspec/constraints/browser` - Validation without file system access
-
-## Deployment
-
-The playground is automatically deployed to GitHub Pages via GitHub Actions.
-
-### Automatic Deployment
-
-Changes pushed to the `main` branch trigger automatic deployment when files in these directories are modified:
-
-- `packages/playground/**`
-- `packages/core/**`
-- `packages/dsl/**`
-- `packages/build/**`
-- `packages/constraints/**`
-
-The workflow (`.github/workflows/deploy-playground.yml`) will:
-
-1. Build all packages
-2. Generate the static site from the playground
-3. Deploy to GitHub Pages with automatic enablement
-
-### GitHub Pages Setup
-
-The workflow uses the `configure-pages` action with `enablement: true`, which will automatically:
-
-- Enable GitHub Pages for the repository (if not already enabled)
-- Configure the Pages deployment source to use GitHub Actions
-- Set up the necessary permissions
-
-**Note**: On the first run, the workflow may require repository administrator permissions to enable Pages. Once enabled, subsequent deployments will work automatically.
-
-The deployed playground is available at: https://mike-north.github.io/formspec/
-
-## Scripts
-
-- `pnpm run dev` - Start development server
-- `pnpm run build` - Build for production
-- `pnpm run preview` - Preview production build
-- `pnpm run test` - Run tests
-- `pnpm run typecheck` - Type check without emitting
+UNLICENSED

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,125 +1,48 @@
 # @formspec/runtime
 
-Runtime helpers for FormSpec - resolvers and data fetching.
+Runtime helpers for dynamic FormSpec data sources.
 
-## Installation
+## Install
 
 ```bash
-npm install @formspec/runtime
-# or
 pnpm add @formspec/runtime
 ```
 
-> **Note:** Most users should install the `formspec` umbrella package instead, which re-exports everything from this package.
+Or use:
 
-## Requirements
-
-This package is ESM-only and requires:
-
-```json
-// package.json
-{
-  "type": "module"
-}
+```bash
+pnpm add formspec
 ```
 
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}
-```
+## Main API
 
-## Usage
+`defineResolvers(form, resolvers)` creates a typed resolver registry for the dynamic enum sources used by a form.
 
-### Define Resolvers for Dynamic Enums
-
-```typescript
+```ts
+import { field, formspec } from "@formspec/dsl";
 import { defineResolvers } from "@formspec/runtime";
-import { formspec, field } from "@formspec/dsl";
 
-// Define a form with dynamic enum fields
-const OrderForm = formspec(
-  field.dynamicEnum("country", "fetch_countries", { label: "Country" }),
-  field.dynamicEnum("state", "fetch_states", { label: "State" })
+const Form = formspec(
+  field.dynamicEnum("country", "countries"),
+  field.dynamicEnum("state", "states")
 );
 
-// Define type-safe resolvers
-const resolvers = defineResolvers(OrderForm, {
-  fetch_countries: async () => ({
+const resolvers = defineResolvers(Form, {
+  countries: async () => ({
     options: [
       { value: "us", label: "United States" },
       { value: "ca", label: "Canada" },
-      { value: "uk", label: "United Kingdom" },
     ],
     validity: "valid",
   }),
-
-  fetch_states: async (params) => {
-    // Params can include any context needed for the lookup (e.g. form data)
-    const response = await fetch(`/api/states?country=${params?.country}`);
-    const states = await response.json();
-    return {
-      options: states.map((s: { code: string; name: string }) => ({
-        value: s.code,
-        label: s.name,
-      })),
-      validity: "valid",
-    };
-  },
+  states: async () => ({
+    options: [],
+    validity: "unknown",
+  }),
 });
 
-// Use the resolver
-const countries = await resolvers.get("fetch_countries")();
-console.log(countries.options);
-// [{ value: "us", label: "United States" }, ...]
-```
-
-### Resolver Response Format
-
-```typescript
-interface FetchOptionsResponse {
-  options: Array<{
-    value: string;
-    label: string;
-  }>;
-  validity: "valid" | "invalid" | "unknown";
-}
-```
-
-## API Reference
-
-### Functions
-
-| Function                           | Description                          |
-| ---------------------------------- | ------------------------------------ |
-| `defineResolvers(form, resolvers)` | Create a type-safe resolver registry |
-
-### Types
-
-| Type                  | Description                           |
-| --------------------- | ------------------------------------- |
-| `Resolver`            | Async function that fetches options   |
-| `ResolverMap<F>`      | Map of data source names to resolvers |
-| `ResolverRegistry<F>` | Registry with `get()` method          |
-
-## Type Safety
-
-The `defineResolvers` function enforces that:
-
-1. All data sources referenced in the form have corresponding resolvers
-2. Resolver names match the data source IDs in the form
-3. Return types match the expected `FetchOptionsResponse` format
-
-```typescript
-// TypeScript error: Missing resolver for "fetch_states"
-const resolvers = defineResolvers(OrderForm, {
-  fetch_countries: async () => ({ ... }),
-  // Error: 'fetch_states' is required
-});
+const countries = await resolvers.get("countries")();
+void countries;
 ```
 
 ## License

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -1,91 +1,42 @@
 # @formspec/validator
 
-JSON Schema validation for FormSpec, powered by [@cfworker/json-schema](https://github.com/nicolo-ribaudo/cfworker-json-schema). Designed for secure runtime environments that prohibit `new Function()` and `eval()`.
+Runtime JSON Schema validation for FormSpec, backed by `@cfworker/json-schema`.
 
-## Installation
+This package is intended for environments where code-generating validators are a bad fit, including workers and CSP-restricted runtimes.
+
+## Install
 
 ```bash
-npm install @formspec/validator
-# or
 pnpm add @formspec/validator
 ```
 
-## Requirements
+## Usage
 
-This package is ESM-only and requires:
-
-```json
-// package.json
-{
-  "type": "module"
-}
-```
-
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}
-```
-
-## Quick Start
-
-```typescript
+```ts
 import { createFormSpecValidator } from "@formspec/validator";
-import { buildFormSchemas, formspec, field } from "formspec";
 
-const form = formspec(field.text("name", { required: true }), field.number("age", { min: 0 }));
+const validator = createFormSpecValidator({
+  type: "object",
+  required: ["name"],
+  properties: {
+    name: { type: "string" },
+    country: { type: "string", "x-formspec-source": "countries" },
+  },
+});
 
-const { jsonSchema } = buildFormSchemas(form);
-
-// Create a validator that ignores x-formspec-* extension keywords
-const validator = createFormSpecValidator(jsonSchema);
-
-const result = validator.validate({ name: "Alice", age: 30 });
-console.log(result.valid); // true
+const result = validator.validate({ name: "Alice", country: "us" });
+void result;
 ```
 
-## Why This Package?
+Unknown `x-formspec-*` keywords are ignored by the underlying validator, so generated schemas work without extra vocabulary registration.
 
-Standard JSON Schema validators like Ajv use `new Function()` internally, which is blocked in:
+## Main Exports
 
-- Cloudflare Workers
-- Deno Deploy
-- Browser extensions (CSP restrictions)
-- Any environment with strict Content Security Policy
-
-`@formspec/validator` wraps `@cfworker/json-schema`, which implements JSON Schema validation without code generation. It also pre-configures the validator to silently ignore `x-formspec-*` vendor extension keywords that FormSpec adds to generated schemas.
-
-## API Reference
-
-### Functions
-
-| Function                                    | Description                                   |
-| ------------------------------------------- | --------------------------------------------- |
-| `createFormSpecValidator(schema, options?)` | Create a validator instance for a JSON Schema |
-
-### Options
-
-```typescript
-interface CreateValidatorOptions {
-  draft?: SchemaDraft; // JSON Schema draft version (default: "2020-12")
-  shortCircuit?: boolean; // Stop on first error (default: true)
-}
-```
-
-### Re-exports
-
-This package re-exports key types from `@cfworker/json-schema`:
-
-| Export             | Description                          |
-| ------------------ | ------------------------------------ |
-| `Validator`        | The validator class                  |
-| `ValidationResult` | Result of `validator.validate()`     |
-| `OutputUnit`       | Individual validation error detail   |
-| `SchemaDraft`      | Supported JSON Schema draft versions |
+- `createFormSpecValidator(schema, options?)`
+- `Validator`
+- `ValidationResult`
+- `OutputUnit`
+- `SchemaDraft`
 
 ## License
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       '@typescript-eslint/rule-tester':
         specifier: ^8.0.0
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
+      eslint-doc-generator:
+        specifier: ^3.3.2
+        version: 3.3.2(eslint@9.39.2)(prettier@3.8.1)(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.7)(tsx@4.21.0)(yaml@2.8.2)
@@ -943,9 +946,21 @@ packages:
     resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
     engines: {node: 20 || >=22}
 
+  '@jest/diff-sequences@30.3.0':
+    resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/schemas@30.0.5':
+    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1166,6 +1181,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@one-ini/wasm@0.2.1':
+    resolution: {integrity: sha512-TUqERXGNTifZ9y2g3wPxQrw3HpHv/02DsW3D90T9x0hhonrL1ZqpSmNrU2XkoIq0fP1N6gZfVQzy2Fw1ZvGBNg==}
+
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
@@ -1343,6 +1361,13 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sinclair/typebox@0.34.48':
+    resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@tsd/typescript@5.4.5':
     resolution: {integrity: sha512-saiCxzHRhUrRxQV2JhH580aQUZiKQUXI38FcAcikcfOomAil4G4lxT0RfrrKywoAYP/rqAdYXYmNRLppcd+hQQ==}
     engines: {node: '>=14.17'}
@@ -1455,6 +1480,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/project-service@8.57.2':
+    resolution: {integrity: sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/rule-tester@8.54.0':
     resolution: {integrity: sha512-+Fc1Y8xmSgdIBJXUKIjlswZ1EvSejqoayHxEfV20piWhKik+GKaJznKCz6XnCIzJLwzRlncnVjTceZohsKYvyg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1473,6 +1504,10 @@ packages:
     resolution: {integrity: sha512-fVu5Omrd3jeqeQLiB9f1YsuK/iHFOwb04bCtY4BSCLgjNbOD33ZdV6KyEqplHr+IlpgT0QTZ/iJ+wT7hvTx49Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.57.2':
+    resolution: {integrity: sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.53.1':
     resolution: {integrity: sha512-qfvLXS6F6b1y43pnf0pPbXJ+YoXIC7HKg0UGZ27uMIemKMKA6XH2DTxsEDdpdN29D+vHV07x/pnlPNVLhdhWiA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1487,6 +1522,12 @@ packages:
 
   '@typescript-eslint/tsconfig-utils@8.55.0':
     resolution: {integrity: sha512-1R9cXqY7RQd7WuqSN47PK9EDpgFUK3VqdmbYrvWJZYDd0cavROGn+74ktWBlmJ13NXUQKlZ/iAEQHI/V0kKe0Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/tsconfig-utils@8.57.2':
+    resolution: {integrity: sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -1510,6 +1551,10 @@ packages:
     resolution: {integrity: sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.57.2':
+    resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.53.1':
     resolution: {integrity: sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1528,6 +1573,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/typescript-estree@8.57.2':
+    resolution: {integrity: sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/utils@8.53.1':
     resolution: {integrity: sha512-c4bMvGVWW4hv6JmDUEG7fSYlWOl3II2I4ylt0NM+seinYQlZMQIaKaXIIVJWt9Ofh6whrpM+EdDQXKXjNovvrg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1542,6 +1593,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@8.57.2':
+    resolution: {integrity: sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@8.53.1':
     resolution: {integrity: sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1552,6 +1610,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.55.0':
     resolution: {integrity: sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.57.2':
+    resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@4.7.0':
@@ -1691,12 +1753,20 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
@@ -1715,6 +1785,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1758,6 +1832,13 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
@@ -1791,6 +1872,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1814,6 +1899,15 @@ packages:
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1852,6 +1946,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1871,9 +1969,18 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
+
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
+
+  editorconfig@3.0.2:
+    resolution: {integrity: sha512-T0ix8GhtxyKVfUFEcvdNDt3YGqlwkFHbD4/5bgFUDgFmxhI/cSRAeJ87/Sz//Cq8Eam6JX/e23RkoFO71P7aAA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
@@ -1881,9 +1988,16 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -1915,6 +2029,17 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
+  eslint-doc-generator@3.3.2:
+    resolution: {integrity: sha512-GhfcqCD28zzV/J5ppvcR4EwTMy3TOPymd8c6HNBeMe78lFw8pXf2GnNdq6bs3pxjmrkRoxPnNUSnlBlY7gN4Ow==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      eslint: '>= 8.57.1'
+      prettier: '>= 3.0.0'
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
   eslint-formatter-pretty@4.1.0:
     resolution: {integrity: sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==}
     engines: {node: '>=10'}
@@ -1933,6 +2058,10 @@ packages:
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
@@ -2193,6 +2322,10 @@ packages:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-diff@30.3.0:
+    resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2234,6 +2367,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2291,6 +2427,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
@@ -2323,6 +2462,9 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   meow@9.0.0:
     resolution: {integrity: sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==}
     engines: {node: '>=10'}
@@ -2342,6 +2484,10 @@ packages:
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
+
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2377,6 +2523,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -2543,6 +2693,10 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  pretty-format@30.3.0:
+    resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2675,6 +2829,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2690,9 +2849,17 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2787,6 +2954,14 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -2894,6 +3069,10 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
 
+  type-fest@5.5.0:
+    resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
+    engines: {node: '>=20'}
+
   typescript-eslint@8.53.1:
     resolution: {integrity: sha512-gB+EVQfP5RDElh9ittfXlhZJdjSU4jUSTyE2+ia8CYyNvet4ElfaLlAIqDvQV9JPknKx0jQH1racTYe/4LaLSg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2921,6 +3100,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3739,9 +3922,17 @@ snapshots:
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
+  '@jest/diff-sequences@30.3.0': {}
+
+  '@jest/get-type@30.1.0': {}
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
+
+  '@jest/schemas@30.0.5':
+    dependencies:
+      '@sinclair/typebox': 0.34.48
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4000,6 +4191,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@one-ini/wasm@0.2.1': {}
+
   '@popperjs/core@2.11.8': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -4119,6 +4312,10 @@ snapshots:
       - '@types/node'
 
   '@sinclair/typebox@0.27.8': {}
+
+  '@sinclair/typebox@0.34.48': {}
+
+  '@sindresorhus/is@4.6.0': {}
 
   '@tsd/typescript@5.4.5': {}
 
@@ -4266,6 +4463,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.57.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.2
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/rule-tester@8.54.0(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2)(typescript@5.9.3)
@@ -4295,6 +4501,11 @@ snapshots:
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/visitor-keys': 8.55.0
 
+  '@typescript-eslint/scope-manager@8.57.2':
+    dependencies:
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/visitor-keys': 8.57.2
+
   '@typescript-eslint/tsconfig-utils@8.53.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
@@ -4304,6 +4515,10 @@ snapshots:
       typescript: 5.9.3
 
   '@typescript-eslint/tsconfig-utils@8.55.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
@@ -4324,6 +4539,8 @@ snapshots:
   '@typescript-eslint/types@8.54.0': {}
 
   '@typescript-eslint/types@8.55.0': {}
+
+  '@typescript-eslint/types@8.57.2': {}
 
   '@typescript-eslint/typescript-estree@8.53.1(typescript@5.9.3)':
     dependencies:
@@ -4370,6 +4587,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.57.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/visitor-keys': 8.57.2
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.53.1(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
@@ -4392,6 +4624,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.57.2(eslint@9.39.2)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
+      '@typescript-eslint/scope-manager': 8.57.2
+      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      eslint: 9.39.2
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.53.1':
     dependencies:
       '@typescript-eslint/types': 8.53.1
@@ -4406,6 +4649,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.55.0
       eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.57.2':
+    dependencies:
+      '@typescript-eslint/types': 8.57.2
+      eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.7)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -4553,6 +4801,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  astral-regex@2.0.0: {}
+
   babel-plugin-macros@3.1.0:
     dependencies:
       '@babel/runtime': 7.28.6
@@ -4560,6 +4810,8 @@ snapshots:
       resolve: 1.22.11
 
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.9.19: {}
 
@@ -4577,6 +4829,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -4622,6 +4878,10 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  change-case@5.4.4: {}
+
+  char-regex@1.0.2: {}
+
   chardet@2.1.1: {}
 
   check-error@2.1.3: {}
@@ -4654,6 +4914,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  commander@14.0.3: {}
+
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
@@ -4673,6 +4935,15 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4701,6 +4972,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.3.1: {}
+
   detect-indent@6.1.0: {}
 
   diff-sequences@29.6.3: {}
@@ -4716,16 +4989,31 @@ snapshots:
       '@babel/runtime': 7.28.6
       csstype: 3.2.3
 
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.5.0
+
   dotenv@8.6.0: {}
+
+  editorconfig@3.0.2:
+    dependencies:
+      '@one-ini/wasm': 0.2.1
+      commander: 14.0.3
+      minimatch: 10.2.4
+      semver: 7.7.4
 
   electron-to-chromium@1.5.286: {}
 
   emoji-regex@8.0.0: {}
 
+  emojilib@2.4.0: {}
+
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  env-paths@2.2.1: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -4799,6 +5087,30 @@ snapshots:
     dependencies:
       eslint: 9.39.2
 
+  eslint-doc-generator@3.3.2(eslint@9.39.2)(prettier@3.8.1)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2)(typescript@5.9.3)
+      ajv: 8.18.0
+      change-case: 5.4.4
+      commander: 14.0.3
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      deepmerge: 4.3.1
+      dot-prop: 10.1.0
+      editorconfig: 3.0.2
+      eslint: 9.39.2
+      jest-diff: 30.3.0
+      json-schema: 0.4.0
+      json-schema-traverse: 1.0.0
+      markdown-table: 3.0.4
+      node-emoji: 2.2.0
+      table: 6.9.0
+      type-fest: 5.5.0
+    optionalDependencies:
+      prettier: 3.8.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   eslint-formatter-pretty@4.1.0:
     dependencies:
       '@types/eslint': 9.6.1
@@ -4820,6 +5132,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.2:
     dependencies:
@@ -5078,6 +5392,13 @@ snapshots:
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
 
+  jest-diff@30.3.0:
+    dependencies:
+      '@jest/diff-sequences': 30.3.0
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.3.0
+
   jest-get-type@29.6.3: {}
 
   jju@1.4.0: {}
@@ -5106,6 +5427,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -5154,6 +5477,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash.truncate@4.4.2: {}
+
   lodash@4.17.23: {}
 
   log-symbols@4.1.0:
@@ -5183,6 +5508,8 @@ snapshots:
 
   map-obj@4.3.0: {}
 
+  markdown-table@3.0.4: {}
+
   meow@9.0.0:
     dependencies:
       '@types/minimist': 1.2.5
@@ -5210,6 +5537,10 @@ snapshots:
   minimatch@10.0.3:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
+
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.5
 
   minimatch@3.1.2:
     dependencies:
@@ -5247,6 +5578,13 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
 
   node-fetch@2.7.0:
     dependencies:
@@ -5379,6 +5717,12 @@ snapshots:
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  pretty-format@30.3.0:
+    dependencies:
+      '@jest/schemas': 30.0.5
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
@@ -5521,6 +5865,8 @@ snapshots:
 
   semver@7.7.3: {}
 
+  semver@7.7.4: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -5531,7 +5877,17 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+
   slash@3.0.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
 
   source-map-js@1.2.1: {}
 
@@ -5618,6 +5974,16 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.18.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  tagged-tag@1.0.0: {}
 
   term-size@2.2.1: {}
 
@@ -5719,6 +6085,10 @@ snapshots:
 
   type-fest@0.8.1: {}
 
+  type-fest@5.5.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   typescript-eslint@8.53.1(eslint@9.39.2)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
@@ -5739,6 +6109,8 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
## Summary
- refresh the root README and each published package README so the documented package boundaries and entry points match the current codebase
- add a changeset for the unpublished build/core/eslint-plugin follow-up fixes that still need release coverage
- integrate `eslint-doc-generator` into `@formspec/eslint-plugin`, generate rule docs, and switch the plugin README to an auto-generated rules table

## Test plan
- `pnpm --filter @formspec/eslint-plugin run build`
- `pnpm --filter @formspec/eslint-plugin run fix:eslint-docs`
- `pnpm --filter @formspec/eslint-plugin run check:eslint-docs`
