### PR TITLE
Tighten white-label follow-up exports

### DIFF
--- a/.changeset/few-rabbits-argue.md
+++ b/.changeset/few-rabbits-argue.md
@@ -1,0 +1,13 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Tighten the white-label tooling surface by fixing protocol-type exports,
+preserving canonical diagnostic categories in the LSP adapter, and avoiding
+lingering refresh timers in direct semantic-service hosts.

--- a/packages/analysis/api-report/analysis.api.md
+++ b/packages/analysis/api-report/analysis.api.md
@@ -6,6 +6,17 @@
 
 import type { PathTarget } from '@formspec/core';
 
+// @public (undocumented)
+export type CommentSourceSpan = CommentSpan;
+
+// @public (undocumented)
+export interface CommentSpan {
+    // (undocumented)
+    readonly end: number;
+    // (undocumented)
+    readonly start: number;
+}
+
 // @public
 export function computeFormSpecTextHash(text: string): string;
 
@@ -17,16 +28,12 @@ export const FORMSPEC_ANALYSIS_SCHEMA_VERSION = 1;
 
 // @public
 export interface FormSpecAnalysisCommentSnapshot {
-    // Warning: (ae-forgotten-export) The symbol "CommentSpan" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly commentSpan: CommentSpan;
     // (undocumented)
     readonly declarationSpan: CommentSpan;
     // (undocumented)
     readonly hostType: string | null;
-    // Warning: (ae-forgotten-export) The symbol "FormSpecPlacement" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly placement: FormSpecPlacement | null;
     // (undocumented)
@@ -137,6 +144,9 @@ export interface FormSpecIpcEndpoint {
     readonly kind: "unix-socket" | "windows-pipe";
 }
 
+// @public (undocumented)
+export type FormSpecPlacement = "class" | "class-field" | "class-method" | "interface" | "interface-field" | "type-alias" | "type-alias-field" | "variable" | "function" | "function-parameter" | "method-parameter";
+
 // @public
 export type FormSpecSemanticQuery = {
     readonly protocolVersion: typeof FORMSPEC_ANALYSIS_PROTOCOL_VERSION;
@@ -197,10 +207,8 @@ export interface FormSpecSerializedCommentTargetSpecifier {
     readonly colonSpan: CommentSpan;
     // (undocumented)
     readonly fullSpan: CommentSpan;
-    // Warning: (ae-forgotten-export) The symbol "ParsedCommentTargetSpecifier" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    readonly kind: ParsedCommentTargetSpecifier["kind"];
+    readonly kind: "path" | "member" | "variant" | "ambiguous";
     // (undocumented)
     readonly rawText: string;
     // (undocumented)
@@ -227,10 +235,8 @@ export type FormSpecSerializedCompletionContext = {
 
 // @public
 export interface FormSpecSerializedHoverInfo {
-    // Warning: (ae-forgotten-export) The symbol "CommentHoverInfo" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    readonly kind: CommentHoverInfo["kind"];
+    readonly kind: "tag-name" | "target" | "argument";
     // (undocumented)
     readonly markdown: string;
 }
@@ -255,8 +261,6 @@ export interface FormSpecSerializedTagSemanticContext {
     readonly placement: FormSpecPlacement | null;
     // (undocumented)
     readonly signatures: readonly FormSpecSerializedTagSignature[];
-    // Warning: (ae-forgotten-export) The symbol "FormSpecTargetKind" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly supportedTargets: readonly FormSpecTargetKind[];
     // (undocumented)
@@ -281,6 +285,9 @@ export interface FormSpecSerializedTagSignature {
     readonly placements: readonly FormSpecPlacement[];
 }
 
+// @public (undocumented)
+export type FormSpecTargetKind = "none" | "path" | "member" | "variant";
+
 // @public
 export function getFormSpecManifestPath(workspaceRoot: string): string;
 
@@ -304,6 +311,8 @@ export function isFormSpecSemanticResponse(value: unknown): value is FormSpecSem
 // @public
 export function serializeCommentTagSemanticContext(semantic: CommentTagSemanticContext): FormSpecSerializedTagSemanticContext;
 
+// Warning: (ae-forgotten-export) The symbol "ParsedCommentTargetSpecifier" needs to be exported by the entry point index.d.ts
+//
 // @public
 export function serializeCommentTargetSpecifier(target: ParsedCommentTargetSpecifier | null): FormSpecSerializedCommentTargetSpecifier | null;
 
@@ -312,6 +321,8 @@ export function serializeCommentTargetSpecifier(target: ParsedCommentTargetSpeci
 // @public
 export function serializeCompletionContext(context: SemanticCommentCompletionContext): FormSpecSerializedCompletionContext;
 
+// Warning: (ae-forgotten-export) The symbol "CommentHoverInfo" needs to be exported by the entry point index.d.ts
+//
 // @public
 export function serializeHoverInfo(hover: CommentHoverInfo | null): FormSpecSerializedHoverInfo | null;
 

--- a/packages/analysis/src/__tests__/semantic-protocol.test.ts
+++ b/packages/analysis/src/__tests__/semantic-protocol.test.ts
@@ -71,6 +71,20 @@ describe("semantic protocol", () => {
     expect(
       isFormSpecSemanticQuery({
         protocolVersion: FORMSPEC_ANALYSIS_PROTOCOL_VERSION,
+        kind: "diagnostics",
+      })
+    ).toBe(false);
+
+    expect(
+      isFormSpecSemanticQuery({
+        protocolVersion: FORMSPEC_ANALYSIS_PROTOCOL_VERSION,
+        kind: "file-snapshot",
+      })
+    ).toBe(false);
+
+    expect(
+      isFormSpecSemanticQuery({
+        protocolVersion: FORMSPEC_ANALYSIS_PROTOCOL_VERSION,
         kind: "bogus",
       })
     ).toBe(false);

--- a/packages/analysis/src/comment-syntax.ts
+++ b/packages/analysis/src/comment-syntax.ts
@@ -6,12 +6,14 @@ import {
   type ExtensionTagSource,
 } from "./tag-registry.js";
 
-export interface CommentSourceSpan {
+/** @public */
+export interface CommentSpan {
   readonly start: number;
   readonly end: number;
 }
 
-export type CommentSpan = CommentSourceSpan;
+/** @public */
+export type CommentSourceSpan = CommentSpan;
 
 export interface ParsedCommentTargetSpecifier {
   readonly rawText: string;

--- a/packages/analysis/src/protocol.ts
+++ b/packages/analysis/src/protocol.ts
@@ -1,3 +1,5 @@
+export type { CommentSourceSpan, CommentSpan } from "./comment-syntax.js";
+export type { FormSpecPlacement, FormSpecTargetKind } from "./tag-registry.js";
 export type {
   FormSpecAnalysisCommentSnapshot,
   FormSpecAnalysisDiagnosticCategory,

--- a/packages/analysis/src/semantic-protocol.ts
+++ b/packages/analysis/src/semantic-protocol.ts
@@ -78,7 +78,7 @@ export interface FormSpecSerializedTagSignature {
 export interface FormSpecSerializedCommentTargetSpecifier {
   readonly rawText: string;
   readonly valid: boolean;
-  readonly kind: ParsedCommentTargetSpecifier["kind"];
+  readonly kind: "path" | "member" | "variant" | "ambiguous";
   readonly fullSpan: CommentSpan;
   readonly colonSpan: CommentSpan;
   readonly span: CommentSpan;
@@ -134,7 +134,7 @@ export type FormSpecSerializedCompletionContext =
  * @public
  */
 export interface FormSpecSerializedHoverInfo {
-  readonly kind: CommentHoverInfo["kind"];
+  readonly kind: "tag-name" | "target" | "argument";
   readonly markdown: string;
 }
 

--- a/packages/analysis/src/tag-registry.ts
+++ b/packages/analysis/src/tag-registry.ts
@@ -13,9 +13,11 @@ export type FormSpecValueKind =
   | "boolean"
   | "condition";
 
+/** @public */
 export type FormSpecTargetKind = "none" | "path" | "member" | "variant";
 export type FormSpecTagCategory = "constraint" | "annotation" | "structure" | "ecosystem";
 
+/** @public */
 export type FormSpecPlacement =
   | "class"
   | "class-field"

--- a/packages/language-server/api-report/language-server.api.md
+++ b/packages/language-server/api-report/language-server.api.md
@@ -12,6 +12,14 @@ import type { Hover } from 'vscode-languageserver/node.js';
 import type { Location } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
+// @public (undocumented)
+export interface CommentSpan {
+    // (undocumented)
+    readonly end: number;
+    // (undocumented)
+    readonly start: number;
+}
+
 // @public
 export function createServer(options?: CreateServerOptions): Connection;
 
@@ -27,28 +35,36 @@ export interface CreateServerOptions {
 
 // @public
 export interface FormSpecAnalysisDiagnostic {
-    // Warning: (ae-forgotten-export) The symbol "FormSpecAnalysisDiagnosticCategory" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly category: FormSpecAnalysisDiagnosticCategory;
     // (undocumented)
     readonly code: string;
-    // Warning: (ae-forgotten-export) The symbol "FormSpecAnalysisDiagnosticDataValue" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly data: Record<string, FormSpecAnalysisDiagnosticDataValue>;
     // (undocumented)
     readonly message: string;
-    // Warning: (ae-forgotten-export) The symbol "CommentSpan" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly range: CommentSpan;
-    // Warning: (ae-forgotten-export) The symbol "FormSpecAnalysisDiagnosticLocation" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly relatedLocations: readonly FormSpecAnalysisDiagnosticLocation[];
     // (undocumented)
     readonly severity: "error" | "warning" | "info";
+}
+
+// @public
+export type FormSpecAnalysisDiagnosticCategory = "tag-recognition" | "value-parsing" | "type-compatibility" | "target-resolution" | "constraint-validation" | "infrastructure";
+
+// @public
+export type FormSpecAnalysisDiagnosticDataValue = string | number | boolean | readonly string[] | readonly number[] | readonly boolean[];
+
+// @public
+export interface FormSpecAnalysisDiagnosticLocation {
+    // (undocumented)
+    readonly filePath: string;
+    // (undocumented)
+    readonly message?: string;
+    // (undocumented)
+    readonly range: CommentSpan;
 }
 
 // @public

--- a/packages/language-server/src/__tests__/diagnostics.test.ts
+++ b/packages/language-server/src/__tests__/diagnostics.test.ts
@@ -128,4 +128,31 @@ describe("toLspDiagnostics", () => {
     expect(diagnostic?.relatedInformation).toHaveLength(1);
     expect(diagnostic?.relatedInformation?.[0]?.message).toBe("Related FormSpec location");
   });
+
+  it("keeps the canonical diagnostic category when data also contains a category key", () => {
+    const document = {
+      uri: "file:///workspace/example.ts",
+      positionAt: vi.fn((offset: number) => ({ line: 0, character: offset })),
+    } as unknown as TextDocument;
+
+    const [diagnostic] = toLspDiagnostics(document, [
+      {
+        code: "TYPE_MISMATCH",
+        category: "type-compatibility",
+        message: "bad target",
+        range: { start: 0, end: 1 },
+        severity: "error",
+        relatedLocations: [],
+        data: {
+          category: "user-overridden",
+          tagName: "minimum",
+        },
+      },
+    ]);
+
+    expect(diagnostic?.data).toEqual({
+      category: "type-compatibility",
+      tagName: "minimum",
+    });
+  });
 });

--- a/packages/language-server/src/diagnostics.ts
+++ b/packages/language-server/src/diagnostics.ts
@@ -2,7 +2,6 @@ import type {
   FormSpecAnalysisDiagnostic,
   FormSpecAnalysisDiagnosticLocation,
 } from "@formspec/analysis/protocol";
-import { fileURLToPath } from "node:url";
 import {
   DiagnosticRelatedInformation,
   DiagnosticSeverity,
@@ -11,6 +10,7 @@ import {
   type Diagnostic,
 } from "vscode-languageserver/node.js";
 import type { TextDocument } from "vscode-languageserver-textdocument";
+import { fileUriToPathOrNull } from "./plugin-client.js";
 export { getPluginDiagnosticsForDocument } from "./plugin-client.js";
 
 /**
@@ -47,8 +47,8 @@ export function toLspDiagnostics(
       message: diagnostic.message,
       ...(relatedInformation === undefined ? {} : { relatedInformation }),
       data: {
-        category: diagnostic.category,
         ...diagnostic.data,
+        category: diagnostic.category,
       },
     };
   });
@@ -96,9 +96,5 @@ function toRelatedInformation(
 }
 
 function getDocumentFilePath(document: TextDocument): string | null {
-  try {
-    return fileURLToPath(document.uri);
-  } catch {
-    return null;
-  }
+  return fileUriToPathOrNull(document.uri);
 }

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -26,7 +26,13 @@
 
 export { createServer } from "./server.js";
 export type { CreateServerOptions } from "./server.js";
-export type { FormSpecAnalysisDiagnostic } from "@formspec/analysis/protocol";
+export type {
+  CommentSpan,
+  FormSpecAnalysisDiagnostic,
+  FormSpecAnalysisDiagnosticCategory,
+  FormSpecAnalysisDiagnosticDataValue,
+  FormSpecAnalysisDiagnosticLocation,
+} from "@formspec/analysis/protocol";
 export {
   getPluginDiagnosticsForDocument,
   toLspDiagnostics,

--- a/packages/ts-plugin/api-report/ts-plugin.api.md
+++ b/packages/ts-plugin/api-report/ts-plugin.api.md
@@ -4,9 +4,19 @@
 
 ```ts
 
-import type { PathTarget } from '@formspec/core';
 import * as ts from 'typescript';
 import type * as tsServer from 'typescript/lib/tsserverlibrary.js';
+
+// @public (undocumented)
+export type CommentSourceSpan = CommentSpan;
+
+// @public (undocumented)
+export interface CommentSpan {
+    // (undocumented)
+    readonly end: number;
+    // (undocumented)
+    readonly start: number;
+}
 
 // @public
 export function createLanguageServiceProxy(languageService: ts.LanguageService, semanticService: FormSpecSemanticService): ts.LanguageService;
@@ -14,26 +24,37 @@ export function createLanguageServiceProxy(languageService: ts.LanguageService, 
 // @public (undocumented)
 export const FORMSPEC_ANALYSIS_PROTOCOL_VERSION = 2;
 
+// @public (undocumented)
+export const FORMSPEC_ANALYSIS_SCHEMA_VERSION = 1;
+
+// @public
+export interface FormSpecAnalysisCommentSnapshot {
+    // (undocumented)
+    readonly commentSpan: CommentSpan;
+    // (undocumented)
+    readonly declarationSpan: CommentSpan;
+    // (undocumented)
+    readonly hostType: string | null;
+    // (undocumented)
+    readonly placement: FormSpecPlacement | null;
+    // (undocumented)
+    readonly subjectType: string | null;
+    // (undocumented)
+    readonly tags: readonly FormSpecAnalysisTagSnapshot[];
+}
+
 // @public
 export interface FormSpecAnalysisDiagnostic {
-    // Warning: (ae-forgotten-export) The symbol "FormSpecAnalysisDiagnosticCategory" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly category: FormSpecAnalysisDiagnosticCategory;
     // (undocumented)
     readonly code: string;
-    // Warning: (ae-forgotten-export) The symbol "FormSpecAnalysisDiagnosticDataValue" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly data: Record<string, FormSpecAnalysisDiagnosticDataValue>;
     // (undocumented)
     readonly message: string;
-    // Warning: (ae-forgotten-export) The symbol "CommentSpan" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly range: CommentSpan;
-    // Warning: (ae-forgotten-export) The symbol "FormSpecAnalysisDiagnosticLocation" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly relatedLocations: readonly FormSpecAnalysisDiagnosticLocation[];
     // (undocumented)
@@ -41,9 +62,23 @@ export interface FormSpecAnalysisDiagnostic {
 }
 
 // @public
+export type FormSpecAnalysisDiagnosticCategory = "tag-recognition" | "value-parsing" | "type-compatibility" | "target-resolution" | "constraint-validation" | "infrastructure";
+
+// @public
+export type FormSpecAnalysisDiagnosticDataValue = string | number | boolean | readonly string[] | readonly number[] | readonly boolean[];
+
+// @public
+export interface FormSpecAnalysisDiagnosticLocation {
+    // (undocumented)
+    readonly filePath: string;
+    // (undocumented)
+    readonly message?: string;
+    // (undocumented)
+    readonly range: CommentSpan;
+}
+
+// @public
 export interface FormSpecAnalysisFileSnapshot {
-    // Warning: (ae-forgotten-export) The symbol "FormSpecAnalysisCommentSnapshot" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly comments: readonly FormSpecAnalysisCommentSnapshot[];
     // (undocumented)
@@ -58,12 +93,8 @@ export interface FormSpecAnalysisFileSnapshot {
 
 // @public
 export interface FormSpecAnalysisManifest {
-    // Warning: (ae-forgotten-export) The symbol "FORMSPEC_ANALYSIS_SCHEMA_VERSION" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly analysisSchemaVersion: typeof FORMSPEC_ANALYSIS_SCHEMA_VERSION;
-    // Warning: (ae-forgotten-export) The symbol "FormSpecIpcEndpoint" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     readonly endpoint: FormSpecIpcEndpoint;
     // (undocumented)
@@ -81,6 +112,41 @@ export interface FormSpecAnalysisManifest {
     // (undocumented)
     readonly workspaceRoot: string;
 }
+
+// @public
+export interface FormSpecAnalysisTagSnapshot {
+    // (undocumented)
+    readonly argumentSpan: CommentSpan | null;
+    // (undocumented)
+    readonly argumentText: string;
+    // (undocumented)
+    readonly fullSpan: CommentSpan;
+    // (undocumented)
+    readonly normalizedTagName: string;
+    // (undocumented)
+    readonly payloadSpan: CommentSpan | null;
+    // (undocumented)
+    readonly rawTagName: string;
+    // (undocumented)
+    readonly recognized: boolean;
+    // (undocumented)
+    readonly semantic: FormSpecSerializedTagSemanticContext;
+    // (undocumented)
+    readonly tagNameSpan: CommentSpan;
+    // (undocumented)
+    readonly target: FormSpecSerializedCommentTargetSpecifier | null;
+}
+
+// @public
+export interface FormSpecIpcEndpoint {
+    // (undocumented)
+    readonly address: string;
+    // (undocumented)
+    readonly kind: "unix-socket" | "windows-pipe";
+}
+
+// @public (undocumented)
+export type FormSpecPlacement = "class" | "class-field" | "class-method" | "interface" | "interface-field" | "type-alias" | "type-alias-field" | "variable" | "function" | "function-parameter" | "method-parameter";
 
 // @public
 export class FormSpecPluginService {
@@ -236,6 +302,22 @@ export interface FormSpecSemanticServiceStats {
 }
 
 // @public
+export interface FormSpecSerializedCommentTargetSpecifier {
+    // (undocumented)
+    readonly colonSpan: CommentSpan;
+    // (undocumented)
+    readonly fullSpan: CommentSpan;
+    // (undocumented)
+    readonly kind: "path" | "member" | "variant" | "ambiguous";
+    // (undocumented)
+    readonly rawText: string;
+    // (undocumented)
+    readonly span: CommentSpan;
+    // (undocumented)
+    readonly valid: boolean;
+}
+
+// @public
 export type FormSpecSerializedCompletionContext = {
     readonly kind: "tag-name";
     readonly prefix: string;
@@ -253,13 +335,58 @@ export type FormSpecSerializedCompletionContext = {
 
 // @public
 export interface FormSpecSerializedHoverInfo {
-    // Warning: (ae-forgotten-export) The symbol "CommentHoverInfo" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    readonly kind: CommentHoverInfo["kind"];
+    readonly kind: "tag-name" | "target" | "argument";
     // (undocumented)
     readonly markdown: string;
 }
+
+// @public
+export interface FormSpecSerializedTagDefinition {
+    // (undocumented)
+    readonly canonicalName: string;
+    // (undocumented)
+    readonly completionDetail: string;
+    // (undocumented)
+    readonly hoverMarkdown: string;
+}
+
+// @public
+export interface FormSpecSerializedTagSemanticContext {
+    // (undocumented)
+    readonly argumentHoverMarkdown: string | null;
+    // (undocumented)
+    readonly compatiblePathTargets: readonly string[];
+    // (undocumented)
+    readonly placement: FormSpecPlacement | null;
+    // (undocumented)
+    readonly signatures: readonly FormSpecSerializedTagSignature[];
+    // (undocumented)
+    readonly supportedTargets: readonly FormSpecTargetKind[];
+    // (undocumented)
+    readonly tagDefinition: FormSpecSerializedTagDefinition | null;
+    // (undocumented)
+    readonly tagHoverMarkdown: string | null;
+    // (undocumented)
+    readonly tagName: string;
+    // (undocumented)
+    readonly targetCompletions: readonly string[];
+    // (undocumented)
+    readonly targetHoverMarkdown: string | null;
+    // (undocumented)
+    readonly valueLabels: readonly string[];
+}
+
+// @public
+export interface FormSpecSerializedTagSignature {
+    // (undocumented)
+    readonly label: string;
+    // (undocumented)
+    readonly placements: readonly FormSpecPlacement[];
+}
+
+// @public (undocumented)
+export type FormSpecTargetKind = "none" | "path" | "member" | "variant";
 
 // @public
 export function init(modules: {
@@ -271,11 +398,6 @@ export interface LoggerLike {
     // (undocumented)
     info(message: string): void;
 }
-
-// Warnings were encountered during analysis:
-//
-// /Users/mnorth/Development/formspec/packages/analysis/src/semantic-protocol.ts:116:7 - (ae-forgotten-export) The symbol "FormSpecSerializedTagDefinition" needs to be exported by the entry point index.d.ts
-// /Users/mnorth/Development/formspec/packages/analysis/src/semantic-protocol.ts:120:7 - (ae-forgotten-export) The symbol "FormSpecSerializedTagSemanticContext" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/ts-plugin/src/__tests__/semantic-service.test.ts
+++ b/packages/ts-plugin/src/__tests__/semantic-service.test.ts
@@ -188,9 +188,66 @@ describe("FormSpecSemanticService", () => {
       typescriptVersion: ts.version,
       getProgram: () => undefined,
     });
+    services.push(service);
 
     expect(service.getCompletionContext("/workspace/formspec/example.ts", 0)).toBeNull();
     expect(service.getHover("/workspace/formspec/example.ts", 0)).toBeNull();
+  });
+
+  it("logs semantic performance summaries when enabled", async () => {
+    const source = `
+      class Checkout {
+        /** @minimum :amount 0 */
+        discount!: {
+          amount: number;
+        };
+      }
+    `;
+    const context = await createProgramContext(source);
+    workspaces.push(context.workspaceRoot);
+    const logger = {
+      info: vi.fn(),
+    };
+    const service = new FormSpecSemanticService({
+      workspaceRoot: context.workspaceRoot,
+      typescriptVersion: ts.version,
+      getProgram: () => context.program,
+      logger,
+      enablePerformanceLogging: true,
+      performanceLogThresholdMs: 0,
+    });
+    services.push(service);
+
+    service.getDiagnostics(context.filePath);
+
+    expect(logger.info).toHaveBeenCalled();
+    const loggedOutput = logger.info.mock.calls.map(([message]) => String(message)).join("\n");
+    expect(loggedOutput).toContain("semantic.getDiagnostics");
+  });
+
+  it("unrefs snapshot refresh timers so direct hosts do not stay alive accidentally", () => {
+    const unref = vi.fn();
+    const clearTimeoutSpy = vi
+      .spyOn(global, "clearTimeout")
+      .mockImplementation((() => undefined) as typeof clearTimeout);
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout").mockImplementation(((
+      callback: () => void
+    ) => {
+      void callback;
+      return { unref } as unknown as NodeJS.Timeout;
+    }) as typeof setTimeout);
+    const service = new FormSpecSemanticService({
+      workspaceRoot: "/workspace/formspec",
+      typescriptVersion: ts.version,
+      getProgram: () => undefined,
+    });
+    services.push(service);
+
+    service.scheduleSnapshotRefresh("/workspace/formspec/example.ts");
+
+    expect(unref).toHaveBeenCalledTimes(1);
+    setTimeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
   });
 
   it("debounces scheduled refreshes and clears timers on dispose", async () => {

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -1,13 +1,28 @@
 import type * as tsServer from "typescript/lib/tsserverlibrary.js";
 export {
   FORMSPEC_ANALYSIS_PROTOCOL_VERSION,
+  FORMSPEC_ANALYSIS_SCHEMA_VERSION,
+  type CommentSourceSpan,
+  type CommentSpan,
+  type FormSpecAnalysisCommentSnapshot,
   type FormSpecAnalysisDiagnostic,
+  type FormSpecAnalysisDiagnosticCategory,
+  type FormSpecAnalysisDiagnosticDataValue,
+  type FormSpecAnalysisDiagnosticLocation,
   type FormSpecAnalysisManifest,
   type FormSpecAnalysisFileSnapshot,
+  type FormSpecAnalysisTagSnapshot,
+  type FormSpecIpcEndpoint,
+  type FormSpecPlacement,
   type FormSpecSemanticQuery,
   type FormSpecSemanticResponse,
+  type FormSpecSerializedCommentTargetSpecifier,
   type FormSpecSerializedCompletionContext,
   type FormSpecSerializedHoverInfo,
+  type FormSpecSerializedTagDefinition,
+  type FormSpecSerializedTagSemanticContext,
+  type FormSpecSerializedTagSignature,
+  type FormSpecTargetKind,
 } from "@formspec/analysis/protocol";
 import { createLanguageServiceProxy, FormSpecPluginService } from "./service.js";
 export {

--- a/packages/ts-plugin/src/semantic-service.ts
+++ b/packages/ts-plugin/src/semantic-service.ts
@@ -294,6 +294,7 @@ export class FormSpecSemanticService {
       }
       this.refreshTimers.delete(filePath);
     }, this.options.snapshotDebounceMs ?? FORM_SPEC_PLUGIN_DEFAULT_SNAPSHOT_DEBOUNCE_MS);
+    timer.unref();
 
     this.refreshTimers.set(filePath, timer);
   }


### PR DESCRIPTION
## Summary
- broaden the white-label protocol re-exports across analysis, ts-plugin, and language-server so downstream hosts can consume the structured diagnostic/types surface directly
- preserve canonical diagnostic categories in the LSP adapter and make semantic-service refresh timers safer for direct hosts
- add targeted tests and matching API report updates for the new public surface

## Test plan
- pnpm --filter @formspec/core run build
- pnpm --filter @formspec/analysis run build
- pnpm --filter @formspec/ts-plugin run build
- pnpm --filter @formspec/language-server run build
- pnpm --filter @formspec/analysis exec vitest run src/__tests__/semantic-protocol.test.ts
- pnpm --filter @formspec/ts-plugin exec vitest run src/__tests__/semantic-service.test.ts
- pnpm --filter @formspec/language-server exec vitest run src/__tests__/diagnostics.test.ts
- pnpm exec eslint packages/analysis/src/comment-syntax.ts packages/analysis/src/protocol.ts packages/analysis/src/semantic-protocol.ts packages/analysis/src/tag-registry.ts packages/analysis/src/__tests__/semantic-protocol.test.ts packages/ts-plugin/src/index.ts packages/ts-plugin/src/semantic-service.ts packages/ts-plugin/src/__tests__/semantic-service.test.ts packages/language-server/src/index.ts packages/language-server/src/diagnostics.ts packages/language-server/src/__tests__/diagnostics.test.ts
- pnpm exec prettier --check .changeset/few-rabbits-argue.md packages/analysis/src/comment-syntax.ts packages/analysis/src/protocol.ts packages/analysis/src/semantic-protocol.ts packages/analysis/src/tag-registry.ts packages/analysis/src/__tests__/semantic-protocol.test.ts packages/ts-plugin/src/index.ts packages/ts-plugin/src/semantic-service.ts packages/ts-plugin/src/__tests__/semantic-service.test.ts packages/language-server/src/index.ts packages/language-server/src/diagnostics.ts packages/language-server/src/__tests__/diagnostics.test.ts
- CHANGED_FILES="$( { git diff --name-only origin/main...HEAD; git diff --name-only; git ls-files --others --exclude-standard; } | sort -u )" node .github/scripts/check-changesets.mjs
