### PR TITLE
Remove duplicate release workflow build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm run build
-
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- remove the standalone build step from the release workflow
- rely on the existing `pnpm run release` build before `changeset publish`
- avoid running the monorepo build twice on the publish path

## Test plan
- inspected the release workflow execution path locally
- verified the only workflow change is removal of the redundant build step
