### PR TITLE
docs: refresh agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Primary packages:
 - `@formspec/cli` — CLI for schema and IR generation
 - `@formspec/validator` — runtime JSON Schema validation
 - `@formspec/playground` — private browser playground app
-- `e2e` — end-to-end and benchmark workspace
+- `@formspec/e2e` — end-to-end and benchmark workspace (`/e2e`)
 
 ## Repo Commands
 
@@ -83,7 +83,7 @@ pnpm --filter @formspec/playground run dev
 
 ## Useful Files
 
-- [ARCHITECTURE.md](/Users/mnorth/Development/formspec/ARCHITECTURE.md)
-- [README.md](/Users/mnorth/Development/formspec/README.md)
-- [docs/002-tsdoc-grammar.md](/Users/mnorth/Development/formspec/docs/002-tsdoc-grammar.md)
-- [docs/004-tooling.md](/Users/mnorth/Development/formspec/docs/004-tooling.md)
+- [ARCHITECTURE.md](./ARCHITECTURE.md)
+- [README.md](./README.md)
+- [docs/002-tsdoc-grammar.md](./docs/002-tsdoc-grammar.md)
+- [docs/004-tooling.md](./docs/004-tooling.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,14 @@ pnpm run clean
 # Run all tests across packages
 pnpm run test
 
-# Run e2e coverage
+# Run e2e tests
 pnpm run test:e2e
 
 # Run tests in a specific package
 pnpm --filter @formspec/dsl run test
 
 # Run tests in watch mode (in a package directory)
-cd packages/dsl && pnpm run test -- --watch
+cd packages/dsl && pnpm exec vitest
 
 # Type checking
 pnpm run typecheck


### PR DESCRIPTION
## Summary
- add a root `AGENTS.md` with repo-specific guidance for coding agents
- refresh `CLAUDE.md` to match the current workspace scripts, package graph, and TSDoc guidance
- document current build entry points, e2e coverage, and the unsupported `@description` tag behavior

## Test plan
- not run (docs-only changes)
