### PR TITLE
Add discovered schema metadata and diagnostics APIs

### DIFF
--- a/.changeset/curvy-timers-care.md
+++ b/.changeset/curvy-timers-care.md
@@ -1,0 +1,5 @@
+---
+"@formspec/build": minor
+---
+
+Add non-throwing static schema generation APIs that return structured diagnostics for single-target and batch workflows, including `generateSchemasDetailed`, `generateSchemasFromProgramDetailed`, `generateSchemasBatch`, and `generateSchemasBatchFromProgram`.

--- a/.changeset/fifty-socks-wonder.md
+++ b/.changeset/fifty-socks-wonder.md
@@ -4,4 +4,4 @@
 "formspec": patch
 ---
 
-Expose resolved type metadata on `DiscoveredTypeSchemas` so static build consumers can read singular and plural API/display names directly from discovered schema generation results, and roll the updated build dependency into the published CLI and umbrella packages.
+Expose resolved type metadata on `DiscoveredTypeSchemas`, add explicit `errorReporting: "throw" | "diagnostics"` overloads on the main static schema generation entry points, and deprecate the older `generateSchemasDetailed()` compatibility wrappers. This also rolls the updated build dependency into the published CLI and umbrella packages.

--- a/.changeset/fifty-socks-wonder.md
+++ b/.changeset/fifty-socks-wonder.md
@@ -1,0 +1,5 @@
+---
+"@formspec/build": minor
+---
+
+Expose resolved type metadata on `DiscoveredTypeSchemas` so static build consumers can read singular and plural API/display names directly from discovered schema generation results.

--- a/.changeset/fifty-socks-wonder.md
+++ b/.changeset/fifty-socks-wonder.md
@@ -1,5 +1,7 @@
 ---
 "@formspec/build": minor
+"@formspec/cli": patch
+"formspec": patch
 ---
 
-Expose resolved type metadata on `DiscoveredTypeSchemas` so static build consumers can read singular and plural API/display names directly from discovered schema generation results.
+Expose resolved type metadata on `DiscoveredTypeSchemas` so static build consumers can read singular and plural API/display names directly from discovered schema generation results, and roll the updated build dependency into the published CLI and umbrella packages.

--- a/README.md
+++ b/README.md
@@ -68,15 +68,29 @@ const resolvers = defineResolvers(Form, {
 Static schema generation lives in `@formspec/build` and `@formspec/cli`.
 
 ```ts
-import { generateSchemas } from "@formspec/build";
+import { generateSchemas, generateSchemasDetailed, generateSchemasBatch } from "@formspec/build";
 
 const { jsonSchema, uiSchema } = generateSchemas({
   filePath: "./src/forms.ts",
   typeName: "UserRegistration",
 });
+
+const detailed = generateSchemasDetailed({
+  filePath: "./src/forms.ts",
+  typeName: "UserRegistration",
+});
+
+const batch = generateSchemasBatch({
+  targets: [
+    { filePath: "./src/forms.ts", typeName: "UserRegistration" },
+    { filePath: "./src/forms.ts", typeName: "BillingAddress" },
+  ],
+});
 ```
 
 For invalid static-analysis inputs, `generateSchemas()` throws with stable diagnostic codes embedded in the error message. In particular, `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` and `SYNTHETIC_SETUP_FAILURE` indicate extension setup problems, while `TYPE_MISMATCH` indicates an incompatible tag application in author source.
+
+Use `generateSchemasDetailed()` when you want structured diagnostics instead of exceptions for a single target, and `generateSchemasBatch()` when you want to accumulate feedback across many targets in one pass.
 
 ```ts
 export interface UserRegistration {
@@ -259,7 +273,7 @@ The default vendor prefix is `x-formspec`. `@formspec/build` also supports custo
 | `@formspec/dsl`             | Chain DSL authoring surface                                                         |
 | `@formspec/build`           | JSON Schema / UI Schema generation and static TypeScript analysis                   |
 | `@formspec/runtime`         | Resolver helpers for dynamic data                                                   |
-| `@formspec/analysis`        | Shared semantic-analysis protocol types and comment-tag utilities                    |
+| `@formspec/analysis`        | Shared semantic-analysis protocol types and comment-tag utilities                   |
 | `@formspec/constraints`     | `.formspec.yml` configuration and DSL capability validation                         |
 | `@formspec/validator`       | Runtime JSON Schema validation for secure environments                              |
 | `@formspec/eslint-plugin`   | ESLint rules for FormSpec tags and DSL usage                                        |

--- a/README.md
+++ b/README.md
@@ -68,16 +68,18 @@ const resolvers = defineResolvers(Form, {
 Static schema generation lives in `@formspec/build` and `@formspec/cli`.
 
 ```ts
-import { generateSchemas, generateSchemasDetailed, generateSchemasBatch } from "@formspec/build";
+import { generateSchemas, generateSchemasBatch } from "@formspec/build";
 
 const { jsonSchema, uiSchema } = generateSchemas({
   filePath: "./src/forms.ts",
   typeName: "UserRegistration",
+  errorReporting: "throw",
 });
 
-const detailed = generateSchemasDetailed({
+const diagnostics = generateSchemas({
   filePath: "./src/forms.ts",
   typeName: "UserRegistration",
+  errorReporting: "diagnostics",
 });
 
 const batch = generateSchemasBatch({
@@ -88,9 +90,9 @@ const batch = generateSchemasBatch({
 });
 ```
 
-For invalid static-analysis inputs, `generateSchemas()` throws with stable diagnostic codes embedded in the error message. In particular, `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` and `SYNTHETIC_SETUP_FAILURE` indicate extension setup problems, while `TYPE_MISMATCH` indicates an incompatible tag application in author source.
+For invalid static-analysis inputs, `generateSchemas({ ..., errorReporting: "throw" })` throws with stable diagnostic codes embedded in the error message. In particular, `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` and `SYNTHETIC_SETUP_FAILURE` indicate extension setup problems, while `TYPE_MISMATCH` indicates an incompatible tag application in author source.
 
-Use `generateSchemasDetailed()` when you want structured diagnostics instead of exceptions for a single target, and `generateSchemasBatch()` when you want to accumulate feedback across many targets in one pass.
+Use `generateSchemas({ ..., errorReporting: "diagnostics" })` when you want structured diagnostics instead of exceptions for a single target, and `generateSchemasBatch()` when you want to accumulate feedback across many targets in one pass. The older `generateSchemasDetailed()` compatibility wrapper is deprecated.
 
 ```ts
 export interface UserRegistration {

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -182,20 +182,22 @@ Generation validates canonical IR before emitting schemas. Invalid inputs now fa
 
 ### Handling Generation Failures
 
-Static generation APIs now come in two forms:
+Static generation now uses explicit error reporting on the main entry points:
 
-- `generateSchemas()` and `generateSchemasFromProgram()` keep the simple throw-on-error contract.
-- `generateSchemasDetailed()`, `generateSchemasFromProgramDetailed()`, `generateSchemasBatch()`, and `generateSchemasBatchFromProgram()` return structured diagnostics instead of throwing for analysis and validation failures.
+- `generateSchemas({ ..., errorReporting: "throw" })` and `generateSchemasFromProgram({ ..., errorReporting: "throw" })` keep the simple throw-on-error contract.
+- `generateSchemas({ ..., errorReporting: "diagnostics" })` and `generateSchemasFromProgram({ ..., errorReporting: "diagnostics" })` return structured diagnostics instead of throwing for analysis and validation failures.
+- `generateSchemasBatch()` and `generateSchemasBatchFromProgram()` continue to return per-target diagnostics across multiple targets.
 
-Use the throwing APIs when you want "schema or failure" ergonomics. Use the detailed APIs when you want to surface as much feedback as possible in one pass, especially in editor, CI, or migration tooling.
+Use the `"throw"` mode when you want "schema or failure" ergonomics. Use the `"diagnostics"` mode when you want to surface as much feedback as possible in one pass, especially in editor, CI, or migration tooling. The older `generateSchemasDetailed()` and `generateSchemasFromProgramDetailed()` wrappers remain available only as deprecated compatibility shims.
 
 ```ts
-import { generateSchemas, generateSchemasDetailed, generateSchemasBatch } from "@formspec/build";
+import { generateSchemas, generateSchemasBatch } from "@formspec/build";
 
 try {
   const { jsonSchema, uiSchema } = generateSchemas({
     filePath: "./src/forms.ts",
     typeName: "Invoice",
+    errorReporting: "throw",
   });
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
@@ -211,9 +213,10 @@ try {
   throw error;
 }
 
-const detailed = generateSchemasDetailed({
+const detailed = generateSchemas({
   filePath: "./src/forms.ts",
   typeName: "Invoice",
+  errorReporting: "diagnostics",
 });
 
 if (!detailed.ok) {
@@ -260,10 +263,8 @@ Low-level canonical IR generators, analyzer primitives, and validation helpers a
 - `generateUiSchema(form)`
 - `writeSchemas(form, options)`
 - `generateSchemas(options)`
-- `generateSchemasDetailed(options)`
 - `generateSchemasFromClass(options)`
 - `generateSchemasFromProgram(options)`
-- `generateSchemasFromProgramDetailed(options)`
 - `generateSchemasBatch(options)`
 - `generateSchemasBatchFromProgram(options)`
 - `buildMixedAuthoringSchemas(options)`

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -182,10 +182,15 @@ Generation validates canonical IR before emitting schemas. Invalid inputs now fa
 
 ### Handling Generation Failures
 
-Static generation APIs such as `generateSchemas()` still throw on invalid input, but the thrown error message now includes stable diagnostic codes that consumers can inspect or surface directly.
+Static generation APIs now come in two forms:
+
+- `generateSchemas()` and `generateSchemasFromProgram()` keep the simple throw-on-error contract.
+- `generateSchemasDetailed()`, `generateSchemasFromProgramDetailed()`, `generateSchemasBatch()`, and `generateSchemasBatchFromProgram()` return structured diagnostics instead of throwing for analysis and validation failures.
+
+Use the throwing APIs when you want "schema or failure" ergonomics. Use the detailed APIs when you want to surface as much feedback as possible in one pass, especially in editor, CI, or migration tooling.
 
 ```ts
-import { generateSchemas } from "@formspec/build";
+import { generateSchemas, generateSchemasDetailed, generateSchemasBatch } from "@formspec/build";
 
 try {
   const { jsonSchema, uiSchema } = generateSchemas({
@@ -205,6 +210,32 @@ try {
 
   throw error;
 }
+
+const detailed = generateSchemasDetailed({
+  filePath: "./src/forms.ts",
+  typeName: "Invoice",
+});
+
+if (!detailed.ok) {
+  for (const diagnostic of detailed.diagnostics) {
+    console.error(`${diagnostic.code}: ${diagnostic.message}`);
+  }
+}
+
+const batch = generateSchemasBatch({
+  targets: [
+    { filePath: "./src/forms.ts", typeName: "Invoice" },
+    { filePath: "./src/forms.ts", typeName: "PaymentTerms" },
+  ],
+});
+
+for (const result of batch) {
+  if (!result.ok) {
+    console.error(
+      `${result.typeName} failed: ${result.diagnostics.map((diagnostic) => diagnostic.code).join(", ")}`
+    );
+  }
+}
 ```
 
 The most relevant codes for extension-backed static analysis failures are:
@@ -212,6 +243,9 @@ The most relevant codes for extension-backed static analysis failures are:
 - `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` for extension custom types that conflict with unsupported TypeScript global built-ins.
 - `SYNTHETIC_SETUP_FAILURE` for invalid or conflicting extension custom type registrations and other synthetic compiler setup failures.
 - `TYPE_MISMATCH` for normal tag-on-type incompatibilities in author source.
+- `TYPE_NOT_FOUND` when a requested exported target cannot be resolved.
+- `UNSUPPORTED_ROOT_TYPE` and `DUPLICATE_ROOT_PROPERTIES` when a requested type alias cannot be treated as a schema root.
+- `PROGRAM_CONTEXT_FAILURE` when the package cannot create or reuse a TypeScript program for the requested file.
 
 As a rule of thumb, `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` and `SYNTHETIC_SETUP_FAILURE` indicate extension configuration problems, while `TYPE_MISMATCH` usually indicates an authoring error in the analyzed source.
 
@@ -226,8 +260,12 @@ Low-level canonical IR generators, analyzer primitives, and validation helpers a
 - `generateUiSchema(form)`
 - `writeSchemas(form, options)`
 - `generateSchemas(options)`
+- `generateSchemasDetailed(options)`
 - `generateSchemasFromClass(options)`
 - `generateSchemasFromProgram(options)`
+- `generateSchemasFromProgramDetailed(options)`
+- `generateSchemasBatch(options)`
+- `generateSchemasBatchFromProgram(options)`
 - `buildMixedAuthoringSchemas(options)`
 - `createExtensionRegistry(extensions)`
 

--- a/packages/build/api-report/build.alpha.api.md
+++ b/packages/build/api-report/build.alpha.api.md
@@ -24,6 +24,7 @@ import { Group } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import { NumberField } from '@formspec/core';
 import { ObjectField } from '@formspec/core';
+import type { ResolvedMetadata } from '@formspec/core';
 import { StaticEnumField } from '@formspec/core';
 import { TextField } from '@formspec/core';
 import * as ts from 'typescript';
@@ -126,6 +127,7 @@ export interface DetailedSchemaGenerationTargetResult extends DetailedClassSchem
 // @public
 export interface DiscoveredTypeSchemas {
     readonly jsonSchema: JsonSchema2020;
+    readonly resolvedMetadata?: ResolvedMetadata | undefined;
     readonly uiSchema: UISchema | null;
 }
 

--- a/packages/build/api-report/build.alpha.api.md
+++ b/packages/build/api-report/build.alpha.api.md
@@ -491,6 +491,40 @@ export type UISchemaElementType = "Control" | "VerticalLayout" | "HorizontalLayo
 export const uiSchemaSchema: z.ZodType<UISchema>;
 
 // @public
+export interface ValidateIROptions {
+    readonly extensionRegistry?: ExtensionRegistry;
+    readonly vendorPrefix?: string;
+}
+
+// @public
+export interface ValidationDiagnostic {
+    readonly code: string;
+    readonly message: string;
+    readonly primaryLocation: ValidationDiagnosticLocation;
+    readonly relatedLocations: readonly ValidationDiagnosticLocation[];
+    readonly severity: ValidationDiagnosticSeverity;
+}
+
+// @public
+export interface ValidationDiagnosticLocation {
+    readonly column: number;
+    readonly file: string;
+    readonly length?: number;
+    readonly line: number;
+    readonly surface: "tsdoc" | "chain-dsl" | "extension" | "inferred";
+    readonly tagName?: string;
+}
+
+// @public
+export type ValidationDiagnosticSeverity = "error" | "warning";
+
+// @public
+export interface ValidationResult {
+    readonly diagnostics: readonly ValidationDiagnostic[];
+    readonly valid: boolean;
+}
+
+// @public
 export interface VerticalLayout {
     readonly [k: string]: unknown;
     readonly elements: UISchemaElement[];

--- a/packages/build/api-report/build.alpha.api.md
+++ b/packages/build/api-report/build.alpha.api.md
@@ -198,7 +198,20 @@ export interface GenerateJsonSchemaOptions {
 }
 
 // @public
-export function generateSchemas(options: GenerateSchemasOptions): GenerateFromClassResult;
+export function generateSchemas(options: GenerateSchemasOptions & {
+    readonly errorReporting: "throw";
+}): GenerateFromClassResult;
+
+// @public
+export function generateSchemas(options: GenerateSchemasOptions & {
+    readonly errorReporting: "diagnostics";
+}): DetailedClassSchemasResult;
+
+// @public @deprecated
+export function generateSchemas(options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+}): GenerateFromClassResult;
 
 // @public
 export function generateSchemasBatch(options: GenerateSchemasBatchOptions): readonly DetailedSchemaGenerationTargetResult[];
@@ -217,8 +230,11 @@ export interface GenerateSchemasBatchOptions extends StaticSchemaGenerationOptio
     readonly targets: readonly SchemaGenerationTarget[];
 }
 
-// @public
-export function generateSchemasDetailed(options: GenerateSchemasOptions): DetailedClassSchemasResult;
+// @public @deprecated
+export function generateSchemasDetailed(options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+}): DetailedClassSchemasResult;
 
 // @public
 export function generateSchemasFromClass(options: GenerateFromClassOptions): GenerateFromClassResult;
@@ -242,13 +258,32 @@ export interface GenerateSchemasFromParameterOptions extends StaticSchemaGenerat
 }
 
 // @public
-export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions): GenerateFromClassResult;
+export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions & {
+    readonly errorReporting: "throw";
+}): GenerateFromClassResult;
 
 // @public
-export function generateSchemasFromProgramDetailed(options: GenerateSchemasFromProgramOptions): DetailedClassSchemasResult;
+export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions & {
+    readonly errorReporting: "diagnostics";
+}): DetailedClassSchemasResult;
+
+// @public @deprecated
+export function generateSchemasFromProgram(options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+}): GenerateFromClassResult;
+
+// @public @deprecated
+export function generateSchemasFromProgramDetailed(options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+}): DetailedClassSchemasResult;
 
 // @public
 export interface GenerateSchemasFromProgramOptions extends StaticSchemaGenerationOptions {
+    readonly errorReporting: "throw" | "diagnostics";
     readonly filePath: string;
     readonly program: ts.Program;
     readonly typeName: string;
@@ -276,8 +311,9 @@ export interface GenerateSchemasFromTypeOptions extends StaticSchemaGenerationOp
 
 // @public
 export interface GenerateSchemasOptions extends StaticSchemaGenerationOptions {
-    filePath: string;
-    typeName: string;
+    readonly errorReporting: "throw" | "diagnostics";
+    readonly filePath: string;
+    readonly typeName: string;
 }
 
 // @public

--- a/packages/build/api-report/build.alpha.api.md
+++ b/packages/build/api-report/build.alpha.api.md
@@ -110,6 +110,20 @@ export { CustomConstraintRegistration }
 export { CustomTypeRegistration }
 
 // @public
+export interface DetailedClassSchemasResult {
+    readonly diagnostics: readonly ValidationDiagnostic[];
+    readonly jsonSchema?: JsonSchema2020 | undefined;
+    readonly ok: boolean;
+    readonly uiSchema?: UISchema | undefined;
+}
+
+// @public
+export interface DetailedSchemaGenerationTargetResult extends DetailedClassSchemasResult {
+    readonly filePath: string;
+    readonly typeName: string;
+}
+
+// @public
 export interface DiscoveredTypeSchemas {
     readonly jsonSchema: JsonSchema2020;
     readonly uiSchema: UISchema | null;
@@ -185,6 +199,26 @@ export interface GenerateJsonSchemaOptions {
 export function generateSchemas(options: GenerateSchemasOptions): GenerateFromClassResult;
 
 // @public
+export function generateSchemasBatch(options: GenerateSchemasBatchOptions): readonly DetailedSchemaGenerationTargetResult[];
+
+// @public
+export function generateSchemasBatchFromProgram(options: GenerateSchemasBatchFromProgramOptions): readonly DetailedSchemaGenerationTargetResult[];
+
+// @public
+export interface GenerateSchemasBatchFromProgramOptions extends StaticSchemaGenerationOptions {
+    readonly program: ts.Program;
+    readonly targets: readonly SchemaGenerationTarget[];
+}
+
+// @public
+export interface GenerateSchemasBatchOptions extends StaticSchemaGenerationOptions {
+    readonly targets: readonly SchemaGenerationTarget[];
+}
+
+// @public
+export function generateSchemasDetailed(options: GenerateSchemasOptions): DetailedClassSchemasResult;
+
+// @public
 export function generateSchemasFromClass(options: GenerateFromClassOptions): GenerateFromClassResult;
 
 // @public
@@ -207,6 +241,9 @@ export interface GenerateSchemasFromParameterOptions extends StaticSchemaGenerat
 
 // @public
 export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions): GenerateFromClassResult;
+
+// @public
+export function generateSchemasFromProgramDetailed(options: GenerateSchemasFromProgramOptions): DetailedClassSchemasResult;
 
 // @public
 export interface GenerateSchemasFromProgramOptions extends StaticSchemaGenerationOptions {
@@ -402,6 +439,12 @@ export type RuleEffect = "SHOW" | "HIDE" | "ENABLE" | "DISABLE";
 export interface SchemaBasedCondition {
     readonly schema: RuleConditionSchema;
     readonly scope: string;
+}
+
+// @public
+export interface SchemaGenerationTarget {
+    readonly filePath: string;
+    readonly typeName: string;
 }
 
 // @public

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -198,7 +198,20 @@ export interface GenerateJsonSchemaOptions {
 }
 
 // @public
-export function generateSchemas(options: GenerateSchemasOptions): GenerateFromClassResult;
+export function generateSchemas(options: GenerateSchemasOptions & {
+    readonly errorReporting: "throw";
+}): GenerateFromClassResult;
+
+// @public
+export function generateSchemas(options: GenerateSchemasOptions & {
+    readonly errorReporting: "diagnostics";
+}): DetailedClassSchemasResult;
+
+// @public @deprecated
+export function generateSchemas(options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+}): GenerateFromClassResult;
 
 // @public
 export function generateSchemasBatch(options: GenerateSchemasBatchOptions): readonly DetailedSchemaGenerationTargetResult[];
@@ -217,8 +230,11 @@ export interface GenerateSchemasBatchOptions extends StaticSchemaGenerationOptio
     readonly targets: readonly SchemaGenerationTarget[];
 }
 
-// @public
-export function generateSchemasDetailed(options: GenerateSchemasOptions): DetailedClassSchemasResult;
+// @public @deprecated
+export function generateSchemasDetailed(options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+}): DetailedClassSchemasResult;
 
 // @public
 export function generateSchemasFromClass(options: GenerateFromClassOptions): GenerateFromClassResult;
@@ -242,13 +258,32 @@ export interface GenerateSchemasFromParameterOptions extends StaticSchemaGenerat
 }
 
 // @public
-export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions): GenerateFromClassResult;
+export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions & {
+    readonly errorReporting: "throw";
+}): GenerateFromClassResult;
 
 // @public
-export function generateSchemasFromProgramDetailed(options: GenerateSchemasFromProgramOptions): DetailedClassSchemasResult;
+export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions & {
+    readonly errorReporting: "diagnostics";
+}): DetailedClassSchemasResult;
+
+// @public @deprecated
+export function generateSchemasFromProgram(options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+}): GenerateFromClassResult;
+
+// @public @deprecated
+export function generateSchemasFromProgramDetailed(options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+}): DetailedClassSchemasResult;
 
 // @public
 export interface GenerateSchemasFromProgramOptions extends StaticSchemaGenerationOptions {
+    readonly errorReporting: "throw" | "diagnostics";
     readonly filePath: string;
     readonly program: ts.Program;
     readonly typeName: string;
@@ -276,8 +311,9 @@ export interface GenerateSchemasFromTypeOptions extends StaticSchemaGenerationOp
 
 // @public
 export interface GenerateSchemasOptions extends StaticSchemaGenerationOptions {
-    filePath: string;
-    typeName: string;
+    readonly errorReporting: "throw" | "diagnostics";
+    readonly filePath: string;
+    readonly typeName: string;
 }
 
 // @public

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -110,6 +110,21 @@ export { CustomConstraintRegistration }
 export { CustomTypeRegistration }
 
 // @public
+export interface DetailedClassSchemasResult {
+    // Warning: (ae-forgotten-export) The symbol "ValidationDiagnostic" needs to be exported by the entry point index.d.ts
+    readonly diagnostics: readonly ValidationDiagnostic[];
+    readonly jsonSchema?: JsonSchema2020 | undefined;
+    readonly ok: boolean;
+    readonly uiSchema?: UISchema | undefined;
+}
+
+// @public
+export interface DetailedSchemaGenerationTargetResult extends DetailedClassSchemasResult {
+    readonly filePath: string;
+    readonly typeName: string;
+}
+
+// @public
 export interface DiscoveredTypeSchemas {
     readonly jsonSchema: JsonSchema2020;
     readonly uiSchema: UISchema | null;
@@ -185,6 +200,26 @@ export interface GenerateJsonSchemaOptions {
 export function generateSchemas(options: GenerateSchemasOptions): GenerateFromClassResult;
 
 // @public
+export function generateSchemasBatch(options: GenerateSchemasBatchOptions): readonly DetailedSchemaGenerationTargetResult[];
+
+// @public
+export function generateSchemasBatchFromProgram(options: GenerateSchemasBatchFromProgramOptions): readonly DetailedSchemaGenerationTargetResult[];
+
+// @public
+export interface GenerateSchemasBatchFromProgramOptions extends StaticSchemaGenerationOptions {
+    readonly program: ts.Program;
+    readonly targets: readonly SchemaGenerationTarget[];
+}
+
+// @public
+export interface GenerateSchemasBatchOptions extends StaticSchemaGenerationOptions {
+    readonly targets: readonly SchemaGenerationTarget[];
+}
+
+// @public
+export function generateSchemasDetailed(options: GenerateSchemasOptions): DetailedClassSchemasResult;
+
+// @public
 export function generateSchemasFromClass(options: GenerateFromClassOptions): GenerateFromClassResult;
 
 // @public
@@ -207,6 +242,9 @@ export interface GenerateSchemasFromParameterOptions extends StaticSchemaGenerat
 
 // @public
 export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions): GenerateFromClassResult;
+
+// @public
+export function generateSchemasFromProgramDetailed(options: GenerateSchemasFromProgramOptions): DetailedClassSchemasResult;
 
 // @public
 export interface GenerateSchemasFromProgramOptions extends StaticSchemaGenerationOptions {
@@ -402,6 +440,12 @@ export type RuleEffect = "SHOW" | "HIDE" | "ENABLE" | "DISABLE";
 export interface SchemaBasedCondition {
     readonly schema: RuleConditionSchema;
     readonly scope: string;
+}
+
+// @public
+export interface SchemaGenerationTarget {
+    readonly filePath: string;
+    readonly typeName: string;
 }
 
 // @public

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -24,6 +24,7 @@ import { Group } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import { NumberField } from '@formspec/core';
 import { ObjectField } from '@formspec/core';
+import type { ResolvedMetadata } from '@formspec/core';
 import { StaticEnumField } from '@formspec/core';
 import { TextField } from '@formspec/core';
 import * as ts from 'typescript';
@@ -127,6 +128,7 @@ export interface DetailedSchemaGenerationTargetResult extends DetailedClassSchem
 // @public
 export interface DiscoveredTypeSchemas {
     readonly jsonSchema: JsonSchema2020;
+    readonly resolvedMetadata?: ResolvedMetadata | undefined;
     readonly uiSchema: UISchema | null;
 }
 

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -112,7 +112,6 @@ export { CustomTypeRegistration }
 
 // @public
 export interface DetailedClassSchemasResult {
-    // Warning: (ae-forgotten-export) The symbol "ValidationDiagnostic" needs to be exported by the entry point index.d.ts
     readonly diagnostics: readonly ValidationDiagnostic[];
     readonly jsonSchema?: JsonSchema2020 | undefined;
     readonly ok: boolean;
@@ -490,6 +489,40 @@ export type UISchemaElementType = "Control" | "VerticalLayout" | "HorizontalLayo
 
 // @public
 export const uiSchemaSchema: z.ZodType<UISchema>;
+
+// @public
+export interface ValidateIROptions {
+    readonly extensionRegistry?: ExtensionRegistry;
+    readonly vendorPrefix?: string;
+}
+
+// @public
+export interface ValidationDiagnostic {
+    readonly code: string;
+    readonly message: string;
+    readonly primaryLocation: ValidationDiagnosticLocation;
+    readonly relatedLocations: readonly ValidationDiagnosticLocation[];
+    readonly severity: ValidationDiagnosticSeverity;
+}
+
+// @public
+export interface ValidationDiagnosticLocation {
+    readonly column: number;
+    readonly file: string;
+    readonly length?: number;
+    readonly line: number;
+    readonly surface: "tsdoc" | "chain-dsl" | "extension" | "inferred";
+    readonly tagName?: string;
+}
+
+// @public
+export type ValidationDiagnosticSeverity = "error" | "warning";
+
+// @public
+export interface ValidationResult {
+    readonly diagnostics: readonly ValidationDiagnostic[];
+    readonly valid: boolean;
+}
 
 // @public
 export interface VerticalLayout {

--- a/packages/build/api-report/build.beta.api.md
+++ b/packages/build/api-report/build.beta.api.md
@@ -24,6 +24,7 @@ import { Group } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import { NumberField } from '@formspec/core';
 import { ObjectField } from '@formspec/core';
+import type { ResolvedMetadata } from '@formspec/core';
 import { StaticEnumField } from '@formspec/core';
 import { TextField } from '@formspec/core';
 import * as ts from 'typescript';
@@ -126,6 +127,7 @@ export interface DetailedSchemaGenerationTargetResult extends DetailedClassSchem
 // @public
 export interface DiscoveredTypeSchemas {
     readonly jsonSchema: JsonSchema2020;
+    readonly resolvedMetadata?: ResolvedMetadata | undefined;
     readonly uiSchema: UISchema | null;
 }
 

--- a/packages/build/api-report/build.beta.api.md
+++ b/packages/build/api-report/build.beta.api.md
@@ -491,6 +491,40 @@ export type UISchemaElementType = "Control" | "VerticalLayout" | "HorizontalLayo
 export const uiSchemaSchema: z.ZodType<UISchema>;
 
 // @public
+export interface ValidateIROptions {
+    readonly extensionRegistry?: ExtensionRegistry;
+    readonly vendorPrefix?: string;
+}
+
+// @public
+export interface ValidationDiagnostic {
+    readonly code: string;
+    readonly message: string;
+    readonly primaryLocation: ValidationDiagnosticLocation;
+    readonly relatedLocations: readonly ValidationDiagnosticLocation[];
+    readonly severity: ValidationDiagnosticSeverity;
+}
+
+// @public
+export interface ValidationDiagnosticLocation {
+    readonly column: number;
+    readonly file: string;
+    readonly length?: number;
+    readonly line: number;
+    readonly surface: "tsdoc" | "chain-dsl" | "extension" | "inferred";
+    readonly tagName?: string;
+}
+
+// @public
+export type ValidationDiagnosticSeverity = "error" | "warning";
+
+// @public
+export interface ValidationResult {
+    readonly diagnostics: readonly ValidationDiagnostic[];
+    readonly valid: boolean;
+}
+
+// @public
 export interface VerticalLayout {
     readonly [k: string]: unknown;
     readonly elements: UISchemaElement[];

--- a/packages/build/api-report/build.beta.api.md
+++ b/packages/build/api-report/build.beta.api.md
@@ -198,7 +198,20 @@ export interface GenerateJsonSchemaOptions {
 }
 
 // @public
-export function generateSchemas(options: GenerateSchemasOptions): GenerateFromClassResult;
+export function generateSchemas(options: GenerateSchemasOptions & {
+    readonly errorReporting: "throw";
+}): GenerateFromClassResult;
+
+// @public
+export function generateSchemas(options: GenerateSchemasOptions & {
+    readonly errorReporting: "diagnostics";
+}): DetailedClassSchemasResult;
+
+// @public @deprecated
+export function generateSchemas(options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+}): GenerateFromClassResult;
 
 // @public
 export function generateSchemasBatch(options: GenerateSchemasBatchOptions): readonly DetailedSchemaGenerationTargetResult[];
@@ -217,8 +230,11 @@ export interface GenerateSchemasBatchOptions extends StaticSchemaGenerationOptio
     readonly targets: readonly SchemaGenerationTarget[];
 }
 
-// @public
-export function generateSchemasDetailed(options: GenerateSchemasOptions): DetailedClassSchemasResult;
+// @public @deprecated
+export function generateSchemasDetailed(options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+}): DetailedClassSchemasResult;
 
 // @public
 export function generateSchemasFromClass(options: GenerateFromClassOptions): GenerateFromClassResult;
@@ -242,13 +258,32 @@ export interface GenerateSchemasFromParameterOptions extends StaticSchemaGenerat
 }
 
 // @public
-export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions): GenerateFromClassResult;
+export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions & {
+    readonly errorReporting: "throw";
+}): GenerateFromClassResult;
 
 // @public
-export function generateSchemasFromProgramDetailed(options: GenerateSchemasFromProgramOptions): DetailedClassSchemasResult;
+export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions & {
+    readonly errorReporting: "diagnostics";
+}): DetailedClassSchemasResult;
+
+// @public @deprecated
+export function generateSchemasFromProgram(options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+}): GenerateFromClassResult;
+
+// @public @deprecated
+export function generateSchemasFromProgramDetailed(options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+}): DetailedClassSchemasResult;
 
 // @public
 export interface GenerateSchemasFromProgramOptions extends StaticSchemaGenerationOptions {
+    readonly errorReporting: "throw" | "diagnostics";
     readonly filePath: string;
     readonly program: ts.Program;
     readonly typeName: string;
@@ -276,8 +311,9 @@ export interface GenerateSchemasFromTypeOptions extends StaticSchemaGenerationOp
 
 // @public
 export interface GenerateSchemasOptions extends StaticSchemaGenerationOptions {
-    filePath: string;
-    typeName: string;
+    readonly errorReporting: "throw" | "diagnostics";
+    readonly filePath: string;
+    readonly typeName: string;
 }
 
 // @public

--- a/packages/build/api-report/build.beta.api.md
+++ b/packages/build/api-report/build.beta.api.md
@@ -110,6 +110,20 @@ export { CustomConstraintRegistration }
 export { CustomTypeRegistration }
 
 // @public
+export interface DetailedClassSchemasResult {
+    readonly diagnostics: readonly ValidationDiagnostic[];
+    readonly jsonSchema?: JsonSchema2020 | undefined;
+    readonly ok: boolean;
+    readonly uiSchema?: UISchema | undefined;
+}
+
+// @public
+export interface DetailedSchemaGenerationTargetResult extends DetailedClassSchemasResult {
+    readonly filePath: string;
+    readonly typeName: string;
+}
+
+// @public
 export interface DiscoveredTypeSchemas {
     readonly jsonSchema: JsonSchema2020;
     readonly uiSchema: UISchema | null;
@@ -185,6 +199,26 @@ export interface GenerateJsonSchemaOptions {
 export function generateSchemas(options: GenerateSchemasOptions): GenerateFromClassResult;
 
 // @public
+export function generateSchemasBatch(options: GenerateSchemasBatchOptions): readonly DetailedSchemaGenerationTargetResult[];
+
+// @public
+export function generateSchemasBatchFromProgram(options: GenerateSchemasBatchFromProgramOptions): readonly DetailedSchemaGenerationTargetResult[];
+
+// @public
+export interface GenerateSchemasBatchFromProgramOptions extends StaticSchemaGenerationOptions {
+    readonly program: ts.Program;
+    readonly targets: readonly SchemaGenerationTarget[];
+}
+
+// @public
+export interface GenerateSchemasBatchOptions extends StaticSchemaGenerationOptions {
+    readonly targets: readonly SchemaGenerationTarget[];
+}
+
+// @public
+export function generateSchemasDetailed(options: GenerateSchemasOptions): DetailedClassSchemasResult;
+
+// @public
 export function generateSchemasFromClass(options: GenerateFromClassOptions): GenerateFromClassResult;
 
 // @public
@@ -207,6 +241,9 @@ export interface GenerateSchemasFromParameterOptions extends StaticSchemaGenerat
 
 // @public
 export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions): GenerateFromClassResult;
+
+// @public
+export function generateSchemasFromProgramDetailed(options: GenerateSchemasFromProgramOptions): DetailedClassSchemasResult;
 
 // @public
 export interface GenerateSchemasFromProgramOptions extends StaticSchemaGenerationOptions {
@@ -402,6 +439,12 @@ export type RuleEffect = "SHOW" | "HIDE" | "ENABLE" | "DISABLE";
 export interface SchemaBasedCondition {
     readonly schema: RuleConditionSchema;
     readonly scope: string;
+}
+
+// @public
+export interface SchemaGenerationTarget {
+    readonly filePath: string;
+    readonly typeName: string;
 }
 
 // @public

--- a/packages/build/api-report/build.public.api.md
+++ b/packages/build/api-report/build.public.api.md
@@ -24,6 +24,7 @@ import { Group } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import { NumberField } from '@formspec/core';
 import { ObjectField } from '@formspec/core';
+import type { ResolvedMetadata } from '@formspec/core';
 import { StaticEnumField } from '@formspec/core';
 import { TextField } from '@formspec/core';
 import * as ts from 'typescript';
@@ -126,6 +127,7 @@ export interface DetailedSchemaGenerationTargetResult extends DetailedClassSchem
 // @public
 export interface DiscoveredTypeSchemas {
     readonly jsonSchema: JsonSchema2020;
+    readonly resolvedMetadata?: ResolvedMetadata | undefined;
     readonly uiSchema: UISchema | null;
 }
 

--- a/packages/build/api-report/build.public.api.md
+++ b/packages/build/api-report/build.public.api.md
@@ -491,6 +491,40 @@ export type UISchemaElementType = "Control" | "VerticalLayout" | "HorizontalLayo
 export const uiSchemaSchema: z.ZodType<UISchema>;
 
 // @public
+export interface ValidateIROptions {
+    readonly extensionRegistry?: ExtensionRegistry;
+    readonly vendorPrefix?: string;
+}
+
+// @public
+export interface ValidationDiagnostic {
+    readonly code: string;
+    readonly message: string;
+    readonly primaryLocation: ValidationDiagnosticLocation;
+    readonly relatedLocations: readonly ValidationDiagnosticLocation[];
+    readonly severity: ValidationDiagnosticSeverity;
+}
+
+// @public
+export interface ValidationDiagnosticLocation {
+    readonly column: number;
+    readonly file: string;
+    readonly length?: number;
+    readonly line: number;
+    readonly surface: "tsdoc" | "chain-dsl" | "extension" | "inferred";
+    readonly tagName?: string;
+}
+
+// @public
+export type ValidationDiagnosticSeverity = "error" | "warning";
+
+// @public
+export interface ValidationResult {
+    readonly diagnostics: readonly ValidationDiagnostic[];
+    readonly valid: boolean;
+}
+
+// @public
 export interface VerticalLayout {
     readonly [k: string]: unknown;
     readonly elements: UISchemaElement[];

--- a/packages/build/api-report/build.public.api.md
+++ b/packages/build/api-report/build.public.api.md
@@ -198,7 +198,20 @@ export interface GenerateJsonSchemaOptions {
 }
 
 // @public
-export function generateSchemas(options: GenerateSchemasOptions): GenerateFromClassResult;
+export function generateSchemas(options: GenerateSchemasOptions & {
+    readonly errorReporting: "throw";
+}): GenerateFromClassResult;
+
+// @public
+export function generateSchemas(options: GenerateSchemasOptions & {
+    readonly errorReporting: "diagnostics";
+}): DetailedClassSchemasResult;
+
+// @public @deprecated
+export function generateSchemas(options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+}): GenerateFromClassResult;
 
 // @public
 export function generateSchemasBatch(options: GenerateSchemasBatchOptions): readonly DetailedSchemaGenerationTargetResult[];
@@ -217,8 +230,11 @@ export interface GenerateSchemasBatchOptions extends StaticSchemaGenerationOptio
     readonly targets: readonly SchemaGenerationTarget[];
 }
 
-// @public
-export function generateSchemasDetailed(options: GenerateSchemasOptions): DetailedClassSchemasResult;
+// @public @deprecated
+export function generateSchemasDetailed(options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+}): DetailedClassSchemasResult;
 
 // @public
 export function generateSchemasFromClass(options: GenerateFromClassOptions): GenerateFromClassResult;
@@ -242,13 +258,32 @@ export interface GenerateSchemasFromParameterOptions extends StaticSchemaGenerat
 }
 
 // @public
-export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions): GenerateFromClassResult;
+export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions & {
+    readonly errorReporting: "throw";
+}): GenerateFromClassResult;
 
 // @public
-export function generateSchemasFromProgramDetailed(options: GenerateSchemasFromProgramOptions): DetailedClassSchemasResult;
+export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions & {
+    readonly errorReporting: "diagnostics";
+}): DetailedClassSchemasResult;
+
+// @public @deprecated
+export function generateSchemasFromProgram(options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+}): GenerateFromClassResult;
+
+// @public @deprecated
+export function generateSchemasFromProgramDetailed(options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+}): DetailedClassSchemasResult;
 
 // @public
 export interface GenerateSchemasFromProgramOptions extends StaticSchemaGenerationOptions {
+    readonly errorReporting: "throw" | "diagnostics";
     readonly filePath: string;
     readonly program: ts.Program;
     readonly typeName: string;
@@ -276,8 +311,9 @@ export interface GenerateSchemasFromTypeOptions extends StaticSchemaGenerationOp
 
 // @public
 export interface GenerateSchemasOptions extends StaticSchemaGenerationOptions {
-    filePath: string;
-    typeName: string;
+    readonly errorReporting: "throw" | "diagnostics";
+    readonly filePath: string;
+    readonly typeName: string;
 }
 
 // @public

--- a/packages/build/api-report/build.public.api.md
+++ b/packages/build/api-report/build.public.api.md
@@ -110,6 +110,20 @@ export { CustomConstraintRegistration }
 export { CustomTypeRegistration }
 
 // @public
+export interface DetailedClassSchemasResult {
+    readonly diagnostics: readonly ValidationDiagnostic[];
+    readonly jsonSchema?: JsonSchema2020 | undefined;
+    readonly ok: boolean;
+    readonly uiSchema?: UISchema | undefined;
+}
+
+// @public
+export interface DetailedSchemaGenerationTargetResult extends DetailedClassSchemasResult {
+    readonly filePath: string;
+    readonly typeName: string;
+}
+
+// @public
 export interface DiscoveredTypeSchemas {
     readonly jsonSchema: JsonSchema2020;
     readonly uiSchema: UISchema | null;
@@ -185,6 +199,26 @@ export interface GenerateJsonSchemaOptions {
 export function generateSchemas(options: GenerateSchemasOptions): GenerateFromClassResult;
 
 // @public
+export function generateSchemasBatch(options: GenerateSchemasBatchOptions): readonly DetailedSchemaGenerationTargetResult[];
+
+// @public
+export function generateSchemasBatchFromProgram(options: GenerateSchemasBatchFromProgramOptions): readonly DetailedSchemaGenerationTargetResult[];
+
+// @public
+export interface GenerateSchemasBatchFromProgramOptions extends StaticSchemaGenerationOptions {
+    readonly program: ts.Program;
+    readonly targets: readonly SchemaGenerationTarget[];
+}
+
+// @public
+export interface GenerateSchemasBatchOptions extends StaticSchemaGenerationOptions {
+    readonly targets: readonly SchemaGenerationTarget[];
+}
+
+// @public
+export function generateSchemasDetailed(options: GenerateSchemasOptions): DetailedClassSchemasResult;
+
+// @public
 export function generateSchemasFromClass(options: GenerateFromClassOptions): GenerateFromClassResult;
 
 // @public
@@ -207,6 +241,9 @@ export interface GenerateSchemasFromParameterOptions extends StaticSchemaGenerat
 
 // @public
 export function generateSchemasFromProgram(options: GenerateSchemasFromProgramOptions): GenerateFromClassResult;
+
+// @public
+export function generateSchemasFromProgramDetailed(options: GenerateSchemasFromProgramOptions): DetailedClassSchemasResult;
 
 // @public
 export interface GenerateSchemasFromProgramOptions extends StaticSchemaGenerationOptions {
@@ -402,6 +439,12 @@ export type RuleEffect = "SHOW" | "HIDE" | "ENABLE" | "DISABLE";
 export interface SchemaBasedCondition {
     readonly schema: RuleConditionSchema;
     readonly scope: string;
+}
+
+// @public
+export interface SchemaGenerationTarget {
+    readonly filePath: string;
+    readonly typeName: string;
 }
 
 // @public

--- a/packages/build/src/__tests__/class-schema.test.ts
+++ b/packages/build/src/__tests__/class-schema.test.ts
@@ -1,7 +1,14 @@
 import * as path from "node:path";
 import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
-import { generateSchemas, generateSchemasFromProgram } from "../generators/class-schema.js";
+import {
+  generateSchemas,
+  generateSchemasBatch,
+  generateSchemasBatchFromProgram,
+  generateSchemasDetailed,
+  generateSchemasFromProgram,
+  generateSchemasFromProgramDetailed,
+} from "../generators/class-schema.js";
 
 const fixturesDir = path.join(__dirname, "fixtures");
 const sampleFormsPath = path.join(fixturesDir, "sample-forms.ts");
@@ -142,6 +149,52 @@ describe("generateSchemas", () => {
     expect(message).toContain("[related:");
   });
 
+  it("returns structured diagnostics instead of throwing from the detailed API", () => {
+    const result = generateSchemasDetailed({
+      filePath: classSchemaRegressionsPath,
+      typeName: "MismatchedForm",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.jsonSchema).toBeUndefined();
+    expect(result.uiSchema).toBeUndefined();
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain("TYPE_MISMATCH");
+  });
+
+  it("returns target-not-found diagnostics from the detailed API", () => {
+    const result = generateSchemasDetailed({
+      filePath: classSchemaRegressionsPath,
+      typeName: "MissingExport",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics).toMatchObject([
+      {
+        code: "TYPE_NOT_FOUND",
+      },
+    ]);
+  });
+
+  it("can accumulate mixed results across a batch request", () => {
+    const results = generateSchemasBatch({
+      targets: [
+        { filePath: classSchemaRegressionsPath, typeName: "NotificationPreferences" },
+        { filePath: classSchemaRegressionsPath, typeName: "MismatchedForm" },
+        { filePath: classSchemaRegressionsPath, typeName: "MissingExport" },
+      ],
+    });
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toMatchObject({
+      filePath: classSchemaRegressionsPath,
+      typeName: "NotificationPreferences",
+      ok: true,
+    });
+    expect(results[0].jsonSchema?.properties?.["channel"]).toMatchObject({ default: "email" });
+    expect(results[1].diagnostics.map((diagnostic) => diagnostic.code)).toContain("TYPE_MISMATCH");
+    expect(results[2].diagnostics.map((diagnostic) => diagnostic.code)).toContain("TYPE_NOT_FOUND");
+  });
+
   it("can analyze within an existing TypeScript program", () => {
     const program = ts.createProgram([sampleFormsPath], {
       target: ts.ScriptTarget.ES2022,
@@ -158,5 +211,36 @@ describe("generateSchemas", () => {
     });
 
     expect(result.jsonSchema.title).toBe("Vehicle Registration");
+  });
+
+  it("returns structured diagnostics from an existing program", () => {
+    const program = ts.createProgram([classSchemaRegressionsPath], {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      strict: true,
+      skipLibCheck: true,
+    });
+
+    const result = generateSchemasFromProgramDetailed({
+      program,
+      filePath: classSchemaRegressionsPath,
+      typeName: "MismatchedForm",
+    });
+    const batchResults = generateSchemasBatchFromProgram({
+      program,
+      targets: [
+        { filePath: classSchemaRegressionsPath, typeName: "NotificationPreferences" },
+        { filePath: classSchemaRegressionsPath, typeName: "MissingExport" },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain("TYPE_MISMATCH");
+    expect(batchResults).toHaveLength(2);
+    expect(batchResults[0].ok).toBe(true);
+    expect(batchResults[1].diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      "TYPE_NOT_FOUND"
+    );
   });
 });

--- a/packages/build/src/__tests__/class-schema.test.ts
+++ b/packages/build/src/__tests__/class-schema.test.ts
@@ -1,7 +1,8 @@
 import * as path from "node:path";
 import * as ts from "typescript";
 import { describe, expect, it, vi } from "vitest";
-import type { FieldNode, IRClassAnalysis, Provenance } from "@formspec/core/internals";
+import type { Provenance } from "@formspec/core/internals";
+import type { IRClassAnalysis } from "../analyzer/class-analyzer.js";
 import { createExtensionRegistry } from "../extensions/index.js";
 import {
   generateClassSchemasDetailed,
@@ -13,6 +14,7 @@ import {
   generateSchemasFromProgramDetailed,
 } from "../generators/class-schema.js";
 import * as validateModule from "../validate/index.js";
+import type { ValidationResult } from "../validate/index.js";
 
 const fixturesDir = path.join(__dirname, "fixtures");
 const sampleFormsPath = path.join(fixturesDir, "sample-forms.ts");
@@ -209,20 +211,21 @@ describe("generateSchemas", () => {
       instanceMethods: [],
       staticMethods: [],
     };
+    const validationResult: ValidationResult = {
+      valid: true,
+      diagnostics: [
+        {
+          code: "UNKNOWN_EXTENSION",
+          message: "warn",
+          severity: "warning",
+          primaryLocation: provenance(1),
+          relatedLocations: [],
+        },
+      ],
+    };
     const validateSpy = vi
       .spyOn(validateModule, "validateIR")
-      .mockReturnValueOnce({
-        valid: true,
-        diagnostics: [
-          {
-            code: "UNKNOWN_EXTENSION",
-            message: "warn",
-            severity: "warning",
-            primaryLocation: provenance(1),
-            relatedLocations: [],
-          },
-        ],
-      });
+      .mockReturnValueOnce(validationResult);
 
     const result = generateClassSchemasDetailed(
       analysis,

--- a/packages/build/src/__tests__/class-schema.test.ts
+++ b/packages/build/src/__tests__/class-schema.test.ts
@@ -6,6 +6,8 @@ import type { IRClassAnalysis } from "../analyzer/class-analyzer.js";
 import { createExtensionRegistry } from "../extensions/index.js";
 import {
   generateClassSchemasDetailed,
+  type GenerateSchemasFromProgramOptions,
+  type GenerateSchemasOptions,
   generateSchemas,
   generateSchemasBatch,
   generateSchemasBatchFromProgram,
@@ -21,6 +23,22 @@ const sampleFormsPath = path.join(fixturesDir, "sample-forms.ts");
 const classSchemaRegressionsPath = path.join(fixturesDir, "class-schema-regressions.ts");
 const testFile = "/project/src/class-schema.test.ts";
 
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({
+    ...options,
+    errorReporting: "throw",
+  });
+}
+
+function generateSchemasFromProgramOrThrow(
+  options: Omit<GenerateSchemasFromProgramOptions, "errorReporting">
+) {
+  return generateSchemasFromProgram({
+    ...options,
+    errorReporting: "throw",
+  });
+}
+
 function provenance(line: number, tagName?: string): Provenance {
   return {
     surface: "chain-dsl",
@@ -33,7 +51,7 @@ function provenance(line: number, tagName?: string): Provenance {
 
 function getGenerationFailureMessage(typeName: string): string {
   try {
-    generateSchemas({
+    generateSchemasOrThrow({
       filePath: classSchemaRegressionsPath,
       typeName,
     });
@@ -46,7 +64,7 @@ function getGenerationFailureMessage(typeName: string): string {
 
 describe("generateSchemas", () => {
   it("emits root title and description from class-level annotations", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: sampleFormsPath,
       typeName: "VehicleRegistration",
     });
@@ -56,7 +74,7 @@ describe("generateSchemas", () => {
   });
 
   it("emits default values from @defaultValue tags", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: classSchemaRegressionsPath,
       typeName: "NotificationPreferences",
     });
@@ -68,11 +86,11 @@ describe("generateSchemas", () => {
   });
 
   it("emits format and placeholder annotations into schema outputs", () => {
-    const schemaResult = generateSchemas({
+    const schemaResult = generateSchemasOrThrow({
       filePath: classSchemaRegressionsPath,
       typeName: "ContactForm",
     });
-    const uiResult = generateSchemas({
+    const uiResult = generateSchemasOrThrow({
       filePath: classSchemaRegressionsPath,
       typeName: "SearchForm",
     });
@@ -85,15 +103,15 @@ describe("generateSchemas", () => {
   });
 
   it("emits deprecation messages, uniqueItems, and typed-array item constraints", () => {
-    const deprecatedResult = generateSchemas({
+    const deprecatedResult = generateSchemasOrThrow({
       filePath: classSchemaRegressionsPath,
       typeName: "SettingsForm",
     });
-    const uniqueItemsResult = generateSchemas({
+    const uniqueItemsResult = generateSchemasOrThrow({
       filePath: classSchemaRegressionsPath,
       typeName: "TagManager",
     });
-    const typedArrayResult = generateSchemas({
+    const typedArrayResult = generateSchemasOrThrow({
       filePath: classSchemaRegressionsPath,
       typeName: "SurveyForm",
     });
@@ -111,7 +129,7 @@ describe("generateSchemas", () => {
   }, 15_000);
 
   it("maps summary text to description and @remarks to x-formspec-remarks", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: classSchemaRegressionsPath,
       typeName: "DescriptionPrecedenceForm",
     });
@@ -166,7 +184,30 @@ describe("generateSchemas", () => {
     expect(message).toContain("[related:");
   });
 
+  it("returns structured diagnostics when errorReporting is diagnostics", () => {
+    const result = generateSchemas({
+      filePath: classSchemaRegressionsPath,
+      typeName: "MismatchedForm",
+      errorReporting: "diagnostics",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.jsonSchema).toBeUndefined();
+    expect(result.uiSchema).toBeUndefined();
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain("TYPE_MISMATCH");
+  });
+
+  it("throws when errorReporting is throw", () => {
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath: classSchemaRegressionsPath,
+        typeName: "MismatchedForm",
+      })
+    ).toThrow(/TYPE_MISMATCH/);
+  });
+
   it("returns structured diagnostics instead of throwing from the detailed API", () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const result = generateSchemasDetailed({
       filePath: classSchemaRegressionsPath,
       typeName: "MismatchedForm",
@@ -179,6 +220,7 @@ describe("generateSchemas", () => {
   });
 
   it("returns target-not-found diagnostics from the detailed API", () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const result = generateSchemasDetailed({
       filePath: classSchemaRegressionsPath,
       typeName: "MissingExport",
@@ -269,13 +311,33 @@ describe("generateSchemas", () => {
       skipLibCheck: true,
     });
 
-    const result = generateSchemasFromProgram({
+    const result = generateSchemasFromProgramOrThrow({
       program,
       filePath: sampleFormsPath,
       typeName: "VehicleRegistration",
     });
 
     expect(result.jsonSchema.title).toBe("Vehicle Registration");
+  });
+
+  it("returns structured diagnostics from an existing program when requested", () => {
+    const program = ts.createProgram([classSchemaRegressionsPath], {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      strict: true,
+      skipLibCheck: true,
+    });
+
+    const result = generateSchemasFromProgram({
+      program,
+      filePath: classSchemaRegressionsPath,
+      typeName: "MismatchedForm",
+      errorReporting: "diagnostics",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain("TYPE_MISMATCH");
   });
 
   it("returns structured diagnostics from an existing program", () => {
@@ -287,6 +349,7 @@ describe("generateSchemas", () => {
       skipLibCheck: true,
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const result = generateSchemasFromProgramDetailed({
       program,
       filePath: classSchemaRegressionsPath,

--- a/packages/build/src/__tests__/class-schema.test.ts
+++ b/packages/build/src/__tests__/class-schema.test.ts
@@ -1,7 +1,10 @@
 import * as path from "node:path";
 import * as ts from "typescript";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { FieldNode, IRClassAnalysis, Provenance } from "@formspec/core/internals";
+import { createExtensionRegistry } from "../extensions/index.js";
 import {
+  generateClassSchemasDetailed,
   generateSchemas,
   generateSchemasBatch,
   generateSchemasBatchFromProgram,
@@ -9,10 +12,22 @@ import {
   generateSchemasFromProgram,
   generateSchemasFromProgramDetailed,
 } from "../generators/class-schema.js";
+import * as validateModule from "../validate/index.js";
 
 const fixturesDir = path.join(__dirname, "fixtures");
 const sampleFormsPath = path.join(fixturesDir, "sample-forms.ts");
 const classSchemaRegressionsPath = path.join(fixturesDir, "class-schema-regressions.ts");
+const testFile = "/project/src/class-schema.test.ts";
+
+function provenance(line: number, tagName?: string): Provenance {
+  return {
+    surface: "chain-dsl",
+    file: testFile,
+    line,
+    column: 0,
+    ...(tagName !== undefined && { tagName }),
+  };
+}
 
 function getGenerationFailureMessage(typeName: string): string {
   try {
@@ -173,6 +188,53 @@ describe("generateSchemas", () => {
         code: "TYPE_NOT_FOUND",
       },
     ]);
+  });
+
+  it("includes validation warnings in successful detailed generation results", () => {
+    const analysis: IRClassAnalysis = {
+      name: "PriceModel",
+      fields: [
+        {
+          kind: "field",
+          name: "price",
+          type: { kind: "primitive", primitiveKind: "string" },
+          required: true,
+          constraints: [],
+          annotations: [],
+          provenance: provenance(1),
+        },
+      ],
+      fieldLayouts: [{}],
+      typeRegistry: {},
+      instanceMethods: [],
+      staticMethods: [],
+    };
+    const validateSpy = vi
+      .spyOn(validateModule, "validateIR")
+      .mockReturnValueOnce({
+        valid: true,
+        diagnostics: [
+          {
+            code: "UNKNOWN_EXTENSION",
+            message: "warn",
+            severity: "warning",
+            primaryLocation: provenance(1),
+            relatedLocations: [],
+          },
+        ],
+      });
+
+    const result = generateClassSchemasDetailed(
+      analysis,
+      { file: testFile },
+      {
+        extensionRegistry: createExtensionRegistry([]),
+      }
+    );
+    validateSpy.mockRestore();
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain("UNKNOWN_EXTENSION");
   });
 
   it("can accumulate mixed results across a batch request", () => {

--- a/packages/build/src/__tests__/date-extension.integration.test.ts
+++ b/packages/build/src/__tests__/date-extension.integration.test.ts
@@ -3,7 +3,10 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { defineCustomType, defineExtension } from "@formspec/core/internals";
-import { generateSchemas, generateSchemasDetailed } from "../generators/class-schema.js";
+import {
+  generateSchemas,
+  type GenerateSchemasOptions,
+} from "../generators/class-schema.js";
 import { createExtensionRegistry } from "../extensions/index.js";
 import {
   createDateExtensionRegistry,
@@ -14,6 +17,13 @@ interface NullableDateTimeSchema {
   readonly $ref?: string;
   readonly oneOf?: readonly unknown[];
   readonly ["x-formspec-after"]?: unknown;
+}
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({
+    ...options,
+    errorReporting: "throw",
+  });
 }
 
 function writeTempSource(source: string): string {
@@ -127,7 +137,7 @@ describe("date extension integration", () => {
     `);
     tempDirs.push(path.dirname(filePath));
 
-    const { jsonSchema, uiSchema } = generateSchemas({
+    const { jsonSchema, uiSchema } = generateSchemasOrThrow({
       filePath,
       typeName: "BookingWindow",
       extensionRegistry: createDateExtensionRegistry(),
@@ -183,7 +193,7 @@ describe("date extension integration", () => {
     tempDirs.push(path.dirname(filePath));
 
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath,
         typeName: "InvalidWindow",
         extensionRegistry: createDateExtensionRegistry(),
@@ -203,7 +213,7 @@ describe("date extension integration", () => {
     `);
     tempDirs.push(path.dirname(filePath));
 
-    const { jsonSchema } = generateSchemas({
+    const { jsonSchema } = generateSchemasOrThrow({
       filePath,
       typeName: "BookingMetadata",
       extensionRegistry: createBuiltInDateRegistry(),
@@ -236,7 +246,7 @@ describe("date extension integration", () => {
     tempDirs.push(path.dirname(filePath));
 
     const message = getThrownMessage(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath,
         typeName: "UnsupportedArrayOverride",
         extensionRegistry: createUnsupportedArrayRegistry(),
@@ -260,11 +270,12 @@ describe("date extension integration", () => {
     `);
     tempDirs.push(path.dirname(filePath));
 
-    const result = generateSchemasDetailed({
+    const result = generateSchemas({
       filePath,
       typeName: "UnsupportedArrayOverrideDetailed",
       extensionRegistry: createUnsupportedArrayRegistry(),
       vendorPrefix: "x-formspec",
+      errorReporting: "diagnostics",
     });
 
     expect(result.ok).toBe(false);
@@ -289,7 +300,7 @@ describe("date extension integration", () => {
     tempDirs.push(path.dirname(filePath));
 
     const message = getThrownMessage(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath,
         typeName: "InvalidCustomTypeRegistration",
         extensionRegistry: createInvalidTypeNameRegistry(),
@@ -312,11 +323,12 @@ describe("date extension integration", () => {
     `);
     tempDirs.push(path.dirname(filePath));
 
-    const result = generateSchemasDetailed({
+    const result = generateSchemas({
       filePath,
       typeName: "InvalidCustomTypeRegistrationDetailed",
       extensionRegistry: createInvalidTypeNameRegistry(),
       vendorPrefix: "x-formspec",
+      errorReporting: "diagnostics",
     });
 
     expect(result.ok).toBe(false);

--- a/packages/build/src/__tests__/date-extension.integration.test.ts
+++ b/packages/build/src/__tests__/date-extension.integration.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { defineCustomType, defineExtension } from "@formspec/core/internals";
-import { generateSchemas } from "../generators/class-schema.js";
+import { generateSchemas, generateSchemasDetailed } from "../generators/class-schema.js";
 import { createExtensionRegistry } from "../extensions/index.js";
 import {
   createDateExtensionRegistry,
@@ -249,6 +249,33 @@ describe("date extension integration", () => {
     expect(message.match(/UNSUPPORTED_CUSTOM_TYPE_OVERRIDE/g)).toHaveLength(1);
   });
 
+  it("returns unsupported global built-in overrides as structured diagnostics", () => {
+    const filePath = writeTempSource(`
+      export interface UnsupportedArrayOverrideDetailed {
+        items: Array<string>;
+
+        /** @minLength 1 */
+        label: string;
+      }
+    `);
+    tempDirs.push(path.dirname(filePath));
+
+    const result = generateSchemasDetailed({
+      filePath,
+      typeName: "UnsupportedArrayOverrideDetailed",
+      extensionRegistry: createUnsupportedArrayRegistry(),
+      vendorPrefix: "x-formspec",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics).toMatchObject([
+      {
+        code: "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE",
+      },
+    ]);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).not.toContain("TYPE_MISMATCH");
+  });
+
   it("surfaces invalid custom type registrations as setup diagnostics", () => {
     const filePath = writeTempSource(`
       export interface InvalidCustomTypeRegistration {
@@ -274,5 +301,31 @@ describe("date extension integration", () => {
     expect(message).toMatch(/Invalid custom type name "Not A Type"/);
     expect(message).not.toMatch(/TYPE_MISMATCH/);
     expect(message.match(/SYNTHETIC_SETUP_FAILURE/g)).toHaveLength(1);
+  });
+
+  it("returns invalid custom type registrations as setup diagnostics without throwing", () => {
+    const filePath = writeTempSource(`
+      export interface InvalidCustomTypeRegistrationDetailed {
+        /** @minLength 1 */
+        label: string;
+      }
+    `);
+    tempDirs.push(path.dirname(filePath));
+
+    const result = generateSchemasDetailed({
+      filePath,
+      typeName: "InvalidCustomTypeRegistrationDetailed",
+      extensionRegistry: createInvalidTypeNameRegistry(),
+      vendorPrefix: "x-formspec",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics).toMatchObject([
+      {
+        code: "SYNTHETIC_SETUP_FAILURE",
+      },
+    ]);
+    expect(result.diagnostics[0]?.message).toMatch(/Invalid custom type name "Not A Type"/);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).not.toContain("TYPE_MISMATCH");
   });
 });

--- a/packages/build/src/__tests__/discriminator.test.ts
+++ b/packages/build/src/__tests__/discriminator.test.ts
@@ -3,7 +3,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { analyzeNamedTypeToIR } from "../analyzer/program.js";
-import { generateSchemas } from "../generators/class-schema.js";
+import { generateSchemas, type GenerateSchemasOptions } from "../generators/class-schema.js";
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({
+    ...options,
+    errorReporting: "throw",
+  });
+}
 
 function expectRecord(value: unknown, label: string): Record<string, unknown> {
   expect(value, label).toBeDefined();
@@ -350,7 +357,7 @@ describe("@discriminator schema generation", () => {
   });
 
   it("specializes discriminator fields to singleton enums for explicit, literal-property, inferred, object-alias, re-export, and generic-instantiation sources", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: fixturePath,
       typeName: "ValidWrapper",
       metadata: {
@@ -411,7 +418,7 @@ describe("@discriminator schema generation", () => {
   });
 
   it("specializes generic object aliases across literal and intersection shapes", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: fixturePath,
       typeName: "GenericObjectAliasWrapper",
       metadata: {
@@ -467,7 +474,7 @@ describe("@discriminator schema generation", () => {
   });
 
   it("applies discriminator apiNamePrefix only to metadata-derived discriminator values", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: fixturePath,
       typeName: "GenericObjectAliasWrapper",
       metadata: {
@@ -521,7 +528,7 @@ describe("@discriminator schema generation", () => {
   });
 
   it("supports same-file conditional helper aliases for metadata-backed discriminator fallback", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: fixturePath,
       typeName: "SameFileConditionalHelperWrapper",
       metadata: {
@@ -576,7 +583,7 @@ describe("@discriminator schema generation", () => {
   });
 
   it("specializes imported generic aliases the same way as local generic aliases", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: fixturePath,
       typeName: "ImportedAliasWrapper",
       metadata: {
@@ -634,7 +641,7 @@ describe("@discriminator schema generation", () => {
 
   it("rejects optional discriminator fields", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: fixturePath,
         typeName: "OptionalWrapper",
       })
@@ -643,7 +650,7 @@ describe("@discriminator schema generation", () => {
 
   it("rejects nested discriminator targets in v1", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: fixturePath,
         typeName: "NestedWrapper",
       })
@@ -652,7 +659,7 @@ describe("@discriminator schema generation", () => {
 
   it("rejects union-valued discriminator sources in v1", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: fixturePath,
         typeName: "UnionWrapper",
       })
@@ -661,7 +668,7 @@ describe("@discriminator schema generation", () => {
 
   it("rejects union-valued identity properties in v1", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: fixturePath,
         typeName: "UnionIdentityWrapper",
       })
@@ -670,7 +677,7 @@ describe("@discriminator schema generation", () => {
 
   it("rejects discriminator targets that are not string-like", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: fixturePath,
         typeName: "NumberKindWrapper",
       })
@@ -679,7 +686,7 @@ describe("@discriminator schema generation", () => {
 
   it("rejects discriminator sources that are not local type parameters", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: fixturePath,
         typeName: "UnknownTypeParameterWrapper",
       })
@@ -688,7 +695,7 @@ describe("@discriminator schema generation", () => {
 
   it("rejects discriminator sources when no JSON-facing value can be derived", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: fixturePath,
         typeName: "MissingCarrierWrapper",
       })

--- a/packages/build/src/__tests__/fixtures/method-signature-schemas.ts
+++ b/packages/build/src/__tests__/fixtures/method-signature-schemas.ts
@@ -17,12 +17,25 @@ export interface SubmitResult {
   approved: boolean;
 }
 
+/**
+ * @apiName :singular payment_method
+ * @apiName :plural payment_methods
+ * @displayName :singular Payment Method
+ * @displayName :plural Payment Methods
+ */
+export interface PaymentMethod {
+  id: string;
+}
+
 export interface Envelope<T> {
   payload: T;
 }
 
 /**
- * @apiName payment_status
+ * @apiName :singular payment_status
+ * @apiName :plural payment_statuses
+ * @displayName :singular Payment Status
+ * @displayName :plural Payment Statuses
  */
 export type PaymentStatus = "ok" | "error";
 

--- a/packages/build/src/__tests__/generate-schemas.test.ts
+++ b/packages/build/src/__tests__/generate-schemas.test.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
-import { generateSchemas } from "../generators/class-schema.js";
+import { generateSchemas, type GenerateSchemasOptions } from "../generators/class-schema.js";
 
 const namedPrimitiveAliasesFixture = path.join(__dirname, "fixtures", "named-primitive-aliases.ts");
 const nestedArrayPathConstraintsFixture = path.join(
@@ -24,6 +24,13 @@ const methodSignatureSchemasFixture = path.join(
   "method-signature-schemas.ts"
 );
 
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({
+    ...options,
+    errorReporting: "throw",
+  });
+}
+
 function findControlByScope(
   elements: readonly Record<string, unknown>[],
   scope: string
@@ -35,7 +42,7 @@ function findControlByScope(
 
 describe("generateSchemas", () => {
   it("emits named primitive aliases into $defs for reused constrained aliases", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: namedPrimitiveAliasesFixture,
       typeName: "ServerConfig",
     });
@@ -67,7 +74,7 @@ describe("generateSchemas", () => {
   });
 
   it("preserves path-targeted uniqueItems on nested array fields", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: nestedArrayPathConstraintsFixture,
       typeName: "BlogConfig",
     });
@@ -96,7 +103,7 @@ describe("generateSchemas", () => {
   }, 15_000);
 
   it("uses resolved apiNames consistently in generated JSON Schema output", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: serializedNameRegressionFixture,
       typeName: "SerializedNameForm",
     });
@@ -132,7 +139,7 @@ describe("generateSchemas", () => {
   });
 
   it("omits consumed metadata tags from descriptions for inline and nested properties", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: metadataDescriptionRegressionFixture,
       typeName: "MetadataDescriptionRegression",
       metadata: {
@@ -171,7 +178,7 @@ describe("generateSchemas", () => {
   });
 
   it("supports direct object aliases through the public generation entry point", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: methodSignatureSchemasFixture,
       typeName: "AliasedSubmitInput",
     });
@@ -189,7 +196,7 @@ describe("generateSchemas", () => {
   });
 
   it("preserves field metadata and optionality for mapped utility aliases", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: methodSignatureSchemasFixture,
       typeName: "PartialSubmitInput",
     });
@@ -210,7 +217,7 @@ describe("generateSchemas", () => {
   });
 
   it("supports Pick aliases without leaking omitted properties", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: methodSignatureSchemasFixture,
       typeName: "AmountOnlySubmitInput",
     });
@@ -226,7 +233,7 @@ describe("generateSchemas", () => {
   });
 
   it("supports utility/intersection aliases that add inline members", () => {
-    const result = generateSchemas({
+    const result = generateSchemasOrThrow({
       filePath: methodSignatureSchemasFixture,
       typeName: "AuditedSubmitInput",
     });
@@ -249,7 +256,7 @@ describe("generateSchemas", () => {
 
   it("rejects mixed alias intersections that duplicate property names", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: methodSignatureSchemasFixture,
         typeName: "ConflictingSubmitInput",
       })
@@ -258,7 +265,7 @@ describe("generateSchemas", () => {
 
   it("rejects mixed alias intersections that duplicate quoted property names", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: methodSignatureSchemasFixture,
         typeName: "QuotedConflictingSubmitInput",
       })
@@ -267,7 +274,7 @@ describe("generateSchemas", () => {
 
   it("rejects callable intersections that only look object-like structurally", () => {
     expect(() =>
-      generateSchemas({
+      generateSchemasOrThrow({
         filePath: methodSignatureSchemasFixture,
         typeName: "CallableSubmitInput",
       })

--- a/packages/build/src/__tests__/nounchecked-index-access.test.ts
+++ b/packages/build/src/__tests__/nounchecked-index-access.test.ts
@@ -13,7 +13,14 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { generateSchemas } from "../generators/class-schema.js";
+import { generateSchemas, type GenerateSchemasOptions } from "../generators/class-schema.js";
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({
+    ...options,
+    errorReporting: "throw",
+  });
+}
 
 describe("generateSchemas with noUncheckedIndexedAccess", () => {
   let tmpDir: string;
@@ -72,14 +79,14 @@ describe("generateSchemas with noUncheckedIndexedAccess", () => {
   });
 
   it("does not produce TYPE_MISMATCH on string constraints", () => {
-    const result = generateSchemas({ filePath: fixturePath, typeName: "Config" });
+    const result = generateSchemasOrThrow({ filePath: fixturePath, typeName: "Config" });
     expect(result.jsonSchema.properties).toMatchObject({
       name: { type: "string", minLength: 1, maxLength: 80, title: "Name" },
     });
   });
 
   it("does not produce TYPE_MISMATCH on numeric constraints", () => {
-    const result = generateSchemas({ filePath: fixturePath, typeName: "Config" });
+    const result = generateSchemasOrThrow({ filePath: fixturePath, typeName: "Config" });
     expect(result.jsonSchema.properties).toMatchObject({
       score: { type: "number", minimum: 0, maximum: 100 },
     });
@@ -141,14 +148,14 @@ describe("generateSchemas with noUncheckedIndexedAccess + Record<string, unknown
   });
 
   it("does not produce TYPE_MISMATCH on string constraints with Record base", () => {
-    const result = generateSchemas({ filePath: fixturePath, typeName: "Config" });
+    const result = generateSchemasOrThrow({ filePath: fixturePath, typeName: "Config" });
     expect(result.jsonSchema.properties).toMatchObject({
       name: { type: "string", minLength: 1, maxLength: 80, title: "Name" },
     });
   });
 
   it("does not produce TYPE_MISMATCH on numeric constraints with Record base", () => {
-    const result = generateSchemas({ filePath: fixturePath, typeName: "Config" });
+    const result = generateSchemasOrThrow({ filePath: fixturePath, typeName: "Config" });
     expect(result.jsonSchema.properties).toMatchObject({
       score: { type: "number", minimum: 0, maximum: 100 },
     });
@@ -224,14 +231,14 @@ describe("generateSchemas with noUncheckedIndexedAccess + cross-module imports",
   });
 
   it("does not produce TYPE_MISMATCH on string constraints with cross-module generics", () => {
-    const result = generateSchemas({ filePath: fixturePath, typeName: "Config" });
+    const result = generateSchemasOrThrow({ filePath: fixturePath, typeName: "Config" });
     expect(result.jsonSchema.properties).toMatchObject({
       name: { type: "string", minLength: 1, maxLength: 80, title: "Name" },
     });
   });
 
   it("does not produce TYPE_MISMATCH on numeric constraints with cross-module generics", () => {
-    const result = generateSchemas({ filePath: fixturePath, typeName: "Config" });
+    const result = generateSchemasOrThrow({ filePath: fixturePath, typeName: "Config" });
     expect(result.jsonSchema.properties).toMatchObject({
       score: { type: "number", minimum: 0, maximum: 100 },
     });

--- a/packages/build/src/__tests__/numeric-extension.integration.test.ts
+++ b/packages/build/src/__tests__/numeric-extension.integration.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { generateSchemas } from "../generators/class-schema.js";
+import { generateSchemas, type GenerateSchemasOptions } from "../generators/class-schema.js";
 import {
   addDecimal,
   compareDecimal,
@@ -16,6 +16,13 @@ interface NullableSchema {
   readonly oneOf?: readonly unknown[];
   readonly ["x-formspec-max-decimal-places"]?: unknown;
   readonly ["x-formspec-decimal-minimum"]?: unknown;
+}
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({
+    ...options,
+    errorReporting: "throw",
+  });
 }
 
 function writeTempSource(source: string): string {
@@ -60,7 +67,7 @@ describe("numeric extension integration", () => {
       ].join("\n")
     );
 
-    const { jsonSchema } = generateSchemas({
+    const { jsonSchema } = generateSchemasOrThrow({
       filePath,
       typeName: "MixedConfig",
       extensionRegistry: createNumericExtensionRegistry(),
@@ -134,7 +141,7 @@ describe("numeric extension integration", () => {
     `);
     tempDirs.push(path.dirname(filePath));
 
-    const { jsonSchema, uiSchema } = generateSchemas({
+    const { jsonSchema, uiSchema } = generateSchemasOrThrow({
       filePath,
       typeName: "Invoice",
       extensionRegistry: createNumericExtensionRegistry(),

--- a/packages/build/src/__tests__/static-build-context.test.ts
+++ b/packages/build/src/__tests__/static-build-context.test.ts
@@ -245,6 +245,62 @@ describe("static build context", () => {
     expect(schemas.jsonSchema.title).toBe("Aliased Submit Input");
   });
 
+  it("returns resolved metadata for declaration-driven object roots", () => {
+    const context = createStaticBuildContext(targetFixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentMethod");
+    if (declaration === null) {
+      throw new Error("PaymentMethod export not found");
+    }
+
+    const schemas = generateSchemasFromDeclaration({
+      context,
+      declaration,
+    });
+
+    expect(schemas.resolvedMetadata).toEqual({
+      apiName: { value: "payment_method", source: "explicit" },
+      apiNamePlural: { value: "payment_methods", source: "explicit" },
+      displayName: { value: "Payment Method", source: "explicit" },
+      displayNamePlural: { value: "Payment Methods", source: "explicit" },
+    });
+    expect(schemas.jsonSchema.title).toBe("Payment Method");
+  });
+
+  it("returns resolved metadata for declaration-driven standalone aliases and type generation", () => {
+    const context = createStaticBuildContext(targetFixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentStatus");
+    if (declaration === null) {
+      throw new Error("PaymentStatus export not found");
+    }
+
+    const declarationSchemas = generateSchemasFromDeclaration({
+      context,
+      declaration,
+    });
+    const typeSchemas = generateSchemasFromType({
+      context,
+      type: context.checker.getTypeAtLocation(declaration),
+      sourceNode: declaration,
+      name: "PaymentStatus",
+    });
+
+    expect(declarationSchemas.resolvedMetadata).toEqual({
+      apiName: { value: "payment_status", source: "explicit" },
+      apiNamePlural: { value: "payment_statuses", source: "explicit" },
+      displayName: { value: "Payment Status", source: "explicit" },
+      displayNamePlural: { value: "Payment Statuses", source: "explicit" },
+    });
+    expect(declarationSchemas.uiSchema).toBeNull();
+    expect(declarationSchemas.jsonSchema.title).toBe("Payment Status");
+
+    expect(typeSchemas.resolvedMetadata).toEqual({
+      apiName: { value: "payment_status", source: "explicit" },
+      apiNamePlural: { value: "payment_statuses", source: "explicit" },
+      displayName: { value: "Payment Status", source: "explicit" },
+      displayNamePlural: { value: "Payment Statuses", source: "explicit" },
+    });
+  });
+
   it("surfaces declaration diagnostics for fallback alias generation", () => {
     const context = createStaticBuildContext(targetFixturePath);
     const declaration = resolveModuleExportDeclaration(context, "InvalidTaggedStatus");

--- a/packages/build/src/analyzer/program.ts
+++ b/packages/build/src/analyzer/program.ts
@@ -7,7 +7,7 @@
 
 import * as ts from "typescript";
 import * as path from "node:path";
-import type { FieldNode, TypeDefinition, TypeNode } from "@formspec/core/internals";
+import type { FieldNode, Provenance, TypeDefinition, TypeNode } from "@formspec/core/internals";
 import type { ConstraintSemanticDiagnostic } from "@formspec/analysis/internal";
 import {
   analyzeDeclarationRootInfo,
@@ -36,6 +36,13 @@ export interface ProgramContext {
   /** The source file being analyzed */
   sourceFile: ts.SourceFile;
 }
+
+export type AnalyzeNamedTypeToIRDetailedResult =
+  | { readonly ok: true; readonly analysis: IRClassAnalysis }
+  | {
+      readonly ok: false;
+      readonly diagnostics: readonly ConstraintSemanticDiagnostic[];
+    };
 
 /**
  * Resolves a source file and checker from an existing TypeScript program.
@@ -295,7 +302,10 @@ function collectFallbackAliasMemberPropertyNames(
   }
 
   if (ts.isTypeReferenceNode(typeNode)) {
-    return checker.getTypeFromTypeNode(typeNode).getProperties().map((property) => property.getName());
+    return checker
+      .getTypeFromTypeNode(typeNode)
+      .getProperties()
+      .map((property) => property.getName());
   }
 
   return null;
@@ -361,40 +371,47 @@ export function analyzeNamedTypeToIR(
 }
 
 /**
- * Analyzes a named type from an existing program context and returns an `IRClassAnalysis`.
+ * Analyzes a named type from an existing program context and returns either an
+ * `IRClassAnalysis` or structured diagnostics instead of throwing.
  */
-export function analyzeNamedTypeToIRFromProgramContext(
+export function analyzeNamedTypeToIRFromProgramContextDetailed(
   ctx: ProgramContext,
   filePath: string,
   typeName: string,
   extensionRegistry?: ExtensionRegistry,
   metadataPolicy?: MetadataPolicyInput,
   discriminatorOptions?: DiscriminatorResolutionOptions
-): IRClassAnalysis {
+): AnalyzeNamedTypeToIRDetailedResult {
   const analysisFilePath = path.resolve(filePath);
 
   const classDecl = findClassByName(ctx.sourceFile, typeName);
   if (classDecl !== null) {
-    return analyzeClassToIR(
-      classDecl,
-      ctx.checker,
-      analysisFilePath,
-      extensionRegistry,
-      metadataPolicy,
-      discriminatorOptions
-    );
+    return {
+      ok: true,
+      analysis: analyzeClassToIR(
+        classDecl,
+        ctx.checker,
+        analysisFilePath,
+        extensionRegistry,
+        metadataPolicy,
+        discriminatorOptions
+      ),
+    };
   }
 
   const interfaceDecl = findInterfaceByName(ctx.sourceFile, typeName);
   if (interfaceDecl !== null) {
-    return analyzeInterfaceToIR(
-      interfaceDecl,
-      ctx.checker,
-      analysisFilePath,
-      extensionRegistry,
-      metadataPolicy,
-      discriminatorOptions
-    );
+    return {
+      ok: true,
+      analysis: analyzeInterfaceToIR(
+        interfaceDecl,
+        ctx.checker,
+        analysisFilePath,
+        extensionRegistry,
+        metadataPolicy,
+        discriminatorOptions
+      ),
+    };
   }
 
   const typeAlias = findTypeAliasByName(ctx.sourceFile, typeName);
@@ -408,7 +425,7 @@ export function analyzeNamedTypeToIRFromProgramContext(
       discriminatorOptions
     );
     if (result.ok) {
-      return result.analysis;
+      return { ok: true, analysis: result.analysis };
     }
 
     const fallbackEligible =
@@ -416,7 +433,18 @@ export function analyzeNamedTypeToIRFromProgramContext(
       isResolvableObjectLikeAliasTypeNode(typeAlias.type) &&
       containsTypeReferenceInObjectLikeAlias(typeAlias.type);
     if (!fallbackEligible) {
-      throw new Error(result.error);
+      return {
+        ok: false,
+        diagnostics: [
+          makeProgramDiagnostic(
+            result.kind === "duplicate-properties"
+              ? "DUPLICATE_ROOT_PROPERTIES"
+              : "UNSUPPORTED_ROOT_TYPE",
+            result.error,
+            makeNodeProvenance(typeAlias, analysisFilePath)
+          ),
+        ],
+      };
     }
 
     const duplicatePropertyNames = findFallbackAliasDuplicatePropertyNames(
@@ -426,9 +454,16 @@ export function analyzeNamedTypeToIRFromProgramContext(
     if (duplicatePropertyNames.length > 0) {
       const sourceFile = typeAlias.getSourceFile();
       const { line } = sourceFile.getLineAndCharacterOfPosition(typeAlias.getStart());
-      throw new Error(
-        `Type alias "${typeAlias.name.text}" at line ${String(line + 1)} contains duplicate property names across object-like members: ${duplicatePropertyNames.join(", ")}`
-      );
+      return {
+        ok: false,
+        diagnostics: [
+          makeProgramDiagnostic(
+            "DUPLICATE_ROOT_PROPERTIES",
+            `Type alias "${typeAlias.name.text}" at line ${String(line + 1)} contains duplicate property names across object-like members: ${duplicatePropertyNames.join(", ")}`,
+            makeNodeProvenance(typeAlias, analysisFilePath)
+          ),
+        ],
+      };
     }
 
     const rootInfo = analyzeDeclarationRootInfo(
@@ -459,13 +494,90 @@ export function analyzeNamedTypeToIRFromProgramContext(
       diagnostics
     );
     if (fallbackAnalysis !== null) {
-      return fallbackAnalysis;
+      return { ok: true, analysis: fallbackAnalysis };
     }
 
-    throw new Error(result.error);
+    return {
+      ok: false,
+      diagnostics: [
+        makeProgramDiagnostic(
+          "UNSUPPORTED_ROOT_TYPE",
+          result.error,
+          makeNodeProvenance(typeAlias, analysisFilePath)
+        ),
+      ],
+    };
   }
 
-  throw new Error(
-    `Type "${typeName}" not found as a class, interface, or type alias in ${analysisFilePath}`
+  return {
+    ok: false,
+    diagnostics: [
+      makeProgramDiagnostic(
+        "TYPE_NOT_FOUND",
+        `Type "${typeName}" not found as a class, interface, or type alias in ${analysisFilePath}`,
+        makeFileProvenance(analysisFilePath)
+      ),
+    ],
+  };
+}
+
+/**
+ * Analyzes a named type from an existing program context and returns an `IRClassAnalysis`.
+ */
+export function analyzeNamedTypeToIRFromProgramContext(
+  ctx: ProgramContext,
+  filePath: string,
+  typeName: string,
+  extensionRegistry?: ExtensionRegistry,
+  metadataPolicy?: MetadataPolicyInput,
+  discriminatorOptions?: DiscriminatorResolutionOptions
+): IRClassAnalysis {
+  const result = analyzeNamedTypeToIRFromProgramContextDetailed(
+    ctx,
+    filePath,
+    typeName,
+    extensionRegistry,
+    metadataPolicy,
+    discriminatorOptions
   );
+  if (result.ok) {
+    return result.analysis;
+  }
+
+  throw new Error(result.diagnostics.map((diagnostic) => diagnostic.message).join("\n"));
+}
+
+function makeProgramDiagnostic(
+  code: string,
+  message: string,
+  primaryLocation: Provenance
+): ConstraintSemanticDiagnostic {
+  return {
+    code,
+    message,
+    severity: "error",
+    primaryLocation,
+    relatedLocations: [],
+  };
+}
+
+function makeNodeProvenance(node: ts.Node, filePath: string): Provenance {
+  const sourceFile = node.getSourceFile();
+  const position = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+  return {
+    surface: "tsdoc",
+    file: filePath,
+    line: position.line + 1,
+    column: position.character,
+    length: node.getWidth(),
+  };
+}
+
+function makeFileProvenance(filePath: string): Provenance {
+  return {
+    surface: "tsdoc",
+    file: filePath,
+    line: 1,
+    column: 0,
+  };
 }

--- a/packages/build/src/generators/class-schema.ts
+++ b/packages/build/src/generators/class-schema.ts
@@ -176,7 +176,7 @@ export function generateClassSchemasDetailed(
 
   return {
     ok: true,
-    diagnostics: analysisDiagnostics,
+    diagnostics: [...analysisDiagnostics, ...validationResult.diagnostics],
     jsonSchema: generateJsonSchemaFromIR(ir, options),
     uiSchema: generateUiSchemaFromIR(ir),
   };
@@ -387,20 +387,17 @@ export function generateSchemasFromProgram(
 export function generateSchemasDetailed(
   options: GenerateSchemasOptions
 ): DetailedClassSchemasResult {
+  let ctx: ProgramContext;
   try {
-    const ctx = createProgramContext(options.filePath);
-    return generateSchemasFromDetailedProgramContext(
-      ctx,
-      options.filePath,
-      options.typeName,
-      options
-    );
+    ctx = createProgramContext(options.filePath);
   } catch (error) {
     return {
       ok: false,
       diagnostics: [createProgramContextFailureDiagnostic(options.filePath, error)],
     };
   }
+
+  return generateSchemasFromDetailedProgramContext(ctx, options.filePath, options.typeName, options);
 }
 
 /**
@@ -413,20 +410,17 @@ export function generateSchemasDetailed(
 export function generateSchemasFromProgramDetailed(
   options: GenerateSchemasFromProgramOptions
 ): DetailedClassSchemasResult {
+  let ctx: ProgramContext;
   try {
-    const ctx = createProgramContextFromProgram(options.program, options.filePath);
-    return generateSchemasFromDetailedProgramContext(
-      ctx,
-      options.filePath,
-      options.typeName,
-      options
-    );
+    ctx = createProgramContextFromProgram(options.program, options.filePath);
   } catch (error) {
     return {
       ok: false,
       diagnostics: [createProgramContextFailureDiagnostic(options.filePath, error)],
     };
   }
+
+  return generateSchemasFromDetailedProgramContext(ctx, options.filePath, options.typeName, options);
 }
 
 /**
@@ -441,26 +435,29 @@ export function generateSchemasBatch(
   const contextCache = new Map<string, ProgramContext>();
 
   return options.targets.map((target) => {
+    let ctx: ProgramContext;
     try {
       const cacheKey = ts.sys.useCaseSensitiveFileNames
         ? target.filePath
         : target.filePath.toLowerCase();
-      let ctx = contextCache.get(cacheKey);
-      if (ctx === undefined) {
+      const cachedContext = contextCache.get(cacheKey);
+      if (cachedContext === undefined) {
         ctx = createProgramContext(target.filePath);
         contextCache.set(cacheKey, ctx);
+      } else {
+        ctx = cachedContext;
       }
-
-      return withTarget(
-        target,
-        generateSchemasFromDetailedProgramContext(ctx, target.filePath, target.typeName, options)
-      );
     } catch (error) {
       return withTarget(target, {
         ok: false,
         diagnostics: [createProgramContextFailureDiagnostic(target.filePath, error)],
       });
     }
+
+    return withTarget(
+      target,
+      generateSchemasFromDetailedProgramContext(ctx, target.filePath, target.typeName, options)
+    );
   });
 }
 
@@ -474,18 +471,20 @@ export function generateSchemasBatchFromProgram(
   options: GenerateSchemasBatchFromProgramOptions
 ): readonly DetailedSchemaGenerationTargetResult[] {
   return options.targets.map((target) => {
+    let ctx: ProgramContext;
     try {
-      const ctx = createProgramContextFromProgram(options.program, target.filePath);
-      return withTarget(
-        target,
-        generateSchemasFromDetailedProgramContext(ctx, target.filePath, target.typeName, options)
-      );
+      ctx = createProgramContextFromProgram(options.program, target.filePath);
     } catch (error) {
       return withTarget(target, {
         ok: false,
         diagnostics: [createProgramContextFailureDiagnostic(target.filePath, error)],
       });
     }
+
+    return withTarget(
+      target,
+      generateSchemasFromDetailedProgramContext(ctx, target.filePath, target.typeName, options)
+    );
   });
 }
 

--- a/packages/build/src/generators/class-schema.ts
+++ b/packages/build/src/generators/class-schema.ts
@@ -256,6 +256,10 @@ export interface GenerateSchemasFromProgramOptions extends StaticSchemaGeneratio
   readonly filePath: string;
   /** Name of the exported class, interface, or type alias to analyze */
   readonly typeName: string;
+  /**
+   * Controls whether error-severity diagnostics throw or are returned in the result.
+   */
+  readonly errorReporting: "throw" | "diagnostics";
 }
 
 /**
@@ -315,10 +319,27 @@ export function generateSchemasFromClass(
  */
 export interface GenerateSchemasOptions extends StaticSchemaGenerationOptions {
   /** Path to the TypeScript source file */
-  filePath: string;
+  readonly filePath: string;
   /** Name of the exported class, interface, or type alias to analyze */
-  typeName: string;
+  readonly typeName: string;
+  /**
+   * Controls whether error-severity diagnostics throw or are returned in the result.
+   */
+  readonly errorReporting: "throw" | "diagnostics";
 }
+
+type GenerateSchemasImplementationOptions = StaticSchemaGenerationOptions & {
+  readonly filePath: string;
+  readonly typeName: string;
+  readonly errorReporting?: "throw" | "diagnostics" | undefined;
+};
+
+type GenerateSchemasFromProgramImplementationOptions = StaticSchemaGenerationOptions & {
+  readonly program: ts.Program;
+  readonly filePath: string;
+  readonly typeName: string;
+  readonly errorReporting?: "throw" | "diagnostics" | undefined;
+};
 
 /**
  * Generates JSON Schema and UI Schema from a named TypeScript
@@ -333,20 +354,66 @@ export interface GenerateSchemasOptions extends StaticSchemaGenerationOptions {
  * const result = generateSchemas({
  *   filePath: "./src/config.ts",
  *   typeName: "DiscountConfig",
+ *   errorReporting: "throw",
  * });
  * ```
+ */
+/**
+ * Generates JSON Schema and UI Schema from a named type and throws when
+ * generation reports error-severity diagnostics.
  *
+ * @param options - File path, type name, and explicit throw-on-error reporting
+ * @returns Generated JSON Schema and UI Schema
+ *
+ * @public
+ */
+export function generateSchemas(
+  options: GenerateSchemasOptions & { readonly errorReporting: "throw" }
+): GenerateFromClassResult;
+/**
+ * Generates JSON Schema and UI Schema from a named type and returns structured
+ * diagnostics instead of throwing on validation or analysis failures.
+ *
+ * @param options - File path, type name, and explicit diagnostics reporting
+ * @returns Structured generation result with diagnostics
+ *
+ * @public
+ */
+export function generateSchemas(
+  options: GenerateSchemasOptions & { readonly errorReporting: "diagnostics" }
+): DetailedClassSchemasResult;
+/**
+ * Generates JSON Schema and UI Schema from a named type.
+ *
+ * @deprecated Pass `errorReporting` explicitly. Omitting it defaults to `"throw"` only for backward compatibility.
  * @param options - File path and type name
  * @returns Generated JSON Schema and UI Schema
  *
  * @public
  */
-export function generateSchemas(options: GenerateSchemasOptions): GenerateFromClassResult {
-  const ctx = createProgramContext(options.filePath);
-  return generateSchemasFromProgram({
-    ...options,
-    program: ctx.program,
-  });
+/* eslint-disable @typescript-eslint/unified-signatures */
+export function generateSchemas(
+  options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+  }
+): GenerateFromClassResult;
+/* eslint-enable @typescript-eslint/unified-signatures */
+export function generateSchemas(
+  options: GenerateSchemasImplementationOptions
+): GenerateFromClassResult | DetailedClassSchemasResult {
+  const result = generateSchemasDetailedInternal(options);
+  if (options.errorReporting === "diagnostics") {
+    return result;
+  }
+  if (!result.ok || result.jsonSchema === undefined || result.uiSchema === undefined) {
+    throw new Error(formatValidationError(result.diagnostics));
+  }
+
+  return {
+    jsonSchema: result.jsonSchema,
+    uiSchema: result.uiSchema,
+  };
 }
 
 /**
@@ -355,19 +422,58 @@ export function generateSchemas(options: GenerateSchemasOptions): GenerateFromCl
  *
  * This low-level entry point lets downstream tooling reuse a host-owned
  * `Program` for both FormSpec extraction and other TypeScript analysis.
+ */
+/**
+ * Generates JSON Schema and UI Schema from a named type within an existing
+ * TypeScript program and throws when generation reports error-severity diagnostics.
  *
- * @param options - Host program, file path, type name, and optional schema generation options
+ * @param options - Host program, file path, type name, and explicit throw-on-error reporting
  * @returns Generated JSON Schema and UI Schema
  *
  * @public
  */
 export function generateSchemasFromProgram(
-  options: GenerateSchemasFromProgramOptions
+  options: GenerateSchemasFromProgramOptions & { readonly errorReporting: "throw" }
 ): GenerateFromClassResult;
+/**
+ * Generates JSON Schema and UI Schema from a named type within an existing
+ * TypeScript program and returns structured diagnostics instead of throwing on
+ * validation or analysis failures.
+ *
+ * @param options - Host program, file path, type name, and explicit diagnostics reporting
+ * @returns Structured generation result with diagnostics
+ *
+ * @public
+ */
 export function generateSchemasFromProgram(
-  options: GenerateSchemasFromProgramOptions
-): GenerateFromClassResult {
-  const result = generateSchemasFromProgramDetailed(options);
+  options: GenerateSchemasFromProgramOptions & { readonly errorReporting: "diagnostics" }
+): DetailedClassSchemasResult;
+/**
+ * Generates JSON Schema and UI Schema from a named type within an existing
+ * TypeScript program.
+ *
+ * @deprecated Pass `errorReporting` explicitly. Omitting it defaults to `"throw"` only for backward compatibility.
+ * @param options - Host program, file path, and type name
+ * @returns Generated JSON Schema and UI Schema
+ *
+ * @public
+ */
+/* eslint-disable @typescript-eslint/unified-signatures */
+export function generateSchemasFromProgram(
+  options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+  }
+): GenerateFromClassResult;
+/* eslint-enable @typescript-eslint/unified-signatures */
+export function generateSchemasFromProgram(
+  options: GenerateSchemasFromProgramImplementationOptions
+): GenerateFromClassResult | DetailedClassSchemasResult {
+  const result = generateSchemasFromProgramDetailedInternal(options);
+  if (options.errorReporting === "diagnostics") {
+    return result;
+  }
   if (!result.ok || result.jsonSchema === undefined || result.uiSchema === undefined) {
     throw new Error(formatValidationError(result.diagnostics));
   }
@@ -381,11 +487,24 @@ export function generateSchemasFromProgram(
 /**
  * Generates JSON Schema and UI Schema from a named type and returns structured
  * diagnostics instead of throwing on validation or analysis failures.
+ * @deprecated Use `generateSchemas({ ...options, errorReporting: "diagnostics" })` instead.
  *
  * @public
  */
 export function generateSchemasDetailed(
-  options: GenerateSchemasOptions
+  options: StaticSchemaGenerationOptions & {
+    readonly filePath: string;
+    readonly typeName: string;
+  }
+): DetailedClassSchemasResult {
+  return generateSchemas({
+    ...options,
+    errorReporting: "diagnostics",
+  });
+}
+
+function generateSchemasDetailedInternal(
+  options: GenerateSchemasImplementationOptions
 ): DetailedClassSchemasResult {
   let ctx: ProgramContext;
   try {
@@ -404,11 +523,25 @@ export function generateSchemasDetailed(
  * Generates JSON Schema and UI Schema from a named type within an existing
  * TypeScript program and returns structured diagnostics instead of throwing on
  * validation or analysis failures.
+ * @deprecated Use `generateSchemasFromProgram({ ...options, errorReporting: "diagnostics" })` instead.
  *
  * @public
  */
 export function generateSchemasFromProgramDetailed(
-  options: GenerateSchemasFromProgramOptions
+  options: StaticSchemaGenerationOptions & {
+    readonly program: ts.Program;
+    readonly filePath: string;
+    readonly typeName: string;
+  }
+): DetailedClassSchemasResult {
+  return generateSchemasFromProgram({
+    ...options,
+    errorReporting: "diagnostics",
+  });
+}
+
+function generateSchemasFromProgramDetailedInternal(
+  options: GenerateSchemasFromProgramImplementationOptions
 ): DetailedClassSchemasResult {
   let ctx: ProgramContext;
   try {

--- a/packages/build/src/generators/class-schema.ts
+++ b/packages/build/src/generators/class-schema.ts
@@ -10,10 +10,12 @@ import * as ts from "typescript";
 import type { UISchema } from "../ui-schema/types.js";
 import type { MetadataPolicyInput } from "@formspec/core";
 import {
-  analyzeNamedTypeToIRFromProgramContext,
+  analyzeNamedTypeToIRFromProgramContextDetailed,
   createProgramContext,
   createProgramContextFromProgram,
   findClassByName,
+  type AnalyzeNamedTypeToIRDetailedResult,
+  type ProgramContext,
 } from "../analyzer/program.js";
 import {
   analyzeClassToIR,
@@ -45,6 +47,68 @@ export interface ClassSchemas {
 }
 
 /**
+ * Non-throwing schema generation result with structured diagnostics.
+ *
+ * @public
+ */
+export interface DetailedClassSchemasResult {
+  /** Whether schema generation completed without error-severity diagnostics. */
+  readonly ok: boolean;
+  /** Collected analysis and validation diagnostics for this target. */
+  readonly diagnostics: readonly ValidationDiagnostic[];
+  /** JSON Schema 2020-12 for validation, when generation succeeds. */
+  readonly jsonSchema?: JsonSchema2020 | undefined;
+  /** JSON Forms UI Schema for rendering, when generation succeeds. */
+  readonly uiSchema?: UISchema | undefined;
+}
+
+/**
+ * A batch target for non-throwing schema generation.
+ *
+ * @public
+ */
+export interface SchemaGenerationTarget {
+  /** Path to the TypeScript source file. */
+  readonly filePath: string;
+  /** Name of the exported class, interface, or type alias to analyze. */
+  readonly typeName: string;
+}
+
+/**
+ * Batch options for non-throwing schema generation.
+ *
+ * @public
+ */
+export interface GenerateSchemasBatchOptions extends StaticSchemaGenerationOptions {
+  /** Targets to analyze and generate. */
+  readonly targets: readonly SchemaGenerationTarget[];
+}
+
+/**
+ * Batch options for non-throwing schema generation using an existing program.
+ *
+ * @public
+ */
+export interface GenerateSchemasBatchFromProgramOptions extends StaticSchemaGenerationOptions {
+  /** Existing TypeScript program supplied by the caller. */
+  readonly program: ts.Program;
+  /** Targets to analyze and generate. */
+  readonly targets: readonly SchemaGenerationTarget[];
+}
+
+/**
+ * Result for a single target in a batch generation request.
+ *
+ * @public
+ */
+export interface DetailedSchemaGenerationTargetResult extends DetailedClassSchemasResult {
+  /** Path to the TypeScript source file. */
+  readonly filePath: string;
+  /** Name of the exported class, interface, or type alias that was analyzed. */
+  readonly typeName: string;
+}
+
+/**
  * Generates JSON Schema 2020-12 and UI Schema from an IR class analysis.
  *
  * Routes through the canonical IR pipeline:
@@ -59,11 +123,37 @@ export function generateClassSchemas(
   source?: TSDocSource,
   options?: GenerateJsonSchemaFromIROptions & { metadata?: MetadataPolicyInput | undefined }
 ): ClassSchemas {
-  const errorDiagnostics = analysis.diagnostics?.filter(
+  const result = generateClassSchemasDetailed(analysis, source, options);
+  if (!result.ok || result.jsonSchema === undefined || result.uiSchema === undefined) {
+    throw new Error(formatValidationError(result.diagnostics));
+  }
+
+  return {
+    jsonSchema: result.jsonSchema,
+    uiSchema: result.uiSchema,
+  };
+}
+
+/**
+ * Generates JSON Schema 2020-12 and UI Schema from an IR class analysis
+ * without throwing on validation diagnostics.
+ *
+ * @public
+ */
+export function generateClassSchemasDetailed(
+  analysis: IRClassAnalysis,
+  source?: TSDocSource,
+  options?: GenerateJsonSchemaFromIROptions & { metadata?: MetadataPolicyInput | undefined }
+): DetailedClassSchemasResult {
+  const analysisDiagnostics = analysis.diagnostics ?? [];
+  const errorDiagnostics = analysisDiagnostics.filter(
     (diagnostic) => diagnostic.severity === "error"
   );
-  if (errorDiagnostics !== undefined && errorDiagnostics.length > 0) {
-    throw new Error(formatValidationError(errorDiagnostics));
+  if (errorDiagnostics.length > 0) {
+    return {
+      ok: false,
+      diagnostics: analysisDiagnostics,
+    };
   }
 
   const ir = canonicalizeTSDoc(
@@ -78,10 +168,15 @@ export function generateClassSchemas(
     ...(options?.vendorPrefix !== undefined && { vendorPrefix: options.vendorPrefix }),
   });
   if (!validationResult.valid) {
-    throw new Error(formatValidationError(validationResult.diagnostics));
+    return {
+      ok: false,
+      diagnostics: [...analysisDiagnostics, ...validationResult.diagnostics],
+    };
   }
 
   return {
+    ok: true,
+    diagnostics: analysisDiagnostics,
     jsonSchema: generateJsonSchemaFromIR(ir, options),
     uiSchema: generateUiSchemaFromIR(ir),
   };
@@ -272,22 +367,186 @@ export function generateSchemasFromProgram(
 export function generateSchemasFromProgram(
   options: GenerateSchemasFromProgramOptions
 ): GenerateFromClassResult {
-  const ctx = createProgramContextFromProgram(options.program, options.filePath);
-  const analysis = analyzeNamedTypeToIRFromProgramContext(
-    ctx,
-    options.filePath,
-    options.typeName,
-    options.extensionRegistry,
-    options.metadata,
-    options.discriminator
-  );
-  return generateClassSchemas(
-    analysis,
-    { file: options.filePath },
+  const result = generateSchemasFromProgramDetailed(options);
+  if (!result.ok || result.jsonSchema === undefined || result.uiSchema === undefined) {
+    throw new Error(formatValidationError(result.diagnostics));
+  }
+
+  return {
+    jsonSchema: result.jsonSchema,
+    uiSchema: result.uiSchema,
+  };
+}
+
+/**
+ * Generates JSON Schema and UI Schema from a named type and returns structured
+ * diagnostics instead of throwing on validation or analysis failures.
+ *
+ * @public
+ */
+export function generateSchemasDetailed(
+  options: GenerateSchemasOptions
+): DetailedClassSchemasResult {
+  try {
+    const ctx = createProgramContext(options.filePath);
+    return generateSchemasFromDetailedProgramContext(
+      ctx,
+      options.filePath,
+      options.typeName,
+      options
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostics: [createProgramContextFailureDiagnostic(options.filePath, error)],
+    };
+  }
+}
+
+/**
+ * Generates JSON Schema and UI Schema from a named type within an existing
+ * TypeScript program and returns structured diagnostics instead of throwing on
+ * validation or analysis failures.
+ *
+ * @public
+ */
+export function generateSchemasFromProgramDetailed(
+  options: GenerateSchemasFromProgramOptions
+): DetailedClassSchemasResult {
+  try {
+    const ctx = createProgramContextFromProgram(options.program, options.filePath);
+    return generateSchemasFromDetailedProgramContext(
+      ctx,
+      options.filePath,
+      options.typeName,
+      options
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostics: [createProgramContextFailureDiagnostic(options.filePath, error)],
+    };
+  }
+}
+
+/**
+ * Generates schemas for many targets and returns per-target diagnostics instead
+ * of failing on the first problem.
+ *
+ * @public
+ */
+export function generateSchemasBatch(
+  options: GenerateSchemasBatchOptions
+): readonly DetailedSchemaGenerationTargetResult[] {
+  const contextCache = new Map<string, ProgramContext>();
+
+  return options.targets.map((target) => {
+    try {
+      const cacheKey = ts.sys.useCaseSensitiveFileNames
+        ? target.filePath
+        : target.filePath.toLowerCase();
+      let ctx = contextCache.get(cacheKey);
+      if (ctx === undefined) {
+        ctx = createProgramContext(target.filePath);
+        contextCache.set(cacheKey, ctx);
+      }
+
+      return withTarget(
+        target,
+        generateSchemasFromDetailedProgramContext(ctx, target.filePath, target.typeName, options)
+      );
+    } catch (error) {
+      return withTarget(target, {
+        ok: false,
+        diagnostics: [createProgramContextFailureDiagnostic(target.filePath, error)],
+      });
+    }
+  });
+}
+
+/**
+ * Generates schemas for many targets from an existing TypeScript program and
+ * returns per-target diagnostics instead of failing on the first problem.
+ *
+ * @public
+ */
+export function generateSchemasBatchFromProgram(
+  options: GenerateSchemasBatchFromProgramOptions
+): readonly DetailedSchemaGenerationTargetResult[] {
+  return options.targets.map((target) => {
+    try {
+      const ctx = createProgramContextFromProgram(options.program, target.filePath);
+      return withTarget(
+        target,
+        generateSchemasFromDetailedProgramContext(ctx, target.filePath, target.typeName, options)
+      );
+    } catch (error) {
+      return withTarget(target, {
+        ok: false,
+        diagnostics: [createProgramContextFailureDiagnostic(target.filePath, error)],
+      });
+    }
+  });
+}
+
+function generateSchemasFromDetailedProgramContext(
+  ctx: ProgramContext,
+  filePath: string,
+  typeName: string,
+  options: StaticSchemaGenerationOptions
+): DetailedClassSchemasResult {
+  const analysisResult: AnalyzeNamedTypeToIRDetailedResult =
+    analyzeNamedTypeToIRFromProgramContextDetailed(
+      ctx,
+      filePath,
+      typeName,
+      options.extensionRegistry,
+      options.metadata,
+      options.discriminator
+    );
+  if (!analysisResult.ok) {
+    return {
+      ok: false,
+      diagnostics: analysisResult.diagnostics,
+    };
+  }
+
+  return generateClassSchemasDetailed(
+    analysisResult.analysis,
+    { file: filePath },
     {
       extensionRegistry: options.extensionRegistry,
       metadata: options.metadata,
       vendorPrefix: options.vendorPrefix,
     }
   );
+}
+
+function withTarget(
+  target: SchemaGenerationTarget,
+  result: DetailedClassSchemasResult
+): DetailedSchemaGenerationTargetResult {
+  return {
+    filePath: target.filePath,
+    typeName: target.typeName,
+    ...result,
+  };
+}
+
+function createProgramContextFailureDiagnostic(
+  filePath: string,
+  error: unknown
+): ValidationDiagnostic {
+  return {
+    code: "PROGRAM_CONTEXT_FAILURE",
+    message: error instanceof Error ? error.message : String(error),
+    severity: "error",
+    primaryLocation: {
+      surface: "tsdoc",
+      file: filePath,
+      line: 1,
+      column: 0,
+    },
+    relatedLocations: [],
+  };
 }

--- a/packages/build/src/generators/discovered-schema.ts
+++ b/packages/build/src/generators/discovered-schema.ts
@@ -40,6 +40,14 @@ export interface DiscoveredTypeSchemas {
   readonly jsonSchema: JsonSchema2020;
   /** UI Schema for object-shaped roots, or `null` when not applicable. */
   readonly uiSchema: UISchema | null;
+  /**
+   * Resolved type-level metadata used during generation, when available.
+   *
+   * This preserves explicit and inferred naming metadata such as singular and
+   * plural API/display names for consumers that need the resolved values in
+   * addition to the emitted schema artifacts.
+   */
+  readonly resolvedMetadata?: ResolvedMetadata | undefined;
 }
 
 /**
@@ -109,8 +117,14 @@ export interface GenerateSchemasFromReturnTypeOptions extends StaticSchemaGenera
   readonly declaration: ts.SignatureDeclaration;
 }
 
-function toDiscoveredTypeSchemas(result: ClassSchemas): DiscoveredTypeSchemas {
-  return result;
+function toDiscoveredTypeSchemas(
+  result: ClassSchemas,
+  resolvedMetadata?: ResolvedMetadata
+): DiscoveredTypeSchemas {
+  return {
+    ...result,
+    ...(resolvedMetadata !== undefined && { resolvedMetadata }),
+  };
 }
 
 function isNamedTypeDeclaration(
@@ -325,7 +339,8 @@ function generateSchemasFromAnalysis(
         metadata: options?.metadata,
         vendorPrefix: options?.vendorPrefix,
       }
-    )
+    ),
+    analysis.metadata
   );
 }
 
@@ -400,6 +415,7 @@ function generateSchemasFromResolvedType(
   return {
     jsonSchema: toStandaloneJsonSchema(root, typeRegistry, options),
     uiSchema: null,
+    ...(root.metadata !== undefined && { resolvedMetadata: root.metadata }),
   };
 }
 

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -105,6 +105,13 @@ export type {
 } from "./generators/class-schema.js";
 export type { StaticBuildContext } from "./static-build.js";
 export type {
+  ValidateIROptions,
+  ValidationDiagnostic,
+  ValidationDiagnosticLocation,
+  ValidationDiagnosticSeverity,
+  ValidationResult,
+} from "./validate/index.js";
+export type {
   DiscoveredTypeSchemas,
   GenerateSchemasFromDeclarationOptions,
   GenerateSchemasFromParameterOptions,

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -91,11 +91,16 @@ export type {
 } from "./ui-schema/types.js";
 
 export type {
+  DetailedClassSchemasResult,
+  DetailedSchemaGenerationTargetResult,
   DiscriminatorResolutionOptions,
   GenerateFromClassOptions,
   GenerateFromClassResult,
   GenerateSchemasOptions,
+  GenerateSchemasBatchFromProgramOptions,
+  GenerateSchemasBatchOptions,
   GenerateSchemasFromProgramOptions,
+  SchemaGenerationTarget,
   StaticSchemaGenerationOptions,
 } from "./generators/class-schema.js";
 export type { StaticBuildContext } from "./static-build.js";
@@ -126,8 +131,12 @@ export { uiSchema as uiSchemaSchema } from "./ui-schema/schema.js";
 export { generateJsonSchema } from "./json-schema/generator.js";
 export { generateUiSchema } from "./ui-schema/generator.js";
 export {
+  generateSchemasBatch,
+  generateSchemasBatchFromProgram,
+  generateSchemasDetailed,
   generateSchemasFromClass,
   generateSchemas,
+  generateSchemasFromProgramDetailed,
   generateSchemasFromProgram,
 } from "./generators/class-schema.js";
 export {

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -140,12 +140,18 @@ export { generateUiSchema } from "./ui-schema/generator.js";
 export {
   generateSchemasBatch,
   generateSchemasBatchFromProgram,
-  generateSchemasDetailed,
   generateSchemasFromClass,
-  generateSchemas,
-  generateSchemasFromProgramDetailed,
-  generateSchemasFromProgram,
 } from "./generators/class-schema.js";
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+export { generateSchemas } from "./generators/class-schema.js";
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+export { generateSchemasFromProgram } from "./generators/class-schema.js";
+/* eslint-disable @typescript-eslint/no-deprecated */
+export {
+  generateSchemasDetailed,
+  generateSchemasFromProgramDetailed,
+} from "./generators/class-schema.js";
+/* eslint-enable @typescript-eslint/no-deprecated */
 export {
   createStaticBuildContext,
   createStaticBuildContextFromProgram,

--- a/packages/build/src/internals.ts
+++ b/packages/build/src/internals.ts
@@ -26,6 +26,7 @@ export {
   findClassByName,
   findInterfaceByName,
   findTypeAliasByName,
+  analyzeNamedTypeToIRFromProgramContextDetailed,
   analyzeNamedTypeToIRFromProgramContext,
 } from "./analyzer/program.js";
 
@@ -41,10 +42,11 @@ export type {
   FieldLayoutMetadata,
   AnalyzeTypeAliasToIRResult,
 } from "./analyzer/class-analyzer.js";
+export type { AnalyzeNamedTypeToIRDetailedResult } from "./analyzer/program.js";
 
 // Generators: class schema (now routes through IR)
-export { generateClassSchemas } from "./generators/class-schema.js";
-export type { ClassSchemas } from "./generators/class-schema.js";
+export { generateClassSchemas, generateClassSchemasDetailed } from "./generators/class-schema.js";
+export type { ClassSchemas, DetailedClassSchemasResult } from "./generators/class-schema.js";
 
 // JSON Schema 2020-12: IR-based generator
 export { generateJsonSchemaFromIR } from "./json-schema/ir-generator.js";

--- a/packages/build/src/validate/constraint-validator.ts
+++ b/packages/build/src/validate/constraint-validator.ts
@@ -11,7 +11,6 @@
 import {
   analyzeConstraintTargets,
   type ConstraintRegistryLike,
-  type ConstraintSemanticDiagnostic,
 } from "@formspec/analysis/internal";
 import type { FormIR, FormIRElement, FieldNode, ObjectProperty } from "@formspec/core/internals";
 import type { ExtensionRegistry } from "../extensions/index.js";

--- a/packages/build/src/validate/constraint-validator.ts
+++ b/packages/build/src/validate/constraint-validator.ts
@@ -17,11 +17,52 @@ import type { FormIR, FormIRElement, FieldNode, ObjectProperty } from "@formspec
 import type { ExtensionRegistry } from "../extensions/index.js";
 
 /**
+ * Supported severity levels returned by static build validation.
+ *
+ * @public
+ */
+export type ValidationDiagnosticSeverity = "error" | "warning";
+
+/**
+ * Public source-location shape attached to validation diagnostics.
+ *
+ * This mirrors the provenance information surfaced by the shared analysis
+ * layer without exposing `@formspec/core/internals` through the public API.
+ *
+ * @public
+ */
+export interface ValidationDiagnosticLocation {
+  /** Authoring surface that produced the diagnostic location. */
+  readonly surface: "tsdoc" | "chain-dsl" | "extension" | "inferred";
+  /** Absolute path to the source file. */
+  readonly file: string;
+  /** 1-based line number in the source file. */
+  readonly line: number;
+  /** 0-based column number in the source file. */
+  readonly column: number;
+  /** Optional span length in characters. */
+  readonly length?: number;
+  /** Optional tag or construct associated with the location. */
+  readonly tagName?: string;
+}
+
+/**
  * A machine-readable validation diagnostic returned by static schema analysis.
  *
  * @public
  */
-export type ValidationDiagnostic = ConstraintSemanticDiagnostic;
+export interface ValidationDiagnostic {
+  /** Stable machine-readable diagnostic code. */
+  readonly code: string;
+  /** Human-readable explanation of the validation problem. */
+  readonly message: string;
+  /** Severity of the reported validation problem. */
+  readonly severity: ValidationDiagnosticSeverity;
+  /** Primary source location associated with the diagnostic. */
+  readonly primaryLocation: ValidationDiagnosticLocation;
+  /** Related source locations that add context to the diagnostic. */
+  readonly relatedLocations: readonly ValidationDiagnosticLocation[];
+}
 
 /**
  * Result of validating canonical FormIR before schema emission.

--- a/packages/build/src/validate/constraint-validator.ts
+++ b/packages/build/src/validate/constraint-validator.ts
@@ -16,15 +16,34 @@ import {
 import type { FormIR, FormIRElement, FieldNode, ObjectProperty } from "@formspec/core/internals";
 import type { ExtensionRegistry } from "../extensions/index.js";
 
+/**
+ * A machine-readable validation diagnostic returned by static schema analysis.
+ *
+ * @public
+ */
 export type ValidationDiagnostic = ConstraintSemanticDiagnostic;
 
+/**
+ * Result of validating canonical FormIR before schema emission.
+ *
+ * @public
+ */
 export interface ValidationResult {
+  /** Diagnostics produced during validation. */
   readonly diagnostics: readonly ValidationDiagnostic[];
+  /** Whether any error-severity diagnostics were produced. */
   readonly valid: boolean;
 }
 
+/**
+ * Options for validating canonical FormIR.
+ *
+ * @public
+ */
 export interface ValidateIROptions {
+  /** Vendor prefix used when resolving extension-backed keywords. */
   readonly vendorPrefix?: string;
+  /** Extension registry used to resolve custom constraints and types. */
   readonly extensionRegistry?: ExtensionRegistry;
 }
 
@@ -103,6 +122,11 @@ function validateElement(ctx: ValidationContext, element: FormIRElement): void {
   }
 }
 
+/**
+ * Validates canonical FormIR and returns all discovered diagnostics.
+ *
+ * @public
+ */
 export function validateIR(ir: FormIR, options?: ValidateIROptions): ValidationResult {
   const ctx: ValidationContext = {
     diagnostics: [],

--- a/packages/build/src/validate/index.ts
+++ b/packages/build/src/validate/index.ts
@@ -7,6 +7,8 @@
 export { validateIR } from "./constraint-validator.js";
 export type {
   ValidationDiagnostic,
+  ValidationDiagnosticLocation,
+  ValidationDiagnosticSeverity,
   ValidationResult,
   ValidateIROptions,
 } from "./constraint-validator.js";


### PR DESCRIPTION
## Summary
- add non-throwing `@formspec/build` APIs for single-target and batch schema generation with structured diagnostics
- expose `resolvedMetadata` on `DiscoveredTypeSchemas` so static build consumers can read resolved singular and plural API/display names
- cover the new API behavior with build integration tests and include changesets for the published package changes

## Test plan
- `pnpm --filter @formspec/build run test`
