### PR TITLE
Expose declaration metadata resolution

### DIFF
--- a/.changeset/eight-pianos-jam.md
+++ b/.changeset/eight-pianos-jam.md
@@ -1,0 +1,7 @@
+---
+"@formspec/build": minor
+"@formspec/cli": patch
+"formspec": patch
+---
+
+Add `resolveDeclarationMetadata()` to the static build workflow so consumers can resolve method-, field-, and type-level metadata from declarations using FormSpec's active metadata policy. This makes method-level `@apiName` and `@displayName` resolution available alongside existing parameter and return-type schema generation helpers.

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -74,6 +74,7 @@ Public helpers in this workflow:
 - `createStaticBuildContextFromProgram(program, filePath)` - Reuse a host-owned `ts.Program`.
 - `resolveModuleExport(context, exportName?)` - Resolve any exported symbol, including functions and other non-schema declarations.
 - `resolveModuleExportDeclaration(context, exportName?)` - Resolve only schema-source declarations (`class`, `interface`, `type` alias).
+- `resolveDeclarationMetadata(...)` - Resolve metadata for supported declarations such as types, fields, and methods using FormSpec's active metadata policy.
 - `generateSchemasFromDeclaration(...)` - Generate from a resolved schema-source declaration.
 - `generateSchemasFromParameter(...)` - Generate from a method or function parameter declaration.
 - `generateSchemasFromReturnType(...)` - Generate from a method or function return type, unwrapping awaited `Promise<T>`-style returns before generation.
@@ -91,6 +92,7 @@ import {
   generateSchemasFromDeclaration,
   generateSchemasFromParameter,
   generateSchemasFromReturnType,
+  resolveDeclarationMetadata,
   resolveModuleExport,
   resolveModuleExportDeclaration,
 } from "@formspec/build";
@@ -107,6 +109,10 @@ if (serviceDeclaration && ts.isClassDeclaration(serviceDeclaration)) {
   );
 
   if (submitMethod?.parameters[0]) {
+    const methodMetadata = resolveDeclarationMetadata({
+      context,
+      declaration: submitMethod,
+    });
     const inputSchemas = generateSchemasFromParameter({
       context,
       parameter: submitMethod.parameters[0],

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -74,7 +74,7 @@ Public helpers in this workflow:
 - `createStaticBuildContextFromProgram(program, filePath)` - Reuse a host-owned `ts.Program`.
 - `resolveModuleExport(context, exportName?)` - Resolve any exported symbol, including functions and other non-schema declarations.
 - `resolveModuleExportDeclaration(context, exportName?)` - Resolve only schema-source declarations (`class`, `interface`, `type` alias).
-- `resolveDeclarationMetadata(...)` - Resolve metadata for supported declarations such as types, fields, and methods using FormSpec's active metadata policy.
+- `resolveDeclarationMetadata(...)` - Resolve metadata for named types, methods, and properties using FormSpec's active metadata policy.
 - `generateSchemasFromDeclaration(...)` - Generate from a resolved schema-source declaration.
 - `generateSchemasFromParameter(...)` - Generate from a method or function parameter declaration.
 - `generateSchemasFromReturnType(...)` - Generate from a method or function return type, unwrapping awaited `Promise<T>`-style returns before generation.

--- a/packages/build/api-report/build.alpha.api.md
+++ b/packages/build/api-report/build.alpha.api.md
@@ -433,6 +433,9 @@ export interface LabelElement {
 }
 
 // @public
+export type MetadataSourceDeclaration = SchemaSourceDeclaration | ts.MethodDeclaration | ts.FunctionDeclaration | ts.PropertyDeclaration | ts.PropertySignature;
+
+// @public
 export interface MixedAuthoringSchemas {
     readonly jsonSchema: JsonSchema2020;
     readonly uiSchema: UISchema;
@@ -441,6 +444,15 @@ export interface MixedAuthoringSchemas {
 export { NumberField }
 
 export { ObjectField }
+
+// @public
+export function resolveDeclarationMetadata(options: ResolveDeclarationMetadataOptions): ResolvedMetadata | undefined;
+
+// @public
+export interface ResolveDeclarationMetadataOptions extends StaticSchemaGenerationOptions {
+    readonly context: StaticBuildContext;
+    readonly declaration: MetadataSourceDeclaration;
+}
 
 // @public
 export function resolveModuleExport(context: StaticBuildContext, exportName?: string): ts.Symbol | null;

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -433,6 +433,9 @@ export interface LabelElement {
 }
 
 // @public
+export type MetadataSourceDeclaration = SchemaSourceDeclaration | ts.MethodDeclaration | ts.FunctionDeclaration | ts.PropertyDeclaration | ts.PropertySignature;
+
+// @public
 export interface MixedAuthoringSchemas {
     readonly jsonSchema: JsonSchema2020;
     readonly uiSchema: UISchema;
@@ -441,6 +444,15 @@ export interface MixedAuthoringSchemas {
 export { NumberField }
 
 export { ObjectField }
+
+// @public
+export function resolveDeclarationMetadata(options: ResolveDeclarationMetadataOptions): ResolvedMetadata | undefined;
+
+// @public
+export interface ResolveDeclarationMetadataOptions extends StaticSchemaGenerationOptions {
+    readonly context: StaticBuildContext;
+    readonly declaration: MetadataSourceDeclaration;
+}
 
 // @public
 export function resolveModuleExport(context: StaticBuildContext, exportName?: string): ts.Symbol | null;

--- a/packages/build/api-report/build.beta.api.md
+++ b/packages/build/api-report/build.beta.api.md
@@ -433,6 +433,9 @@ export interface LabelElement {
 }
 
 // @public
+export type MetadataSourceDeclaration = SchemaSourceDeclaration | ts.MethodDeclaration | ts.FunctionDeclaration | ts.PropertyDeclaration | ts.PropertySignature;
+
+// @public
 export interface MixedAuthoringSchemas {
     readonly jsonSchema: JsonSchema2020;
     readonly uiSchema: UISchema;
@@ -441,6 +444,15 @@ export interface MixedAuthoringSchemas {
 export { NumberField }
 
 export { ObjectField }
+
+// @public
+export function resolveDeclarationMetadata(options: ResolveDeclarationMetadataOptions): ResolvedMetadata | undefined;
+
+// @public
+export interface ResolveDeclarationMetadataOptions extends StaticSchemaGenerationOptions {
+    readonly context: StaticBuildContext;
+    readonly declaration: MetadataSourceDeclaration;
+}
 
 // @public
 export function resolveModuleExport(context: StaticBuildContext, exportName?: string): ts.Symbol | null;

--- a/packages/build/api-report/build.public.api.md
+++ b/packages/build/api-report/build.public.api.md
@@ -433,6 +433,9 @@ export interface LabelElement {
 }
 
 // @public
+export type MetadataSourceDeclaration = SchemaSourceDeclaration | ts.MethodDeclaration | ts.FunctionDeclaration | ts.PropertyDeclaration | ts.PropertySignature;
+
+// @public
 export interface MixedAuthoringSchemas {
     readonly jsonSchema: JsonSchema2020;
     readonly uiSchema: UISchema;
@@ -441,6 +444,15 @@ export interface MixedAuthoringSchemas {
 export { NumberField }
 
 export { ObjectField }
+
+// @public
+export function resolveDeclarationMetadata(options: ResolveDeclarationMetadataOptions): ResolvedMetadata | undefined;
+
+// @public
+export interface ResolveDeclarationMetadataOptions extends StaticSchemaGenerationOptions {
+    readonly context: StaticBuildContext;
+    readonly declaration: MetadataSourceDeclaration;
+}
 
 // @public
 export function resolveModuleExport(context: StaticBuildContext, exportName?: string): ts.Symbol | null;

--- a/packages/build/src/__tests__/fixtures/method-signature-schemas.ts
+++ b/packages/build/src/__tests__/fixtures/method-signature-schemas.ts
@@ -98,6 +98,10 @@ export interface MergedConfig {
 }
 
 export class PaymentService {
+  /**
+   * @apiName submit_payment
+   * @displayName Submit Payment
+   */
   submit(input: SubmitInput): SubmitResult {
     return {
       approved: input.amount > 0,

--- a/packages/build/src/__tests__/fixtures/method-signature-schemas.ts
+++ b/packages/build/src/__tests__/fixtures/method-signature-schemas.ts
@@ -115,6 +115,12 @@ export class PaymentService {
     };
   }
 
+  ["submitComputed"](input: SubmitInput): SubmitResult {
+    return {
+      approved: input.amount > 0,
+    };
+  }
+
   async wrappedSubmitAsync(): Promise<Envelope<SubmitInput>> {
     await Promise.resolve();
     return {

--- a/packages/build/src/__tests__/static-build-context.test.ts
+++ b/packages/build/src/__tests__/static-build-context.test.ts
@@ -45,6 +45,25 @@ function getMethod(
   return method;
 }
 
+function getComputedMethod(
+  classDeclaration: ts.ClassDeclaration,
+  methodName: string
+): ts.MethodDeclaration {
+  const method = classDeclaration.members.find(
+    (member): member is ts.MethodDeclaration =>
+      ts.isMethodDeclaration(member) &&
+      ts.isComputedPropertyName(member.name) &&
+      ts.isStringLiteral(member.name.expression) &&
+      member.name.expression.text === methodName
+  );
+
+  if (method === undefined) {
+    throw new Error(`Computed method "${methodName}" not found`);
+  }
+
+  return method;
+}
+
 describe("static build context", () => {
   it("creates a reusable compiler context from a file path", () => {
     const context = createStaticBuildContext(entryFixturePath);
@@ -367,5 +386,36 @@ describe("static build context", () => {
       apiName: { value: "submit_async", source: "inferred" },
       displayName: { value: "Submit Async", source: "inferred" },
     });
+  });
+
+  it("does not infer metadata for computed method names", () => {
+    const context = createStaticBuildContext(targetFixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService export not found");
+    }
+
+    const metadata = resolveDeclarationMetadata({
+      context,
+      declaration: getComputedMethod(declaration, "submitComputed"),
+      metadata: {
+        method: {
+          apiName: {
+            mode: "infer-if-missing",
+            infer: ({ logicalName }) =>
+              logicalName.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase(),
+          },
+          displayName: {
+            mode: "infer-if-missing",
+            infer: ({ logicalName }) =>
+              logicalName
+                .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+                .replace(/^./, (char) => char.toUpperCase()),
+          },
+        },
+      },
+    });
+
+    expect(metadata).toBeUndefined();
   });
 });

--- a/packages/build/src/__tests__/static-build-context.test.ts
+++ b/packages/build/src/__tests__/static-build-context.test.ts
@@ -8,6 +8,7 @@ import {
   generateSchemasFromParameter,
   generateSchemasFromReturnType,
   generateSchemasFromType,
+  resolveDeclarationMetadata,
   resolveModuleExport,
   resolveModuleExportDeclaration,
 } from "../index.js";
@@ -314,5 +315,57 @@ describe("static build context", () => {
         declaration,
       })
     ).toThrow(/INVALID_TAG_PLACEMENT/);
+  });
+
+  it("resolves explicit method metadata through the public build context workflow", () => {
+    const context = createStaticBuildContext(targetFixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService export not found");
+    }
+
+    const metadata = resolveDeclarationMetadata({
+      context,
+      declaration: getMethod(declaration, "submit"),
+    });
+
+    expect(metadata).toEqual({
+      apiName: { value: "submit_payment", source: "explicit" },
+      displayName: { value: "Submit Payment", source: "explicit" },
+    });
+  });
+
+  it("resolves inferred method metadata through the public build context workflow", () => {
+    const context = createStaticBuildContext(targetFixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService export not found");
+    }
+
+    const metadata = resolveDeclarationMetadata({
+      context,
+      declaration: getMethod(declaration, "submitAsync"),
+      metadata: {
+        method: {
+          apiName: {
+            mode: "infer-if-missing",
+            infer: ({ logicalName }) =>
+              logicalName.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase(),
+          },
+          displayName: {
+            mode: "infer-if-missing",
+            infer: ({ logicalName }) =>
+              logicalName
+                .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+                .replace(/^./, (char) => char.toUpperCase()),
+          },
+        },
+      },
+    });
+
+    expect(metadata).toEqual({
+      apiName: { value: "submit_async", source: "inferred" },
+      displayName: { value: "Submit Async", source: "inferred" },
+    });
   });
 });

--- a/packages/build/src/generators/discovered-schema.ts
+++ b/packages/build/src/generators/discovered-schema.ts
@@ -68,6 +68,10 @@ export type SchemaSourceDeclaration =
 /**
  * Supported declaration kinds for standalone metadata resolution.
  *
+ * This helper is intentionally limited to named type declarations,
+ * methods/functions, and object-like properties. It does not currently expose
+ * parameter or variable metadata resolution on the public build surface.
+ *
  * @public
  */
 export type MetadataSourceDeclaration =
@@ -265,61 +269,6 @@ function omitApiName(metadata: ResolvedMetadata | undefined): ResolvedMetadata |
 
   const { apiName: _apiName, ...rest } = metadata;
   return Object.keys(rest).length > 0 ? rest : undefined;
-}
-
-function getDeclarationLogicalName(
-  declaration: MetadataSourceDeclaration,
-  fallback: string
-): string {
-  if (ts.isClassDeclaration(declaration)) {
-    return declaration.name?.text ?? fallback;
-  }
-
-  if (
-    ts.isInterfaceDeclaration(declaration) ||
-    ts.isTypeAliasDeclaration(declaration) ||
-    ts.isFunctionDeclaration(declaration)
-  ) {
-    return declaration.name?.text ?? fallback;
-  }
-
-  const name = declaration.name;
-  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
-    return name.text;
-  }
-  if (ts.isPrivateIdentifier(name)) {
-    return name.text;
-  }
-
-  return name.getText(declaration.getSourceFile());
-}
-
-function getDeclarationMetadataInfo(declaration: MetadataSourceDeclaration): {
-  readonly declarationKind: "type" | "field" | "method";
-  readonly logicalName: string;
-} {
-  if (
-    ts.isClassDeclaration(declaration) ||
-    ts.isInterfaceDeclaration(declaration) ||
-    ts.isTypeAliasDeclaration(declaration)
-  ) {
-    return {
-      declarationKind: "type",
-      logicalName: getDeclarationLogicalName(declaration, "AnonymousType"),
-    };
-  }
-
-  if (ts.isMethodDeclaration(declaration) || ts.isFunctionDeclaration(declaration)) {
-    return {
-      declarationKind: "method",
-      logicalName: getDeclarationLogicalName(declaration, "AnonymousMethod"),
-    };
-  }
-
-  return {
-    declarationKind: "field",
-    logicalName: getDeclarationLogicalName(declaration, "AnonymousField"),
-  };
 }
 
 function enforceRequiredMetadata(
@@ -715,18 +664,20 @@ export function generateSchemasFromReturnType(
 export function resolveDeclarationMetadata(
   options: ResolveDeclarationMetadataOptions
 ): ResolvedMetadata | undefined {
-  const { declarationKind, logicalName } = getDeclarationMetadataInfo(options.declaration);
   const analysis = analyzeMetadataForNodeWithChecker({
     checker: options.context.checker,
     node: options.declaration,
-    logicalName,
     metadata: options.metadata,
     extensions: options.extensionRegistry?.extensions,
     buildContext: options.context,
   });
-  const metadata = analysis?.resolvedMetadata;
+  if (analysis === null) {
+    return undefined;
+  }
 
-  enforceRequiredMetadata(metadata, declarationKind, logicalName, options);
+  const metadata = analysis.resolvedMetadata;
+
+  enforceRequiredMetadata(metadata, analysis.declarationKind, analysis.logicalName, options);
   return metadata;
 }
 

--- a/packages/build/src/generators/discovered-schema.ts
+++ b/packages/build/src/generators/discovered-schema.ts
@@ -1,4 +1,5 @@
 import * as ts from "typescript";
+import { analyzeMetadataForNodeWithChecker } from "@formspec/analysis/internal";
 import type {
   AnnotationNode,
   ObjectProperty,
@@ -25,7 +26,11 @@ import {
 import { generateJsonSchemaFromIR, type JsonSchema2020 } from "../json-schema/ir-generator.js";
 import { IR_VERSION, type FieldNode } from "@formspec/core/internals";
 import type { ConstraintSemanticDiagnostic } from "@formspec/analysis/internal";
-import { mergeResolvedMetadata } from "../metadata/index.js";
+import {
+  getDeclarationMetadataPolicy,
+  mergeResolvedMetadata,
+  normalizeMetadataPolicy,
+} from "../metadata/index.js";
 
 /**
  * Generated schemas for a discovered declaration or signature type.
@@ -59,6 +64,18 @@ export type SchemaSourceDeclaration =
   | ts.ClassDeclaration
   | ts.InterfaceDeclaration
   | ts.TypeAliasDeclaration;
+
+/**
+ * Supported declaration kinds for standalone metadata resolution.
+ *
+ * @public
+ */
+export type MetadataSourceDeclaration =
+  | SchemaSourceDeclaration
+  | ts.MethodDeclaration
+  | ts.FunctionDeclaration
+  | ts.PropertyDeclaration
+  | ts.PropertySignature;
 
 /**
  * Options for generating schemas from a resolved declaration.
@@ -115,6 +132,19 @@ export interface GenerateSchemasFromReturnTypeOptions extends StaticSchemaGenera
   readonly context: StaticBuildContext;
   /** Signature declaration whose return type should be converted into schemas. */
   readonly declaration: ts.SignatureDeclaration;
+}
+
+/**
+ * Options for resolving metadata from a declaration against the active
+ * metadata policy.
+ *
+ * @public
+ */
+export interface ResolveDeclarationMetadataOptions extends StaticSchemaGenerationOptions {
+  /** Supported build context used for checker access and related analysis. */
+  readonly context: StaticBuildContext;
+  /** Declaration whose metadata should be resolved. */
+  readonly declaration: MetadataSourceDeclaration;
 }
 
 function toDiscoveredTypeSchemas(
@@ -235,6 +265,103 @@ function omitApiName(metadata: ResolvedMetadata | undefined): ResolvedMetadata |
 
   const { apiName: _apiName, ...rest } = metadata;
   return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
+function getDeclarationLogicalName(
+  declaration: MetadataSourceDeclaration,
+  fallback: string
+): string {
+  if (ts.isClassDeclaration(declaration)) {
+    return declaration.name?.text ?? fallback;
+  }
+
+  if (
+    ts.isInterfaceDeclaration(declaration) ||
+    ts.isTypeAliasDeclaration(declaration) ||
+    ts.isFunctionDeclaration(declaration)
+  ) {
+    return declaration.name?.text ?? fallback;
+  }
+
+  const name = declaration.name;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  if (ts.isPrivateIdentifier(name)) {
+    return name.text;
+  }
+
+  return name.getText(declaration.getSourceFile());
+}
+
+function getDeclarationMetadataInfo(declaration: MetadataSourceDeclaration): {
+  readonly declarationKind: "type" | "field" | "method";
+  readonly logicalName: string;
+} {
+  if (
+    ts.isClassDeclaration(declaration) ||
+    ts.isInterfaceDeclaration(declaration) ||
+    ts.isTypeAliasDeclaration(declaration)
+  ) {
+    return {
+      declarationKind: "type",
+      logicalName: getDeclarationLogicalName(declaration, "AnonymousType"),
+    };
+  }
+
+  if (ts.isMethodDeclaration(declaration) || ts.isFunctionDeclaration(declaration)) {
+    return {
+      declarationKind: "method",
+      logicalName: getDeclarationLogicalName(declaration, "AnonymousMethod"),
+    };
+  }
+
+  return {
+    declarationKind: "field",
+    logicalName: getDeclarationLogicalName(declaration, "AnonymousField"),
+  };
+}
+
+function enforceRequiredMetadata(
+  metadata: ResolvedMetadata | undefined,
+  declarationKind: "type" | "field" | "method",
+  logicalName: string,
+  options: ResolveDeclarationMetadataOptions
+): void {
+  const declarationPolicy = getDeclarationMetadataPolicy(
+    normalizeMetadataPolicy(options.metadata),
+    declarationKind
+  );
+
+  if (metadata?.apiName === undefined && declarationPolicy.apiName.mode === "require-explicit") {
+    throw new Error(
+      `Metadata policy requires explicit apiName for ${declarationKind} "${logicalName}" on the tsdoc surface.`
+    );
+  }
+  if (
+    metadata?.displayName === undefined &&
+    declarationPolicy.displayName.mode === "require-explicit"
+  ) {
+    throw new Error(
+      `Metadata policy requires explicit displayName for ${declarationKind} "${logicalName}" on the tsdoc surface.`
+    );
+  }
+  if (
+    metadata?.apiNamePlural === undefined &&
+    declarationPolicy.apiName.pluralization.mode === "require-explicit"
+  ) {
+    throw new Error(
+      `Metadata policy requires explicit apiNamePlural for ${declarationKind} "${logicalName}" on the tsdoc surface.`
+    );
+  }
+  if (
+    metadata?.displayNamePlural === undefined &&
+    declarationPolicy.displayName.pluralization.mode === "require-explicit"
+  ) {
+    throw new Error(
+      `Metadata policy requires explicit displayNamePlural for ${declarationKind} "${logicalName}" on the tsdoc surface.`
+    );
+  }
 }
 
 function describeRootType(
@@ -577,6 +704,30 @@ export function generateSchemasFromReturnType(
     sourceNode,
     name: fallbackName,
   });
+}
+
+/**
+ * Resolves metadata from a declaration using FormSpec's configured metadata
+ * policy for the matching declaration kind.
+ *
+ * @public
+ */
+export function resolveDeclarationMetadata(
+  options: ResolveDeclarationMetadataOptions
+): ResolvedMetadata | undefined {
+  const { declarationKind, logicalName } = getDeclarationMetadataInfo(options.declaration);
+  const analysis = analyzeMetadataForNodeWithChecker({
+    checker: options.context.checker,
+    node: options.declaration,
+    logicalName,
+    metadata: options.metadata,
+    extensions: options.extensionRegistry?.extensions,
+    buildContext: options.context,
+  });
+  const metadata = analysis?.resolvedMetadata;
+
+  enforceRequiredMetadata(metadata, declarationKind, logicalName, options);
+  return metadata;
 }
 
 function unwrapPromiseType(checker: ts.TypeChecker, type: ts.Type): ts.Type {

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -114,9 +114,11 @@ export type {
 export type {
   DiscoveredTypeSchemas,
   GenerateSchemasFromDeclarationOptions,
+  MetadataSourceDeclaration,
   GenerateSchemasFromParameterOptions,
   GenerateSchemasFromReturnTypeOptions,
   GenerateSchemasFromTypeOptions,
+  ResolveDeclarationMetadataOptions,
   SchemaSourceDeclaration,
 } from "./generators/discovered-schema.js";
 export type {
@@ -163,6 +165,7 @@ export {
   generateSchemasFromParameter,
   generateSchemasFromReturnType,
   generateSchemasFromType,
+  resolveDeclarationMetadata,
 } from "./generators/discovered-schema.js";
 export { buildMixedAuthoringSchemas } from "./generators/mixed-authoring.js";
 


### PR DESCRIPTION
## Summary
- add `resolveDeclarationMetadata()` to the `@formspec/build` static-build workflow
- export the new metadata resolution types and document method-level metadata resolution
- tighten the helper to follow the canonical analyzer behavior for unsupported computed names

## Test plan
- pnpm --filter @formspec/build exec vitest run src/__tests__/signature-schema-generation.test.ts src/__tests__/static-build-context.test.ts
- pnpm --filter @formspec/build build
- pnpm run lint
- pnpm --filter @formspec/build exec vitest run src/__tests__/static-build-context.test.ts
- pnpm exec eslint packages/build/src/generators/discovered-schema.ts packages/build/src/__tests__/static-build-context.test.ts packages/build/src/__tests__/fixtures/method-signature-schemas.ts