### PR TITLE
feat: allow custom constraints to emit vocabulary keywords

### DIFF
--- a/.changeset/vocabulary-keywords-constraint.md
+++ b/.changeset/vocabulary-keywords-constraint.md
@@ -1,6 +1,15 @@
 ---
 "@formspec/core": minor
 "@formspec/build": minor
+"@formspec/analysis": patch
+"@formspec/cli": patch
+"@formspec/constraints": patch
+"@formspec/dsl": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/runtime": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
 ---
 
 Add `emitsVocabularyKeywords` option to `CustomConstraintRegistration` that allows custom constraints to emit non-vendor-prefixed JSON Schema keywords. This enables extensions to define their own JSON Schema vocabulary (e.g., `decimalMinimum`) instead of being forced to namespace under the vendor prefix.

--- a/.changeset/vocabulary-keywords-constraint.md
+++ b/.changeset/vocabulary-keywords-constraint.md
@@ -1,0 +1,6 @@
+---
+"@formspec/core": minor
+"@formspec/build": minor
+---
+
+Add `emitsVocabularyKeywords` option to `CustomConstraintRegistration` that allows custom constraints to emit non-vendor-prefixed JSON Schema keywords. This enables extensions to define their own JSON Schema vocabulary (e.g., `decimalMinimum`) instead of being forced to namespace under the vendor prefix.

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -476,6 +476,88 @@ describe("Extension API", () => {
         })
       ).toThrow(/may only emit "x-test-\*" JSON Schema keywords/);
     });
+
+    it("allows non-prefixed keywords when emitsVocabularyKeywords is true", () => {
+      const vocabConstraint = defineConstraint({
+        constraintName: "DecimalMinimum",
+        compositionRule: "intersect",
+        applicableTypes: ["custom"],
+        emitsVocabularyKeywords: true,
+        toJsonSchema: (payload) => ({
+          decimalMinimum: payload,
+        }),
+      });
+      const registry = createExtensionRegistry([
+        defineExtension({
+          extensionId: "x-test/decimal",
+          types: [decimalType],
+          constraints: [vocabConstraint],
+        }),
+      ]);
+
+      const customType: CustomTypeNode = {
+        kind: "custom",
+        typeId: "x-test/decimal/Decimal",
+        payload: null,
+      };
+      const customCon: CustomConstraintNode = {
+        kind: "constraint",
+        constraintKind: "custom",
+        constraintId: "x-test/decimal/DecimalMinimum",
+        payload: "0.01",
+        compositionRule: "intersect",
+        provenance: prov(1, "DecimalMinimum"),
+      };
+
+      const ir = makeIR([makeField("amount", customType, [customCon])]);
+      const result = generateJsonSchemaFromIR(ir, {
+        extensionRegistry: registry,
+        vendorPrefix: "x-test",
+      });
+
+      const props = result.properties ?? {};
+      expect(props.amount).toMatchObject({
+        type: "string",
+        "x-test-decimal": true,
+        decimalMinimum: "0.01",
+      });
+    });
+
+    it("still rejects non-prefixed keywords when emitsVocabularyKeywords is not set", () => {
+      const nonVocabConstraint = defineConstraint({
+        constraintName: "BadConstraint",
+        compositionRule: "intersect",
+        applicableTypes: ["primitive"],
+        // no emitsVocabularyKeywords
+        toJsonSchema: () => ({
+          decimalMinimum: "0.01",
+        }),
+      });
+      const registry = createExtensionRegistry([
+        defineExtension({
+          extensionId: "x-test/bad",
+          constraints: [nonVocabConstraint],
+        }),
+      ]);
+
+      const customCon: CustomConstraintNode = {
+        kind: "constraint",
+        constraintKind: "custom",
+        constraintId: "x-test/bad/BadConstraint",
+        payload: null,
+        compositionRule: "intersect",
+        provenance: prov(1, "BadConstraint"),
+      };
+
+      const ir = makeIR([makeField("amount", NUMBER_TYPE, [customCon])]);
+
+      expect(() =>
+        generateJsonSchemaFromIR(ir, {
+          extensionRegistry: registry,
+          vendorPrefix: "x-test",
+        })
+      ).toThrow(/may only emit "x-test-\*" JSON Schema keywords/);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -558,6 +558,48 @@ describe("Extension API", () => {
         })
       ).toThrow(/may only emit "x-test-\*" JSON Schema keywords/);
     });
+
+    it("rejects vocabulary constraints that overwrite standard JSON Schema keywords", () => {
+      const collidingConstraint = defineConstraint({
+        constraintName: "Collider",
+        compositionRule: "intersect",
+        applicableTypes: ["custom"],
+        emitsVocabularyKeywords: true,
+        toJsonSchema: () => ({
+          type: "number", // collides with the base schema's type: "string"
+        }),
+      });
+      const registry = createExtensionRegistry([
+        defineExtension({
+          extensionId: "x-test/collide",
+          types: [decimalType],
+          constraints: [collidingConstraint],
+        }),
+      ]);
+
+      const customType: CustomTypeNode = {
+        kind: "custom",
+        typeId: "x-test/collide/Decimal",
+        payload: null,
+      };
+      const customCon: CustomConstraintNode = {
+        kind: "constraint",
+        constraintKind: "custom",
+        constraintId: "x-test/collide/Collider",
+        payload: null,
+        compositionRule: "intersect",
+        provenance: prov(1, "Collider"),
+      };
+
+      const ir = makeIR([makeField("amount", customType, [customCon])]);
+
+      expect(() =>
+        generateJsonSchemaFromIR(ir, {
+          extensionRegistry: registry,
+          vendorPrefix: "x-test",
+        })
+      ).toThrow(/must not overwrite standard JSON Schema keyword "type"/);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -1205,12 +1205,24 @@ function applyCustomConstraint(
     );
   }
 
-  assignVendorPrefixedExtensionKeywords(
-    schema,
-    registration.toJsonSchema(constraint.payload, ctx.vendorPrefix),
-    ctx.vendorPrefix,
-    `custom constraint "${constraint.constraintId}"`
-  );
+  const extensionSchema = registration.toJsonSchema(constraint.payload, ctx.vendorPrefix);
+
+  if (registration.emitsVocabularyKeywords) {
+    // Vocabulary-mode: assign keywords directly without prefix enforcement.
+    // The cast is safe — vocabulary keywords are extension-defined and don't
+    // overlap with the built-in JsonSchema2020 index signature.
+    const target = schema as Record<string, unknown>;
+    for (const [key, value] of Object.entries(extensionSchema)) {
+      target[key] = value;
+    }
+  } else {
+    assignVendorPrefixedExtensionKeywords(
+      schema,
+      extensionSchema,
+      ctx.vendorPrefix,
+      `custom constraint "${constraint.constraintId}"`
+    );
+  }
 }
 
 function applyCustomAnnotation(

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -1193,6 +1193,29 @@ function generateCustomType(type: CustomTypeNode, ctx: GeneratorContext): JsonSc
   return registration.toJsonSchema(type.payload, ctx.vendorPrefix) as JsonSchema2020;
 }
 
+/**
+ * Standard JSON Schema 2020-12 keywords that vocabulary-mode constraints must
+ * not overwrite. Prevents accidental corruption of structural schema properties.
+ */
+const JSON_SCHEMA_STRUCTURAL_KEYWORDS = new Set([
+  "$schema", "$ref", "$defs", "$id", "$anchor", "$dynamicRef", "$dynamicAnchor",
+  "$vocabulary", "$comment",
+  "type", "enum", "const",
+  "properties", "patternProperties", "additionalProperties", "required",
+  "items", "prefixItems", "additionalItems", "contains",
+  "allOf", "oneOf", "anyOf", "not", "if", "then", "else",
+  "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
+  "minLength", "maxLength", "pattern",
+  "minItems", "maxItems", "uniqueItems",
+  "minProperties", "maxProperties",
+  "minContains", "maxContains",
+  "format", "title", "description", "default", "deprecated",
+  "readOnly", "writeOnly", "examples",
+  "dependentRequired", "dependentSchemas",
+  "propertyNames", "unevaluatedItems", "unevaluatedProperties",
+  "contentEncoding", "contentMediaType", "contentSchema",
+]);
+
 function applyCustomConstraint(
   schema: JsonSchema2020,
   constraint: Extract<ConstraintNode, { constraintKind: "custom" }>,
@@ -1209,10 +1232,15 @@ function applyCustomConstraint(
 
   if (registration.emitsVocabularyKeywords) {
     // Vocabulary-mode: assign keywords directly without prefix enforcement.
-    // The cast is safe — vocabulary keywords are extension-defined and don't
-    // overlap with the built-in JsonSchema2020 index signature.
+    // Guard against accidental collisions with standard JSON Schema keywords.
     const target = schema as Record<string, unknown>;
     for (const [key, value] of Object.entries(extensionSchema)) {
+      if (JSON_SCHEMA_STRUCTURAL_KEYWORDS.has(key)) {
+        throw new Error(
+          `Custom constraint "${constraint.constraintId}" with emitsVocabularyKeywords ` +
+          `must not overwrite standard JSON Schema keyword "${key}"`
+        );
+      }
       target[key] = value;
     }
   } else {

--- a/packages/core/api-report/core.alpha.api.md
+++ b/packages/core/api-report/core.alpha.api.md
@@ -139,6 +139,7 @@ export interface CustomConstraintRegistration {
     readonly comparePayloads?: (left: ExtensionPayloadValue, right: ExtensionPayloadValue) => number;
     readonly compositionRule: "intersect" | "override";
     readonly constraintName: string;
+    readonly emitsVocabularyKeywords?: boolean;
     readonly isApplicableToType?: (type: ExtensionApplicableType) => boolean;
     readonly semanticRole?: ConstraintSemanticRole;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -139,6 +139,7 @@ export interface CustomConstraintRegistration {
     readonly comparePayloads?: (left: ExtensionPayloadValue, right: ExtensionPayloadValue) => number;
     readonly compositionRule: "intersect" | "override";
     readonly constraintName: string;
+    readonly emitsVocabularyKeywords?: boolean;
     readonly isApplicableToType?: (type: ExtensionApplicableType) => boolean;
     readonly semanticRole?: ConstraintSemanticRole;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;

--- a/packages/core/api-report/core.beta.api.md
+++ b/packages/core/api-report/core.beta.api.md
@@ -139,6 +139,7 @@ export interface CustomConstraintRegistration {
     readonly comparePayloads?: (left: ExtensionPayloadValue, right: ExtensionPayloadValue) => number;
     readonly compositionRule: "intersect" | "override";
     readonly constraintName: string;
+    readonly emitsVocabularyKeywords?: boolean;
     readonly isApplicableToType?: (type: ExtensionApplicableType) => boolean;
     readonly semanticRole?: ConstraintSemanticRole;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;

--- a/packages/core/api-report/core.public.api.md
+++ b/packages/core/api-report/core.public.api.md
@@ -80,6 +80,7 @@ export interface CustomConstraintRegistration {
     readonly comparePayloads?: (left: ExtensionPayloadValue, right: ExtensionPayloadValue) => number;
     readonly compositionRule: "intersect" | "override";
     readonly constraintName: string;
+    readonly emitsVocabularyKeywords?: boolean;
     readonly isApplicableToType?: (type: ExtensionApplicableType) => boolean;
     readonly semanticRole?: ConstraintSemanticRole;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -147,6 +147,17 @@ export interface CustomConstraintRegistration {
     payload: ExtensionPayloadValue,
     vendorPrefix: string
   ) => Record<string, unknown>;
+  /**
+   * When true, `toJsonSchema` may emit vocabulary keywords that do not carry
+   * the vendor prefix. By default, all keys returned from `toJsonSchema` must
+   * start with `${vendorPrefix}-`; setting this flag relaxes that check so
+   * the constraint can produce standard or custom vocabulary keywords such as
+   * `decimalMinimum`.
+   *
+   * Use this for constraints that define their own JSON Schema vocabulary
+   * rather than namespacing under the vendor prefix.
+   */
+  readonly emitsVocabularyKeywords?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Why?

Custom constraints are currently forced to emit JSON Schema keywords prefixed with the vendor prefix (e.g., `x-formspec-*`). This prevents extensions from defining their own JSON Schema vocabulary with clean, non-prefixed keywords like `decimalMinimum` or `decimalMaximum`.

The Stripe extensibility SDK needs this to support numeric constraint tags (`@minimum`, `@maximum`, etc.) on Decimal fields, emitting `{ type: "string", format: "decimal", decimalMinimum: "0.01" }` — where the constraint keywords are part of a custom vocabulary, not namespaced under a vendor prefix.

## What?

- Add `emitsVocabularyKeywords?: boolean` to `CustomConstraintRegistration` in `@formspec/core`
- When `true`, the `toJsonSchema` callback's output bypasses vendor-prefix enforcement in `@formspec/build`
- When `false` or omitted (default), existing behavior is unchanged — all keywords must start with `${vendorPrefix}-`

## Test Plan

- [x] New test: vocabulary-mode constraint emits non-prefixed keywords on the schema
- [x] New test: non-vocabulary constraint still rejects non-prefixed keywords (regression)
- [x] All existing tests pass (266 tests across unit + e2e)

## See Also

Consumer PR in extensibility-sdk will follow once this is released.