### PR TITLE
Fix tag-only TSDoc description leakage

### DIFF
--- a/.changeset/green-taxis-help.md
+++ b/.changeset/green-taxis-help.md
@@ -1,0 +1,7 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"formspec": patch
+---
+
+Prevent tag-only TSDoc comments from leaking into emitted schema descriptions.

--- a/packages/build/src/__tests__/class-schema.test.ts
+++ b/packages/build/src/__tests__/class-schema.test.ts
@@ -155,6 +155,9 @@ describe("generateSchemas", () => {
     expect(result.jsonSchema.properties?.["remarksOnly"]).toMatchObject({
       "x-formspec-remarks": "Remarks go to x-formspec-remarks, not description.",
     });
+
+    // tag-only comments should not leak tag text into the description
+    expect(result.jsonSchema.properties?.["modifierTagOnly"]).not.toHaveProperty("description");
   });
 
   it("throws with CONTRADICTING_CONSTRAINTS for contradictory constraints", () => {

--- a/packages/build/src/__tests__/fixtures/class-schema-regressions.ts
+++ b/packages/build/src/__tests__/fixtures/class-schema-regressions.ts
@@ -61,6 +61,9 @@ export class DescriptionPrecedenceForm {
 
   /** @remarks Remarks go to x-formspec-remarks, not description. */
   remarksOnly!: string;
+
+  /** @primaryField */
+  modifierTagOnly!: string;
 }
 
 export class PriceRange {

--- a/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
+++ b/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
@@ -533,6 +533,19 @@ describe("extractJSDocAnnotationNodes", () => {
     expect(descriptions).toHaveLength(0);
   });
 
+  it("does not treat a tag-only comment as summary text", () => {
+    const prop = getInterfacePropertyFromSource(`
+      interface Foo {
+        /** @primaryField */
+        name: string;
+      }
+    `);
+
+    const result = extractJSDocAnnotationNodes(prop);
+    const descriptions = result.filter((n) => n.annotationKind === "description");
+    expect(descriptions).toHaveLength(0);
+  });
+
   it("summary + @remarks produces both description and remarks annotations (spec 002 §2.3)", () => {
     const prop = getInterfacePropertyFromSource(`
       interface Foo {

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -40,6 +40,7 @@
 import * as ts from "typescript";
 import {
   checkSyntheticTagApplication,
+  extractCommentSummaryText,
   extractPathTarget as extractSharedPathTarget,
   getTagDefinition,
   hasTypeSemanticCapability,
@@ -1000,7 +1001,14 @@ export function parseTSDocTags(
       // Summary text → description annotation (spec 002 §2.3)
       {
         const summary = extractPlainText(docComment.summarySection).trim();
-        if (summary !== "") {
+        const sharedSummary = extractCommentSummaryText(commentText);
+
+        // TSDoc leaves unknown/custom modifier tags in the summary text when
+        // they are not registered with the parser. Fall back to the raw
+        // comment projection to detect the "tag-only, no summary" case so
+        // tag text does not leak into JSON Schema descriptions.
+        const hasTagOnlySummary = summary !== "" && sharedSummary === "" && parsedComment.tags.length > 0;
+        if (!hasTagOnlySummary && summary !== "") {
           annotations.push({
             kind: "annotation",
             annotationKind: "description",


### PR DESCRIPTION
## Summary
- prevent tag-only TSDoc comments from leaking modifier text into emitted JSON Schema descriptions
- fall back to raw comment summary parsing when TSDoc treats unknown tags as summary text
- add regression coverage for annotation extraction and schema generation

## Test plan
- `pnpm --filter @formspec/build exec vitest run src/__tests__/ir-jsdoc-constraints.test.ts src/__tests__/class-schema.test.ts`
