### PR TITLE
Register all formspec tags in tsdoc.json

### DIFF
--- a/.changeset/tsdoc-tag-registration.md
+++ b/.changeset/tsdoc-tag-registration.md
@@ -1,0 +1,7 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"formspec": patch
+---
+
+Register all formspec annotation, structure, and ecosystem tags with both tsdoc.json and the programmatic TSDoc parser so mid-prose tag mentions are parsed correctly.

--- a/packages/analysis/src/__tests__/metadata-analysis.test.ts
+++ b/packages/analysis/src/__tests__/metadata-analysis.test.ts
@@ -72,6 +72,33 @@ describe("metadata analysis", () => {
     ).toEqual(expect.arrayContaining(["apiName:default", "displayName:default"]));
   });
 
+  it("treats @apiName mid-prose as a real tag per TSDoc semantics (issue #424)", () => {
+    const { program, sourceFile } = createProgram(`
+      export interface MyRecord {
+        /**
+         * Field with @apiName override mentioned in prose.
+         * @apiName actual_name
+         */
+        myField: string;
+      }
+    `);
+    const declaration = findInterface(sourceFile, "MyRecord");
+    const property = findInterfaceProperty(declaration, "myField");
+
+    const analysis = analyzeMetadataForNode({
+      program,
+      node: property,
+      metadata: {},
+    });
+
+    // TSDoc treats @apiName mid-prose as a block tag — first occurrence wins.
+    // The value is everything from @apiName to the end of the line.
+    expect(analysis?.resolvedMetadata?.apiName).toEqual({
+      value: "override mentioned in prose.",
+      source: "explicit",
+    });
+  });
+
   it("honors an internal logical-name override for inferred metadata", () => {
     const { program, sourceFile } = createProgram(`
       export interface CustomerRecord {

--- a/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
+++ b/packages/build/src/__tests__/ir-jsdoc-constraints.test.ts
@@ -644,6 +644,56 @@ describe("extractJSDocAnnotationNodes", () => {
     });
   });
 
+  it("treats @apiName mid-prose as a real tag per TSDoc semantics (issue #424)", () => {
+    const prop = getInterfacePropertyFromSource(`
+      interface Foo {
+        /**
+         * Field with @apiName override mentioned in prose.
+         * @apiName actual_api_name
+         */
+        name: string;
+      }
+    `);
+
+    const result = extractJSDocAnnotationNodes(prop);
+    const description = result.find((n) => n.annotationKind === "description");
+
+    // TSDoc treats @apiName mid-prose as a block tag, so the summary stops before it.
+    // "Field with" is the prose before the first @apiName tag.
+    expect(description).toMatchObject({
+      annotationKind: "description",
+      value: "Field with",
+    });
+  });
+
+  it("treats @displayName mid-prose as a real tag per TSDoc semantics (issue #424)", () => {
+    const prop = getInterfacePropertyFromSource(`
+      interface Foo {
+        /**
+         * Use the @displayName tag to set a label.
+         * @displayName Actual Label
+         */
+        name: string;
+      }
+    `);
+
+    const result = extractJSDocAnnotationNodes(prop);
+    const displayName = result.find((n) => n.annotationKind === "displayName");
+    const description = result.find((n) => n.annotationKind === "description");
+
+    // TSDoc sees @displayName mid-prose as the first occurrence — first tag wins.
+    // The value is everything after @displayName up to the next tag/line boundary.
+    expect(displayName).toMatchObject({
+      annotationKind: "displayName",
+      value: "tag to set a label.",
+    });
+    // Summary is just the text before the first @displayName
+    expect(description).toMatchObject({
+      annotationKind: "description",
+      value: "Use the",
+    });
+  });
+
   it("parses multiple displayName tags for enum member labels via display-name metadata", () => {
     const prop = getInterfacePropertyFromSource(`
       interface Foo {

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -117,9 +117,23 @@ function createFormSpecTSDocConfig(extensionTagNames: readonly string[] = []): T
     );
   }
 
-  // Register FormSpec metadata and annotation tags so summary extraction
-  // stops at recognized tags without having to scrub emitted descriptions.
-  for (const tagName of ["apiName", "displayName", "format", "placeholder"]) {
+  // Register FormSpec annotation and structure tags so summary extraction
+  // stops at recognized tags and mid-prose mentions are parsed as real
+  // tags per TSDoc semantics. Tags that are standard TSDoc (@description,
+  // @example, @defaultValue, @deprecated) are already registered.
+  for (const tagName of [
+    "apiName",
+    "displayName",
+    "format",
+    "placeholder",
+    "order",
+    "group",
+    "showWhen",
+    "hideWhen",
+    "enableWhen",
+    "disableWhen",
+    "discriminator",
+  ]) {
     config.addTagDefinition(
       new TSDocTagDefinition({
         tagName: "@" + tagName,

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -55,6 +55,76 @@
       "tagName": "@enumOptions",
       "syntaxKind": "block",
       "allowMultiple": true
+    },
+    {
+      "tagName": "@displayName",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@apiName",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@format",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@placeholder",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@order",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@group",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@showWhen",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@hideWhen",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@enableWhen",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@disableWhen",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@defaultValue",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@example",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@discriminator",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@description",
+      "syntaxKind": "block",
+      "allowMultiple": false
     }
   ],
   "supportForTags": {
@@ -68,6 +138,20 @@
     "@minItems": true,
     "@maxItems": true,
     "@pattern": true,
-    "@enumOptions": true
+    "@enumOptions": true,
+    "@displayName": true,
+    "@apiName": true,
+    "@format": true,
+    "@placeholder": true,
+    "@order": true,
+    "@group": true,
+    "@showWhen": true,
+    "@hideWhen": true,
+    "@enableWhen": true,
+    "@disableWhen": true,
+    "@defaultValue": true,
+    "@example": true,
+    "@discriminator": true,
+    "@description": true
   }
 }


### PR DESCRIPTION
## Summary

Only constraint tags (`@minimum`, `@maximum`, etc.) were registered in `tsdoc.json`. This adds all 14 formspec-specific annotation, structure, and ecosystem tags so IDE tooling (TSDoc ESLint rule, hover info) recognizes them and users see mid-prose `@`-tags highlighted as real tags.

Also adds regression tests documenting that TSDoc correctly parses mid-prose `@apiName` and `@displayName` as real tags (per TSDoc semantics). This is the expected behavior — the existing `no-duplicate-tags` ESLint rule catches the resulting duplicates when a tag name appears both in prose and as a dedicated tag.

Relates to stripe/extensibility-sdk#424.

## Test plan

- [x] `@formspec/build` IR JSDoc tests pass (48/48), including 2 new mid-prose tag tests
- [x] `@formspec/analysis` metadata tests pass (133/133), including 1 new mid-prose tag test