### PR TITLE
Allow numeric constraint keywords in vocabulary-mode extensions

### DIFF
--- a/.changeset/allow-numeric-vocabulary.md
+++ b/.changeset/allow-numeric-vocabulary.md
@@ -1,6 +1,7 @@
 ---
 "@formspec/build": patch
 "@formspec/cli": patch
+"@formspec/eslint-plugin": patch
 "formspec": patch
 ---
 

--- a/.changeset/allow-numeric-vocabulary.md
+++ b/.changeset/allow-numeric-vocabulary.md
@@ -1,0 +1,7 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"formspec": patch
+---
+
+Allow numeric constraint keywords (minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf) in vocabulary-mode custom constraints. Enables Integer custom types to emit standard JSON Schema numeric keywords via emitsVocabularyKeywords.

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -559,6 +559,54 @@ describe("Extension API", () => {
       ).toThrow(/may only emit "x-test-\*" JSON Schema keywords/);
     });
 
+    it("allows standard numeric keywords (minimum, maximum) in vocabulary mode", () => {
+      const integerType = defineCustomType({
+        typeName: "Integer",
+        tsTypeNames: ["Integer"],
+        toJsonSchema: () => ({ type: "integer" }),
+      });
+      const integerMinimum = defineConstraint({
+        constraintName: "integerMinimum",
+        compositionRule: "intersect",
+        applicableTypes: ["custom"],
+        emitsVocabularyKeywords: true,
+        toJsonSchema: (payload) => ({ minimum: payload }),
+      });
+      const registry = createExtensionRegistry([
+        defineExtension({
+          extensionId: "x-test/integer",
+          types: [integerType],
+          constraints: [integerMinimum],
+        }),
+      ]);
+
+      const customType: CustomTypeNode = {
+        kind: "custom",
+        typeId: "x-test/integer/Integer",
+        payload: null,
+      };
+      const customCon: CustomConstraintNode = {
+        kind: "constraint",
+        constraintKind: "custom",
+        constraintId: "x-test/integer/integerMinimum",
+        payload: 0,
+        compositionRule: "intersect",
+        provenance: prov(1, "integerMinimum"),
+      };
+
+      const ir = makeIR([makeField("count", customType, [customCon])]);
+      const result = generateJsonSchemaFromIR(ir, {
+        extensionRegistry: registry,
+        vendorPrefix: "x-test",
+      });
+
+      const props = result.properties ?? {};
+      expect(props.count).toMatchObject({
+        type: "integer",
+        minimum: 0,
+      });
+    });
+
     it("rejects vocabulary constraints that overwrite standard JSON Schema keywords", () => {
       const collidingConstraint = defineConstraint({
         constraintName: "Collider",

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -1196,6 +1196,17 @@ function generateCustomType(type: CustomTypeNode, ctx: GeneratorContext): JsonSc
 /**
  * Standard JSON Schema 2020-12 keywords that vocabulary-mode constraints must
  * not overwrite. Prevents accidental corruption of structural schema properties.
+ *
+ * Numeric constraint keywords (`minimum`, `maximum`, `exclusiveMinimum`,
+ * `exclusiveMaximum`, `multipleOf`) are intentionally excluded from this list.
+ * Custom types that emit `{ type: "integer" }` (or other numeric JSON Schema
+ * types) and use `builtinConstraintBroadenings` need to forward numeric
+ * constraints as standard JSON Schema keywords — for example, `Integer` fields
+ * annotated with `@minimum 0` should produce `{ minimum: 0 }`. Blocking those
+ * keywords here would prevent that pattern entirely.
+ *
+ * Schema- and object-structural keywords remain protected because overwriting
+ * them (e.g., `type`, `properties`, `$ref`) could silently corrupt output.
  */
 const JSON_SCHEMA_STRUCTURAL_KEYWORDS = new Set([
   "$schema", "$ref", "$defs", "$id", "$anchor", "$dynamicRef", "$dynamicAnchor",
@@ -1204,7 +1215,6 @@ const JSON_SCHEMA_STRUCTURAL_KEYWORDS = new Set([
   "properties", "patternProperties", "additionalProperties", "required",
   "items", "prefixItems", "additionalItems", "contains",
   "allOf", "oneOf", "anyOf", "not", "if", "then", "else",
-  "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
   "minLength", "maxLength", "pattern",
   "minItems", "maxItems", "uniqueItems",
   "minProperties", "maxProperties",

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -1194,21 +1194,17 @@ function generateCustomType(type: CustomTypeNode, ctx: GeneratorContext): JsonSc
 }
 
 /**
- * Standard JSON Schema 2020-12 keywords that vocabulary-mode constraints must
- * not overwrite. Prevents accidental corruption of structural schema properties.
+ * JSON Schema keywords that vocabulary-mode constraints (`emitsVocabularyKeywords`)
+ * must not overwrite. Includes structural keywords (`type`, `properties`, `$ref`),
+ * annotation keywords (`title`, `description`), and validation keywords for
+ * strings/arrays/objects. Overwriting these could silently corrupt schema output.
  *
- * Numeric constraint keywords (`minimum`, `maximum`, `exclusiveMinimum`,
- * `exclusiveMaximum`, `multipleOf`) are intentionally excluded from this list.
- * Custom types that emit `{ type: "integer" }` (or other numeric JSON Schema
- * types) and use `builtinConstraintBroadenings` need to forward numeric
- * constraints as standard JSON Schema keywords — for example, `Integer` fields
- * annotated with `@minimum 0` should produce `{ minimum: 0 }`. Blocking those
- * keywords here would prevent that pattern entirely.
- *
- * Schema- and object-structural keywords remain protected because overwriting
- * them (e.g., `type`, `properties`, `$ref`) could silently corrupt output.
+ * Numeric validation keywords (`minimum`, `maximum`, `exclusiveMinimum`,
+ * `exclusiveMaximum`, `multipleOf`) are intentionally excluded — custom types
+ * like `Integer` (`{ type: "integer" }`) need to emit these as standard JSON
+ * Schema keywords via `builtinConstraintBroadenings`.
  */
-const JSON_SCHEMA_STRUCTURAL_KEYWORDS = new Set([
+const VOCABULARY_MODE_BLOCKED_KEYWORDS = new Set([
   "$schema", "$ref", "$defs", "$id", "$anchor", "$dynamicRef", "$dynamicAnchor",
   "$vocabulary", "$comment",
   "type", "enum", "const",
@@ -1245,7 +1241,7 @@ function applyCustomConstraint(
     // Guard against accidental collisions with standard JSON Schema keywords.
     const target = schema as Record<string, unknown>;
     for (const [key, value] of Object.entries(extensionSchema)) {
-      if (JSON_SCHEMA_STRUCTURAL_KEYWORDS.has(key)) {
+      if (VOCABULARY_MODE_BLOCKED_KEYWORDS.has(key)) {
         throw new Error(
           `Custom constraint "${constraint.constraintId}" with emitsVocabularyKeywords ` +
           `must not overwrite standard JSON Schema keyword "${key}"`


### PR DESCRIPTION
## Summary

Removes `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, and `multipleOf` from the `JSON_SCHEMA_STRUCTURAL_KEYWORDS` blocklist so custom types that map to `{ type: "integer" }` can emit standard numeric JSON Schema keywords via `emitsVocabularyKeywords: true`.

Without this, an Integer custom type using `@minimum 0` throws: `must not overwrite standard JSON Schema keyword "minimum"`. The numeric keywords are annotation keywords, not structural ones — blocking them was overly conservative.

Needed by stripe/extensibility-sdk#449 to support `@minimum`/`@maximum` on Integer and PositiveInteger custom types.

## Test plan

- [x] All formspec tests pass (1,339 + 266 e2e)