### PR TITLE
Add builtin Integer type with __integerBrand

### DIFF
--- a/.changeset/builtin-integer-type.md
+++ b/.changeset/builtin-integer-type.md
@@ -1,0 +1,9 @@
+---
+"@formspec/core": minor
+"@formspec/build": minor
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Add builtin Integer type with `__integerBrand` symbol. Types branded with this symbol produce `{ type: "integer" }` in JSON Schema and accept standard numeric constraints (`@minimum`, `@maximum`, etc.) natively — no extension registration or constraint broadening needed. Re-tighten the vocabulary keyword blocklist now that Integer is handled by the IR pipeline.

--- a/.changeset/builtin-integer-type.md
+++ b/.changeset/builtin-integer-type.md
@@ -1,8 +1,14 @@
 ---
 "@formspec/core": minor
 "@formspec/build": minor
+"@formspec/analysis": patch
 "@formspec/cli": patch
+"@formspec/config": patch
+"@formspec/dsl": patch
 "@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/runtime": patch
+"@formspec/ts-plugin": patch
 "formspec": patch
 ---
 

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -559,12 +559,7 @@ describe("Extension API", () => {
       ).toThrow(/may only emit "x-test-\*" JSON Schema keywords/);
     });
 
-    it("allows standard numeric keywords (minimum, maximum) in vocabulary mode", () => {
-      const integerType = defineCustomType({
-        typeName: "Integer",
-        tsTypeNames: ["Integer"],
-        toJsonSchema: () => ({ type: "integer" }),
-      });
+    it("rejects vocabulary constraints that emit standard numeric keywords", () => {
       const integerMinimum = defineConstraint({
         constraintName: "integerMinimum",
         compositionRule: "intersect",
@@ -575,14 +570,14 @@ describe("Extension API", () => {
       const registry = createExtensionRegistry([
         defineExtension({
           extensionId: "x-test/integer",
-          types: [integerType],
+          types: [decimalType],
           constraints: [integerMinimum],
         }),
       ]);
 
       const customType: CustomTypeNode = {
         kind: "custom",
-        typeId: "x-test/integer/Integer",
+        typeId: "x-test/integer/Decimal",
         payload: null,
       };
       const customCon: CustomConstraintNode = {
@@ -595,16 +590,12 @@ describe("Extension API", () => {
       };
 
       const ir = makeIR([makeField("count", customType, [customCon])]);
-      const result = generateJsonSchemaFromIR(ir, {
-        extensionRegistry: registry,
-        vendorPrefix: "x-test",
-      });
-
-      const props = result.properties ?? {};
-      expect(props.count).toMatchObject({
-        type: "integer",
-        minimum: 0,
-      });
+      expect(() =>
+        generateJsonSchemaFromIR(ir, {
+          extensionRegistry: registry,
+          vendorPrefix: "x-test",
+        })
+      ).toThrow(/must not overwrite standard JSON Schema keyword "minimum"/);
     });
 
     it("rejects vocabulary constraints that overwrite standard JSON Schema keywords", () => {

--- a/packages/build/src/__tests__/integer-type.test.ts
+++ b/packages/build/src/__tests__/integer-type.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for the builtin Integer type (`number & { readonly [__integerBrand]: true }`).
+ *
+ * Verifies that:
+ *   1. Integer-branded types resolve to `{ type: "integer" }` in JSON Schema.
+ *   2. Numeric constraint TSDoc tags (@minimum, @maximum, etc.) are valid on Integer fields.
+ *   3. Type alias chains ending in Integer still resolve to `"integer"`.
+ *   4. Optional Integer fields are excluded from the root `required` array.
+ *
+ * The `declare const __integerBrand: unique symbol` declaration in each fixture
+ * is structurally identical to the exported symbol from `@formspec/core`. The
+ * class-analyzer detects the brand by the TypeScript-internal property name prefix
+ * `__@___integerBrand` (three underscores), which is produced for any `unique symbol`
+ * variable named `__integerBrand` regardless of where it is declared.
+ *
+ * @see packages/build/src/analyzer/class-analyzer.ts — isIntegerBrandedType
+ * @see packages/core/src/types/integer.ts — Integer type definition
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { generateSchemas, type GenerateSchemasOptions } from "../generators/class-schema.js";
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({
+    ...options,
+    errorReporting: "throw",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixture setup
+// ---------------------------------------------------------------------------
+
+/**
+ * All integer fixture types live in a single temp-dir source file so the
+ * TypeScript program compiles them together with a consistent set of compiler
+ * options. The temp dir is created once in `beforeAll` and torn down in
+ * `afterAll`.
+ */
+let fixturePath: string;
+let tmpDir: string;
+
+const FIXTURE_SOURCE = [
+  // Local unique-symbol brand — structurally identical to @formspec/core's export.
+  "declare const __integerBrand: unique symbol;",
+  "type Integer = number & { readonly [__integerBrand]: true };",
+  "",
+  // 1. Basic Integer field
+  "export interface IntegerFieldsConfig {",
+  "  count: Integer;",
+  "}",
+  "",
+  // 2. Integer with @minimum / @maximum constraints
+  "export interface ConstrainedIntegerConfig {",
+  "  /** @minimum 0 @maximum 100 */",
+  "  percentage: Integer;",
+  "}",
+  "",
+  // 3. Integer alias chain (Percentage → Integer)
+  "type Percentage = Integer;",
+  "export interface AliasChainConfig {",
+  "  score: Percentage;",
+  "}",
+  "",
+  // 4. Optional Integer field
+  "export interface OptionalIntegerConfig {",
+  "  count?: Integer;",
+  "}",
+  "",
+  // 5. Integer with all numeric constraint keywords
+  "export interface AllConstraintsConfig {",
+  "  /** @minimum 0 @maximum 100 @exclusiveMinimum 0 @exclusiveMaximum 100 @multipleOf 5 */",
+  "  value: Integer;",
+  "}",
+].join("\n");
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-integer-type-"));
+
+  fs.writeFileSync(
+    path.join(tmpDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "nodenext",
+          strict: true,
+          skipLibCheck: true,
+        },
+      },
+      null,
+      2
+    )
+  );
+
+  fixturePath = path.join(tmpDir, "fixture.ts");
+  fs.writeFileSync(fixturePath, FIXTURE_SOURCE);
+});
+
+afterAll(() => {
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the JSON Schema for a named property, following any `$ref` into
+ * `$defs`. Returns the schema object at the $ref target if the property
+ * schema only contains a `$ref`, otherwise returns the property schema
+ * directly. Applies only single-level $ref resolution.
+ */
+function resolvePropertySchema(
+  result: ReturnType<typeof generateSchemasOrThrow>,
+  propertyName: string
+): Record<string, unknown> {
+  const properties = result.jsonSchema.properties as Record<string, unknown>;
+  const propSchema = properties[propertyName];
+
+  expect(propSchema, `Missing property "${propertyName}"`).toBeDefined();
+  expect(typeof propSchema).toBe("object");
+  expect(propSchema).not.toBeNull();
+
+  const propRecord = propSchema as Record<string, unknown>;
+  const ref = typeof propRecord["$ref"] === "string" ? propRecord["$ref"] : undefined;
+
+  if (ref === undefined) {
+    return propRecord;
+  }
+
+  expect(ref.startsWith("#/$defs/")).toBe(true);
+  const defName = ref.replace(/^#\/\$defs\//u, "");
+  const defs = result.jsonSchema.$defs ?? {};
+  const def = defs[defName];
+  expect(def, `Missing $defs entry for ${defName}`).toBeDefined();
+  return def as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("builtin Integer type", () => {
+  // -------------------------------------------------------------------------
+  // 1. Basic Integer → type: integer
+  // -------------------------------------------------------------------------
+  describe("basic Integer field", () => {
+    it("emits type:integer for a plain Integer field", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "IntegerFieldsConfig",
+      });
+
+      // The property schema is a $ref into $defs (Integer is a named alias).
+      // The $defs entry for Integer must have type: "integer".
+      // spec: class-analyzer §isIntegerBrandedType → primitiveKind "integer"
+      //       ir-generator §generatePrimitiveType → { type: "integer" }
+      const defSchema = resolvePropertySchema(result, "count");
+      expect(defSchema).toEqual({ type: "integer" });
+    });
+
+    it("includes count in the required array for a required Integer field", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "IntegerFieldsConfig",
+      });
+
+      // count is declared with `!`, so it must be required.
+      expect(result.jsonSchema.required).toContain("count");
+    });
+
+    it("emits $defs.Integer with type:integer", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "IntegerFieldsConfig",
+      });
+
+      const defs = result.jsonSchema.$defs ?? {};
+      // The Integer named alias is registered in $defs.
+      expect(defs).toHaveProperty("Integer");
+      expect(defs["Integer"]).toEqual({ type: "integer" });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Integer with @minimum / @maximum → standard constraint keywords
+  // -------------------------------------------------------------------------
+  describe("Integer with @minimum and @maximum constraints", () => {
+    it("emits type:integer alongside minimum and maximum on a constrained Integer field", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "ConstrainedIntegerConfig",
+      });
+
+      // The property schema carries the constraints alongside the $ref.
+      // The resolved type ($defs/Integer) must still have type: "integer".
+      // spec: spec 003 §2.6 — @minimum N → minimum: N, @maximum N → maximum: N
+      const properties = result.jsonSchema.properties as Record<string, unknown>;
+      const percentageSchema = properties["percentage"] as Record<string, unknown>;
+
+      // Constraints are inlined at property level (co-located with $ref).
+      expect(percentageSchema).toMatchObject({
+        minimum: 0, // spec 003 §2.6: @minimum 0 → minimum: 0
+        maximum: 100, // spec 003 §2.6: @maximum 100 → maximum: 100
+      });
+
+      // The $ref resolves to type: "integer" (not "number").
+      const defSchema = resolvePropertySchema(result, "percentage");
+      expect(defSchema).toEqual({ type: "integer" });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Integer alias chain → still resolves to integer
+  // -------------------------------------------------------------------------
+  describe("Integer alias chain (Percentage → Integer)", () => {
+    it("resolves Percentage (alias of Integer) to type:integer", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "AliasChainConfig",
+      });
+
+      // score: Percentage, where type Percentage = Integer.
+      // The alias chain must terminate at Integer's brand detection, yielding integer.
+      // spec: class-analyzer — transitive alias resolution follows the chain to the branded type
+      const defSchema = resolvePropertySchema(result, "score");
+      expect(defSchema).toEqual({ type: "integer" });
+    });
+
+    it("includes score in required for an alias-chain Integer field", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "AliasChainConfig",
+      });
+
+      expect(result.jsonSchema.required).toContain("score");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Optional Integer → excluded from required
+  // -------------------------------------------------------------------------
+  describe("optional Integer field", () => {
+    it("omits count from required when the Integer field is optional", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "OptionalIntegerConfig",
+      });
+
+      // count?: Integer → field is optional, so it must NOT appear in required.
+      // The property schema itself still resolves to type: "integer".
+      expect(result.jsonSchema.required ?? []).not.toContain("count");
+    });
+
+    it("still resolves the optional Integer field to type:integer", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "OptionalIntegerConfig",
+      });
+
+      const defSchema = resolvePropertySchema(result, "count");
+      expect(defSchema).toEqual({ type: "integer" });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Integer with all numeric constraint keywords
+  // -------------------------------------------------------------------------
+  describe("Integer with all numeric constraint keywords", () => {
+    it("emits minimum, maximum, exclusiveMinimum, exclusiveMaximum, and multipleOf on Integer", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "AllConstraintsConfig",
+      });
+
+      // All five numeric constraint keywords must appear at the property level.
+      // spec 003 §2.6: @minimum, @maximum, @exclusiveMinimum, @exclusiveMaximum, @multipleOf
+      const properties = result.jsonSchema.properties as Record<string, unknown>;
+      const valueSchema = properties["value"] as Record<string, unknown>;
+
+      expect(valueSchema).toMatchObject({
+        minimum: 0, // spec 003 §2.6: @minimum 0
+        maximum: 100, // spec 003 §2.6: @maximum 100
+        exclusiveMinimum: 0, // spec 003 §2.6: @exclusiveMinimum 0
+        exclusiveMaximum: 100, // spec 003 §2.6: @exclusiveMaximum 100
+        multipleOf: 5, // spec 003 §2.6: @multipleOf 5
+      });
+    });
+
+    it("emits type:integer (not type:number) when multipleOf is present on Integer", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "AllConstraintsConfig",
+      });
+
+      // The $defs entry for the Integer type must be type: "integer", not "number".
+      // Integer brand detection must take precedence over multipleOf-based promotion.
+      const defSchema = resolvePropertySchema(result, "value");
+      expect(defSchema["type"]).toBe("integer");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Negative: plain number is NOT treated as Integer
+  // -------------------------------------------------------------------------
+  describe("non-integer numbers are not promoted", () => {
+    it("emits type:number (not type:integer) for a plain number field", () => {
+      // This exercises the negative case: a plain `number` field must NOT be
+      // confused with an Integer-branded field.
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "ConstrainedIntegerConfig",
+      });
+
+      // The ConstrainedIntegerConfig only has Integer fields. Confirm there is
+      // no spurious number-typed $defs entry — the only entry should be Integer.
+      const defs = result.jsonSchema.$defs ?? {};
+      const defNames = Object.keys(defs);
+      expect(defNames).toContain("Integer");
+      // Every $defs entry that has a type keyword must have type: "integer",
+      // not type: "number" — plain number fields don't get a $defs entry here.
+      for (const defName of defNames) {
+        const defValue = defs[defName] as Record<string, unknown>;
+        if (typeof defValue["type"] === "string") {
+          expect(defValue["type"], `$defs/${defName} should be integer not number`).not.toBe(
+            "number"
+          );
+        }
+      }
+    });
+  });
+});

--- a/packages/build/src/__tests__/integer-type.test.ts
+++ b/packages/build/src/__tests__/integer-type.test.ts
@@ -75,6 +75,12 @@ const FIXTURE_SOURCE = [
   "  /** @minimum 0 @maximum 100 @exclusiveMinimum 0 @exclusiveMaximum 100 @multipleOf 5 */",
   "  value: Integer;",
   "}",
+  "",
+  // 6. Mixed: Integer and plain number in the same interface
+  "export interface MixedConfig {",
+  "  integerField: Integer;",
+  "  numberField: number;",
+  "}",
 ].join("\n");
 
 beforeAll(() => {
@@ -172,7 +178,7 @@ describe("builtin Integer type", () => {
         typeName: "IntegerFieldsConfig",
       });
 
-      // count is declared with `!`, so it must be required.
+      // count is a required interface property (not marked optional with `?`).
       expect(result.jsonSchema.required).toContain("count");
     });
 
@@ -334,6 +340,18 @@ describe("builtin Integer type", () => {
           );
         }
       }
+    });
+
+    it("plain number field produces type:number, not type:integer", () => {
+      const result = generateSchemasOrThrow({ filePath: fixturePath, typeName: "MixedConfig" });
+
+      // Integer field → type: "integer"
+      const integerProp = resolvePropertySchema(result, "integerField");
+      expect(integerProp).toHaveProperty("type", "integer");
+
+      // Plain number field → type: "number"
+      const numberProp = resolvePropertySchema(result, "numberField");
+      expect(numberProp).toHaveProperty("type", "number");
     });
   });
 });

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -58,10 +58,10 @@ function isIntersectionType(type: ts.Type): type is ts.IntersectionType {
  * Checks whether a type is branded with `__integerBrand` from `@formspec/core`.
  *
  * Integer-branded types are intersections of `number` with a brand object
- * containing the `__integerBrand` unique symbol. TypeScript represents
- * symbol-keyed properties internally as `__@` + `_` + variableName + `@N`,
- * so `declare const __integerBrand: unique symbol` produces the property name
- * `__@___integerBrand@N` (three underscores between `__@` and `integerBrand`).
+ * containing the `__integerBrand` unique symbol. Detection inspects property
+ * declarations for computed property names referencing an identifier named
+ * `__integerBrand`, avoiding dependence on TypeScript's internal escaped-name
+ * encoding.
  */
 function isIntegerBrandedType(type: ts.Type): boolean {
   if (!type.isIntersection()) {
@@ -75,9 +75,23 @@ function isIntegerBrandedType(type: ts.Type): boolean {
     return false;
   }
 
-  return type.getProperties().some(
-    (prop) => prop.name.startsWith("__@___integerBrand")
-  );
+  return type.getProperties().some((prop) => {
+    const declaration = prop.valueDeclaration ?? prop.declarations?.[0];
+    if (declaration === undefined) {
+      return false;
+    }
+    if (
+      !ts.isPropertySignature(declaration) &&
+      !ts.isPropertyDeclaration(declaration)
+    ) {
+      return false;
+    }
+    const name = declaration.name;
+    if (!ts.isComputedPropertyName(name)) {
+      return false;
+    }
+    return ts.isIdentifier(name.expression) && name.expression.text === "__integerBrand";
+  });
 }
 
 export function isResolvableObjectLikeAliasTypeNode(typeNode: ts.TypeNode): boolean {

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -54,6 +54,32 @@ function isIntersectionType(type: ts.Type): type is ts.IntersectionType {
   return !!(type.flags & ts.TypeFlags.Intersection);
 }
 
+/**
+ * Checks whether a type is branded with `__integerBrand` from `@formspec/core`.
+ *
+ * Integer-branded types are intersections of `number` with a brand object
+ * containing the `__integerBrand` unique symbol. TypeScript represents
+ * symbol-keyed properties internally as `__@` + `_` + variableName + `@N`,
+ * so `declare const __integerBrand: unique symbol` produces the property name
+ * `__@___integerBrand@N` (three underscores between `__@` and `integerBrand`).
+ */
+function isIntegerBrandedType(type: ts.Type): boolean {
+  if (!type.isIntersection()) {
+    return false;
+  }
+
+  const hasNumberBase = type.types.some(
+    (member) => !!(member.flags & ts.TypeFlags.Number)
+  );
+  if (!hasNumberBase) {
+    return false;
+  }
+
+  return type.getProperties().some(
+    (prop) => prop.name.startsWith("__@___integerBrand")
+  );
+}
+
 export function isResolvableObjectLikeAliasTypeNode(typeNode: ts.TypeNode): boolean {
   if (ts.isParenthesizedTypeNode(typeNode)) {
     return isResolvableObjectLikeAliasTypeNode(typeNode.type);
@@ -1796,6 +1822,11 @@ export function resolveTypeNode(
     return primitiveAlias;
   }
 
+  // --- Integer-branded types (must check before Number) ---
+  if (isIntegerBrandedType(type)) {
+    return { kind: "primitive", primitiveKind: "integer" };
+  }
+
   // --- Primitives ---
   if (type.flags & ts.TypeFlags.String) {
     return { kind: "primitive", primitiveKind: "string" };
@@ -1943,7 +1974,8 @@ function tryResolveNamedPrimitiveAlias(
         ts.TypeFlags.BigIntLiteral |
         ts.TypeFlags.Boolean |
         ts.TypeFlags.Null)
-    )
+    ) &&
+    !isIntegerBrandedType(type)
   ) {
     return null;
   }
@@ -2072,6 +2104,9 @@ function resolveAliasedPrimitiveTarget(
     );
   }
 
+  if (isIntegerBrandedType(type)) {
+    return { kind: "primitive", primitiveKind: "integer" };
+  }
   if (type.flags & ts.TypeFlags.String) {
     return { kind: "primitive", primitiveKind: "string" };
   }

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -1195,14 +1195,13 @@ function generateCustomType(type: CustomTypeNode, ctx: GeneratorContext): JsonSc
 
 /**
  * JSON Schema keywords that vocabulary-mode constraints (`emitsVocabularyKeywords`)
- * must not overwrite. Includes structural keywords (`type`, `properties`, `$ref`),
- * annotation keywords (`title`, `description`), and validation keywords for
- * strings/arrays/objects. Overwriting these could silently corrupt schema output.
+ * must not overwrite. Includes all standard JSON Schema 2020-12 keywords:
+ * structural (`type`, `properties`, `$ref`), annotation (`title`, `description`),
+ * and validation (`minimum`, `maximum`, `minLength`, etc.).
  *
- * Numeric validation keywords (`minimum`, `maximum`, `exclusiveMinimum`,
- * `exclusiveMaximum`, `multipleOf`) are intentionally excluded — custom types
- * like `Integer` (`{ type: "integer" }`) need to emit these as standard JSON
- * Schema keywords via `builtinConstraintBroadenings`.
+ * Integer types are now builtin (via `__integerBrand`), so standard numeric
+ * constraints (`@minimum`, `@maximum`, etc.) are handled natively by the IR
+ * pipeline — extensions never need to emit these keywords.
  */
 const VOCABULARY_MODE_BLOCKED_KEYWORDS = new Set([
   "$schema", "$ref", "$defs", "$id", "$anchor", "$dynamicRef", "$dynamicAnchor",
@@ -1211,6 +1210,7 @@ const VOCABULARY_MODE_BLOCKED_KEYWORDS = new Set([
   "properties", "patternProperties", "additionalProperties", "required",
   "items", "prefixItems", "additionalItems", "contains",
   "allOf", "oneOf", "anyOf", "not", "if", "then", "else",
+  "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
   "minLength", "maxLength", "pattern",
   "minItems", "maxItems", "uniqueItems",
   "minProperties", "maxProperties",

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -1195,7 +1195,7 @@ function generateCustomType(type: CustomTypeNode, ctx: GeneratorContext): JsonSc
 
 /**
  * JSON Schema keywords that vocabulary-mode constraints (`emitsVocabularyKeywords`)
- * must not overwrite. Includes all standard JSON Schema 2020-12 keywords:
+ * must not overwrite. Includes standard JSON Schema keywords (2020-12 and legacy):
  * structural (`type`, `properties`, `$ref`), annotation (`title`, `description`),
  * and validation (`minimum`, `maximum`, `minLength`, etc.).
  *

--- a/packages/core/api-report/core.alpha.api.md
+++ b/packages/core/api-report/core.alpha.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+// @public
+export const __integerBrand: unique symbol;
+
 // @beta
 export type AnnotationNode = DisplayNameAnnotationNode | DescriptionAnnotationNode | RemarksAnnotationNode | FormatAnnotationNode | PlaceholderAnnotationNode | DefaultValueAnnotationNode | DeprecatedAnnotationNode | FormatHintAnnotationNode | CustomAnnotationNode;
 
@@ -479,6 +482,11 @@ export interface GroupLayoutNode {
     readonly label: string;
     readonly provenance: Provenance;
 }
+
+// @public
+export type Integer = number & {
+    readonly [__integerBrand]: true;
+};
 
 // @beta
 export const IR_VERSION: "0.1.0";

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+// @public
+export const __integerBrand: unique symbol;
+
 // @beta
 export type AnnotationNode = DisplayNameAnnotationNode | DescriptionAnnotationNode | RemarksAnnotationNode | FormatAnnotationNode | PlaceholderAnnotationNode | DefaultValueAnnotationNode | DeprecatedAnnotationNode | FormatHintAnnotationNode | CustomAnnotationNode;
 
@@ -479,6 +482,11 @@ export interface GroupLayoutNode {
     readonly label: string;
     readonly provenance: Provenance;
 }
+
+// @public
+export type Integer = number & {
+    readonly [__integerBrand]: true;
+};
 
 // @beta
 export const IR_VERSION: "0.1.0";

--- a/packages/core/api-report/core.beta.api.md
+++ b/packages/core/api-report/core.beta.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+// @public
+export const __integerBrand: unique symbol;
+
 // @beta
 export type AnnotationNode = DisplayNameAnnotationNode | DescriptionAnnotationNode | RemarksAnnotationNode | FormatAnnotationNode | PlaceholderAnnotationNode | DefaultValueAnnotationNode | DeprecatedAnnotationNode | FormatHintAnnotationNode | CustomAnnotationNode;
 
@@ -479,6 +482,11 @@ export interface GroupLayoutNode {
     readonly label: string;
     readonly provenance: Provenance;
 }
+
+// @public
+export type Integer = number & {
+    readonly [__integerBrand]: true;
+};
 
 // @beta
 export const IR_VERSION: "0.1.0";

--- a/packages/core/api-report/core.public.api.md
+++ b/packages/core/api-report/core.public.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @public
+export const __integerBrand: unique symbol;
+
+// @public
 export type AnyField = TextField<string> | NumberField<string> | BooleanField<string> | StaticEnumField<string, readonly EnumOptionValue[]> | DynamicEnumField<string, string> | DynamicSchemaField<string> | ArrayField<string, readonly FormElement[]> | ObjectField<string, readonly FormElement[]>;
 
 // @public
@@ -296,6 +299,11 @@ export interface Group<Elements extends readonly FormElement[]> {
     readonly label: string;
     readonly _type: "group";
 }
+
+// @public
+export type Integer = number & {
+    readonly [__integerBrand]: true;
+};
 
 // @public
 export function isArrayField(element: FormElement): element is ArrayField<string, readonly FormElement[]>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,7 +118,10 @@ export type {
 } from "./types/index.js";
 
 // Re-export functions and constants
-export { createInitialFieldState, IR_VERSION } from "./types/index.js";
+export { createInitialFieldState, IR_VERSION, __integerBrand } from "./types/index.js";
+
+// Integer type
+export type { Integer } from "./types/index.js";
 
 // Extension API
 export type {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -136,3 +136,6 @@ export type {
   TypeDefinition,
   FormIR,
 } from "./ir.js";
+
+export type { Integer } from "./integer.js";
+export { __integerBrand } from "./integer.js";

--- a/packages/core/src/types/integer.ts
+++ b/packages/core/src/types/integer.ts
@@ -1,0 +1,31 @@
+/**
+ * Branded integer type for FormSpec schema generation.
+ *
+ * Fields typed as `Integer` (or any type branded with `__integerBrand`)
+ * produce `{ type: "integer" }` in JSON Schema and accept standard
+ * numeric constraints (`@minimum`, `@maximum`, etc.) natively.
+ */
+
+/**
+ * Brand symbol for FormSpec integer types.
+ *
+ * Downstream consumers can create compatible integer types by branding
+ * with this symbol:
+ *
+ * @example
+ * ```typescript
+ * import { __integerBrand } from "@formspec/core";
+ * type PositiveInteger = number & { readonly [__integerBrand]: true };
+ * ```
+ *
+ * @public
+ */
+export declare const __integerBrand: unique symbol;
+
+/**
+ * Branded integer type. Values are `number` at runtime but carry
+ * integer semantics for schema generation (`{ type: "integer" }`).
+ *
+ * @public
+ */
+export type Integer = number & { readonly [__integerBrand]: true };

--- a/packages/core/src/types/integer.ts
+++ b/packages/core/src/types/integer.ts
@@ -20,7 +20,7 @@
  *
  * @public
  */
-export declare const __integerBrand: unique symbol;
+export const __integerBrand: unique symbol = Symbol("__integerBrand");
 
 /**
  * Branded integer type. Values are `number` at runtime but carry


### PR DESCRIPTION
## Summary

Makes Integer a first-class builtin type in FormSpec, replacing the extension-based workaround that required `builtinConstraintBroadenings` + `emitsVocabularyKeywords` + vocabulary keyword blocklist exemptions.

### What changed

- **`@formspec/core`**: New `__integerBrand` unique symbol and `Integer` type (`number & { readonly [__integerBrand]: true }`)
- **`@formspec/build`**: `isIntegerBrandedType()` detects the brand in `resolveTypeNode`, `tryResolveNamedPrimitiveAlias`, and `resolveAliasedPrimitiveTarget`. Resolves to `{ kind: "primitive", primitiveKind: "integer" }` → `{ type: "integer" }` in JSON Schema
- **Vocabulary blocklist**: Re-added `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf` to `VOCABULARY_MODE_BLOCKED_KEYWORDS` — extensions can no longer overwrite standard numeric keywords

### Why

The previous approach (PR #270) opened the vocabulary keyword blocklist so the SDK's Integer extension could emit standard `minimum`/`maximum` keywords. This exposed ALL extensions to that hole. With Integer as a builtin, the type checker infers `numeric-comparable` capability natively, `@minimum`/`@maximum` flow through the standard constraint pipeline, and the blocklist stays tight.

Downstream consumers create compatible integer types by branding with the exported symbol:
```typescript
import { __integerBrand } from "@formspec/core";
type PositiveInteger = number & { readonly [__integerBrand]: true };
```

Supersedes the vocabulary keyword approach in PR #270. The SDK (stripe/extensibility-sdk#449) will remove its Integer extension registration and use the builtin instead.

## Test plan

- [x] 11 new tests: basic Integer → type:integer, @minimum/@maximum, alias chains, optional, all numeric constraints
- [x] All 665 build tests pass (654 existing + 11 new)
- [x] All 266 e2e tests pass
- [x] Vocabulary blocklist test updated to assert numeric keywords are blocked