### PR TITLE
Add brand field to CustomTypeRegistration for structural type detection

### DIFF
--- a/.changeset/brand-registration.md
+++ b/.changeset/brand-registration.md
@@ -1,8 +1,14 @@
 ---
 "@formspec/core": minor
 "@formspec/build": minor
+"@formspec/analysis": patch
 "@formspec/cli": patch
+"@formspec/config": patch
+"@formspec/dsl": patch
 "@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/runtime": patch
+"@formspec/ts-plugin": patch
 "formspec": patch
 ---
 

--- a/.changeset/brand-registration.md
+++ b/.changeset/brand-registration.md
@@ -12,4 +12,4 @@
 "formspec": patch
 ---
 
-Add `brand` field to `CustomTypeRegistration` for structural type detection via unique symbol brands. More reliable than `tsTypeNames` string matching — works with import aliases and prevents name collisions. Phase 2 of the tsTypeNames deprecation roadmap.
+Add `brand` field to `CustomTypeRegistration` for structural type detection via unique symbol brands. More reliable than `tsTypeNames` for aliased branded types because it does not depend on the local type name. Phase 2 of the tsTypeNames deprecation roadmap.

--- a/.changeset/brand-registration.md
+++ b/.changeset/brand-registration.md
@@ -1,0 +1,9 @@
+---
+"@formspec/core": minor
+"@formspec/build": minor
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Add `brand` field to `CustomTypeRegistration` for structural type detection via unique symbol brands. More reliable than `tsTypeNames` string matching — works with import aliases and prevents name collisions. Phase 2 of the tsTypeNames deprecation roadmap.

--- a/packages/build/api-report/build.alpha.api.md
+++ b/packages/build/api-report/build.alpha.api.md
@@ -163,6 +163,10 @@ export interface ExtensionRegistry {
         readonly registration: ConstraintTagRegistration;
     } | undefined;
     findType(typeId: string): CustomTypeRegistration | undefined;
+    findTypeByBrand(brand: string): {
+        readonly extensionId: string;
+        readonly registration: CustomTypeRegistration;
+    } | undefined;
     findTypeByName(typeName: string): {
         readonly extensionId: string;
         readonly registration: CustomTypeRegistration;

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -163,6 +163,10 @@ export interface ExtensionRegistry {
         readonly registration: ConstraintTagRegistration;
     } | undefined;
     findType(typeId: string): CustomTypeRegistration | undefined;
+    findTypeByBrand(brand: string): {
+        readonly extensionId: string;
+        readonly registration: CustomTypeRegistration;
+    } | undefined;
     findTypeByName(typeName: string): {
         readonly extensionId: string;
         readonly registration: CustomTypeRegistration;

--- a/packages/build/api-report/build.beta.api.md
+++ b/packages/build/api-report/build.beta.api.md
@@ -163,6 +163,10 @@ export interface ExtensionRegistry {
         readonly registration: ConstraintTagRegistration;
     } | undefined;
     findType(typeId: string): CustomTypeRegistration | undefined;
+    findTypeByBrand(brand: string): {
+        readonly extensionId: string;
+        readonly registration: CustomTypeRegistration;
+    } | undefined;
     findTypeByName(typeName: string): {
         readonly extensionId: string;
         readonly registration: CustomTypeRegistration;

--- a/packages/build/api-report/build.public.api.md
+++ b/packages/build/api-report/build.public.api.md
@@ -163,6 +163,10 @@ export interface ExtensionRegistry {
         readonly registration: ConstraintTagRegistration;
     } | undefined;
     findType(typeId: string): CustomTypeRegistration | undefined;
+    findTypeByBrand(brand: string): {
+        readonly extensionId: string;
+        readonly registration: CustomTypeRegistration;
+    } | undefined;
     findTypeByName(typeName: string): {
         readonly extensionId: string;
         readonly registration: CustomTypeRegistration;

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -1074,21 +1074,32 @@ describe("Extension API", () => {
         });
       });
 
-      it("falls back to name-based detection when brand is not registered", () => {
-        // Without a brand registration, the type should be unresolvable and
-        // fall through to object/structural resolution (resulting in a non-custom-type schema).
+      it("falls back to name-based detection when the brand is unregistered", () => {
+        // The fixture type is still structurally branded, but this registration
+        // only exposes a TS-facing type name. Resolution must still succeed via
+        // `tsTypeNames` even though there is no brand registration.
+        const nameOnlyType = defineCustomType({
+          typeName: "RegisteredByName",
+          tsTypeNames: ["TestBranded"],
+          toJsonSchema: () => ({ type: "string", format: "name-fallback" }),
+        });
+        const registry = createExtensionRegistry([
+          defineExtension({ extensionId: "x-test/name-only", types: [nameOnlyType] }),
+        ]);
+
         const result = generateSchemas({
           filePath: fixturePath,
           typeName: "Config",
           errorReporting: "throw",
+          extensionRegistry: registry,
           vendorPrefix: "x-test",
-          // No extensionRegistry provided — no brand or name registrations
         });
 
         const properties = result.jsonSchema.properties as Record<string, unknown>;
-        // Without registration, TestBranded is an intersection type resolved structurally.
-        // It must NOT produce `{ format: "test" }` (no extension registry present).
-        expect(properties["field"]).not.toMatchObject({ format: "test" });
+        expect(properties["field"]).toMatchObject({
+          type: "string",
+          format: "name-fallback",
+        });
       });
     });
 
@@ -1122,11 +1133,18 @@ describe("Extension API", () => {
           )
         );
 
-        // The local type name is "AliasedBranded" — completely different from
-        // the registered typeName "RegisteredBranded". Name-based lookup would fail.
+        fs.writeFileSync(
+          path.join(tmpDir, "branded-types.ts"),
+          [
+            "declare const __aliasBrand: unique symbol;",
+            "export type SourceBranded = string & { readonly [__aliasBrand]: true };",
+          ].join("\n")
+        );
+
+        // The consuming file imports the branded type under an alias that does
+        // not match the registered type name. Name-based lookup would fail.
         const fixtureSource = [
-          "declare const __aliasBrand: unique symbol;",
-          "type AliasedBranded = string & { readonly [__aliasBrand]: true };",
+          'import type { SourceBranded as AliasedBranded } from "./branded-types.js";',
           "",
           "export interface AliasConfig {",
           "  field: AliasedBranded;",
@@ -1143,10 +1161,10 @@ describe("Extension API", () => {
         }
       });
 
-      it("detects brand even when TS type name differs from registered typeName", () => {
-        // "RegisteredBranded" does not match the local alias "AliasedBranded",
-        // so name-based lookup fails. Brand detection must succeed instead.
-        // spec: class-analyzer §resolveBrandedCustomType → works with aliased types
+      it("detects brand through an imported alias when the registered typeName differs", () => {
+        // "RegisteredBranded" does not match the imported alias "AliasedBranded",
+        // so the new brand-based path must succeed for the field to resolve.
+        // spec: class-analyzer §resolveBrandedCustomType → works with aliased imports
         const registeredType = defineCustomType({
           typeName: "RegisteredBranded",
           brand: "__aliasBrand",
@@ -1201,86 +1219,143 @@ describe("Extension API", () => {
         // If someone writes `type Bad = string & { __testBrand: true }` (string key,
         // not [__testBrand] computed key), brand detection must NOT fire.
         const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-string-key-"));
-        const fixturePath = path.join(tmpDir, "string-key-brand.ts");
-        fs.writeFileSync(
-          fixturePath,
-          [
-            '// String-keyed property — NOT a computed symbol key',
-            'type FakeBranded = string & { __fakeBrand: true };',
-            '',
-            'export interface FakeConfig {',
-            '  field: FakeBranded;',
-            '}',
-          ].join("\n")
-        );
 
-        const fakeType = defineCustomType({
-          typeName: "Fake",
-          brand: "__fakeBrand",
-          toJsonSchema: () => ({ type: "string", format: "fake" }),
-        });
-        const registry = createExtensionRegistry([
-          defineExtension({ extensionId: "x-test/fake", types: [fakeType] }),
-        ]);
+        try {
+          const fixturePath = path.join(tmpDir, "string-key-brand.ts");
+          fs.writeFileSync(
+            fixturePath,
+            [
+              '// String-keyed property — NOT a computed symbol key',
+              'type FakeBranded = string & { __fakeBrand: true };',
+              '',
+              'export interface FakeConfig {',
+              '  field: FakeBranded;',
+              '}',
+            ].join("\n")
+          );
 
-        const result = generateSchemas({
-          filePath: fixturePath,
-          typeName: "FakeConfig",
-          errorReporting: "throw",
-          extensionRegistry: registry,
-          vendorPrefix: "x-test",
-        });
+          const fakeType = defineCustomType({
+            typeName: "Fake",
+            brand: "__fakeBrand",
+            toJsonSchema: () => ({ type: "string", format: "fake" }),
+          });
+          const registry = createExtensionRegistry([
+            defineExtension({ extensionId: "x-test/fake", types: [fakeType] }),
+          ]);
 
-        const properties = result.jsonSchema.properties as Record<string, unknown>;
-        // String-keyed __fakeBrand is NOT a computed property name,
-        // so brand detection must not fire
-        expect(properties["field"]).not.toMatchObject({ format: "fake" });
+          const result = generateSchemas({
+            filePath: fixturePath,
+            typeName: "FakeConfig",
+            errorReporting: "throw",
+            extensionRegistry: registry,
+            vendorPrefix: "x-test",
+          });
 
-        fs.rmSync(tmpDir, { recursive: true });
+          const properties = result.jsonSchema.properties as Record<string, unknown>;
+          // String-keyed __fakeBrand is NOT a computed property name,
+          // so brand detection must not fire
+          expect(properties["field"]).not.toMatchObject({ format: "fake" });
+        } finally {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
       });
 
-      it("brand + tsTypeNames: name-based resolution takes priority when name matches", () => {
+      it("keeps scanning computed symbol keys until it finds a registered brand", () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-multiple-symbols-"));
+
+        try {
+          const fixturePath = path.join(tmpDir, "multiple-symbol-brands.ts");
+          fs.writeFileSync(
+            fixturePath,
+            [
+              'declare const __otherBrand: unique symbol;',
+              'declare const __realBrand: unique symbol;',
+              'type MultiBranded = string & { readonly [__otherBrand]: true; readonly [__realBrand]: true };',
+              '',
+              'export interface MultiBrandConfig {',
+              '  field: MultiBranded;',
+              '}',
+            ].join("\n")
+          );
+
+          const registeredType = defineCustomType({
+            typeName: "RegisteredBranded",
+            brand: "__realBrand",
+            toJsonSchema: () => ({ type: "string", format: "multi-brand" }),
+          });
+          const registry = createExtensionRegistry([
+            defineExtension({ extensionId: "x-test/multi-brand", types: [registeredType] }),
+          ]);
+
+          const result = generateSchemas({
+            filePath: fixturePath,
+            typeName: "MultiBrandConfig",
+            errorReporting: "throw",
+            extensionRegistry: registry,
+            vendorPrefix: "x-test",
+          });
+
+          const properties = result.jsonSchema.properties as Record<string, unknown>;
+          expect(properties["field"]).toMatchObject({
+            type: "string",
+            format: "multi-brand",
+          });
+        } finally {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+      });
+
+      it("prefers the name-based registration when name and brand could both match", () => {
         const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-dual-"));
-        const fixturePath = path.join(tmpDir, "dual-registration.ts");
-        fs.writeFileSync(
-          fixturePath,
-          [
-            'declare const __dualBrand: unique symbol;',
-            'type DualType = string & { readonly [__dualBrand]: true };',
-            '',
-            'export interface DualConfig {',
-            '  field: DualType;',
-            '}',
-          ].join("\n")
-        );
 
-        const dualType = defineCustomType({
-          typeName: "DualType",
-          tsTypeNames: ["DualType"],
-          brand: "__dualBrand",
-          toJsonSchema: () => ({ type: "string", format: "dual" }),
-        });
-        const registry = createExtensionRegistry([
-          defineExtension({ extensionId: "x-test/dual", types: [dualType] }),
-        ]);
+        try {
+          const fixturePath = path.join(tmpDir, "dual-registration.ts");
+          fs.writeFileSync(
+            fixturePath,
+            [
+              'declare const __dualBrand: unique symbol;',
+              'type DualType = string & { readonly [__dualBrand]: true };',
+              '',
+              'export interface DualConfig {',
+              '  field: DualType;',
+              '}',
+            ].join("\n")
+          );
 
-        const result = generateSchemas({
-          filePath: fixturePath,
-          typeName: "DualConfig",
-          errorReporting: "throw",
-          extensionRegistry: registry,
-          vendorPrefix: "x-test",
-        });
+          const nameMatchedType = defineCustomType({
+            typeName: "NameMatchedType",
+            tsTypeNames: ["DualType"],
+            toJsonSchema: () => ({ type: "string", format: "name-wins" }),
+          });
+          const brandMatchedType = defineCustomType({
+            typeName: "BrandMatchedType",
+            brand: "__dualBrand",
+            toJsonSchema: () => ({ type: "string", format: "brand-wins" }),
+          });
+          const registry = createExtensionRegistry([
+            defineExtension({
+              extensionId: "x-test/dual",
+              types: [nameMatchedType, brandMatchedType],
+            }),
+          ]);
 
-        const properties = result.jsonSchema.properties as Record<string, unknown>;
-        // With both brand and tsTypeNames, name-based resolution runs first
-        // and succeeds — produces the same result either way
-        expect(properties["field"]).toMatchObject({
-          type: "string",
-          format: "dual",
-        });
+          const result = generateSchemas({
+            filePath: fixturePath,
+            typeName: "DualConfig",
+            errorReporting: "throw",
+            extensionRegistry: registry,
+            vendorPrefix: "x-test",
+          });
 
-        fs.rmSync(tmpDir, { recursive: true });
+          const properties = result.jsonSchema.properties as Record<string, unknown>;
+          // If brand resolution ran first, this would emit `brand-wins` instead.
+          expect(properties["field"]).toMatchObject({
+            type: "string",
+            format: "name-wins",
+          });
+        } finally {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
       });
     });
   });

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -1192,5 +1192,102 @@ describe("Extension API", () => {
         expect(registry.findTypeByBrand("Decimal")).toBeUndefined();
       });
     });
+
+    // -------------------------------------------------------------------------
+    // 10f. Edge cases for brand detection robustness
+    // -------------------------------------------------------------------------
+    describe("brand detection edge cases", () => {
+      it("does not match a string-keyed property with the same name as a registered brand", () => {
+        // If someone writes `type Bad = string & { __testBrand: true }` (string key,
+        // not [__testBrand] computed key), brand detection must NOT fire.
+        let tmpDir: string;
+        let fixturePath: string;
+
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-string-key-"));
+        fixturePath = path.join(tmpDir, "string-key-brand.ts");
+        fs.writeFileSync(
+          fixturePath,
+          [
+            '// String-keyed property — NOT a computed symbol key',
+            'type FakeBranded = string & { __fakeBrand: true };',
+            '',
+            'export interface FakeConfig {',
+            '  field: FakeBranded;',
+            '}',
+          ].join("\n")
+        );
+
+        const fakeType = defineCustomType({
+          typeName: "Fake",
+          brand: "__fakeBrand",
+          toJsonSchema: () => ({ type: "string", format: "fake" }),
+        });
+        const registry = createExtensionRegistry([
+          defineExtension({ extensionId: "x-test/fake", types: [fakeType] }),
+        ]);
+
+        const result = generateSchemas({
+          filePath: fixturePath,
+          typeName: "FakeConfig",
+          errorReporting: "throw",
+          extensionRegistry: registry,
+          vendorPrefix: "x-test",
+        });
+
+        const properties = result.jsonSchema.properties as Record<string, unknown>;
+        // String-keyed __fakeBrand is NOT a computed property name,
+        // so brand detection must not fire
+        expect(properties["field"]).not.toMatchObject({ format: "fake" });
+
+        fs.rmSync(tmpDir, { recursive: true });
+      });
+
+      it("brand + tsTypeNames: name-based resolution takes priority when name matches", () => {
+        let tmpDir: string;
+        let fixturePath: string;
+
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-dual-"));
+        fixturePath = path.join(tmpDir, "dual-registration.ts");
+        fs.writeFileSync(
+          fixturePath,
+          [
+            'declare const __dualBrand: unique symbol;',
+            'type DualType = string & { readonly [__dualBrand]: true };',
+            '',
+            'export interface DualConfig {',
+            '  field: DualType;',
+            '}',
+          ].join("\n")
+        );
+
+        const dualType = defineCustomType({
+          typeName: "DualType",
+          tsTypeNames: ["DualType"],
+          brand: "__dualBrand",
+          toJsonSchema: () => ({ type: "string", format: "dual" }),
+        });
+        const registry = createExtensionRegistry([
+          defineExtension({ extensionId: "x-test/dual", types: [dualType] }),
+        ]);
+
+        const result = generateSchemas({
+          filePath: fixturePath,
+          typeName: "DualConfig",
+          errorReporting: "throw",
+          extensionRegistry: registry,
+          vendorPrefix: "x-test",
+        });
+
+        const properties = result.jsonSchema.properties as Record<string, unknown>;
+        // With both brand and tsTypeNames, name-based resolution runs first
+        // and succeeds — produces the same result either way
+        expect(properties["field"]).toMatchObject({
+          type: "string",
+          format: "dual",
+        });
+
+        fs.rmSync(tmpDir, { recursive: true });
+      });
+    });
   });
 });

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -1200,11 +1200,8 @@ describe("Extension API", () => {
       it("does not match a string-keyed property with the same name as a registered brand", () => {
         // If someone writes `type Bad = string & { __testBrand: true }` (string key,
         // not [__testBrand] computed key), brand detection must NOT fire.
-        let tmpDir: string;
-        let fixturePath: string;
-
-        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-string-key-"));
-        fixturePath = path.join(tmpDir, "string-key-brand.ts");
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-string-key-"));
+        const fixturePath = path.join(tmpDir, "string-key-brand.ts");
         fs.writeFileSync(
           fixturePath,
           [
@@ -1243,11 +1240,8 @@ describe("Extension API", () => {
       });
 
       it("brand + tsTypeNames: name-based resolution takes priority when name matches", () => {
-        let tmpDir: string;
-        let fixturePath: string;
-
-        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-dual-"));
-        fixturePath = path.join(tmpDir, "dual-registration.ts");
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-dual-"));
+        const fixturePath = path.join(tmpDir, "dual-registration.ts");
         fs.writeFileSync(
           fixturePath,
           [

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -978,6 +978,19 @@ describe("Extension API", () => {
       });
     });
 
+    it("rejects the reserved __integerBrand", () => {
+      const integerType = defineCustomType({
+        typeName: "MyInteger",
+        brand: "__integerBrand",
+        toJsonSchema: () => ({ type: "integer" }),
+      });
+      expect(() =>
+        createExtensionRegistry([
+          defineExtension({ extensionId: "x-test/reserved", types: [integerType] }),
+        ])
+      ).toThrow(/reserved for the builtin Integer type/);
+    });
+
     // -------------------------------------------------------------------------
     // 10c. Brand-based schema generation (integration test with real TS program)
     //

--- a/packages/build/src/__tests__/extension-api.test.ts
+++ b/packages/build/src/__tests__/extension-api.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, it, expect } from "vitest";
 import {
   defineExtension,
   defineCustomType,
@@ -21,6 +24,7 @@ import type {
 import { createExtensionRegistry } from "../extensions/index.js";
 import { generateJsonSchemaFromIR } from "../json-schema/ir-generator.js";
 import { validateIR } from "../validate/index.js";
+import { generateSchemas } from "../generators/class-schema.js";
 
 // =============================================================================
 // HELPERS
@@ -887,6 +891,292 @@ describe("Extension API", () => {
       const result = currencyConstraint.toJsonSchema("EUR", "x-acme");
       expect(result).toEqual({
         "x-acme-currency": "EUR",
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 10. Brand-based type registration and detection
+  // ---------------------------------------------------------------------------
+
+  describe("brand-based type registration", () => {
+    // -------------------------------------------------------------------------
+    // 10a. Registry lookup by brand
+    // -------------------------------------------------------------------------
+    describe("findTypeByBrand", () => {
+      it("returns the registration for a known brand", () => {
+        const brandedType = defineCustomType({
+          typeName: "Decimal",
+          brand: "__decimalBrand",
+          toJsonSchema: (_payload, vendorPrefix) => ({
+            type: "string",
+            [`${vendorPrefix}-decimal`]: true,
+          }),
+        });
+        const registry = createExtensionRegistry([
+          defineExtension({ extensionId: "x-test/branded", types: [brandedType] }),
+        ]);
+
+        // brand: "__decimalBrand" → registered under that identifier
+        const result = registry.findTypeByBrand("__decimalBrand");
+        expect(result).toBeDefined();
+        expect(result?.extensionId).toBe("x-test/branded");
+        expect(result?.registration).toBe(brandedType);
+      });
+
+      it("returns undefined for an unknown brand", () => {
+        const registry = createExtensionRegistry([monetaryExtension]);
+        // monetaryExtension has no brand registrations
+        expect(registry.findTypeByBrand("__unknownBrand")).toBeUndefined();
+      });
+
+      it("returns undefined when no types are registered with brands", () => {
+        const registry = createExtensionRegistry([]);
+        expect(registry.findTypeByBrand("__anyBrand")).toBeUndefined();
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // 10b. Duplicate brand detection
+    // -------------------------------------------------------------------------
+    describe("duplicate brand", () => {
+      it("throws when two types within the same extension share a brand", () => {
+        const typeA = defineCustomType({
+          typeName: "TypeA",
+          brand: "__sharedBrand",
+          toJsonSchema: () => ({ type: "string" }),
+        });
+        const typeB = defineCustomType({
+          typeName: "TypeB",
+          brand: "__sharedBrand",
+          toJsonSchema: () => ({ type: "number" }),
+        });
+        expect(() =>
+          createExtensionRegistry([
+            defineExtension({ extensionId: "x-test/dup", types: [typeA, typeB] }),
+          ])
+        ).toThrow('Duplicate custom type brand: "__sharedBrand"');
+      });
+
+      it("throws when two types across different extensions share a brand", () => {
+        const typeA = defineCustomType({
+          typeName: "TypeA",
+          brand: "__sharedBrand",
+          toJsonSchema: () => ({ type: "string" }),
+        });
+        const typeB = defineCustomType({
+          typeName: "TypeB",
+          brand: "__sharedBrand",
+          toJsonSchema: () => ({ type: "number" }),
+        });
+        expect(() =>
+          createExtensionRegistry([
+            defineExtension({ extensionId: "x-test/ext1", types: [typeA] }),
+            defineExtension({ extensionId: "x-test/ext2", types: [typeB] }),
+          ])
+        ).toThrow('Duplicate custom type brand: "__sharedBrand"');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // 10c. Brand-based schema generation (integration test with real TS program)
+    //
+    // The fixture defines a `unique symbol` brand and uses it as a computed
+    // property key in a branded intersection type. The extension registers the
+    // type with `brand: "__testBrand"`. The class-analyzer must detect the brand
+    // structurally (via property declarations) and resolve the field to the
+    // correct custom type, emitting `{ type: "string", format: "test" }`.
+    // -------------------------------------------------------------------------
+    describe("brand detection in schema generation", () => {
+      let tmpDir: string;
+      let fixturePath: string;
+
+      beforeAll(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-brand-detection-"));
+
+        fs.writeFileSync(
+          path.join(tmpDir, "tsconfig.json"),
+          JSON.stringify(
+            {
+              compilerOptions: {
+                target: "ES2022",
+                module: "NodeNext",
+                moduleResolution: "nodenext",
+                strict: true,
+                skipLibCheck: true,
+              },
+            },
+            null,
+            2
+          )
+        );
+
+        const fixtureSource = [
+          "declare const __testBrand: unique symbol;",
+          "type TestBranded = string & { readonly [__testBrand]: true };",
+          "",
+          "export interface Config {",
+          "  field: TestBranded;",
+          "}",
+        ].join("\n");
+
+        fixturePath = path.join(tmpDir, "fixture.ts");
+        fs.writeFileSync(fixturePath, fixtureSource);
+      });
+
+      afterAll(() => {
+        if (fs.existsSync(tmpDir)) {
+          fs.rmSync(tmpDir, { recursive: true });
+        }
+      });
+
+      it("resolves a brand-registered custom type to its JSON Schema via brand detection", () => {
+        // Register the type using the brand identifier that matches the unique symbol
+        // declared in the fixture source. The brand-based resolver checks for a
+        // computed property named `__testBrand` on the intersection type.
+        // spec: class-analyzer §resolveBrandedCustomType → custom type IR node
+        const testBrandedType = defineCustomType({
+          typeName: "TestBranded",
+          brand: "__testBrand",
+          toJsonSchema: () => ({ type: "string", format: "test" }),
+        });
+        const registry = createExtensionRegistry([
+          defineExtension({ extensionId: "x-test/branded", types: [testBrandedType] }),
+        ]);
+
+        const result = generateSchemas({
+          filePath: fixturePath,
+          typeName: "Config",
+          errorReporting: "throw",
+          extensionRegistry: registry,
+          vendorPrefix: "x-test",
+        });
+
+        // The field `field: TestBranded` must resolve via brand detection to
+        // the registered custom type, which emits `{ type: "string", format: "test" }`.
+        const properties = result.jsonSchema.properties as Record<string, unknown>;
+        expect(properties["field"]).toMatchObject({
+          type: "string",  // per toJsonSchema above
+          format: "test",  // per toJsonSchema above
+        });
+      });
+
+      it("falls back to name-based detection when brand is not registered", () => {
+        // Without a brand registration, the type should be unresolvable and
+        // fall through to object/structural resolution (resulting in a non-custom-type schema).
+        const result = generateSchemas({
+          filePath: fixturePath,
+          typeName: "Config",
+          errorReporting: "throw",
+          vendorPrefix: "x-test",
+          // No extensionRegistry provided — no brand or name registrations
+        });
+
+        const properties = result.jsonSchema.properties as Record<string, unknown>;
+        // Without registration, TestBranded is an intersection type resolved structurally.
+        // It must NOT produce `{ format: "test" }` (no extension registry present).
+        expect(properties["field"]).not.toMatchObject({ format: "test" });
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // 10d. Brand takes priority over name when name doesn't match
+    //
+    // Register a type with `brand` only (no `tsTypeNames`). Import it under an
+    // alias so the name-based lookup would fail. Verify brand detection succeeds.
+    // -------------------------------------------------------------------------
+    describe("brand detection works regardless of import alias", () => {
+      let tmpDir: string;
+      let fixturePath: string;
+
+      beforeAll(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-brand-alias-"));
+
+        fs.writeFileSync(
+          path.join(tmpDir, "tsconfig.json"),
+          JSON.stringify(
+            {
+              compilerOptions: {
+                target: "ES2022",
+                module: "NodeNext",
+                moduleResolution: "nodenext",
+                strict: true,
+                skipLibCheck: true,
+              },
+            },
+            null,
+            2
+          )
+        );
+
+        // The local type name is "AliasedBranded" — completely different from
+        // the registered typeName "RegisteredBranded". Name-based lookup would fail.
+        const fixtureSource = [
+          "declare const __aliasBrand: unique symbol;",
+          "type AliasedBranded = string & { readonly [__aliasBrand]: true };",
+          "",
+          "export interface AliasConfig {",
+          "  field: AliasedBranded;",
+          "}",
+        ].join("\n");
+
+        fixturePath = path.join(tmpDir, "fixture.ts");
+        fs.writeFileSync(fixturePath, fixtureSource);
+      });
+
+      afterAll(() => {
+        if (fs.existsSync(tmpDir)) {
+          fs.rmSync(tmpDir, { recursive: true });
+        }
+      });
+
+      it("detects brand even when TS type name differs from registered typeName", () => {
+        // "RegisteredBranded" does not match the local alias "AliasedBranded",
+        // so name-based lookup fails. Brand detection must succeed instead.
+        // spec: class-analyzer §resolveBrandedCustomType → works with aliased types
+        const registeredType = defineCustomType({
+          typeName: "RegisteredBranded",
+          brand: "__aliasBrand",
+          toJsonSchema: () => ({ type: "string", format: "alias-test" }),
+        });
+        const registry = createExtensionRegistry([
+          defineExtension({ extensionId: "x-test/alias", types: [registeredType] }),
+        ]);
+
+        const result = generateSchemas({
+          filePath: fixturePath,
+          typeName: "AliasConfig",
+          errorReporting: "throw",
+          extensionRegistry: registry,
+          vendorPrefix: "x-test",
+        });
+
+        const properties = result.jsonSchema.properties as Record<string, unknown>;
+        // Brand detection resolves to "RegisteredBranded" via the __aliasBrand symbol,
+        // which emits { type: "string", format: "alias-test" }.
+        expect(properties["field"]).toMatchObject({
+          type: "string",
+          format: "alias-test",
+        });
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // 10e. Type without brand still works via tsTypeNames
+    // -------------------------------------------------------------------------
+    describe("name-based fallback still works when no brand is provided", () => {
+      it("resolves a type without brand via tsTypeNames", () => {
+        // decimalType has no brand; it should still be findable by name
+        const registry = createExtensionRegistry([monetaryExtension]);
+
+        // Name-based lookup must still work — brand field is undefined
+        const result = registry.findTypeByName("Decimal");
+        expect(result).toBeDefined();
+        expect(result?.extensionId).toBe("x-stripe/monetary");
+        expect(result?.registration).toBe(decimalType);
+
+        // Brand lookup for a name the type was not registered with must return undefined
+        expect(registry.findTypeByBrand("Decimal")).toBeUndefined();
       });
     });
   });

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -55,13 +55,35 @@ function isIntersectionType(type: ts.Type): type is ts.IntersectionType {
 }
 
 /**
+ * Extracts the brand identifier text from an intersection type's computed
+ * property names. Returns the first matching identifier or `null`.
+ *
+ * Shared by both `isIntegerBrandedType` (builtin) and `resolveBrandedCustomType`
+ * (extension). Walks `type.getProperties()` looking for computed property names
+ * backed by plain identifiers — the standard `unique symbol` brand pattern.
+ */
+function findBrandIdentifier(type: ts.Type): string | null {
+  if (!type.isIntersection()) {
+    return null;
+  }
+
+  for (const prop of type.getProperties()) {
+    const decl = prop.valueDeclaration ?? prop.declarations?.[0];
+    if (decl === undefined) continue;
+    if (!ts.isPropertySignature(decl) && !ts.isPropertyDeclaration(decl)) continue;
+    if (!ts.isComputedPropertyName(decl.name)) continue;
+    if (!ts.isIdentifier(decl.name.expression)) continue;
+    return decl.name.expression.text;
+  }
+
+  return null;
+}
+
+/**
  * Checks whether a type is branded with `__integerBrand` from `@formspec/core`.
  *
  * Integer-branded types are intersections of `number` with a brand object
- * containing the `__integerBrand` unique symbol. Detection inspects property
- * declarations for computed property names referencing an identifier named
- * `__integerBrand`, avoiding dependence on TypeScript's internal escaped-name
- * encoding.
+ * containing the `__integerBrand` unique symbol.
  */
 function isIntegerBrandedType(type: ts.Type): boolean {
   if (!type.isIntersection()) {
@@ -75,23 +97,7 @@ function isIntegerBrandedType(type: ts.Type): boolean {
     return false;
   }
 
-  return type.getProperties().some((prop) => {
-    const declaration = prop.valueDeclaration ?? prop.declarations?.[0];
-    if (declaration === undefined) {
-      return false;
-    }
-    if (
-      !ts.isPropertySignature(declaration) &&
-      !ts.isPropertyDeclaration(declaration)
-    ) {
-      return false;
-    }
-    const name = declaration.name;
-    if (!ts.isComputedPropertyName(name)) {
-      return false;
-    }
-    return ts.isIdentifier(name.expression) && name.expression.text === "__integerBrand";
-  });
+  return findBrandIdentifier(type) === "__integerBrand";
 }
 
 /**
@@ -99,40 +105,36 @@ function isIntegerBrandedType(type: ts.Type): boolean {
  * by inspecting computed property names for a brand identifier match.
  *
  * This is more robust than name-based lookup because it works even when the
- * type is imported under an alias. Detection inspects property declarations for
- * computed property names whose expression is an identifier matching a registered
- * brand string.
+ * type is imported under an alias. Brand detection is attempted after name-based
+ * resolution as a structural fallback.
  *
  * Returns `null` if the type is not an intersection, has no branded properties,
- * or no registered brand matches.
+ * or no registered brand matches. Note: the builtin `__integerBrand` is reserved
+ * and handled separately by `isIntegerBrandedType` — extensions cannot register it.
  */
 function resolveBrandedCustomType(
   type: ts.Type,
   extensionRegistry: ExtensionRegistry | undefined
 ): TypeNode | null {
-  if (extensionRegistry === undefined || !type.isIntersection()) {
+  if (extensionRegistry === undefined) {
     return null;
   }
 
-  for (const prop of type.getProperties()) {
-    const decl = prop.valueDeclaration ?? prop.declarations?.[0];
-    if (decl === undefined) continue;
-    if (!ts.isPropertySignature(decl) && !ts.isPropertyDeclaration(decl)) continue;
-    if (!ts.isComputedPropertyName(decl.name)) continue;
-    if (!ts.isIdentifier(decl.name.expression)) continue;
-
-    const brandName = decl.name.expression.text;
-    const registration = extensionRegistry.findTypeByBrand(brandName);
-    if (registration !== undefined) {
-      return {
-        kind: "custom",
-        typeId: `${registration.extensionId}/${registration.registration.typeName}`,
-        payload: null,
-      };
-    }
+  const brand = findBrandIdentifier(type);
+  if (brand === null) {
+    return null;
   }
 
-  return null;
+  const registration = extensionRegistry.findTypeByBrand(brand);
+  if (registration === undefined) {
+    return null;
+  }
+
+  return {
+    kind: "custom",
+    typeId: `${registration.extensionId}/${registration.registration.typeName}`,
+    payload: null,
+  };
 }
 
 export function isResolvableObjectLikeAliasTypeNode(typeNode: ts.TypeNode): boolean {

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -94,6 +94,47 @@ function isIntegerBrandedType(type: ts.Type): boolean {
   });
 }
 
+/**
+ * Resolves a TypeScript intersection type to an extension-registered custom type
+ * by inspecting computed property names for a brand identifier match.
+ *
+ * This is more robust than name-based lookup because it works even when the
+ * type is imported under an alias. Detection inspects property declarations for
+ * computed property names whose expression is an identifier matching a registered
+ * brand string.
+ *
+ * Returns `null` if the type is not an intersection, has no branded properties,
+ * or no registered brand matches.
+ */
+function resolveBrandedCustomType(
+  type: ts.Type,
+  extensionRegistry: ExtensionRegistry | undefined
+): TypeNode | null {
+  if (extensionRegistry === undefined || !type.isIntersection()) {
+    return null;
+  }
+
+  for (const prop of type.getProperties()) {
+    const decl = prop.valueDeclaration ?? prop.declarations?.[0];
+    if (decl === undefined) continue;
+    if (!ts.isPropertySignature(decl) && !ts.isPropertyDeclaration(decl)) continue;
+    if (!ts.isComputedPropertyName(decl.name)) continue;
+    if (!ts.isIdentifier(decl.name.expression)) continue;
+
+    const brandName = decl.name.expression.text;
+    const registration = extensionRegistry.findTypeByBrand(brandName);
+    if (registration !== undefined) {
+      return {
+        kind: "custom",
+        typeId: `${registration.extensionId}/${registration.registration.typeName}`,
+        payload: null,
+      };
+    }
+  }
+
+  return null;
+}
+
 export function isResolvableObjectLikeAliasTypeNode(typeNode: ts.TypeNode): boolean {
   if (ts.isParenthesizedTypeNode(typeNode)) {
     return isResolvableObjectLikeAliasTypeNode(typeNode.type);
@@ -1820,6 +1861,10 @@ export function resolveTypeNode(
   const customType = resolveRegisteredCustomType(sourceNode, extensionRegistry, checker);
   if (customType) {
     return customType;
+  }
+  const brandedCustomType = resolveBrandedCustomType(type, extensionRegistry);
+  if (brandedCustomType) {
+    return brandedCustomType;
   }
   const primitiveAlias = tryResolveNamedPrimitiveAlias(
     type,

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -127,13 +127,15 @@ function resolveBrandedCustomType(
 
   for (const brand of collectBrandIdentifiers(type)) {
     const registration = extensionRegistry.findTypeByBrand(brand);
-    if (registration !== undefined) {
-      return {
-        kind: "custom",
-        typeId: `${registration.extensionId}/${registration.registration.typeName}`,
-        payload: null,
-      };
+    if (registration === undefined) {
+      continue;
     }
+
+    return {
+      kind: "custom",
+      typeId: `${registration.extensionId}/${registration.registration.typeName}`,
+      payload: null,
+    };
   }
 
   return null;

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -55,28 +55,33 @@ function isIntersectionType(type: ts.Type): type is ts.IntersectionType {
 }
 
 /**
- * Extracts the brand identifier text from an intersection type's computed
- * property names. Returns the first matching identifier or `null`.
+ * Collects all brand identifier texts from an intersection type's computed
+ * property names.
  *
  * Shared by both `isIntegerBrandedType` (builtin) and `resolveBrandedCustomType`
  * (extension). Walks `type.getProperties()` looking for computed property names
  * backed by plain identifiers — the standard `unique symbol` brand pattern.
+ *
+ * Returns all matching identifiers so that types with multiple brands (e.g.,
+ * `number & { [__integerBrand]: true } & { [__otherBrand]: true }`) are
+ * fully inspected regardless of property order.
  */
-function findBrandIdentifier(type: ts.Type): string | null {
+function collectBrandIdentifiers(type: ts.Type): readonly string[] {
   if (!type.isIntersection()) {
-    return null;
+    return [];
   }
 
+  const brands: string[] = [];
   for (const prop of type.getProperties()) {
     const decl = prop.valueDeclaration ?? prop.declarations?.[0];
     if (decl === undefined) continue;
     if (!ts.isPropertySignature(decl) && !ts.isPropertyDeclaration(decl)) continue;
     if (!ts.isComputedPropertyName(decl.name)) continue;
     if (!ts.isIdentifier(decl.name.expression)) continue;
-    return decl.name.expression.text;
+    brands.push(decl.name.expression.text);
   }
 
-  return null;
+  return brands;
 }
 
 /**
@@ -97,7 +102,7 @@ function isIntegerBrandedType(type: ts.Type): boolean {
     return false;
   }
 
-  return findBrandIdentifier(type) === "__integerBrand";
+  return collectBrandIdentifiers(type).includes("__integerBrand");
 }
 
 /**
@@ -120,21 +125,18 @@ function resolveBrandedCustomType(
     return null;
   }
 
-  const brand = findBrandIdentifier(type);
-  if (brand === null) {
-    return null;
+  for (const brand of collectBrandIdentifiers(type)) {
+    const registration = extensionRegistry.findTypeByBrand(brand);
+    if (registration !== undefined) {
+      return {
+        kind: "custom",
+        typeId: `${registration.extensionId}/${registration.registration.typeName}`,
+        payload: null,
+      };
+    }
   }
 
-  const registration = extensionRegistry.findTypeByBrand(brand);
-  if (registration === undefined) {
-    return null;
-  }
-
-  return {
-    kind: "custom",
-    typeId: `${registration.extensionId}/${registration.registration.typeName}`,
-    payload: null,
-  };
+  return null;
 }
 
 export function isResolvableObjectLikeAliasTypeNode(typeNode: ts.TypeNode): boolean {

--- a/packages/build/src/extensions/registry.ts
+++ b/packages/build/src/extensions/registry.ts
@@ -64,6 +64,8 @@ export interface ExtensionRegistry {
    *
    * This is used during class analysis to resolve extension-defined custom types
    * via structural brand detection (`unique symbol` computed property keys).
+   * Brand identifiers are stored as plain strings, so they must be unique
+   * across all extensions loaded into the registry.
    *
    * @param brand - The identifier text of the `unique symbol` brand variable.
    */

--- a/packages/build/src/extensions/registry.ts
+++ b/packages/build/src/extensions/registry.ts
@@ -189,6 +189,11 @@ export function createExtensionRegistry(
         }
 
         if (type.brand !== undefined) {
+          if (type.brand === "__integerBrand") {
+            throw new Error(
+              `Brand "__integerBrand" is reserved for the builtin Integer type and cannot be registered by extensions`
+            );
+          }
           if (brandMap.has(type.brand)) {
             throw new Error(`Duplicate custom type brand: "${type.brand}"`);
           }

--- a/packages/build/src/extensions/registry.ts
+++ b/packages/build/src/extensions/registry.ts
@@ -59,6 +59,17 @@ export interface ExtensionRegistry {
   findTypeByName(
     typeName: string
   ): { readonly extensionId: string; readonly registration: CustomTypeRegistration } | undefined;
+  /**
+   * Look up a custom type registration by a brand identifier.
+   *
+   * This is used during class analysis to resolve extension-defined custom types
+   * via structural brand detection (`unique symbol` computed property keys).
+   *
+   * @param brand - The identifier text of the `unique symbol` brand variable.
+   */
+  findTypeByBrand(
+    brand: string
+  ): { readonly extensionId: string; readonly registration: CustomTypeRegistration } | undefined;
 
   /**
    * Look up a custom constraint registration by its fully-qualified constraint ID.
@@ -141,6 +152,10 @@ export function createExtensionRegistry(
     string,
     { readonly extensionId: string; readonly registration: CustomTypeRegistration }
   >();
+  const brandMap = new Map<
+    string,
+    { readonly extensionId: string; readonly registration: CustomTypeRegistration }
+  >();
   const constraintMap = new Map<string, CustomConstraintRegistration>();
   const constraintTagMap = new Map<
     string,
@@ -168,6 +183,16 @@ export function createExtensionRegistry(
             throw new Error(`Duplicate custom type source name: "${sourceTypeName}"`);
           }
           typeNameMap.set(sourceTypeName, {
+            extensionId: ext.extensionId,
+            registration: type,
+          });
+        }
+
+        if (type.brand !== undefined) {
+          if (brandMap.has(type.brand)) {
+            throw new Error(`Duplicate custom type brand: "${type.brand}"`);
+          }
+          brandMap.set(type.brand, {
             extensionId: ext.extensionId,
             registration: type,
           });
@@ -273,6 +298,7 @@ export function createExtensionRegistry(
     extensions,
     findType: (typeId: string) => typeMap.get(typeId),
     findTypeByName: (typeName: string) => typeNameMap.get(typeName),
+    findTypeByBrand: (brand: string) => brandMap.get(brand),
     findConstraint: (constraintId: string) => constraintMap.get(constraintId),
     findConstraintTag: (tagName: string) =>
       constraintTagMap.get(normalizeFormSpecTagName(tagName)),

--- a/packages/core/api-report/core.alpha.api.md
+++ b/packages/core/api-report/core.alpha.api.md
@@ -157,6 +157,7 @@ export interface CustomTypeNode {
 
 // @public
 export interface CustomTypeRegistration {
+    readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -157,6 +157,7 @@ export interface CustomTypeNode {
 
 // @public
 export interface CustomTypeRegistration {
+    readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.beta.api.md
+++ b/packages/core/api-report/core.beta.api.md
@@ -157,6 +157,7 @@ export interface CustomTypeNode {
 
 // @public
 export interface CustomTypeRegistration {
+    readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.public.api.md
+++ b/packages/core/api-report/core.public.api.md
@@ -91,6 +91,7 @@ export interface CustomConstraintRegistration {
 
 // @public
 export interface CustomTypeRegistration {
+    readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -82,6 +82,20 @@ export interface CustomTypeRegistration {
    */
   readonly tsTypeNames?: readonly string[];
   /**
+   * Optional brand identifier for structural type detection.
+   *
+   * When provided, the type resolver checks `type.getProperties()` for a
+   * computed property whose name matches this identifier. This is more
+   * reliable than `tsTypeNames` because it works with import aliases and
+   * prevents name collisions.
+   *
+   * The value should match the identifier text of a `unique symbol` declaration
+   * used as a computed property key on the branded type. For example, if the
+   * type is `string & { readonly [__decimalBrand]: true }`, the brand is
+   * `"__decimalBrand"`.
+   */
+  readonly brand?: string;
+  /**
    * Converts the custom type's payload into a JSON Schema fragment.
    *
    * @param payload - The opaque JSON payload stored on the custom type node.

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -89,10 +89,15 @@ export interface CustomTypeRegistration {
    * reliable than `tsTypeNames` because it works with import aliases and
    * prevents name collisions.
    *
+   * Brand detection is attempted after name-based resolution (`tsTypeNames`)
+   * as a structural fallback. If both match, name-based resolution wins.
+   *
    * The value should match the identifier text of a `unique symbol` declaration
    * used as a computed property key on the branded type. For example, if the
    * type is `string & { readonly [__decimalBrand]: true }`, the brand is
    * `"__decimalBrand"`.
+   *
+   * Note: `"__integerBrand"` is reserved for the builtin Integer type.
    */
   readonly brand?: string;
   /**

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -86,8 +86,8 @@ export interface CustomTypeRegistration {
    *
    * When provided, the type resolver checks `type.getProperties()` for a
    * computed property whose name matches this identifier. This is more
-   * reliable than `tsTypeNames` because it works with import aliases and
-   * prevents name collisions.
+   * reliable than `tsTypeNames` for aliased branded types because it does not
+   * depend on the local type name.
    *
    * Brand detection is attempted after name-based resolution (`tsTypeNames`)
    * as a structural fallback. If both match, name-based resolution wins.
@@ -96,6 +96,9 @@ export interface CustomTypeRegistration {
    * used as a computed property key on the branded type. For example, if the
    * type is `string & { readonly [__decimalBrand]: true }`, the brand is
    * `"__decimalBrand"`.
+   *
+   * Brand identifiers are stored as plain strings in the extension registry, so
+   * they must be unique across the extensions loaded into the same build.
    *
    * Note: `"__integerBrand"` is reserved for the builtin Integer type.
    */


### PR DESCRIPTION
## Summary

Phase 2 of the `tsTypeNames` deprecation roadmap. Extensions can now register a `brand` string on custom types for structural detection via unique symbol brands, which is more reliable than name-matching (works with import aliases, prevents name collisions).

### Changes

- `CustomTypeRegistration` gains optional `brand?: string` field
- `ExtensionRegistry` builds a `brandMap` and exposes `findTypeByBrand`
- `resolveBrandedCustomType` in the type resolver checks intersection type properties for registered brands
- Shared `findBrandIdentifier` helper extracts brand identifiers (used by both builtin Integer detection and extension brand detection)
- Reserved brand check: `__integerBrand` cannot be registered by extensions
- 11 new tests covering registry lookup, duplicates, reserved brand, integration with real TS programs, alias resilience, and fallback

### Deprecation roadmap

| Phase | Status |
|---|---|
| 1. Builtin Integer via `__integerBrand` | Done (PR #272) |
| **2. `brand` field on `CustomTypeRegistration`** | **This PR** |
| 3. `defineCustomType<T>()` type parameter extraction | Planned |
| 4. Remove `tsTypeNames` | Major version |

## Test plan

- [x] 676 build tests pass (11 new)
- [x] All e2e tests pass (266)
- [x] Typecheck clean