### PR TITLE
Export resolveStaticOptions for config-first schema generation

### DIFF
--- a/.changeset/resolve-static-options.md
+++ b/.changeset/resolve-static-options.md
@@ -1,0 +1,8 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Export resolveStaticOptions and migrate discovered-schema functions to resolve config internally. Low-level functions (generateSchemasFromDeclaration, generateSchemasFromType, etc.) now support the `config` field on StaticSchemaGenerationOptions, eliminating the need to pass deprecated individual fields.

--- a/packages/build/src/__tests__/static-build-context.test.ts
+++ b/packages/build/src/__tests__/static-build-context.test.ts
@@ -388,6 +388,94 @@ describe("static build context", () => {
     });
   });
 
+  // Regression: resolveStaticOptions must read metadata from config.metadata
+  // (not only from the deprecated top-level metadata field).
+  it("generates declaration schemas using metadata policy from config (config-only path)", () => {
+    const context = createStaticBuildContext(entryFixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentSubmitInput");
+    if (declaration === null) {
+      throw new Error("PaymentSubmitInput export not found");
+    }
+
+    // Pass metadata exclusively via config — the deprecated top-level metadata
+    // field is intentionally absent here to exercise the config fallback in
+    // resolveStaticOptions.
+    const schemas = generateSchemasFromDeclaration({
+      context,
+      declaration,
+      config: {
+        metadata: {
+          field: {
+            apiName: {
+              mode: "infer-if-missing",
+              infer: ({ logicalName }) =>
+                logicalName.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase(),
+            },
+          },
+        },
+      },
+    });
+
+    // Per the fixture: SubmitInput.amount has explicit @apiName "amount_cents";
+    // SubmitInput.currency has explicit @displayName "Currency" but no @apiName,
+    // so the infer-if-missing policy kicks in and produces "currency".
+    expect(schemas.jsonSchema.title).toBe("Submit Input"); // spec: @displayName on SubmitInput
+    expect(schemas.jsonSchema.properties).toMatchObject({
+      amount_cents: { type: "number" }, // spec: explicit @apiName on amount field
+      currency: { type: "string", title: "Currency" }, // spec: explicit @displayName, inferred apiName
+    });
+    expect(schemas.uiSchema).toMatchObject({
+      type: "VerticalLayout",
+      elements: [
+        { type: "Control", scope: "#/properties/amount_cents" },
+        { type: "Control", scope: "#/properties/currency", label: "Currency" },
+      ],
+    });
+  });
+
+  // Regression: resolveStaticOptions must read metadata from config.metadata
+  // when resolving declaration-level (method) metadata.
+  it("resolves inferred method metadata from config (config-only path)", () => {
+    const context = createStaticBuildContext(targetFixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService export not found");
+    }
+
+    // Pass metadata exclusively via config — the deprecated top-level metadata
+    // field is intentionally absent here to exercise the config fallback in
+    // resolveStaticOptions.
+    const metadata = resolveDeclarationMetadata({
+      context,
+      declaration: getMethod(declaration, "submitAsync"),
+      config: {
+        metadata: {
+          method: {
+            apiName: {
+              mode: "infer-if-missing",
+              infer: ({ logicalName }) =>
+                logicalName.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase(),
+            },
+            displayName: {
+              mode: "infer-if-missing",
+              infer: ({ logicalName }) =>
+                logicalName
+                  .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+                  .replace(/^./, (char) => char.toUpperCase()),
+            },
+          },
+        },
+      },
+    });
+
+    // submitAsync has no explicit @apiName or @displayName, so both are inferred
+    // by the policy supplied via config.
+    expect(metadata).toEqual({
+      apiName: { value: "submit_async", source: "inferred" },
+      displayName: { value: "Submit Async", source: "inferred" },
+    });
+  });
+
   it("does not infer metadata for computed method names", () => {
     const context = createStaticBuildContext(targetFixturePath);
     const declaration = resolveModuleExportDeclaration(context, "PaymentService");

--- a/packages/build/src/generators/class-schema.ts
+++ b/packages/build/src/generators/class-schema.ts
@@ -733,13 +733,16 @@ export function resolveStaticOptions(options: StaticSchemaGenerationOptions): {
   enumSerialization: "enum" | "oneOf" | undefined;
   metadata: MetadataPolicyInput | undefined;
 } {
-  const configRegistry =
-    options.config?.extensions !== undefined
-      ? createExtensionRegistry(options.config.extensions)
-      : undefined;
-
   // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
   const legacyRegistry = options.extensionRegistry;
+
+  // Only construct the config registry if the deprecated field is absent.
+  // This avoids throwing on invalid config.extensions when the caller
+  // explicitly provided extensionRegistry (which takes precedence).
+  const configRegistry =
+    legacyRegistry === undefined && options.config?.extensions !== undefined
+      ? createExtensionRegistry(options.config.extensions)
+      : undefined;
 
   return {
     extensionRegistry: legacyRegistry ?? configRegistry,

--- a/packages/build/src/generators/class-schema.ts
+++ b/packages/build/src/generators/class-schema.ts
@@ -717,6 +717,41 @@ function isMutableRegistry(reg: ExtensionRegistry): reg is MutableExtensionRegis
   return "setSymbolMap" in reg && typeof (reg as MutableExtensionRegistry).setSymbolMap === "function";
 }
 
+/**
+ * Resolves the effective extension registry, vendor prefix, enum serialization,
+ * and metadata from a `StaticSchemaGenerationOptions` object.
+ *
+ * Prefers explicit deprecated fields when present, falling back to the
+ * `config` object. This is the migration bridge — once all callers use
+ * `config`, the deprecated field reads can be removed.
+ *
+ * @internal
+ */
+export function resolveStaticOptions(options: StaticSchemaGenerationOptions): {
+  extensionRegistry: ExtensionRegistry | undefined;
+  vendorPrefix: string | undefined;
+  enumSerialization: "enum" | "oneOf" | undefined;
+  metadata: MetadataPolicyInput | undefined;
+} {
+  const configRegistry =
+    options.config?.extensions !== undefined
+      ? createExtensionRegistry(options.config.extensions)
+      : undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
+  const legacyRegistry = options.extensionRegistry;
+
+  return {
+    extensionRegistry: legacyRegistry ?? configRegistry,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
+    vendorPrefix: options.vendorPrefix ?? options.config?.vendorPrefix,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
+    enumSerialization: options.enumSerialization ?? options.config?.enumSerialization,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
+    metadata: options.metadata ?? options.config?.metadata,
+  };
+}
+
 function resolveOptions(options: StaticSchemaGenerationOptions): {
   extensionRegistry: MutableExtensionRegistry | undefined;
   vendorPrefix: string | undefined;

--- a/packages/build/src/generators/discovered-schema.ts
+++ b/packages/build/src/generators/discovered-schema.ts
@@ -6,7 +6,7 @@ import type {
   TypeDefinition,
   TypeNode,
 } from "@formspec/core/internals";
-import type { ResolvedMetadata } from "@formspec/core";
+import type { MetadataPolicyInput, ResolvedMetadata } from "@formspec/core";
 import type { UISchema } from "../ui-schema/types.js";
 import type { StaticBuildContext } from "../static-build.js";
 import {
@@ -20,6 +20,7 @@ import {
 } from "../analyzer/class-analyzer.js";
 import {
   generateClassSchemas,
+  resolveStaticOptions,
   type ClassSchemas,
   type StaticSchemaGenerationOptions,
 } from "./class-schema.js";
@@ -276,11 +277,10 @@ function enforceRequiredMetadata(
   metadata: ResolvedMetadata | undefined,
   declarationKind: "type" | "field" | "method",
   logicalName: string,
-  options: ResolveDeclarationMetadataOptions
+  metadataPolicy: MetadataPolicyInput | undefined
 ): void {
   const declarationPolicy = getDeclarationMetadataPolicy(
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-    normalizeMetadataPolicy(options.metadata),
+    normalizeMetadataPolicy(metadataPolicy),
     declarationKind
   );
 
@@ -347,7 +347,7 @@ function describeRootType(
 function toStandaloneJsonSchema(
   root: RootTypeDescriptor,
   typeRegistry: Record<string, TypeDefinition>,
-  options: StaticSchemaGenerationOptions | undefined
+  resolved: ReturnType<typeof resolveStaticOptions> | undefined
 ): JsonSchema2020 {
   const syntheticFieldMetadata = omitApiName(root.metadata);
   const syntheticField: FieldNode = {
@@ -379,20 +379,16 @@ function toStandaloneJsonSchema(
       provenance: syntheticField.provenance,
     },
     {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-      policy: normalizeMetadataPolicy(options?.metadata),
+      policy: normalizeMetadataPolicy(resolved?.metadata),
       surface: "tsdoc",
       rootLogicalName: root.name,
     }
   );
 
   const schema = generateJsonSchemaFromIR(ir, {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-    extensionRegistry: options?.extensionRegistry,
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-    enumSerialization: options?.enumSerialization,
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-    vendorPrefix: options?.vendorPrefix,
+    extensionRegistry: resolved?.extensionRegistry,
+    enumSerialization: resolved?.enumSerialization,
+    vendorPrefix: resolved?.vendorPrefix,
   });
 
   const result = schema.properties?.["__result"];
@@ -417,21 +413,17 @@ function toStandaloneJsonSchema(
 function generateSchemasFromAnalysis(
   analysis: IRClassAnalysis,
   filePath: string,
-  options: StaticSchemaGenerationOptions | undefined
+  resolved: ReturnType<typeof resolveStaticOptions> | undefined
 ): DiscoveredTypeSchemas {
   return toDiscoveredTypeSchemas(
     generateClassSchemas(
       analysis,
       { file: filePath },
       {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-        extensionRegistry: options?.extensionRegistry,
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-        enumSerialization: options?.enumSerialization,
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-        metadata: options?.metadata,
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-        vendorPrefix: options?.vendorPrefix,
+        extensionRegistry: resolved?.extensionRegistry,
+        enumSerialization: resolved?.enumSerialization,
+        metadata: resolved?.metadata,
+        vendorPrefix: resolved?.vendorPrefix,
       }
     ),
     analysis.metadata
@@ -443,6 +435,7 @@ function generateSchemasFromResolvedType(
   skipNamedDeclaration = false,
   rootOverride?: RootTypeOverride
 ): DiscoveredTypeSchemas {
+  const resolved = resolveStaticOptions(options);
   const namedDeclaration =
     skipNamedDeclaration || hasConcreteTypeArguments(options.type, options.context.checker)
       ? undefined
@@ -465,10 +458,8 @@ function generateSchemasFromResolvedType(
     typeRegistry,
     new Set<ts.Type>(),
     options.sourceNode,
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-    createAnalyzerMetadataPolicy(options.metadata, options.discriminator),
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-    options.extensionRegistry,
+    createAnalyzerMetadataPolicy(resolved.metadata, options.discriminator),
+    resolved.extensionRegistry,
     diagnostics
   );
 
@@ -504,12 +495,12 @@ function generateSchemasFromResolvedType(
         root.annotations
       ),
       filePath,
-      options
+      resolved
     );
   }
 
   return {
-    jsonSchema: toStandaloneJsonSchema(root, typeRegistry, options),
+    jsonSchema: toStandaloneJsonSchema(root, typeRegistry, resolved),
     uiSchema: null,
     ...(root.metadata !== undefined && { resolvedMetadata: root.metadata }),
   };
@@ -529,6 +520,7 @@ export function generateSchemasFromDeclaration(
   options: GenerateSchemasFromDeclarationOptions
 ): DiscoveredTypeSchemas {
   const filePath = options.declaration.getSourceFile().fileName;
+  const resolved = resolveStaticOptions(options);
 
   if (ts.isClassDeclaration(options.declaration)) {
     return generateSchemasFromAnalysis(
@@ -536,14 +528,12 @@ export function generateSchemasFromDeclaration(
         options.declaration,
         options.context.checker,
         filePath,
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-        options.extensionRegistry,
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-        options.metadata,
+        resolved.extensionRegistry,
+        resolved.metadata,
         options.discriminator
       ),
       filePath,
-      options
+      resolved
     );
   }
 
@@ -553,14 +543,12 @@ export function generateSchemasFromDeclaration(
         options.declaration,
         options.context.checker,
         filePath,
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-        options.extensionRegistry,
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-        options.metadata,
+        resolved.extensionRegistry,
+        resolved.metadata,
         options.discriminator
       ),
       filePath,
-      options
+      resolved
     );
   }
 
@@ -569,23 +557,19 @@ export function generateSchemasFromDeclaration(
       options.declaration,
       options.context.checker,
       filePath,
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-      options.extensionRegistry,
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-      options.metadata,
+      resolved.extensionRegistry,
+      resolved.metadata,
       options.discriminator
     );
     if (analyzedAlias.ok) {
-      return generateSchemasFromAnalysis(analyzedAlias.analysis, filePath, options);
+      return generateSchemasFromAnalysis(analyzedAlias.analysis, filePath, resolved);
     }
     const aliasRootInfo = analyzeDeclarationRootInfo(
       options.declaration,
       options.context.checker,
       filePath,
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-      options.extensionRegistry,
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-      options.metadata
+      resolved.extensionRegistry,
+      resolved.metadata
     );
     if (aliasRootInfo.diagnostics.length > 0) {
       const diagnosticDetails = aliasRootInfo.diagnostics
@@ -692,13 +676,12 @@ export function generateSchemasFromReturnType(
 export function resolveDeclarationMetadata(
   options: ResolveDeclarationMetadataOptions
 ): ResolvedMetadata | undefined {
+  const resolved = resolveStaticOptions(options);
   const analysis = analyzeMetadataForNodeWithChecker({
     checker: options.context.checker,
     node: options.declaration,
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-    metadata: options.metadata,
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
-    extensions: options.extensionRegistry?.extensions,
+    metadata: resolved.metadata,
+    extensions: resolved.extensionRegistry?.extensions,
     buildContext: options.context,
   });
   if (analysis === null) {
@@ -707,7 +690,7 @@ export function resolveDeclarationMetadata(
 
   const metadata = analysis.resolvedMetadata;
 
-  enforceRequiredMetadata(metadata, analysis.declarationKind, analysis.logicalName, options);
+  enforceRequiredMetadata(metadata, analysis.declarationKind, analysis.logicalName, resolved.metadata);
   return metadata;
 }
 

--- a/packages/build/src/internals.ts
+++ b/packages/build/src/internals.ts
@@ -45,7 +45,11 @@ export type {
 export type { AnalyzeNamedTypeToIRDetailedResult } from "./analyzer/program.js";
 
 // Generators: class schema (now routes through IR)
-export { generateClassSchemas, generateClassSchemasDetailed } from "./generators/class-schema.js";
+export {
+  generateClassSchemas,
+  generateClassSchemasDetailed,
+  resolveStaticOptions,
+} from "./generators/class-schema.js";
 export type { ClassSchemas, DetailedClassSchemasResult } from "./generators/class-schema.js";
 
 // JSON Schema 2020-12: IR-based generator


### PR DESCRIPTION
## Summary

Low-level schema generation functions (`generateSchemasFromDeclaration`, `generateSchemasFromType`, `generateSchemasFromParameter`, `resolveDeclarationMetadata`) now resolve `config.extensions` and `config.metadata` internally via `resolveStaticOptions()`. Previously they only read the deprecated individual fields, forcing callers to pass both `config` and the deprecated fields.

This enables the extensibility SDK to pass just `config: stripeFormSpecConfig` without duplicating the deprecated fields. `resolveStaticOptions` is exported from `@formspec/build/internals` for downstream use.

## Test plan

- [x] 695 build tests pass
- [x] 266 e2e tests pass
- [x] All other packages pass