### PR TITLE
Fix tag-type-check false positive for annotation tags on non-string fields

### DIFF
--- a/.changeset/fix-annotation-tag-type-check.md
+++ b/.changeset/fix-annotation-tag-type-check.md
@@ -10,4 +10,4 @@
 
 Fix `tag-type-check` false positive for annotation tags on non-string fields
 
-Annotation tags like `@displayName` accept a string *value* but can annotate fields of any type. Previously, `buildExtraTagDefinition` derived `capabilities` from the tag's value kind, so `@displayName` was assigned `string-like` capability and incorrectly rejected on fields like `MonetaryAmount` or `boolean`.
+Annotation tags like `@displayName` accept a string *value* but can annotate fields of any type. Previously, `buildExtraTagDefinition` and `buildExtensionMetadataTagDefinition` both derived `capabilities` from the tag's value kind, so annotation tags were assigned `string-like` capability and incorrectly rejected on fields like `MonetaryAmount` or `boolean`. Both functions now return empty capabilities for annotation-category tags.

--- a/.changeset/fix-annotation-tag-type-check.md
+++ b/.changeset/fix-annotation-tag-type-check.md
@@ -1,0 +1,8 @@
+---
+"@formspec/analysis": patch
+"@formspec/eslint-plugin": patch
+---
+
+Fix `tag-type-check` false positive for annotation tags on non-string fields
+
+Annotation tags like `@displayName` accept a string *value* but can annotate fields of any type. Previously, `buildExtraTagDefinition` derived `capabilities` from the tag's value kind, so `@displayName` was assigned `string-like` capability and incorrectly rejected on fields like `MonetaryAmount` or `boolean`.

--- a/.changeset/fix-annotation-tag-type-check.md
+++ b/.changeset/fix-annotation-tag-type-check.md
@@ -1,6 +1,11 @@
 ---
 "@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
 "@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
 ---
 
 Fix `tag-type-check` false positive for annotation tags on non-string fields

--- a/packages/analysis/src/__tests__/tag-registry.test.ts
+++ b/packages/analysis/src/__tests__/tag-registry.test.ts
@@ -55,10 +55,22 @@ describe("tag-registry", () => {
   });
 
   it("annotation tags have empty capabilities regardless of value kind", () => {
+    const extension = defineExtension({
+      extensionId: "x-example/metadata",
+      metadataSlots: [
+        defineMetadataSlot({
+          slotId: "externalName",
+          tagName: "ExternalName",
+          declarationKinds: ["field"],
+        }),
+      ],
+    });
+
     // displayName takes a string value but must not be restricted to string fields
     expect(getTagDefinition("displayName")?.capabilities).toEqual([]);
     expect(getTagDefinition("apiName")?.capabilities).toEqual([]);
     expect(getTagDefinition("description")?.capabilities).toEqual([]);
+    expect(getTagDefinition("externalName", [extension])?.capabilities).toEqual([]);
   });
 
   it("normalizes extension metadata tag registrations to canonical names", () => {

--- a/packages/analysis/src/__tests__/tag-registry.test.ts
+++ b/packages/analysis/src/__tests__/tag-registry.test.ts
@@ -54,6 +54,13 @@ describe("tag-registry", () => {
     expect(getTagDefinition("ApiName")?.canonicalName).toBe("apiName");
   });
 
+  it("annotation tags have empty capabilities regardless of value kind", () => {
+    // displayName takes a string value but must not be restricted to string fields
+    expect(getTagDefinition("displayName")?.capabilities).toEqual([]);
+    expect(getTagDefinition("apiName")?.capabilities).toEqual([]);
+    expect(getTagDefinition("description")?.capabilities).toEqual([]);
+  });
+
   it("normalizes extension metadata tag registrations to canonical names", () => {
     const extension = defineExtension({
       extensionId: "x-example/metadata",

--- a/packages/analysis/src/tag-registry.ts
+++ b/packages/analysis/src/tag-registry.ts
@@ -799,7 +799,7 @@ function buildExtraTagDefinition(canonicalName: string, spec: ExtraTagSpec): Tag
     allowDuplicates: spec.allowDuplicates,
     category: spec.category,
     placements: spec.placements,
-    capabilities: capabilitiesForValueKind(valueKind),
+    capabilities: spec.category === "annotation" ? [] : capabilitiesForValueKind(valueKind),
     completionDetail: spec.completionDetail,
     hoverSummary: spec.hoverSummary,
     hoverMarkdown: buildHoverMarkdown(canonicalName, spec.hoverSummary, signatures, valueLabel),

--- a/packages/analysis/src/tag-registry.ts
+++ b/packages/analysis/src/tag-registry.ts
@@ -875,7 +875,7 @@ function buildExtensionMetadataTagDefinition(
     allowDuplicates: false,
     category: "annotation",
     placements,
-    capabilities: capabilitiesForValueKind(valueKind),
+    capabilities: [],
     completionDetail: `Extension metadata tag from ${extensionId}`,
     hoverSummary: `Extension-defined metadata tag from \`${extensionId}\`.`,
     hoverMarkdown: [

--- a/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
@@ -331,6 +331,26 @@ ruleTester.run("tag-type-check", tagTypeCheck, {
         }
       `,
     },
+    // @displayName with a value on a non-string field — annotation tags must not
+    // be constrained by the field's type (regression: displayName was in
+    // STRING_VALUE_TAGS, so buildExtraTagDefinition gave it string-like capability)
+    {
+      code: `
+        type MonetaryAmount = { amount: number; currency: string };
+        class Form {
+          /** @displayName Maximum Credit Amount */
+          maximumCreditAmount!: MonetaryAmount;
+        }
+      `,
+    },
+    {
+      code: `
+        class Form {
+          /** @displayName Active Flag */
+          isActive!: boolean;
+        }
+      `,
+    },
 
     // -------------------------------------------------------------------------
     // Path-targeted constraints — skipped entirely regardless of field type


### PR DESCRIPTION
Annotation tags like `@displayName` accept a string _value_ but must not be
restricted to string-typed _fields_. A field of type `MonetaryAmount` or
`boolean` is perfectly valid target for `@displayName "My Label"`.

**Root cause:** `buildExtraTagDefinition` in `@formspec/analysis` derived
`capabilities` from the tag's value kind. Since `displayName` is in
`STRING_VALUE_TAGS`, it got `capabilities: ["string-like"]`. The
`tag-type-check` rule then treated this as a field-type constraint and rejected
`@displayName` on any non-string field.

**Fix:** Annotation-category tags always get `capabilities: []`, so
`getExpectedTypesForTag` returns `null` and the type check is skipped for them
entirely.

**Tests added:**

- `tag-registry`: asserts `displayName`, `apiName`, and `description` all have
  empty capabilities
- `constraint-type-mismatch`: two regression cases — `@displayName` on
  `MonetaryAmount` and `boolean` fields
