### PR TITLE
Fix field-type rejections for non-constraint tags across all categories

### DIFF
--- a/.changeset/non-constraint-tag-capabilities.md
+++ b/.changeset/non-constraint-tag-capabilities.md
@@ -1,0 +1,17 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Fix spurious field-type rejections for non-constraint tags across all non-constraint categories.
+
+Tags like `@displayName`, `@group`, `@example`, `@remarks`, and `@see` accept a typed argument (usually a string) but describe or decorate a declaration — they are not field-type constraints. `buildExtraTagDefinition` previously derived `capabilities` from the tag's value-kind, so every one of these tags inherited a stray field-type requirement (e.g., `@displayName` → `["string-like"]`), which the `tag-type-check` ESLint rule and the narrow synthetic applicability check both surfaced as a rejection on non-matching fields (objects, numbers, booleans, branded `Integer`, etc.).
+
+`buildExtraTagDefinition` now emits `capabilities: []` for every non-constraint category (`annotation`, `structure`, `ecosystem`) — only `constraint`-category tags (the built-ins in `BUILTIN_TAG_DEFINITIONS`) carry a field-type capability. `buildExtensionMetadataTagDefinition` is aligned to the same invariant.
+
+Affected tags that previously produced false positives: `@displayName`, `@description`, `@format`, `@placeholder`, `@order`, `@apiName`, `@group`, `@example`, `@remarks`, `@see`.

--- a/packages/analysis/src/__tests__/tag-capability-applicability.test.ts
+++ b/packages/analysis/src/__tests__/tag-capability-applicability.test.ts
@@ -121,8 +121,13 @@ const FIELD_TYPES: readonly FieldTypeCase[] = [
     typeExpression: "{ amount: number; currency: string }",
   },
   {
-    name: "branded Integer (number & symbol brand)",
-    typeExpression: "number & { readonly __integerBrand: unique symbol }",
+    // Approximates a branded numeric intersection. Not the real `Integer`
+    // brand from `@formspec/core` — that one is keyed by a `unique symbol`,
+    // which can't be inlined in a raw type expression without a binding.
+    // This case exercises the general "intersection with a non-numeric
+    // property" shape that branded numerics take.
+    name: "branded/intersection number",
+    typeExpression: "number & { readonly __brand: 'int' }",
   },
   { name: "string[]", typeExpression: "string[]" },
   {
@@ -180,11 +185,11 @@ describe("built-in constraint tags still enforce field-type capabilities", () =>
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
-  it("@minimum is accepted on a branded Integer field", () => {
+  it("@minimum is accepted on a branded/intersection number field", () => {
     const result = checkNarrowSyntheticTagApplicability({
       tagName: "minimum",
       placement: "class-field",
-      resolvedTargetType: "number & { readonly __integerBrand: unique symbol }",
+      resolvedTargetType: "number & { readonly __brand: 'int' }",
       argumentExpression: "0",
     });
 

--- a/packages/analysis/src/__tests__/tag-capability-applicability.test.ts
+++ b/packages/analysis/src/__tests__/tag-capability-applicability.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Regression tests: annotation, structure, and ecosystem tags must not
+ * constrain the field type they decorate.
+ *
+ * Before the fix to `buildExtraTagDefinition`, non-constraint tags inherited
+ * a `capabilities` array derived from their value-kind (e.g. `@displayName`
+ * has a string argument, so it was tagged `capabilities: ["string-like"]`).
+ * Consumers of that array then treated the capability as a *field-type*
+ * requirement, rejecting the tag on any non-matching field — even though
+ * the value-kind describes the tag's argument, not the field.
+ *
+ * Capabilities should only be populated for `constraint`-category tags
+ * (the built-ins in `BUILTIN_TAG_DEFINITIONS`). The ESLint rule
+ * `tag-type-check` and the narrow synthetic applicability check both read
+ * `definition.capabilities` to derive a field-type requirement, so both
+ * paths regressed for non-constraint tags with a typed value.
+ *
+ * @see packages/analysis/src/tag-registry.ts — buildExtraTagDefinition
+ * @see packages/analysis/src/compiler-signatures.ts — getTargetCapabilityForSignature
+ * @see packages/eslint-plugin/src/rules/type-compatibility/tag-type-check.ts — getExpectedTypesForTag
+ */
+import { describe, expect, it } from "vitest";
+import { checkNarrowSyntheticTagApplicability } from "../compiler-signatures.js";
+
+interface TagCase {
+  readonly tagName: string;
+  readonly category: "annotation" | "structure" | "ecosystem";
+  readonly valueKindLabel: string;
+  readonly argumentExpression: string;
+}
+
+interface FieldTypeCase {
+  readonly name: string;
+  // Inlined TypeScript type expression. The narrow synthetic check doesn't
+  // take supporting declarations, so the whole type must be self-contained.
+  readonly typeExpression: string;
+}
+
+// Every `EXTRA_TAG_SPECS` entry whose value-kind previously produced a
+// non-empty `capabilities` array. All of these inherited a stray field-type
+// capability before the fix. `showWhen`/`hideWhen`/`enableWhen`/`disableWhen`
+// had `["condition-like"]` too, but `condition-like` maps to an empty list
+// of expected field types downstream, so they never triggered rejections —
+// still, the fix clears their capability array alongside the others for
+// consistency. We focus the matrix on the tags that actually regressed.
+const NON_CONSTRAINT_TAGS: readonly TagCase[] = [
+  // annotation category
+  {
+    tagName: "displayName",
+    category: "annotation",
+    valueKindLabel: "string",
+    argumentExpression: '"Maximum Credit Amount"',
+  },
+  {
+    tagName: "description",
+    category: "annotation",
+    valueKindLabel: "string",
+    argumentExpression: '"descriptive text"',
+  },
+  {
+    tagName: "format",
+    category: "annotation",
+    valueKindLabel: "string",
+    argumentExpression: '"currency"',
+  },
+  {
+    tagName: "placeholder",
+    category: "annotation",
+    valueKindLabel: "string",
+    argumentExpression: '"placeholder"',
+  },
+  {
+    tagName: "order",
+    category: "annotation",
+    valueKindLabel: "signedInteger",
+    argumentExpression: "5",
+  },
+  {
+    tagName: "apiName",
+    category: "annotation",
+    valueKindLabel: "string",
+    argumentExpression: '"legacy_field"',
+  },
+  // structure category
+  {
+    tagName: "group",
+    category: "structure",
+    valueKindLabel: "string",
+    argumentExpression: '"Advanced"',
+  },
+  // ecosystem category
+  {
+    tagName: "example",
+    category: "ecosystem",
+    valueKindLabel: "string",
+    argumentExpression: '"Acme Corp"',
+  },
+  {
+    tagName: "remarks",
+    category: "ecosystem",
+    valueKindLabel: "string",
+    argumentExpression: '"implementation notes"',
+  },
+  {
+    tagName: "see",
+    category: "ecosystem",
+    valueKindLabel: "string",
+    argumentExpression: '"https://docs.example.com"',
+  },
+];
+
+// A matrix of field types a tag can land on. The bug manifested for types
+// that don't satisfy the value-kind-derived capability (e.g. a
+// `MonetaryAmount` object is not "string-like", so `@displayName` was
+// rejected even though `displayName` is a pure label).
+const FIELD_TYPES: readonly FieldTypeCase[] = [
+  { name: "number", typeExpression: "number" },
+  { name: "boolean", typeExpression: "boolean" },
+  {
+    name: "object with numeric field",
+    typeExpression: "{ amount: number; currency: string }",
+  },
+  {
+    name: "branded Integer (number & symbol brand)",
+    typeExpression: "number & { readonly __integerBrand: unique symbol }",
+  },
+  { name: "string[]", typeExpression: "string[]" },
+  {
+    name: 'literal union "draft" | "sent"',
+    typeExpression: '"draft" | "sent"',
+  },
+];
+
+describe("non-constraint tags do not impose a field-type capability", () => {
+  for (const tagCase of NON_CONSTRAINT_TAGS) {
+    describe(`@${tagCase.tagName} (${tagCase.category}, value-kind ${tagCase.valueKindLabel})`, () => {
+      for (const fieldType of FIELD_TYPES) {
+        it(`is accepted on ${fieldType.name}`, () => {
+          const result = checkNarrowSyntheticTagApplicability({
+            tagName: tagCase.tagName,
+            placement: "class-field",
+            resolvedTargetType: fieldType.typeExpression,
+            argumentExpression: tagCase.argumentExpression,
+          });
+
+          expect(
+            result.diagnostics,
+            `@${tagCase.tagName} should not be rejected on ${fieldType.name} — ` +
+              `it's a ${tagCase.category} tag that decorates the field, not a constraint`
+          ).toEqual([]);
+        });
+      }
+    });
+  }
+});
+
+// Sanity: built-in *constraint* tags must STILL enforce field-type
+// capabilities. The fix must not weaken constraint semantics — only the
+// incorrectly-inherited capabilities on non-constraint tags go away.
+describe("built-in constraint tags still enforce field-type capabilities", () => {
+  it("@minLength is rejected on a number field", () => {
+    const result = checkNarrowSyntheticTagApplicability({
+      tagName: "minLength",
+      placement: "class-field",
+      resolvedTargetType: "number",
+      argumentExpression: "1",
+    });
+
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("@minimum is rejected on a string field", () => {
+    const result = checkNarrowSyntheticTagApplicability({
+      tagName: "minimum",
+      placement: "class-field",
+      resolvedTargetType: "string",
+      argumentExpression: "0",
+    });
+
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("@minimum is accepted on a branded Integer field", () => {
+    const result = checkNarrowSyntheticTagApplicability({
+      tagName: "minimum",
+      placement: "class-field",
+      resolvedTargetType: "number & { readonly __integerBrand: unique symbol }",
+      argumentExpression: "0",
+    });
+
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/analysis/src/__tests__/tag-registry.test.ts
+++ b/packages/analysis/src/__tests__/tag-registry.test.ts
@@ -54,6 +54,69 @@ describe("tag-registry", () => {
     expect(getTagDefinition("ApiName")?.canonicalName).toBe("apiName");
   });
 
+  // Regression: prior to fixing `buildExtraTagDefinition`, non-constraint
+  // tags inherited a `capabilities` array derived from their value-kind
+  // (e.g. `@displayName` → "string-like"), which then propagated into the
+  // ESLint rule and narrow synthetic check as a field-type requirement.
+  // Only built-in *constraint* tags should carry field-type capabilities.
+  it("assigns empty capabilities to every non-constraint tag", () => {
+    const NON_CONSTRAINT_TAGS = [
+      // annotation
+      "displayName",
+      "description",
+      "format",
+      "placeholder",
+      "order",
+      "apiName",
+      "discriminator",
+      // structure
+      "group",
+      "showWhen",
+      "hideWhen",
+      "enableWhen",
+      "disableWhen",
+      // ecosystem
+      "defaultValue",
+      "deprecated",
+      "example",
+      "remarks",
+      "see",
+    ] as const;
+
+    for (const tagName of NON_CONSTRAINT_TAGS) {
+      const definition = getTagDefinition(tagName);
+      expect(definition, `expected @${tagName} to be registered`).not.toBeNull();
+      expect(
+        definition?.capabilities,
+        `@${tagName} is non-constraint — its capabilities must be empty`
+      ).toEqual([]);
+    }
+  });
+
+  it("preserves capabilities on built-in constraint tags", () => {
+    // Constraint tags legitimately express a field-type requirement; the
+    // fix must not strip their capabilities.
+    expect(getTagDefinition("minimum")?.capabilities).toEqual(["numeric-comparable"]);
+    expect(getTagDefinition("minLength")?.capabilities).toEqual(["string-like"]);
+    expect(getTagDefinition("minItems")?.capabilities).toEqual(["array-like"]);
+    expect(getTagDefinition("enumOptions")?.capabilities).toEqual(["enum-member-addressable"]);
+  });
+
+  it("assigns empty capabilities to extension metadata tags regardless of value kind", () => {
+    const extension = defineExtension({
+      extensionId: "x-example/metadata",
+      metadataSlots: [
+        defineMetadataSlot({
+          slotId: "externalName",
+          tagName: "ExternalName",
+          declarationKinds: ["field"],
+        }),
+      ],
+    });
+
+    expect(getTagDefinition("externalName", [extension])?.capabilities).toEqual([]);
+  });
+
   it("normalizes extension metadata tag registrations to canonical names", () => {
     const extension = defineExtension({
       extensionId: "x-example/metadata",

--- a/packages/analysis/src/tag-registry.ts
+++ b/packages/analysis/src/tag-registry.ts
@@ -799,7 +799,13 @@ function buildExtraTagDefinition(canonicalName: string, spec: ExtraTagSpec): Tag
     allowDuplicates: spec.allowDuplicates,
     category: spec.category,
     placements: spec.placements,
-    capabilities: capabilitiesForValueKind(valueKind),
+    // Capabilities express a *field-type* requirement (e.g. `@minLength` needs
+    // a string-like field). Only constraint-category tags carry that meaning;
+    // annotation, structure, and ecosystem tags describe or decorate the field
+    // regardless of its type, so their value-kind must not leak into a field
+    // constraint. `EXTRA_TAG_SPECS` currently has no constraint entries, but
+    // we keep the `spec.category === "constraint"` check for future-proofing.
+    capabilities: spec.category === "constraint" ? capabilitiesForValueKind(valueKind) : [],
     completionDetail: spec.completionDetail,
     hoverSummary: spec.hoverSummary,
     hoverMarkdown: buildHoverMarkdown(canonicalName, spec.hoverSummary, signatures, valueLabel),
@@ -875,7 +881,10 @@ function buildExtensionMetadataTagDefinition(
     allowDuplicates: false,
     category: "annotation",
     placements,
-    capabilities: capabilitiesForValueKind(valueKind),
+    // Extension metadata tags are always annotations — they attach a typed
+    // value to a declaration without constraining the declaration's type.
+    // See `buildExtraTagDefinition` for the rationale.
+    capabilities: [],
     completionDetail: `Extension metadata tag from ${extensionId}`,
     hoverSummary: `Extension-defined metadata tag from \`${extensionId}\`.`,
     hoverMarkdown: [

--- a/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
@@ -448,6 +448,23 @@ ruleTester.run("tag-type-check", tagTypeCheck, {
       `,
     },
 
+    // @displayName on the real `@formspec/core` Integer brand — a
+    // `number` intersected with a symbol-keyed brand property. Mirrors
+    // `type Integer = number & { readonly [__integerBrand]: true }`.
+    // This is exactly the shape that would previously have been rejected
+    // under `capabilities: ["string-like"]` via `getFieldTypeCategory`
+    // returning "number" rather than "string".
+    {
+      code: `
+        declare const __integerBrand: unique symbol;
+        type Integer = number & { readonly [__integerBrand]: true };
+        class Form {
+          /** @displayName Item Count */
+          count!: Integer;
+        }
+      `,
+    },
+
     // @order (annotation / signedInteger): order is a UI ordering hint —
     // should work on any field regardless of type
     {

--- a/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/constraint-type-mismatch.test.ts
@@ -418,6 +418,117 @@ ruleTester.run("tag-type-check", tagTypeCheck, {
         },
       },
     },
+
+    // -------------------------------------------------------------------------
+    // Non-constraint tags — annotation, structure, ecosystem categories do
+    // NOT impose a field-type requirement. Value-kind describes the tag's
+    // *argument*, not the field.
+    //
+    // Regression: `buildExtraTagDefinition` used to copy the value-kind into
+    // `capabilities`, which `getExpectedTypesForTag` then surfaced as an
+    // expected field type — causing spurious rejections.
+    // -------------------------------------------------------------------------
+
+    // @displayName (annotation / string): any field type is allowed
+    {
+      code: `
+        type MonetaryAmount = { amount: number; currency: string };
+        class Form {
+          /** @displayName Maximum Credit Amount */
+          maximumCreditAmount!: MonetaryAmount;
+        }
+      `,
+    },
+    {
+      code: `
+        class Form {
+          /** @displayName Active Flag */
+          isActive!: boolean;
+        }
+      `,
+    },
+
+    // @order (annotation / signedInteger): order is a UI ordering hint —
+    // should work on any field regardless of type
+    {
+      code: `
+        class Form {
+          /** @order 3 */
+          created!: Date;
+        }
+      `,
+    },
+
+    // @apiName (annotation / string): API-facing name works on any field
+    {
+      code: `
+        class Form {
+          /** @apiName legacy_amount */
+          amount!: number;
+        }
+      `,
+    },
+
+    // @group (structure / string): UI grouping hint works on any field
+    {
+      code: `
+        type MonetaryAmount = { amount: number; currency: string };
+        class Form {
+          /** @group Advanced */
+          limit!: MonetaryAmount;
+        }
+      `,
+    },
+
+    // @example (ecosystem / string): example text works regardless of type
+    {
+      code: `
+        class Form {
+          /** @example 2024-01-15 */
+          issuedOn!: Date;
+        }
+      `,
+    },
+
+    // @remarks (ecosystem / string): free-form remarks work on any field
+    {
+      code: `
+        class Form {
+          /** @remarks Historical note: migrated from v1. */
+          legacyId!: number;
+        }
+      `,
+    },
+
+    // @see (ecosystem / string): references work on any field
+    {
+      code: `
+        class Form {
+          /** @see https://docs.example.com/fields/count */
+          count!: number;
+        }
+      `,
+    },
+
+    // @placeholder (annotation / string) and @format (annotation / string)
+    // on non-string fields — both placeholder and format are presentational
+    // hints that should not constrain the field type.
+    {
+      code: `
+        class Form {
+          /** @placeholder Enter an amount */
+          amount!: number;
+        }
+      `,
+    },
+    {
+      code: `
+        class Form {
+          /** @format date */
+          issuedOn!: Date;
+        }
+      `,
+    },
   ],
   invalid: [
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extends the narrow fix in #280 to cover every tag category that inherits from
`buildExtraTagDefinition`, and adds regression tests at the layers where the
bug actually manifests.

**Root cause.** `buildExtraTagDefinition` derived `capabilities` from the
tag's *value-kind* (e.g. `@displayName` has a string argument, so it was
tagged `capabilities: ["string-like"]`). But `capabilities` expresses a
*field-type* requirement — it's used by both `getExpectedTypesForTag` in the
ESLint `tag-type-check` rule and `getTargetCapabilityForSignature` in the
narrow synthetic applicability check. Non-constraint tags (annotation,
structure, ecosystem) describe or decorate the field and must not constrain
it, so those capabilities were false positives.

**Fix.** Only `constraint`-category tags legitimately carry a field-type
capability. `buildExtraTagDefinition` now returns `capabilities: []` for any
non-constraint category. `buildExtensionMetadataTagDefinition` is aligned to
the same invariant.

## Tags fixed

| Tag | Category | Previous capabilities |
|---|---|---|
| `@displayName` | annotation | `["string-like"]` |
| `@description` | annotation | `["string-like"]` |
| `@format` | annotation | `["string-like"]` |
| `@placeholder` | annotation | `["string-like"]` |
| `@order` | annotation | `["numeric-comparable"]` |
| `@apiName` | annotation | `["string-like"]` |
| `@group` | structure | `["string-like"]` |
| `@example` | ecosystem | `["string-like"]` |
| `@remarks` | ecosystem | `["string-like"]` |
| `@see` | ecosystem | `["string-like"]` |

`showWhen`/`hideWhen`/`enableWhen`/`disableWhen` carried `["condition-like"]`,
which mapped to an empty expected-types list and so never triggered a
rejection in practice — the fix normalizes their capabilities to `[]` too
for consistency.

## Relation to #280

#280 fixed only the `annotation` category (6 tags) and placed its regression
tests on the `tag-type-check` rule — which, since a recent refactor, routes
through `getExpectedTypesForTag` reading `definition.capabilities`. But
`@group`, `@example`, `@remarks`, and `@see` have the same architectural
issue and were left broken. This PR supersedes #280.

## Test plan

- [x] New file `tag-capability-applicability.test.ts`: 60-case matrix running
      every affected non-constraint tag through `checkNarrowSyntheticTagApplicability`
      against six field types (number, boolean, object, branded `Integer`,
      `string[]`, literal union).
- [x] Extended `tag-registry.test.ts`: asserts every non-constraint tag has
      `capabilities: []` and every listed constraint tag retains its
      capability — a direct check of the invariant.
- [x] Extended `constraint-type-mismatch.test.ts`: adds ESLint `valid` cases
      for `@displayName`, `@group`, `@example`, `@remarks`, `@see`,
      `@apiName`, `@order`, `@placeholder`, `@format` on non-string fields.
- [x] Verified the new tests actually catch the regression: reverting the
      `tag-registry.ts` change causes 51 of 71 new assertions to fail.
- [x] `pnpm run clean && pnpm run build && pnpm run lint && pnpm run test` —
      all green (1,921 tests across 11 packages + e2e).