### PR TITLE
Suggest path-targeted syntax in TYPE_MISMATCH errors

### DIFF
--- a/.changeset/hint-path-target-on-type-mismatch.md
+++ b/.changeset/hint-path-target-on-type-mismatch.md
@@ -1,0 +1,6 @@
+---
+"@formspec/build": patch
+"formspec": patch
+---
+
+Improve `TYPE_MISMATCH` diagnostics: when a constraint like `@exclusiveMinimum` is applied to an object field whose type contains a subfield that satisfies the constraint's required capability, the error now includes a `Hint:` showing the corrected path-targeted syntax (e.g., `@exclusiveMinimum :value 0`). When multiple subfields qualify, the hint lists them.

--- a/.changeset/hint-path-target-on-type-mismatch.md
+++ b/.changeset/hint-path-target-on-type-mismatch.md
@@ -1,5 +1,7 @@
 ---
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
 "formspec": patch
 ---
 

--- a/packages/build/src/__tests__/class-schema.test.ts
+++ b/packages/build/src/__tests__/class-schema.test.ts
@@ -176,6 +176,48 @@ describe("generateSchemas", () => {
     expect(getGenerationFailureMessage("BoxForm")).toContain("TYPE_MISMATCH");
   });
 
+  it("appends a path-target hint when an object field has exactly one matching subfield", () => {
+    const message = getGenerationFailureMessage("HintedSingleCandidateForm");
+
+    expect(message).toContain("TYPE_MISMATCH");
+    expect(message).toContain("Hint:");
+    // Single-candidate form: full corrected example with the user's value preserved.
+    expect(message).toContain("@exclusiveMinimum :value 0");
+    // Should NOT use the multi-candidate "(candidates: …)" listing form.
+    expect(message).not.toContain("candidates:");
+  });
+
+  it("lists candidates when an object field has multiple matching subfields", () => {
+    const message = getGenerationFailureMessage("HintedMultipleCandidatesForm");
+
+    expect(message).toContain("TYPE_MISMATCH");
+    expect(message).toContain("Hint:");
+    expect(message).toContain("candidates:");
+    // Both numeric subfields are listed as candidates.
+    expect(message).toContain("width");
+    expect(message).toContain("height");
+    // The non-numeric subfield must NOT appear as a candidate.
+    expect(message).not.toMatch(/candidates: [^)]*\blabel\b/);
+    // Concrete worked example uses one of the candidates.
+    expect(message).toMatch(/e\.g\. @minimum :(width|height) 1/);
+  });
+
+  it("does not append a hint when no subfield satisfies the capability", () => {
+    const message = getGenerationFailureMessage("HintlessNoCandidatesForm");
+
+    expect(message).toContain("TYPE_MISMATCH");
+    expect(message).not.toContain("Hint:");
+  });
+
+  it("does not append a hint when the existing primitive-mismatch is on a non-object field", () => {
+    // Pre-existing fixture: @minimum 0 on `label!: string` — primitive type, no
+    // subfields to suggest. The hint must remain off in this case.
+    const message = getGenerationFailureMessage("MismatchedForm");
+
+    expect(message).toContain("TYPE_MISMATCH");
+    expect(message).not.toContain("Hint:");
+  });
+
   it("throws with INVALID_TAG_PLACEMENT for builtin constraints on class declarations", () => {
     expect(getGenerationFailureMessage("InvalidPlacementForm")).toContain("INVALID_TAG_PLACEMENT");
   });

--- a/packages/build/src/__tests__/class-schema.test.ts
+++ b/packages/build/src/__tests__/class-schema.test.ts
@@ -218,6 +218,37 @@ describe("generateSchemas", () => {
     expect(message).not.toContain("Hint:");
   });
 
+  it("surfaces subfield candidates through nullish unions (regression: Copilot review on #283)", () => {
+    const message = getGenerationFailureMessage("HintedNullablePriceForm");
+
+    expect(message).toContain("TYPE_MISMATCH");
+    expect(message).toContain("Hint:");
+    expect(message).toContain("@exclusiveMinimum :value 0");
+  });
+
+  it("suggests `string[]` subfields for string-like constraints (regression: Copilot review on #283)", () => {
+    const message = getGenerationFailureMessage("HintedStringLikeArrayCandidateForm");
+
+    expect(message).toContain("TYPE_MISMATCH");
+    expect(message).toContain("Hint:");
+    // `tags: string[]` qualifies via supportsConstraintCapability's array unwrap.
+    expect(message).toContain("tags");
+    // `count: number` must not appear as a string-like candidate.
+    expect(message).not.toMatch(/:count\b/);
+  });
+
+  it("ignores intrinsic Function members when recursing into method types (regression: Copilot review on #283)", () => {
+    const message = getGenerationFailureMessage("HintedFiltersCallableMembersForm");
+
+    expect(message).toContain("TYPE_MISMATCH");
+    expect(message).toContain("Hint:");
+    expect(message).toContain("value");
+    // Function.prototype members must not leak into the suggestion list.
+    expect(message).not.toMatch(/:helper\./);
+    expect(message).not.toContain("apply");
+    expect(message).not.toContain("__brand");
+  });
+
   it("throws with INVALID_TAG_PLACEMENT for builtin constraints on class declarations", () => {
     expect(getGenerationFailureMessage("InvalidPlacementForm")).toContain("INVALID_TAG_PLACEMENT");
   });

--- a/packages/build/src/__tests__/fixtures/class-schema-regressions.ts
+++ b/packages/build/src/__tests__/fixtures/class-schema-regressions.ts
@@ -139,3 +139,34 @@ export class HintlessNoCandidatesForm {
   /** @minimum 0 */
   info!: LabeledOnly;
 }
+
+// Nullable union: hint should still surface `value` because the non-null
+// member (PriceAmount) has a matching subfield.
+export class HintedNullablePriceForm {
+  /** @exclusiveMinimum 0 */
+  totalPrice!: PriceAmount | null;
+}
+
+// `@pattern` is a string-like constraint. `tags: string[]` satisfies
+// `string-like` via `supportsConstraintCapability`'s array-element unwrap,
+// so the hint should list it; `count: number` should not be listed.
+interface TaggedItem {
+  tags: string[];
+  count: number;
+}
+export class HintedStringLikeArrayCandidateForm {
+  /** @pattern ^[a-z]+$ */
+  item!: TaggedItem;
+}
+
+// Object with a method: the method's type carries intrinsic `Function`
+// members (`length`, `name`, `apply`, …). The hint must not recurse into
+// callable types, so only the user-declared `value` subfield should appear.
+interface WithMethod {
+  helper(): number;
+  value: number;
+}
+export class HintedFiltersCallableMembersForm {
+  /** @minimum 0 */
+  widget!: WithMethod;
+}

--- a/packages/build/src/__tests__/fixtures/class-schema-regressions.ts
+++ b/packages/build/src/__tests__/fixtures/class-schema-regressions.ts
@@ -108,3 +108,34 @@ export class ThermostatForm {
 export class InvalidPlacementForm {
   value!: number;
 }
+
+interface PriceAmount {
+  value: number;
+  currency: string;
+}
+
+export class HintedSingleCandidateForm {
+  /** @exclusiveMinimum 0 */
+  totalPrice!: PriceAmount;
+}
+
+interface BoundingBox {
+  width: number;
+  height: number;
+  label: string;
+}
+
+export class HintedMultipleCandidatesForm {
+  /** @minimum 1 */
+  region!: BoundingBox;
+}
+
+interface LabeledOnly {
+  label: string;
+  description: string;
+}
+
+export class HintlessNoCandidatesForm {
+  /** @minimum 0 */
+  info!: LabeledOnly;
+}

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -352,6 +352,81 @@ function supportsConstraintCapability(
   return false;
 }
 
+const MAX_HINT_CANDIDATES = 5;
+const MAX_HINT_DEPTH = 3;
+
+/**
+ * Collects user-declared subfields whose type satisfies the constraint
+ * `capability`. Only descends into object-like types — never traverses into
+ * primitives' intrinsic properties (e.g. would not surface `string.length`
+ * on a `string` subfield).
+ */
+function collectObjectSubfieldCandidates(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  capability: SemanticCapability
+): readonly string[] {
+  const out: string[] = [];
+  const visit = (current: ts.Type, prefix: readonly string[], depth: number): void => {
+    if (depth > MAX_HINT_DEPTH) {
+      return;
+    }
+    if (!hasTypeSemanticCapability(current, checker, "object-like")) {
+      return;
+    }
+    for (const property of current.getProperties()) {
+      const declaration = property.valueDeclaration ?? property.declarations?.[0];
+      if (declaration === undefined) {
+        continue;
+      }
+      const propertyType = checker.getTypeOfSymbolAtLocation(property, declaration);
+      const path = [...prefix, property.name];
+      if (hasTypeSemanticCapability(propertyType, checker, capability)) {
+        out.push(path.join("."));
+        continue;
+      }
+      if (hasTypeSemanticCapability(propertyType, checker, "object-like")) {
+        visit(propertyType, path, depth + 1);
+      }
+    }
+  };
+  visit(type, [], 0);
+  return out;
+}
+
+function buildPathTargetHint(
+  subjectType: ts.Type,
+  checker: ts.TypeChecker,
+  capability: SemanticCapability,
+  tagName: string,
+  argumentText: string | undefined
+): string | null {
+  // Only suggest path targeting when the subject is itself an object — for
+  // primitive mismatches (e.g. `@minimum` on a `string`), the user almost
+  // certainly meant a different constraint, not a path target.
+  if (!hasTypeSemanticCapability(subjectType, checker, "object-like")) {
+    return null;
+  }
+
+  const candidates = collectObjectSubfieldCandidates(subjectType, checker, capability);
+  const primary = candidates[0];
+  if (primary === undefined) {
+    return null;
+  }
+
+  const argText = argumentText?.trim() ?? "";
+  const renderExample = (path: string): string =>
+    argText === "" ? `@${tagName} :${path}` : `@${tagName} :${path} ${argText}`;
+
+  if (candidates.length === 1) {
+    return `Hint: use a path target to constrain a subfield, e.g. ${renderExample(primary)}`;
+  }
+
+  const shown = candidates.slice(0, MAX_HINT_CANDIDATES);
+  const overflow = candidates.length > MAX_HINT_CANDIDATES ? ", …" : "";
+  return `Hint: use a path target to constrain a subfield (candidates: ${shown.join(", ")}${overflow}), e.g. ${renderExample(primary)}`;
+}
+
 function makeDiagnostic(
   code: string,
   message: string,
@@ -560,10 +635,18 @@ function buildCompilerBackedConstraintDiagnostics(
       !supportsConstraintCapability(subjectType, checker, requiredCapability)
     ) {
       const actualType = checker.typeToString(subjectType, node, SYNTHETIC_TYPE_FORMAT_FLAGS);
+      const baseMessage = `Target "${node.getText(sourceFile)}": constraint "${tagName}" is only valid on ${capabilityLabel(requiredCapability)} targets, but field type is "${actualType}"`;
+      const hint = buildPathTargetHint(
+        subjectType,
+        checker,
+        requiredCapability,
+        tagName,
+        parsedTag?.argumentText
+      );
       return [
         makeDiagnostic(
           "TYPE_MISMATCH",
-          `Target "${node.getText(sourceFile)}": constraint "${tagName}" is only valid on ${capabilityLabel(requiredCapability)} targets, but field type is "${actualType}"`,
+          hint === null ? baseMessage : `${baseMessage}. ${hint}`,
           provenance
         ),
       ];

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -355,11 +355,57 @@ function supportsConstraintCapability(
 const MAX_HINT_CANDIDATES = 5;
 const MAX_HINT_DEPTH = 3;
 
+function stripHintNullishUnion(type: ts.Type): ts.Type {
+  if (!type.isUnion()) {
+    return type;
+  }
+  const nonNullish = type.types.filter(
+    (member) => (member.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) === 0
+  );
+  if (nonNullish.length === 1 && nonNullish[0] !== undefined) {
+    return nonNullish[0];
+  }
+  return type;
+}
+
+function isCallableType(type: ts.Type): boolean {
+  return type.getCallSignatures().length > 0 || type.getConstructSignatures().length > 0;
+}
+
+function isUserEmittableHintProperty(
+  property: ts.Symbol,
+  declaration: ts.Declaration
+): boolean {
+  if (property.name.startsWith("__")) {
+    return false;
+  }
+  if ("name" in declaration && declaration.name !== undefined) {
+    const name = declaration.name as ts.PropertyName;
+    if (ts.isComputedPropertyName(name) || ts.isPrivateIdentifier(name)) {
+      return false;
+    }
+    if (
+      !ts.isIdentifier(name) &&
+      !ts.isStringLiteral(name) &&
+      !ts.isNumericLiteral(name)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Collects user-declared subfields whose type satisfies the constraint
  * `capability`. Only descends into object-like types — never traverses into
  * primitives' intrinsic properties (e.g. would not surface `string.length`
- * on a `string` subfield).
+ * on a `string` subfield), into function/call-signature types (which would
+ * surface `Function.prototype` members like `length`, `name`, `apply`), or
+ * through synthetic property names like `__brand` / computed / private ones.
+ * Nullish unions are stripped so `Foo | null` can still surface candidates
+ * declared on `Foo`. Terminal matches use `supportsConstraintCapability` so
+ * the hint aligns with the capability rules used by the TYPE_MISMATCH
+ * diagnostic (for example, `string[]` satisfies `string-like`).
  */
 function collectObjectSubfieldCandidates(
   type: ts.Type,
@@ -371,22 +417,33 @@ function collectObjectSubfieldCandidates(
     if (depth > MAX_HINT_DEPTH) {
       return;
     }
-    if (!hasTypeSemanticCapability(current, checker, "object-like")) {
+    const stripped = stripHintNullishUnion(current);
+    if (isCallableType(stripped)) {
       return;
     }
-    for (const property of current.getProperties()) {
+    if (!hasTypeSemanticCapability(stripped, checker, "object-like")) {
+      return;
+    }
+    for (const property of stripped.getProperties()) {
       const declaration = property.valueDeclaration ?? property.declarations?.[0];
       if (declaration === undefined) {
         continue;
       }
+      if (!isUserEmittableHintProperty(property, declaration)) {
+        continue;
+      }
       const propertyType = checker.getTypeOfSymbolAtLocation(property, declaration);
       const path = [...prefix, property.name];
-      if (hasTypeSemanticCapability(propertyType, checker, capability)) {
+      if (supportsConstraintCapability(propertyType, checker, capability)) {
         out.push(path.join("."));
         continue;
       }
-      if (hasTypeSemanticCapability(propertyType, checker, "object-like")) {
-        visit(propertyType, path, depth + 1);
+      const strippedPropertyType = stripHintNullishUnion(propertyType);
+      if (
+        !isCallableType(strippedPropertyType) &&
+        hasTypeSemanticCapability(strippedPropertyType, checker, "object-like")
+      ) {
+        visit(strippedPropertyType, path, depth + 1);
       }
     }
   };


### PR DESCRIPTION
## Summary

- When `@exclusiveMinimum` (or any constraint requiring a specific capability) is applied to an object field, the `TYPE_MISMATCH` diagnostic now appends a `Hint:` suggesting the corrected path-targeted syntax — e.g. `@exclusiveMinimum :value 0` — instead of leaving the user to discover it on their own.
- When more than one subfield qualifies, the hint lists the candidates and shows a worked example using the first.
- Gated to object subjects (primitive mismatches still get the original message — those are usually a wrong-constraint mistake, not a missing path target).
- Subfield walker descends only through user-declared object-like types, so JS intrinsics like `string.length` never appear as suggestions.

## Example

Before:
```
TYPE_MISMATCH: Target "totalPrice: PriceRange;": constraint "exclusiveMinimum"
is only valid on number targets, but field type is "PriceRange"
```

After:
```
TYPE_MISMATCH: Target "totalPrice: PriceRange;": constraint "exclusiveMinimum"
is only valid on number targets, but field type is "PriceRange". Hint: use a
path target to constrain a subfield, e.g. @exclusiveMinimum :value 0
```

Closes #282.

## Test plan

- [x] New unit/e2e fixtures + tests in `packages/build/src/__tests__/class-schema.test.ts` cover: single candidate, multiple candidates (with `candidates: …` listing), no compatible subfield (no hint), and primitive mismatch (no hint, preserves prior behavior).
- [x] `pnpm run build` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm -r run test` — 1,946 tests pass across all packages