### PR TITLE
Fix silent data loss on Promise unwrap failures and void return types

### DIFF
--- a/.changeset/fail-loud-on-unresolvable-types.md
+++ b/.changeset/fail-loud-on-unresolvable-types.md
@@ -1,5 +1,7 @@
 ---
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
 "formspec": patch
 ---
 

--- a/.changeset/fail-loud-on-unresolvable-types.md
+++ b/.changeset/fail-loud-on-unresolvable-types.md
@@ -1,0 +1,9 @@
+---
+"@formspec/build": patch
+"formspec": patch
+---
+
+Surface Promise-unwrap failures and map `void` to null in schema generation.
+
+- `unwrapPromiseType` now throws a descriptive error when `checker.getAwaitedType` fails to unwrap a `Promise<T>`-shaped return type. Previously the payload would silently degrade to `{ type: "string" }`; this commonly occurred when the TypeScript compiler host could not locate its default lib files (e.g. after bundling `typescript` with esbuild), as described in #256.
+- `void` types (e.g. `void`, `Promise<void>` return types) now map to `{ type: "null" }`, matching the treatment of `undefined`. Previously `void` fell through to the string fallback and was indistinguishable from an actual `string` return type (#257).

--- a/packages/build/src/__tests__/fixtures/method-signature-schemas.ts
+++ b/packages/build/src/__tests__/fixtures/method-signature-schemas.ts
@@ -157,6 +157,23 @@ export class PaymentService {
       },
     };
   }
+
+  returnsVoid(): void {
+    return;
+  }
+
+  async returnsVoidAsync(): Promise<void> {
+    await Promise.resolve();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- fixture intentionally exercises `any` resolution
+  returnsAny(): any {
+    return "anything";
+  }
+
+  returnsUnknown(): unknown {
+    return "anything";
+  }
 }
 
 export function submitPayment(input: SubmitInput): SubmitResult {

--- a/packages/build/src/__tests__/signature-schema-generation.test.ts
+++ b/packages/build/src/__tests__/signature-schema-generation.test.ts
@@ -248,6 +248,117 @@ describe("method-signature schema generation", () => {
     expect(schemas.uiSchema).toBeNull();
   });
 
+  it("maps `void` return types to null schemas (regression: issue #257)", () => {
+    const context = createStaticBuildContext(fixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService class not found");
+    }
+
+    const method = getMethod(declaration, "returnsVoid");
+    const schemas = generateSchemasFromReturnType({
+      context,
+      declaration: method,
+    });
+
+    // Before the fix, `void` silently fell through to `{ type: "string" }`,
+    // making it indistinguishable from an actual string return type.
+    expect(schemas.jsonSchema).toMatchObject({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "null",
+    });
+  });
+
+  it("maps `Promise<void>` return types to null schemas (regression: issue #257)", () => {
+    const context = createStaticBuildContext(fixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService class not found");
+    }
+
+    const method = getMethod(declaration, "returnsVoidAsync");
+    const schemas = generateSchemasFromReturnType({
+      context,
+      declaration: method,
+    });
+
+    expect(schemas.jsonSchema).toMatchObject({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "null",
+    });
+  });
+
+  it("still maps `any` return types to a permissive string schema", () => {
+    const context = createStaticBuildContext(fixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService class not found");
+    }
+
+    const method = getMethod(declaration, "returnsAny");
+    const schemas = generateSchemasFromReturnType({
+      context,
+      declaration: method,
+    });
+
+    expect(schemas.jsonSchema).toMatchObject({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "string",
+    });
+  });
+
+  it("still maps `unknown` return types to a permissive string schema", () => {
+    const context = createStaticBuildContext(fixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService class not found");
+    }
+
+    const method = getMethod(declaration, "returnsUnknown");
+    const schemas = generateSchemasFromReturnType({
+      context,
+      declaration: method,
+    });
+
+    expect(schemas.jsonSchema).toMatchObject({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "string",
+    });
+  });
+
+  it("throws when a Promise return type cannot be unwrapped (regression: issue #256)", () => {
+    // Simulate the "missing lib files" scenario from issue #256: when the
+    // TypeScript compiler host cannot locate `lib.es2015.promise.d.ts`,
+    // `checker.getAwaitedType(Promise<T>)` returns the input type unchanged.
+    // Previously the payload would silently degrade to `{ type: "string" }`;
+    // now `unwrapPromiseType` throws with a descriptive error.
+    const context = createStaticBuildContext(fixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService class not found");
+    }
+
+    const method = getMethod(declaration, "submitAsync");
+    const brokenChecker: ts.TypeChecker = new Proxy(context.checker, {
+      get(target, prop, receiver): unknown {
+        if (prop === "getAwaitedType") {
+          // Simulate a broken host by returning the Promise type as-is.
+          return (type: ts.Type): ts.Type => type;
+        }
+        return Reflect.get(target, prop, receiver) as unknown;
+      },
+    });
+
+    const brokenContext = { ...context, checker: brokenChecker };
+
+    expect(() =>
+      generateSchemasFromReturnType({
+        context: brokenContext,
+        declaration: method,
+      })
+    ).toThrow(/could not unwrap the awaited type from "Promise<.*>"/);
+  });
+
   it("preserves concrete generic type arguments for discovered signature types", () => {
     const context = createStaticBuildContext(fixturePath);
     const declaration = resolveModuleExportDeclaration(context, "PaymentService");

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -2080,8 +2080,9 @@ export function resolveTypeNode(
   // This includes `any`, `unknown`, type parameters (e.g. `payload: T` inside
   // `Envelope<T>` when walking the declaration), conditional types, indexed
   // access types, and other patterns the analyzer cannot represent in the
-  // canonical IR. Promise-unwrapping failures (see `unwrapPromisePayloadType`)
-  // are caught separately to surface the most common cause of silent data loss.
+  // canonical IR. Promise-unwrapping failures (see `unwrapPromiseType` in
+  // `packages/build/src/generators/discovered-schema.ts`) are caught separately
+  // to surface the most common cause of silent data loss.
   return { kind: "primitive", primitiveKind: "string" };
 }
 

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -1968,6 +1968,11 @@ export function resolveTypeNode(
     // Undefined maps to null for nullable semantics in JSON Schema
     return { kind: "primitive", primitiveKind: "null" };
   }
+  if (type.flags & ts.TypeFlags.Void) {
+    // Void (e.g. `Promise<void>` return types) maps to null — matches the
+    // treatment of `undefined` and avoids collisions with actual `string` types.
+    return { kind: "primitive", primitiveKind: "null" };
+  }
 
   // --- String literal ---
   if (type.isStringLiteral()) {
@@ -2071,7 +2076,12 @@ export function resolveTypeNode(
     );
   }
 
-  // --- Fallback: treat unknown/any/void as string ---
+  // --- Fallback: treat any/unknown/unresolved types as string ---
+  // This includes `any`, `unknown`, type parameters (e.g. `payload: T` inside
+  // `Envelope<T>` when walking the declaration), conditional types, indexed
+  // access types, and other patterns the analyzer cannot represent in the
+  // canonical IR. Promise-unwrapping failures (see `unwrapPromisePayloadType`)
+  // are caught separately to surface the most common cause of silent data loss.
   return { kind: "primitive", primitiveKind: "string" };
 }
 

--- a/packages/build/src/generators/discovered-schema.ts
+++ b/packages/build/src/generators/discovered-schema.ts
@@ -699,7 +699,31 @@ function unwrapPromiseType(checker: ts.TypeChecker, type: ts.Type): ts.Type {
     return type;
   }
 
-  return checker.getAwaitedType(type) ?? type;
+  const awaited = checker.getAwaitedType(type) ?? type;
+  if (awaited === type && looksLikePromiseType(checker, type)) {
+    // The type prints as `Promise<T>` but the checker could not await it. The
+    // most common cause is a TypeScript compiler host that cannot locate its
+    // default lib files (e.g. `lib.es2015.promise.d.ts`) — for example after
+    // bundling `typescript` with esbuild. Without this check, the payload type
+    // would silently degrade to `{ type: "string" }` in the generated schema
+    // (see issue #256).
+    throw new Error(
+      `FormSpec could not unwrap the awaited type from "${checker.typeToString(type)}". ` +
+        `This usually indicates the TypeScript compiler host cannot resolve its default ` +
+        `lib files (for example "lib.es2015.promise.d.ts"). Ensure the program is configured ` +
+        `with the standard library available to \`ts.createProgram\`.`
+    );
+  }
+
+  return awaited;
+}
+
+function looksLikePromiseType(checker: ts.TypeChecker, type: ts.Type): boolean {
+  const symbolName = type.getSymbol()?.getName();
+  if (symbolName === "Promise" || symbolName === "PromiseLike") {
+    return true;
+  }
+  return /^(?:Promise|PromiseLike)\b/.test(checker.typeToString(type));
 }
 
 function unwrapPromiseTypeNode(typeNode: ts.TypeNode | undefined): ts.TypeNode | undefined {


### PR DESCRIPTION
Two silent data-loss bugs in `@formspec/build` schema generation for TypeScript method signatures.

**Problem.** `void` and `Promise<void>` return types fell through to the `resolveTypeNode` string fallback, producing `{ type: "string" }` — indistinguishable from an actual `string` return (#257). Separately, when the TypeScript compiler host cannot locate `lib.es2015.promise.d.ts` (common when `typescript` is bundled with esbuild), `checker.getAwaitedType(Promise<T>)` returns the input unchanged; the unresolved payload then passed through as `{ type: "string" }` with no error or warning (#256).

**Fix.**

- Added an explicit `TypeFlags.Void` branch in `resolveTypeNode` that maps `void` to `{ kind: "primitive", primitiveKind: "null" }`, matching `undefined`.
- `unwrapPromiseType` now detects when `getAwaitedType` fails to change a Promise-shaped input type (symbol name match or `Promise<`/`PromiseLike<` prefix) and throws a descriptive error pointing at the likely lib-file cause, rather than silently letting the unresolved type reach the fallback.

The broader catch-all fallback in `resolveTypeNode` is left as a permissive string — it legitimately catches unresolved type parameters, conditional types, indexed access types, and custom branded types across the existing code paths; tightening it further is out of scope here.

Closes #256, closes #257.