### PR TITLE
Fix toStandaloneJsonSchema __result renamed by metadata policy

### DIFF
--- a/.changeset/fix-standalone-apiname.md
+++ b/.changeset/fix-standalone-apiname.md
@@ -1,0 +1,5 @@
+---
+'@formspec/build': patch
+---
+
+Fix toStandaloneJsonSchema failing when metadata policy renames the synthetic __result field

--- a/.changeset/fix-standalone-apiname.md
+++ b/.changeset/fix-standalone-apiname.md
@@ -1,5 +1,8 @@
 ---
 '@formspec/build': patch
+'@formspec/cli': patch
+'@formspec/eslint-plugin': patch
+'formspec': patch
 ---
 
 Fix toStandaloneJsonSchema failing when metadata policy renames the synthetic __result field

--- a/packages/build/src/generators/discovered-schema.ts
+++ b/packages/build/src/generators/discovered-schema.ts
@@ -353,7 +353,13 @@ function toStandaloneJsonSchema(
   const syntheticField: FieldNode = {
     kind: "field",
     name: "__result",
-    ...(syntheticFieldMetadata !== undefined && { metadata: syntheticFieldMetadata }),
+    metadata: {
+      ...syntheticFieldMetadata,
+      // Pin apiName so metadata-policy transforms (e.g. toStripeApiCase)
+      // cannot rename this synthetic wrapper field. The lookup below
+      // expects "__result" in the output schema properties.
+      apiName: { value: "__result", source: "explicit" },
+    },
     type: root.type,
     required: true,
     constraints: [],


### PR DESCRIPTION
## Summary

`toStandaloneJsonSchema` wraps a type in a synthetic `__result` field to extract its schema through the IR pipeline. When a metadata policy with apiName inference is active (e.g., one that applies snake_case conversion), the `__result` field name gets transformed to `result`. The subsequent `schema.properties["__result"]` lookup fails, throwing "FormSpec failed to extract the standalone schema root from the synthetic IR."

## Root Cause

The synthetic field had no explicit `apiName` metadata, so the metadata policy treated the name as inferrable and transformed it.

## Fix

Set `apiName: { value: "__result", source: "explicit" }` on the synthetic field. The `"explicit"` source tells the metadata policy this name is intentional and should not be overridden by inference — the same mechanism authors use with `@apiName`.

## Reproduction

Any call to `generateSchemasFromType` or `generateSchemasFromParameter` with a metadata policy that transforms field names will fail. This affects custom object action return types when the Stripe naming policy is active.

## Tests

All 714 existing tests pass. The fix was verified end-to-end against the `stripe generate custom-objects-sdk` CLI command with real custom object definitions.