### PR TITLE
Fix path-targeted broadening for all custom-type registrations

### DIFF
--- a/.changeset/holistic-custom-type-broadening.md
+++ b/.changeset/holistic-custom-type-broadening.md
@@ -3,6 +3,8 @@
 "@formspec/build": patch
 "@formspec/cli": patch
 "@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
 "formspec": patch
 ---
 

--- a/.changeset/holistic-custom-type-broadening.md
+++ b/.changeset/holistic-custom-type-broadening.md
@@ -1,0 +1,17 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Fix TYPE_MISMATCH false positives for path-targeted constraints on any extension-registered custom type, and consolidate duplicated custom-type resolution.
+
+- Path-targeted built-in constraint tags (e.g. `@exclusiveMinimum :amount 0`) now defer to the IR-layer validator when the resolved sub-type is an extension-registered custom type with broadening for the tag — previously the compiler-backed validator rejected them as capability mismatches.
+- Detection covers all three registration mechanisms: `tsTypeNames` (name), `brand` (structural brand identifiers), and symbol-based registration from `defineCustomType<T>()`. The deferral is tag-aware: only tags with broadening registered on the resolved custom type skip the capability check. Unrelated tags (e.g., `@pattern` on a numeric `Decimal`) still reject via the capability layer.
+- The two branches of `buildCompilerBackedConstraintDiagnostics` (path-targeted vs. direct field) are now structurally symmetric — both resolve the type once, check broadening, then run a unified capability check.
+- `@formspec/analysis/internal` now exports `stripNullishUnion` — the single source of truth for `T | null`/`T | undefined` collapsing used across the analysis and build layers.
+- `class-analyzer.ts`'s private three-resolver chain (`resolveRegisteredCustomType` / `resolveSymbolBasedCustomType` / `resolveBrandedCustomType`) is replaced by a single call to the new shared helper in `@formspec/build/src/extensions/resolve-custom-type.ts`.
+
+No public API changes. The shared helpers are internal to `@formspec/build`.

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -137,6 +137,7 @@ export {
   hasTypeSemanticCapability,
   resolveDeclarationPlacement,
   resolvePathTargetType,
+  stripNullishUnion,
   type FormSpecSemanticCapability,
   type ResolvedPathTargetType,
 } from "./ts-binding.js";

--- a/packages/analysis/src/ts-binding.ts
+++ b/packages/analysis/src/ts-binding.ts
@@ -20,7 +20,14 @@ export type ResolvedPathTargetType =
       readonly type: ts.Type;
     };
 
-function stripNullishUnion(type: ts.Type): ts.Type {
+/**
+ * Collapses `T | null`, `T | undefined`, and `T | null | undefined` to `T`.
+ *
+ * Only collapses when exactly one non-nullish member remains — wider unions
+ * (e.g. `A | B | null`) pass through unchanged. Used throughout the analysis
+ * layer to normalize nullable fields before capability checks.
+ */
+export function stripNullishUnion(type: ts.Type): ts.Type {
   if (!type.isUnion()) {
     return type;
   }

--- a/packages/build/src/__tests__/generate-schemas-config.test.ts
+++ b/packages/build/src/__tests__/generate-schemas-config.test.ts
@@ -3,8 +3,11 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import { describe, expect, it } from "vitest";
 import type { FormSpecConfig } from "@formspec/config";
-import { generateSchemas } from "../generators/class-schema.js";
+import { defineCustomType, defineExtension } from "@formspec/core/internals";
+import { type ClassSchemas, generateSchemas } from "../generators/class-schema.js";
 import { numericExtension } from "./fixtures/example-numeric-extension.js";
+
+type JsonSchemaObject = Record<string, unknown>;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -182,6 +185,253 @@ describe("generateSchemas with FormSpecConfig", () => {
     } finally {
       fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
     }
+  });
+
+  // =========================================================================
+  // Path-targeted broadening on extension-registered custom types.
+  //
+  // A built-in constraint tag (e.g. `@exclusiveMinimum`) applied through a
+  // path target (`@exclusiveMinimum :amount 0`) must defer to the IR-layer
+  // validator when the path resolves to an extension-registered custom type
+  // that has broadening for that tag. Previously the compiler-backed
+  // validator rejected these at the capability check, silently shadowing
+  // legitimate broadening.
+  //
+  // This suite exercises the full matrix of registration mechanisms
+  // (name / brand) × tag kinds × wrapping shapes.
+  // =========================================================================
+  describe("path-targeted broadening on registered custom types", () => {
+    // Separate `Decimal` extension registered via `brand`. Same broadenings
+    // as `numericExtension`'s name-registered Decimal, but detected
+    // structurally through the computed-property brand key rather than the
+    // alias identifier.
+    const brandedDecimalExtension = defineExtension({
+      extensionId: "x-test/branded-decimal",
+      types: [
+        defineCustomType({
+          typeName: "Decimal",
+          brand: "__decimalBrand",
+          builtinConstraintBroadenings: [
+            { tagName: "minimum", constraintName: "DecimalMinimum" },
+            { tagName: "maximum", constraintName: "DecimalMaximum" },
+            { tagName: "exclusiveMinimum", constraintName: "DecimalExclusiveMinimum" },
+            { tagName: "exclusiveMaximum", constraintName: "DecimalExclusiveMaximum" },
+            { tagName: "multipleOf", constraintName: "DecimalMultipleOf" },
+          ],
+          toJsonSchema: () => ({ type: "string" }),
+        }),
+      ],
+    });
+
+    const nameBasedConfig: FormSpecConfig = {
+      extensions: [numericExtension],
+      vendorPrefix: "x-formspec",
+    };
+    const brandBasedConfig: FormSpecConfig = {
+      extensions: [brandedDecimalExtension],
+      vendorPrefix: "x-test",
+    };
+
+    // Source declarations for Decimal under each registration mechanism.
+    const nameBasedDecimal = `export type Decimal = string & { readonly __brand: "Decimal" };`;
+    const brandBasedDecimal = [
+      "declare const __decimalBrand: unique symbol;",
+      "export type Decimal = string & { readonly [__decimalBrand]: true };",
+    ].join("\n");
+
+    function runSchema(source: string, config: FormSpecConfig) {
+      const filePath = writeTempSource(source);
+      try {
+        return generateSchemas({
+          filePath,
+          typeName: "PaymentForm",
+          config,
+          errorReporting: "throw",
+        });
+      } finally {
+        fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+      }
+    }
+
+    // A path-target override is emitted as an `allOf` entry with
+    // `properties.<segment>.<jsonSchemaKeyword>: <value>`. Asserting via a
+    // direct `allOf` shape — then scanning its entries — keeps the Jest
+    // matcher types clean (no unsafe-any from `expect.arrayContaining`).
+    function expectPathOverride(
+      result: ClassSchemas,
+      fieldName: string,
+      segment: string,
+      keyword: string,
+      value: unknown
+    ) {
+      const field = (result.jsonSchema.properties as JsonSchemaObject | undefined)?.[fieldName];
+      const allOf = (field as { allOf?: readonly JsonSchemaObject[] } | undefined)?.allOf;
+      expect(allOf).toBeDefined();
+      const overrideEntry = allOf?.find((entry) => {
+        const properties = entry["properties"] as JsonSchemaObject | undefined;
+        const segmentSchema = properties?.[segment] as JsonSchemaObject | undefined;
+        return segmentSchema !== undefined && segmentSchema[keyword] === value;
+      });
+      expect(overrideEntry).toBeDefined();
+    }
+
+    // Path-target overrides emit the standard JSON Schema keyword directly
+    // on the sub-path — not the vendor-prefixed custom-constraint keyword
+    // that's used for the type's own direct-target broadening. See the
+    // `allOf: [{ $ref }, { properties: { amount: { minimum: 0 } } }]`
+    // shape asserted by `expectPathOverride`.
+    const numericTagCases: readonly {
+      tag: string;
+      argument: string;
+      jsonKeyword: string;
+      jsonValue: number;
+    }[] = [
+      { tag: "minimum", argument: "0", jsonKeyword: "minimum", jsonValue: 0 },
+      { tag: "maximum", argument: "100", jsonKeyword: "maximum", jsonValue: 100 },
+      { tag: "exclusiveMinimum", argument: "0", jsonKeyword: "exclusiveMinimum", jsonValue: 0 },
+      {
+        tag: "exclusiveMaximum",
+        argument: "1000",
+        jsonKeyword: "exclusiveMaximum",
+        jsonValue: 1000,
+      },
+      { tag: "multipleOf", argument: "0.01", jsonKeyword: "multipleOf", jsonValue: 0.01 },
+    ];
+
+    describe("name-based registration (tsTypeNames)", () => {
+      it.each(numericTagCases)(
+        "broadens @$tag through a path target onto a Decimal subfield",
+        ({ tag, argument, jsonKeyword, jsonValue }) => {
+          const source = `
+            ${nameBasedDecimal}
+            export interface MonetaryAmount { amount: Decimal; currency: string; }
+            export interface PaymentForm {
+              /** @${tag} :amount ${argument} */
+              total: MonetaryAmount;
+            }
+          `;
+          const result = runSchema(source, nameBasedConfig);
+          expectPathOverride(result, "total", "amount", jsonKeyword, jsonValue);
+        }
+      );
+
+      it("broadens across a nullable Decimal", () => {
+        const source = `
+          ${nameBasedDecimal}
+          export interface MonetaryAmount { amount: Decimal | null; currency: string; }
+          export interface PaymentForm {
+            /** @exclusiveMinimum :amount 0 */
+            total: MonetaryAmount;
+          }
+        `;
+        const result = runSchema(source, nameBasedConfig);
+        expectPathOverride(result, "total", "amount", "exclusiveMinimum", 0);
+      });
+
+      it("broadens through a deeply-nested path", () => {
+        const source = `
+          ${nameBasedDecimal}
+          export interface Nested { inner: { amount: Decimal }; }
+          export interface PaymentForm {
+            /** @minimum :inner.amount 0 */
+            total: Nested;
+          }
+        `;
+        const result = runSchema(source, nameBasedConfig);
+        // For nested paths, the path override lives inside the top-level
+        // "allOf" entry keyed off the first segment; walk the chain manually
+        // to avoid unsafe-any from `expect.objectContaining`.
+        const total = (result.jsonSchema.properties as JsonSchemaObject | undefined)?.["total"];
+        const allOf = (total as { allOf?: readonly JsonSchemaObject[] } | undefined)?.allOf;
+        const override = allOf?.find((entry) => {
+          const properties = entry["properties"] as JsonSchemaObject | undefined;
+          const inner = properties?.["inner"] as JsonSchemaObject | undefined;
+          const innerProps = inner?.["properties"] as JsonSchemaObject | undefined;
+          const amount = innerProps?.["amount"] as JsonSchemaObject | undefined;
+          return amount?.["minimum"] === 0;
+        });
+        expect(override).toBeDefined();
+      });
+    });
+
+    describe("brand-based registration", () => {
+      it.each(numericTagCases)(
+        "broadens @$tag through a path target onto a brand-registered Decimal",
+        ({ tag, argument }) => {
+          const source = `
+            ${brandBasedDecimal}
+            export interface MonetaryAmount { amount: Decimal; currency: string; }
+            export interface PaymentForm {
+              /** @${tag} :amount ${argument} */
+              total: MonetaryAmount;
+            }
+          `;
+          // We don't assert the x-prefixed keyword value because the
+          // branded extension uses a different vendor prefix; the test only
+          // needs to confirm generation succeeds without TYPE_MISMATCH.
+          expect(() => runSchema(source, brandBasedConfig)).not.toThrow();
+        }
+      );
+
+      it("broadens across a nullable brand-registered Decimal", () => {
+        const source = `
+          ${brandBasedDecimal}
+          export interface MonetaryAmount { amount: Decimal | null; currency: string; }
+          export interface PaymentForm {
+            /** @exclusiveMinimum :amount 0 */
+            total: MonetaryAmount;
+          }
+        `;
+        expect(() => runSchema(source, brandBasedConfig)).not.toThrow();
+      });
+    });
+
+    describe("negative cases (fix must not paper over real type mismatches)", () => {
+      it("rejects numeric constraints when the path resolves to a non-custom string", () => {
+        const source = `
+          ${nameBasedDecimal}
+          export interface MonetaryAmount { amount: Decimal; currency: string; }
+          export interface PaymentForm {
+            /** @exclusiveMinimum :currency 0 */
+            total: MonetaryAmount;
+          }
+        `;
+        // Assert the error specifically names the offending segment and tag
+        // so it cannot mask a TYPE_MISMATCH from a different code path.
+        expect(() => runSchema(source, nameBasedConfig)).toThrow(
+          /TYPE_MISMATCH.*currency.*exclusiveMinimum|exclusiveMinimum.*currency/
+        );
+      });
+
+      it("rejects a string-only tag (@pattern) on a numeric-only Decimal path", () => {
+        // `@pattern` is a string-like constraint. Decimal has numeric
+        // broadenings registered but no string-pattern broadening, so the
+        // deferral must not kick in and the capability check must reject.
+        const source = `
+          ${nameBasedDecimal}
+          export interface MonetaryAmount { amount: Decimal; currency: string; }
+          export interface PaymentForm {
+            /** @pattern :amount ^[0-9]+$ */
+            total: MonetaryAmount;
+          }
+        `;
+        expect(() => runSchema(source, nameBasedConfig)).toThrow(/TYPE_MISMATCH/);
+      });
+
+      it("still rejects direct-field capability mismatches (non-path)", () => {
+        // Ensures the refactor hasn't regressed the non-path code path:
+        // `@exclusiveMinimum` on a bare `string` field must still fail.
+        const source = `
+          export interface PaymentForm {
+            /** @exclusiveMinimum 0 */
+            label: string;
+          }
+        `;
+        expect(() => runSchema(source, { vendorPrefix: "x-formspec" })).toThrow(
+          /TYPE_MISMATCH/
+        );
+      });
+    });
   });
 
   it("works without config (backward compatibility)", () => {

--- a/packages/build/src/__tests__/generate-schemas-config.test.ts
+++ b/packages/build/src/__tests__/generate-schemas-config.test.ts
@@ -1,13 +1,12 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
 import * as os from "node:os";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { FormSpecConfig } from "@formspec/config";
 import { defineCustomType, defineExtension } from "@formspec/core/internals";
 import { type ClassSchemas, generateSchemas } from "../generators/class-schema.js";
+import type { JsonSchema2020 } from "../json-schema/ir-generator.js";
 import { numericExtension } from "./fixtures/example-numeric-extension.js";
-
-type JsonSchemaObject = Record<string, unknown>;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -256,7 +255,24 @@ describe("generateSchemas with FormSpecConfig", () => {
     // A path-target override is emitted as an `allOf` entry with
     // `properties.<segment>.<jsonSchemaKeyword>: <value>`. Asserting via a
     // direct `allOf` shape — then scanning its entries — keeps the Jest
-    // matcher types clean (no unsafe-any from `expect.arrayContaining`).
+    // matcher types clean (no unsafe-any from `expect.arrayContaining`) while
+    // using the real `JsonSchema2020` typing for property access.
+    function findPathOverride(
+      result: ClassSchemas,
+      fieldName: string,
+      predicate: (entry: JsonSchema2020) => boolean
+    ): JsonSchema2020 | undefined {
+      const field = result.jsonSchema.properties?.[fieldName];
+      const allOf = field?.allOf;
+      expect(
+        allOf,
+        `expected allOf on property '${fieldName}' but found ${
+          allOf === undefined ? "none" : "empty"
+        }`
+      ).toBeDefined();
+      return allOf?.find(predicate);
+    }
+
     function expectPathOverride(
       result: ClassSchemas,
       fieldName: string,
@@ -264,15 +280,21 @@ describe("generateSchemas with FormSpecConfig", () => {
       keyword: string,
       value: unknown
     ) {
-      const field = (result.jsonSchema.properties as JsonSchemaObject | undefined)?.[fieldName];
-      const allOf = (field as { allOf?: readonly JsonSchemaObject[] } | undefined)?.allOf;
-      expect(allOf).toBeDefined();
-      const overrideEntry = allOf?.find((entry) => {
-        const properties = entry["properties"] as JsonSchemaObject | undefined;
-        const segmentSchema = properties?.[segment] as JsonSchemaObject | undefined;
-        return segmentSchema !== undefined && segmentSchema[keyword] === value;
-      });
-      expect(overrideEntry).toBeDefined();
+      const override = findPathOverride(
+        result,
+        fieldName,
+        (entry) => {
+          const segmentSchema = entry.properties?.[segment];
+          if (segmentSchema === undefined) return false;
+          return (segmentSchema as Record<string, unknown>)[keyword] === value;
+        }
+      );
+      expect(
+        override,
+        `no allOf entry with properties.${segment}.${keyword} === ${String(
+          value
+        )} on field '${fieldName}'`
+      ).toBeDefined();
     }
 
     // Path-target overrides emit the standard JSON Schema keyword directly
@@ -328,29 +350,27 @@ describe("generateSchemas with FormSpecConfig", () => {
         expectPathOverride(result, "total", "amount", "exclusiveMinimum", 0);
       });
 
-      it("broadens through a deeply-nested path", () => {
+      it("broadens through a deeply-nested path with a distinctive value", () => {
+        // Use 42 (distinctive) rather than 0 to guard against an override
+        // that happens to match a default.
         const source = `
           ${nameBasedDecimal}
           export interface Nested { inner: { amount: Decimal }; }
           export interface PaymentForm {
-            /** @minimum :inner.amount 0 */
+            /** @minimum :inner.amount 42 */
             total: Nested;
           }
         `;
         const result = runSchema(source, nameBasedConfig);
-        // For nested paths, the path override lives inside the top-level
-        // "allOf" entry keyed off the first segment; walk the chain manually
-        // to avoid unsafe-any from `expect.objectContaining`.
-        const total = (result.jsonSchema.properties as JsonSchemaObject | undefined)?.["total"];
-        const allOf = (total as { allOf?: readonly JsonSchemaObject[] } | undefined)?.allOf;
-        const override = allOf?.find((entry) => {
-          const properties = entry["properties"] as JsonSchemaObject | undefined;
-          const inner = properties?.["inner"] as JsonSchemaObject | undefined;
-          const innerProps = inner?.["properties"] as JsonSchemaObject | undefined;
-          const amount = innerProps?.["amount"] as JsonSchemaObject | undefined;
-          return amount?.["minimum"] === 0;
+        const override = findPathOverride(result, "total", (entry) => {
+          const inner = entry.properties?.["inner"];
+          const amount = inner?.properties?.["amount"];
+          return amount?.minimum === 42;
         });
-        expect(override).toBeDefined();
+        expect(
+          override,
+          "expected nested path override properties.inner.properties.amount.minimum === 42"
+        ).toBeDefined();
       });
     });
 
@@ -366,10 +386,21 @@ describe("generateSchemas with FormSpecConfig", () => {
               total: MonetaryAmount;
             }
           `;
-          // We don't assert the x-prefixed keyword value because the
-          // branded extension uses a different vendor prefix; the test only
-          // needs to confirm generation succeeds without TYPE_MISMATCH.
-          expect(() => runSchema(source, brandBasedConfig)).not.toThrow();
+          // Vendor-prefix-agnostic smoke: we don't assert the keyword value
+          // because the branded extension uses a different prefix, but we
+          // DO require an allOf entry that targets `amount`. A regression
+          // that silently drops the override (no throw, no entry) would
+          // otherwise pass.
+          const result = runSchema(source, brandBasedConfig);
+          const override = findPathOverride(
+            result,
+            "total",
+            (entry) => entry.properties?.["amount"] !== undefined
+          );
+          expect(
+            override,
+            `expected a path override entry targeting 'amount' for @${tag}`
+          ).toBeDefined();
         }
       );
 
@@ -382,7 +413,13 @@ describe("generateSchemas with FormSpecConfig", () => {
             total: MonetaryAmount;
           }
         `;
-        expect(() => runSchema(source, brandBasedConfig)).not.toThrow();
+        const result = runSchema(source, brandBasedConfig);
+        const override = findPathOverride(
+          result,
+          "total",
+          (entry) => entry.properties?.["amount"] !== undefined
+        );
+        expect(override).toBeDefined();
       });
     });
 
@@ -415,7 +452,12 @@ describe("generateSchemas with FormSpecConfig", () => {
             total: MonetaryAmount;
           }
         `;
-        expect(() => runSchema(source, nameBasedConfig)).toThrow(/TYPE_MISMATCH/);
+        // Tighten to require both the offending segment (amount) and tag
+        // (pattern) so a TYPE_MISMATCH from an unrelated code path can't
+        // silently pass this assertion.
+        expect(() => runSchema(source, nameBasedConfig)).toThrow(
+          /TYPE_MISMATCH.*amount.*pattern|pattern.*amount/
+        );
       });
 
       it("still rejects direct-field capability mismatches (non-path)", () => {
@@ -430,6 +472,134 @@ describe("generateSchemas with FormSpecConfig", () => {
         expect(() => runSchema(source, { vendorPrefix: "x-formspec" })).toThrow(
           /TYPE_MISMATCH/
         );
+      });
+    });
+
+    // Symbol-based registration is a separate shape from name / brand: it
+    // pairs a `defineCustomType<T>()` type parameter in the config file with
+    // the user-visible alias in the source. `generateSchemas` resolves the
+    // symbol map via the `configPath` option, so the integration test
+    // requires a multi-file fixture (decimal.ts + formspec.config.ts +
+    // model.ts). Uses a `typeName` that does NOT match the alias identifier
+    // so name-based lookup cannot accidentally satisfy the test.
+    describe("symbol-based registration (defineCustomType<T>())", () => {
+      let tmpDir: string;
+      let modelPath: string;
+      let configPath: string;
+
+      beforeAll(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-symbol-broadening-"));
+
+        fs.writeFileSync(
+          path.join(tmpDir, "tsconfig.json"),
+          JSON.stringify(
+            {
+              compilerOptions: {
+                target: "ES2022",
+                module: "NodeNext",
+                moduleResolution: "nodenext",
+                strict: true,
+                skipLibCheck: true,
+              },
+            },
+            null,
+            2
+          )
+        );
+
+        fs.writeFileSync(
+          path.join(tmpDir, "decimal.ts"),
+          [
+            "declare const __sym_decimal: unique symbol;",
+            "export type SymDecimal = string & { readonly [__sym_decimal]: true };",
+          ].join("\n")
+        );
+
+        configPath = path.join(tmpDir, "formspec.config.ts");
+        fs.writeFileSync(
+          configPath,
+          [
+            'import type { SymDecimal } from "./decimal.js";',
+            'import { defineCustomType, defineExtension } from "@formspec/core";',
+            "",
+            "export const extension = defineExtension({",
+            '  extensionId: "x-symtest",',
+            "  types: [",
+            "    defineCustomType<SymDecimal>({",
+            // typeName intentionally does NOT match the alias identifier
+            // ("SymDecimal") — this forces resolution to go through the
+            // symbol map rather than the name map.
+            '      typeName: "OpaqueDecimal",',
+            "      builtinConstraintBroadenings: [",
+            '        { tagName: "minimum", constraintName: "DecimalMinimum" },',
+            '        { tagName: "exclusiveMinimum", constraintName: "DecimalExclusiveMinimum" },',
+            "      ],",
+            '      toJsonSchema: () => ({ type: "string" }),',
+            "    }),",
+            "  ],",
+            "});",
+          ].join("\n")
+        );
+
+        modelPath = path.join(tmpDir, "model.ts");
+        fs.writeFileSync(
+          modelPath,
+          [
+            'import type { SymDecimal } from "./decimal.js";',
+            "",
+            "export interface MonetaryAmount {",
+            "  amount: SymDecimal;",
+            "  currency: string;",
+            "}",
+            "",
+            "export interface PaymentForm {",
+            "  /** @exclusiveMinimum :amount 0 */",
+            "  total: MonetaryAmount;",
+            "}",
+          ].join("\n")
+        );
+      });
+
+      afterAll(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      });
+
+      it("broadens @exclusiveMinimum through a path target onto a symbol-registered custom type", () => {
+        // The in-memory registration here mirrors the `defineCustomType<SymDecimal>`
+        // in the on-disk config file. `generateSchemas` walks the config
+        // file's AST (via `configPath`) to extract the `SymDecimal` type
+        // parameter and build the symbol map — no runtime import of the
+        // config file occurs. The registry's name map is keyed by
+        // "OpaqueDecimal" (the typeName), NOT by the alias "SymDecimal" —
+        // so only the symbol-based lookup path can satisfy this test.
+        const opaqueDecimal = defineCustomType({
+          typeName: "OpaqueDecimal",
+          builtinConstraintBroadenings: [
+            { tagName: "minimum", constraintName: "DecimalMinimum" },
+            { tagName: "exclusiveMinimum", constraintName: "DecimalExclusiveMinimum" },
+          ],
+          toJsonSchema: () => ({ type: "string" }),
+        });
+        const extension = defineExtension({
+          extensionId: "x-symtest",
+          types: [opaqueDecimal],
+        });
+        const result = generateSchemas({
+          filePath: modelPath,
+          typeName: "PaymentForm",
+          errorReporting: "throw",
+          config: { extensions: [extension], vendorPrefix: "x-symtest" },
+          configPath,
+        });
+        const override = findPathOverride(
+          result,
+          "total",
+          (entry) => entry.properties?.["amount"] !== undefined
+        );
+        expect(
+          override,
+          "expected a path override entry targeting 'amount' on the symbol-registered custom type"
+        ).toBeDefined();
       });
     });
   });

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -36,6 +36,10 @@ import {
 } from "./jsdoc-constraints.js";
 import { extractDisplayNameMetadata } from "./tsdoc-parser.js";
 import type { ExtensionRegistry } from "../extensions/index.js";
+import {
+  customTypeIdFromLookup,
+  resolveCustomTypeFromTsType,
+} from "../extensions/resolve-custom-type.js";
 import type { MetadataPolicyInput } from "@formspec/core";
 import { getDeclarationMetadataPolicy, normalizeMetadataPolicy } from "../metadata/index.js";
 
@@ -85,63 +89,14 @@ function collectBrandIdentifiers(type: ts.Type): readonly string[] {
 }
 
 /**
- * Resolves a TypeScript type to its canonical `ts.Symbol`, following alias chains.
- *
- * `aliasSymbol` tracks type aliases (e.g. `type Foo = Bar`); `getSymbol()` tracks
- * the structural symbol. We prefer `aliasSymbol` when present so that aliased types
- * resolve to the declaration site rather than the structural shape.
- *
- * Returns `undefined` for bare primitives and anonymous types, which have no symbol.
- */
-function resolveCanonicalSymbol(type: ts.Type, checker: ts.TypeChecker): ts.Symbol | undefined {
-  const raw = type.aliasSymbol ?? type.getSymbol();
-  if (raw === undefined) return undefined;
-  return raw.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(raw) : raw;
-}
-
-/**
- * Resolves a type to an extension-registered custom type via ts.Symbol identity.
- *
- * This is the most precise detection mechanism — it uses TypeScript's own type
- * identity, immune to import aliases and name collisions. Built from
- * `defineCustomType<T>()` type parameter extraction in the config file.
- *
- * Returns `null` when:
- * - `extensionRegistry` is undefined (no registry provided)
- * - The type has no symbol (bare primitive, anonymous type)
- * - The canonical symbol is not in the registry's symbol map
- */
-function resolveSymbolBasedCustomType(
-  type: ts.Type,
-  extensionRegistry: ExtensionRegistry | undefined,
-  checker: ts.TypeChecker
-): TypeNode | null {
-  if (extensionRegistry === undefined) {
-    return null;
-  }
-
-  const canonical = resolveCanonicalSymbol(type, checker);
-  if (canonical === undefined) {
-    return null;
-  }
-
-  const registration = extensionRegistry.findTypeBySymbol(canonical);
-  if (registration === undefined) {
-    return null;
-  }
-
-  return {
-    kind: "custom",
-    typeId: `${registration.extensionId}/${registration.registration.typeName}`,
-    payload: null,
-  };
-}
-
-/**
  * Checks whether a type is branded with `__integerBrand` from `@formspec/core`.
  *
  * Integer-branded types are intersections of `number` with a brand object
  * containing the `__integerBrand` unique symbol.
+ *
+ * Extension-registered custom types (name-, brand-, or symbol-based) are
+ * resolved separately via `resolveCustomTypeFromTsType` in
+ * `extensions/resolve-custom-type.ts`.
  */
 function isIntegerBrandedType(type: ts.Type): boolean {
   if (!type.isIntersection()) {
@@ -154,42 +109,6 @@ function isIntegerBrandedType(type: ts.Type): boolean {
   }
 
   return collectBrandIdentifiers(type).includes("__integerBrand");
-}
-
-/**
- * Resolves a TypeScript intersection type to an extension-registered custom type
- * by inspecting computed property names for a brand identifier match.
- *
- * This is more robust than name-based lookup because it works even when the
- * type is imported under an alias. Brand detection is attempted after name-based
- * resolution as a structural fallback.
- *
- * Returns `null` if the type is not an intersection, has no branded properties,
- * or no registered brand matches. Note: the builtin `__integerBrand` is reserved
- * and handled separately by `isIntegerBrandedType` — extensions cannot register it.
- */
-function resolveBrandedCustomType(
-  type: ts.Type,
-  extensionRegistry: ExtensionRegistry | undefined
-): TypeNode | null {
-  if (extensionRegistry === undefined) {
-    return null;
-  }
-
-  for (const brand of collectBrandIdentifiers(type)) {
-    const registration = extensionRegistry.findTypeByBrand(brand);
-    if (registration === undefined) {
-      continue;
-    }
-
-    return {
-      kind: "custom",
-      typeId: `${registration.extensionId}/${registration.registration.typeName}`,
-      payload: null,
-    };
-  }
-
-  return null;
 }
 
 export function isResolvableObjectLikeAliasTypeNode(typeNode: ts.TypeNode): boolean {
@@ -1806,56 +1725,6 @@ function parseEnumMemberDisplayName(value: string): { value: string; label: stri
   return { value: match[1], label };
 }
 
-function resolveRegisteredCustomType(
-  sourceNode: ts.Node | undefined,
-  extensionRegistry: ExtensionRegistry | undefined,
-  checker: ts.TypeChecker
-): TypeNode | null {
-  if (sourceNode === undefined || extensionRegistry === undefined) {
-    return null;
-  }
-
-  const typeNode = extractTypeNodeFromSource(sourceNode);
-  if (typeNode === undefined) {
-    return null;
-  }
-
-  return resolveRegisteredCustomTypeFromTypeNode(typeNode, extensionRegistry, checker);
-}
-
-function resolveRegisteredCustomTypeFromTypeNode(
-  typeNode: ts.TypeNode,
-  extensionRegistry: ExtensionRegistry,
-  checker: ts.TypeChecker
-): TypeNode | null {
-  if (ts.isParenthesizedTypeNode(typeNode)) {
-    return resolveRegisteredCustomTypeFromTypeNode(typeNode.type, extensionRegistry, checker);
-  }
-
-  const typeName = getTypeNodeRegistrationName(typeNode);
-  if (typeName === null) {
-    return null;
-  }
-
-  const registration = extensionRegistry.findTypeByName(typeName);
-  if (registration !== undefined) {
-    return {
-      kind: "custom",
-      typeId: `${registration.extensionId}/${registration.registration.typeName}`,
-      payload: null,
-    };
-  }
-
-  if (ts.isTypeReferenceNode(typeNode) && ts.isIdentifier(typeNode.typeName)) {
-    const aliasDecl = getTypeAliasDeclarationFromTypeReference(typeNode, checker);
-    if (aliasDecl !== undefined) {
-      return resolveRegisteredCustomTypeFromTypeNode(aliasDecl.type, extensionRegistry, checker);
-    }
-  }
-
-  return null;
-}
-
 function extractTypeNodeFromSource(sourceNode: ts.Node): ts.TypeNode | undefined {
   if (
     ts.isPropertyDeclaration(sourceNode) ||
@@ -1871,29 +1740,6 @@ function extractTypeNodeFromSource(sourceNode: ts.Node): ts.TypeNode | undefined
   }
 
   return undefined;
-}
-
-function getTypeNodeRegistrationName(typeNode: ts.TypeNode): string | null {
-  if (ts.isTypeReferenceNode(typeNode)) {
-    return ts.isIdentifier(typeNode.typeName)
-      ? typeNode.typeName.text
-      : typeNode.typeName.right.text;
-  }
-
-  if (ts.isParenthesizedTypeNode(typeNode)) {
-    return getTypeNodeRegistrationName(typeNode.type);
-  }
-
-  if (
-    typeNode.kind === ts.SyntaxKind.BigIntKeyword ||
-    typeNode.kind === ts.SyntaxKind.StringKeyword ||
-    typeNode.kind === ts.SyntaxKind.NumberKeyword ||
-    typeNode.kind === ts.SyntaxKind.BooleanKeyword
-  ) {
-    return typeNode.getText();
-  }
-
-  return null;
 }
 
 // =============================================================================
@@ -1914,19 +1760,21 @@ export function resolveTypeNode(
   extensionRegistry?: ExtensionRegistry,
   diagnostics?: ConstraintSemanticDiagnostic[]
 ): TypeNode {
-  const customType = resolveRegisteredCustomType(sourceNode, extensionRegistry, checker);
-  if (customType) {
-    return customType;
-  }
-  // Symbol-based custom type detection (most precise, checked after name-based;
-  // uses ts.Symbol identity from defineCustomType<T>() type parameters).
-  const symbolCustomType = resolveSymbolBasedCustomType(type, extensionRegistry, checker);
-  if (symbolCustomType) {
-    return symbolCustomType;
-  }
-  const brandedCustomType = resolveBrandedCustomType(type, extensionRegistry);
-  if (brandedCustomType) {
-    return brandedCustomType;
+  // Unified custom-type resolution: tries name → symbol → brand in sequence,
+  // strips nullish unions, and returns the first match. Shared with
+  // `tsdoc-parser.ts`'s path-target broadening check.
+  const customTypeLookup = resolveCustomTypeFromTsType(
+    type,
+    checker,
+    extensionRegistry,
+    sourceNode
+  );
+  if (customTypeLookup !== null) {
+    return {
+      kind: "custom",
+      typeId: customTypeIdFromLookup(customTypeLookup),
+      payload: null,
+    };
   }
   const primitiveAlias = tryResolveNamedPrimitiveAlias(
     type,

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -40,6 +40,11 @@ import {
   customTypeIdFromLookup,
   resolveCustomTypeFromTsType,
 } from "../extensions/resolve-custom-type.js";
+import {
+  collectBrandIdentifiers,
+  extractTypeNodeFromSource,
+  getTypeAliasDeclarationFromTypeReference,
+} from "../extensions/ts-type-utils.js";
 import type { MetadataPolicyInput } from "@formspec/core";
 import { getDeclarationMetadataPolicy, normalizeMetadataPolicy } from "../metadata/index.js";
 
@@ -56,36 +61,6 @@ function isObjectType(type: ts.Type): type is ts.ObjectType {
 
 function isIntersectionType(type: ts.Type): type is ts.IntersectionType {
   return !!(type.flags & ts.TypeFlags.Intersection);
-}
-
-/**
- * Collects all brand identifier texts from an intersection type's computed
- * property names.
- *
- * Shared by both `isIntegerBrandedType` (builtin) and `resolveBrandedCustomType`
- * (extension). Walks `type.getProperties()` looking for computed property names
- * backed by plain identifiers — the standard `unique symbol` brand pattern.
- *
- * Returns all matching identifiers so that types with multiple brands (e.g.,
- * `number & { [__integerBrand]: true } & { [__otherBrand]: true }`) are
- * fully inspected regardless of property order.
- */
-function collectBrandIdentifiers(type: ts.Type): readonly string[] {
-  if (!type.isIntersection()) {
-    return [];
-  }
-
-  const brands: string[] = [];
-  for (const prop of type.getProperties()) {
-    const decl = prop.valueDeclaration ?? prop.declarations?.[0];
-    if (decl === undefined) continue;
-    if (!ts.isPropertySignature(decl) && !ts.isPropertyDeclaration(decl)) continue;
-    if (!ts.isComputedPropertyName(decl.name)) continue;
-    if (!ts.isIdentifier(decl.name.expression)) continue;
-    brands.push(decl.name.expression.text);
-  }
-
-  return brands;
 }
 
 /**
@@ -1725,23 +1700,6 @@ function parseEnumMemberDisplayName(value: string): { value: string; label: stri
   return { value: match[1], label };
 }
 
-function extractTypeNodeFromSource(sourceNode: ts.Node): ts.TypeNode | undefined {
-  if (
-    ts.isPropertyDeclaration(sourceNode) ||
-    ts.isPropertySignature(sourceNode) ||
-    ts.isParameter(sourceNode) ||
-    ts.isTypeAliasDeclaration(sourceNode)
-  ) {
-    return sourceNode.type;
-  }
-
-  if (ts.isTypeNode(sourceNode)) {
-    return sourceNode;
-  }
-
-  return undefined;
-}
-
 // =============================================================================
 // TYPE RESOLUTION — ts.Type → TypeNode
 // =============================================================================
@@ -2947,8 +2905,7 @@ function extractTypeAliasConstraintNodes(
     );
   }
 
-  const symbol = checker.getSymbolAtLocation(typeNode.typeName);
-  const aliasDecl = getAliasedTypeAliasDeclaration(symbol, checker);
+  const aliasDecl = getTypeAliasDeclarationFromTypeReference(typeNode, checker);
   if (!aliasDecl) return [];
 
   // Don't extract from object type aliases
@@ -2980,30 +2937,6 @@ function extractTypeAliasConstraintNodes(
   return constraints;
 }
 
-function getAliasedSymbol(
-  symbol: ts.Symbol | undefined,
-  checker: ts.TypeChecker
-): ts.Symbol | undefined {
-  if (symbol === undefined) {
-    return undefined;
-  }
-
-  return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
-}
-
-function getAliasedTypeAliasDeclaration(
-  symbol: ts.Symbol | undefined,
-  checker: ts.TypeChecker
-): ts.TypeAliasDeclaration | undefined {
-  return getAliasedSymbol(symbol, checker)?.declarations?.find(ts.isTypeAliasDeclaration);
-}
-
-function getTypeAliasDeclarationFromTypeReference(
-  typeNode: ts.TypeReferenceNode,
-  checker: ts.TypeChecker
-): ts.TypeAliasDeclaration | undefined {
-  return getAliasedTypeAliasDeclaration(checker.getSymbolAtLocation(typeNode.typeName), checker);
-}
 
 // =============================================================================
 // PROVENANCE HELPERS

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -70,7 +70,10 @@ import {
   type TypeNode,
 } from "@formspec/core/internals";
 import type { ExtensionRegistry } from "../extensions/index.js";
-import { isTagBroadenedOnTsType } from "../extensions/resolve-custom-type.js";
+import {
+  customTypeIdFromLookup,
+  resolveCustomTypeFromTsType,
+} from "../extensions/resolve-custom-type.js";
 
 function sharedTagValueOptions(options?: ParseTSDocOptions) {
   return {
@@ -692,10 +695,19 @@ function buildCompilerBackedConstraintDiagnostics(
   // the type we're about to validate?" — and short-circuit the capability
   // check below in favour of the IR-layer validator which understands
   // extension-defined constraint semantics.
-  const hasBroadening =
-    target === null
-      ? hasBuiltinConstraintBroadening(tagName, options)
-      : isTagBroadenedOnTsType(evaluatedType, checker, options?.extensionRegistry, tagName);
+  const hasBroadening = ((): boolean => {
+    if (target === null) {
+      return hasBuiltinConstraintBroadening(tagName, options);
+    }
+    const registry = options?.extensionRegistry;
+    if (registry === undefined) return false;
+    const resolved = resolveCustomTypeFromTsType(evaluatedType, checker, registry);
+    return (
+      resolved !== null &&
+      registry.findBuiltinConstraintBroadening(customTypeIdFromLookup(resolved), tagName) !==
+        undefined
+    );
+  })();
 
   if (!hasBroadening) {
     const requiredCapability = definition.capabilities[0];

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -70,6 +70,7 @@ import {
   type TypeNode,
 } from "@formspec/core/internals";
 import type { ExtensionRegistry } from "../extensions/index.js";
+import { isTagBroadenedOnTsType } from "../extensions/resolve-custom-type.js";
 
 function sharedTagValueOptions(options?: ParseTSDocOptions) {
   return {
@@ -627,7 +628,11 @@ function buildCompilerBackedConstraintDiagnostics(
   }
 
   const target = parsedTag?.target ?? null;
-  const hasBroadening = target === null && hasBuiltinConstraintBroadening(tagName, options);
+
+  // Resolve the type the capability check should run against: the path-target
+  // destination for `:foo` constraints, otherwise the field's own type.
+  let evaluatedType: ts.Type = subjectType;
+  let targetLabel = node.getText(sourceFile);
   if (target !== null) {
     if (target.kind !== "path") {
       return [
@@ -671,35 +676,48 @@ function buildCompilerBackedConstraintDiagnostics(
       ];
     }
 
+    evaluatedType = resolution.type;
+    targetLabel = target.rawText;
+  }
+
+  // Unified broadening check:
+  //  - Direct field (`target === null`): uses the IR-layer `FieldType`
+  //    carried on `options.fieldType`. This is the pre-existing path.
+  //  - Path target (`target !== null`): no IR is available for the
+  //    path-resolved sub-type, so resolve the custom type from the raw
+  //    `ts.Type` via the shared extension-registry resolver and look up
+  //    broadening by `(customTypeId, tagName)`.
+  //
+  // Both variants answer the same question — "is `tagName` broadened onto
+  // the type we're about to validate?" — and short-circuit the capability
+  // check below in favour of the IR-layer validator which understands
+  // extension-defined constraint semantics.
+  const hasBroadening =
+    target === null
+      ? hasBuiltinConstraintBroadening(tagName, options)
+      : isTagBroadenedOnTsType(evaluatedType, checker, options?.extensionRegistry, tagName);
+
+  if (!hasBroadening) {
     const requiredCapability = definition.capabilities[0];
     if (
       requiredCapability !== undefined &&
-      !supportsConstraintCapability(resolution.type, checker, requiredCapability)
+      !supportsConstraintCapability(evaluatedType, checker, requiredCapability)
     ) {
-      const actualType = checker.typeToString(resolution.type, node, SYNTHETIC_TYPE_FORMAT_FLAGS);
-      return [
-        makeDiagnostic(
-          "TYPE_MISMATCH",
-          `Target "${target.rawText}": constraint "${tagName}" is only valid on ${capabilityLabel(requiredCapability)} targets, but field type is "${actualType}"`,
-          provenance
-        ),
-      ];
-    }
-  } else if (!hasBroadening) {
-    const requiredCapability = definition.capabilities[0];
-    if (
-      requiredCapability !== undefined &&
-      !supportsConstraintCapability(subjectType, checker, requiredCapability)
-    ) {
-      const actualType = checker.typeToString(subjectType, node, SYNTHETIC_TYPE_FORMAT_FLAGS);
-      const baseMessage = `Target "${node.getText(sourceFile)}": constraint "${tagName}" is only valid on ${capabilityLabel(requiredCapability)} targets, but field type is "${actualType}"`;
-      const hint = buildPathTargetHint(
-        subjectType,
-        checker,
-        requiredCapability,
-        tagName,
-        parsedTag?.argumentText
-      );
+      const actualType = checker.typeToString(evaluatedType, node, SYNTHETIC_TYPE_FORMAT_FLAGS);
+      const baseMessage = `Target "${targetLabel}": constraint "${tagName}" is only valid on ${capabilityLabel(requiredCapability)} targets, but field type is "${actualType}"`;
+      // Path-target hints only apply to direct-field mismatches — the hint
+      // suggests "did you mean a sub-path?" which is nonsensical when the
+      // user is already path-targeting.
+      const hint =
+        target === null
+          ? buildPathTargetHint(
+              subjectType,
+              checker,
+              requiredCapability,
+              tagName,
+              parsedTag?.argumentText
+            )
+          : null;
       return [
         makeDiagnostic(
           "TYPE_MISMATCH",

--- a/packages/build/src/extensions/resolve-custom-type.ts
+++ b/packages/build/src/extensions/resolve-custom-type.ts
@@ -1,0 +1,244 @@
+import { stripNullishUnion } from "@formspec/analysis/internal";
+import * as ts from "typescript";
+
+import type { ExtensionRegistry, ExtensionTypeLookupResult } from "./registry.js";
+
+/**
+ * Collects all brand identifier texts from an intersection type's computed
+ * property names. Mirrors the helper in `analyzer/class-analyzer.ts`; kept
+ * local so this module has no dependency on the analyzer layer.
+ */
+function collectBrandIdentifiers(type: ts.Type): readonly string[] {
+  if (!type.isIntersection()) {
+    return [];
+  }
+  const brands: string[] = [];
+  for (const prop of type.getProperties()) {
+    const decl = prop.valueDeclaration ?? prop.declarations?.[0];
+    if (decl === undefined) continue;
+    if (!ts.isPropertySignature(decl) && !ts.isPropertyDeclaration(decl)) continue;
+    if (!ts.isComputedPropertyName(decl.name)) continue;
+    if (!ts.isIdentifier(decl.name.expression)) continue;
+    brands.push(decl.name.expression.text);
+  }
+  return brands;
+}
+
+/**
+ * Resolves a `ts.Type` to its canonical symbol, following alias chains.
+ *
+ * `aliasSymbol` is preferred over `getSymbol()` so that aliased types resolve
+ * to the declaration site rather than the structural shape. This matches the
+ * convention in `analyzer/class-analyzer.ts`'s `resolveCanonicalSymbol`.
+ */
+function resolveCanonicalSymbol(
+  type: ts.Type,
+  checker: ts.TypeChecker
+): ts.Symbol | undefined {
+  const raw = type.aliasSymbol ?? type.getSymbol();
+  if (raw === undefined) return undefined;
+  return raw.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(raw) : raw;
+}
+
+function getTypeNodeRegistrationName(typeNode: ts.TypeNode): string | null {
+  if (ts.isTypeReferenceNode(typeNode)) {
+    return ts.isIdentifier(typeNode.typeName)
+      ? typeNode.typeName.text
+      : typeNode.typeName.right.text;
+  }
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return getTypeNodeRegistrationName(typeNode.type);
+  }
+  if (
+    typeNode.kind === ts.SyntaxKind.BigIntKeyword ||
+    typeNode.kind === ts.SyntaxKind.StringKeyword ||
+    typeNode.kind === ts.SyntaxKind.NumberKeyword ||
+    typeNode.kind === ts.SyntaxKind.BooleanKeyword
+  ) {
+    return typeNode.getText();
+  }
+  return null;
+}
+
+function extractTypeNodeFromSource(sourceNode: ts.Node): ts.TypeNode | undefined {
+  if (
+    ts.isPropertyDeclaration(sourceNode) ||
+    ts.isPropertySignature(sourceNode) ||
+    ts.isParameter(sourceNode) ||
+    ts.isTypeAliasDeclaration(sourceNode)
+  ) {
+    return sourceNode.type;
+  }
+  if (ts.isTypeNode(sourceNode)) {
+    return sourceNode;
+  }
+  return undefined;
+}
+
+function getTypeAliasDeclarationFromTypeReference(
+  typeNode: ts.TypeReferenceNode,
+  checker: ts.TypeChecker
+): ts.TypeAliasDeclaration | undefined {
+  if (!ts.isIdentifier(typeNode.typeName)) return undefined;
+  const symbol = checker.getSymbolAtLocation(typeNode.typeName);
+  if (symbol === undefined) return undefined;
+  const declaration = symbol.declarations?.find(ts.isTypeAliasDeclaration);
+  return declaration;
+}
+
+function resolveByNameFromTypeNode(
+  typeNode: ts.TypeNode,
+  registry: ExtensionRegistry,
+  checker: ts.TypeChecker
+): ExtensionTypeLookupResult | null {
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return resolveByNameFromTypeNode(typeNode.type, registry, checker);
+  }
+  const typeName = getTypeNodeRegistrationName(typeNode);
+  if (typeName !== null) {
+    const byName = registry.findTypeByName(typeName);
+    if (byName !== undefined) {
+      return byName;
+    }
+  }
+  if (ts.isTypeReferenceNode(typeNode) && ts.isIdentifier(typeNode.typeName)) {
+    const aliasDecl = getTypeAliasDeclarationFromTypeReference(typeNode, checker);
+    if (aliasDecl !== undefined) {
+      return resolveByNameFromTypeNode(aliasDecl.type, registry, checker);
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolves a TypeScript type to an extension-registered custom type, trying
+ * all three registration mechanisms in order of precision:
+ *
+ * 1. **Name-based** (via `sourceNode` AST walk) — matches the user-written
+ *    alias identifier (e.g. `amount: Decimal` → `"Decimal"`). Requires a
+ *    source node to walk; used by the direct-field code path.
+ * 2. **Symbol-based** — matches `ts.Symbol` identity via
+ *    `ExtensionRegistry.findTypeBySymbol`, populated from
+ *    `defineCustomType<T>()` type parameter extraction. Works for any type
+ *    regardless of import aliases or name collisions.
+ * 3. **Brand-based** — matches the `brand` identifier encoded into
+ *    intersection types as computed-property keys (e.g.
+ *    `string & { [__decimalBrand]: true }`). Structural; independent of
+ *    declaration names.
+ *
+ * Name-based resolution also has a symbol-fallback path that uses
+ * `type.aliasSymbol?.getName()` when no `sourceNode` is provided, so
+ * path-resolved types can still match name-registered custom types.
+ *
+ * Nullable unions (`T | null`, `T | undefined`, `T | null | undefined`) are
+ * stripped before every detection attempt, so registrations apply through
+ * nullable wrappers transparently.
+ *
+ * Returns `null` when no registered custom type matches.
+ */
+export function resolveCustomTypeFromTsType(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  registry: ExtensionRegistry | undefined,
+  sourceNode?: ts.Node
+): ExtensionTypeLookupResult | null {
+  if (registry === undefined) {
+    return null;
+  }
+
+  const stripped = stripNullishUnion(type);
+
+  // 1. Name-based: prefer walking the source AST for the user-written
+  // identifier; fall back to the canonical symbol name for path-resolved
+  // types that have no syntactic source.
+  if (sourceNode !== undefined) {
+    const typeNode = extractTypeNodeFromSource(sourceNode);
+    if (typeNode !== undefined) {
+      const byName = resolveByNameFromTypeNode(typeNode, registry, checker);
+      if (byName !== null) {
+        return byName;
+      }
+    }
+  } else {
+    const typeName = (stripped.aliasSymbol ?? stripped.getSymbol())?.getName();
+    if (typeName !== undefined) {
+      const byName = registry.findTypeByName(typeName);
+      if (byName !== undefined) {
+        return byName;
+      }
+    }
+  }
+
+  // 2. Symbol-based.
+  const canonical = resolveCanonicalSymbol(stripped, checker);
+  if (canonical !== undefined) {
+    const bySymbol = registry.findTypeBySymbol(canonical);
+    if (bySymbol !== undefined) {
+      return bySymbol;
+    }
+  }
+
+  // 3. Brand-based.
+  for (const brand of collectBrandIdentifiers(stripped)) {
+    const byBrand = registry.findTypeByBrand(brand);
+    if (byBrand !== undefined) {
+      return byBrand;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Returns the fully-qualified type ID for a resolved custom-type lookup.
+ *
+ * Type IDs have the form `${extensionId}/${typeName}`, matching the format
+ * produced elsewhere in the build pipeline.
+ */
+export function customTypeIdFromLookup(result: ExtensionTypeLookupResult): string {
+  return `${result.extensionId}/${result.registration.typeName}`;
+}
+
+/**
+ * Checks whether a built-in constraint tag has broadening registered for the
+ * given custom type.
+ *
+ * Broadening declares "this built-in tag (e.g., `@exclusiveMinimum`) is
+ * semantically valid on this custom type (e.g., `Decimal`) even though the
+ * compiler-backed capability check would reject it." Callers use this to
+ * skip capability checks that the IR-layer is better equipped to perform.
+ */
+export function hasBroadeningForCustomType(
+  result: ExtensionTypeLookupResult,
+  tagName: string,
+  registry: ExtensionRegistry
+): boolean {
+  return (
+    registry.findBuiltinConstraintBroadening(customTypeIdFromLookup(result), tagName) !==
+    undefined
+  );
+}
+
+/**
+ * Composite helper: resolves `type` to a registered custom type and, if one
+ * is found, checks whether `tagName` is broadened onto it.
+ *
+ * Returns `false` when the type is not registered OR when the tag has no
+ * broadening registered for the resolved custom type.
+ */
+export function isTagBroadenedOnTsType(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  registry: ExtensionRegistry | undefined,
+  tagName: string,
+  sourceNode?: ts.Node
+): boolean {
+  if (registry === undefined) {
+    return false;
+  }
+  const resolved = resolveCustomTypeFromTsType(type, checker, registry, sourceNode);
+  if (resolved === null) {
+    return false;
+  }
+  return hasBroadeningForCustomType(resolved, tagName, registry);
+}

--- a/packages/build/src/extensions/resolve-custom-type.ts
+++ b/packages/build/src/extensions/resolve-custom-type.ts
@@ -1,44 +1,14 @@
-import { stripNullishUnion } from "@formspec/analysis/internal";
 import * as ts from "typescript";
 
+import { stripNullishUnion } from "@formspec/analysis/internal";
+
 import type { ExtensionRegistry, ExtensionTypeLookupResult } from "./registry.js";
-
-/**
- * Collects all brand identifier texts from an intersection type's computed
- * property names. Mirrors the helper in `analyzer/class-analyzer.ts`; kept
- * local so this module has no dependency on the analyzer layer.
- */
-function collectBrandIdentifiers(type: ts.Type): readonly string[] {
-  if (!type.isIntersection()) {
-    return [];
-  }
-  const brands: string[] = [];
-  for (const prop of type.getProperties()) {
-    const decl = prop.valueDeclaration ?? prop.declarations?.[0];
-    if (decl === undefined) continue;
-    if (!ts.isPropertySignature(decl) && !ts.isPropertyDeclaration(decl)) continue;
-    if (!ts.isComputedPropertyName(decl.name)) continue;
-    if (!ts.isIdentifier(decl.name.expression)) continue;
-    brands.push(decl.name.expression.text);
-  }
-  return brands;
-}
-
-/**
- * Resolves a `ts.Type` to its canonical symbol, following alias chains.
- *
- * `aliasSymbol` is preferred over `getSymbol()` so that aliased types resolve
- * to the declaration site rather than the structural shape. This matches the
- * convention in `analyzer/class-analyzer.ts`'s `resolveCanonicalSymbol`.
- */
-function resolveCanonicalSymbol(
-  type: ts.Type,
-  checker: ts.TypeChecker
-): ts.Symbol | undefined {
-  const raw = type.aliasSymbol ?? type.getSymbol();
-  if (raw === undefined) return undefined;
-  return raw.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(raw) : raw;
-}
+import {
+  collectBrandIdentifiers,
+  extractTypeNodeFromSource,
+  getTypeAliasDeclarationFromTypeReference,
+  resolveCanonicalSymbol,
+} from "./ts-type-utils.js";
 
 function getTypeNodeRegistrationName(typeNode: ts.TypeNode): string | null {
   if (ts.isTypeReferenceNode(typeNode)) {
@@ -58,32 +28,6 @@ function getTypeNodeRegistrationName(typeNode: ts.TypeNode): string | null {
     return typeNode.getText();
   }
   return null;
-}
-
-function extractTypeNodeFromSource(sourceNode: ts.Node): ts.TypeNode | undefined {
-  if (
-    ts.isPropertyDeclaration(sourceNode) ||
-    ts.isPropertySignature(sourceNode) ||
-    ts.isParameter(sourceNode) ||
-    ts.isTypeAliasDeclaration(sourceNode)
-  ) {
-    return sourceNode.type;
-  }
-  if (ts.isTypeNode(sourceNode)) {
-    return sourceNode;
-  }
-  return undefined;
-}
-
-function getTypeAliasDeclarationFromTypeReference(
-  typeNode: ts.TypeReferenceNode,
-  checker: ts.TypeChecker
-): ts.TypeAliasDeclaration | undefined {
-  if (!ts.isIdentifier(typeNode.typeName)) return undefined;
-  const symbol = checker.getSymbolAtLocation(typeNode.typeName);
-  if (symbol === undefined) return undefined;
-  const declaration = symbol.declarations?.find(ts.isTypeAliasDeclaration);
-  return declaration;
 }
 
 function resolveByNameFromTypeNode(
@@ -197,48 +141,4 @@ export function resolveCustomTypeFromTsType(
  */
 export function customTypeIdFromLookup(result: ExtensionTypeLookupResult): string {
   return `${result.extensionId}/${result.registration.typeName}`;
-}
-
-/**
- * Checks whether a built-in constraint tag has broadening registered for the
- * given custom type.
- *
- * Broadening declares "this built-in tag (e.g., `@exclusiveMinimum`) is
- * semantically valid on this custom type (e.g., `Decimal`) even though the
- * compiler-backed capability check would reject it." Callers use this to
- * skip capability checks that the IR-layer is better equipped to perform.
- */
-export function hasBroadeningForCustomType(
-  result: ExtensionTypeLookupResult,
-  tagName: string,
-  registry: ExtensionRegistry
-): boolean {
-  return (
-    registry.findBuiltinConstraintBroadening(customTypeIdFromLookup(result), tagName) !==
-    undefined
-  );
-}
-
-/**
- * Composite helper: resolves `type` to a registered custom type and, if one
- * is found, checks whether `tagName` is broadened onto it.
- *
- * Returns `false` when the type is not registered OR when the tag has no
- * broadening registered for the resolved custom type.
- */
-export function isTagBroadenedOnTsType(
-  type: ts.Type,
-  checker: ts.TypeChecker,
-  registry: ExtensionRegistry | undefined,
-  tagName: string,
-  sourceNode?: ts.Node
-): boolean {
-  if (registry === undefined) {
-    return false;
-  }
-  const resolved = resolveCustomTypeFromTsType(type, checker, registry, sourceNode);
-  if (resolved === null) {
-    return false;
-  }
-  return hasBroadeningForCustomType(resolved, tagName, registry);
 }

--- a/packages/build/src/extensions/symbol-registry.ts
+++ b/packages/build/src/extensions/symbol-registry.ts
@@ -14,6 +14,7 @@
 import * as ts from "typescript";
 import * as path from "node:path";
 import type { ExtensionRegistry, ExtensionTypeLookupResult } from "./registry.js";
+import { resolveCanonicalSymbol } from "./ts-type-utils.js";
 
 // =============================================================================
 // IMPLEMENTATION
@@ -152,20 +153,6 @@ function isDefineCustomTypeCall(node: ts.CallExpression, checker: ts.TypeChecker
   return ts.isIdentifier(node.expression) && node.expression.text === "defineCustomType";
 }
 
-/**
- * Resolves a TypeScript type to its canonical `ts.Symbol`, following alias chains.
- *
- * `aliasSymbol` tracks type aliases (e.g. `type Foo = Bar`); `getSymbol()` tracks
- * the structural symbol. We prefer `aliasSymbol` when present so that aliased types
- * resolve to the declaration site rather than the structural shape.
- *
- * Returns `undefined` for bare primitives and anonymous types, which have no symbol.
- */
-function resolveCanonicalSymbol(type: ts.Type, checker: ts.TypeChecker): ts.Symbol | undefined {
-  const raw = type.aliasSymbol ?? type.getSymbol();
-  if (raw === undefined) return undefined;
-  return raw.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(raw) : raw;
-}
 
 /**
  * Extracts the `typeName` string from a `defineCustomType({ typeName: "..." })` call.

--- a/packages/build/src/extensions/ts-type-utils.ts
+++ b/packages/build/src/extensions/ts-type-utils.ts
@@ -1,0 +1,91 @@
+import * as ts from "typescript";
+
+/**
+ * Collects all brand identifier texts from an intersection type's computed
+ * property names.
+ *
+ * Walks `type.getProperties()` looking for computed property names backed
+ * by plain identifiers — the standard `unique symbol` brand pattern. Returns
+ * all matching identifiers so that types with multiple brands (e.g.,
+ * `number & { [__integerBrand]: true } & { [__otherBrand]: true }`) are
+ * fully inspected regardless of property order.
+ */
+export function collectBrandIdentifiers(type: ts.Type): readonly string[] {
+  if (!type.isIntersection()) {
+    return [];
+  }
+  const brands: string[] = [];
+  for (const prop of type.getProperties()) {
+    const decl = prop.valueDeclaration ?? prop.declarations?.[0];
+    if (decl === undefined) continue;
+    if (!ts.isPropertySignature(decl) && !ts.isPropertyDeclaration(decl)) continue;
+    if (!ts.isComputedPropertyName(decl.name)) continue;
+    if (!ts.isIdentifier(decl.name.expression)) continue;
+    brands.push(decl.name.expression.text);
+  }
+  return brands;
+}
+
+/**
+ * Resolves a TypeScript type to its canonical `ts.Symbol`, following alias chains.
+ *
+ * `aliasSymbol` tracks type aliases (e.g. `type Foo = Bar`); `getSymbol()` tracks
+ * the structural symbol. We prefer `aliasSymbol` when present so that aliased
+ * types resolve to the declaration site rather than the structural shape.
+ *
+ * Returns `undefined` for bare primitives and anonymous types, which have no
+ * symbol.
+ */
+export function resolveCanonicalSymbol(
+  type: ts.Type,
+  checker: ts.TypeChecker
+): ts.Symbol | undefined {
+  const raw = type.aliasSymbol ?? type.getSymbol();
+  if (raw === undefined) return undefined;
+  return raw.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(raw) : raw;
+}
+
+/**
+ * Extracts the `ts.TypeNode` backing a property / parameter / type-alias
+ * declaration. Returns the node itself when `sourceNode` is already a type
+ * node, or `undefined` otherwise.
+ */
+export function extractTypeNodeFromSource(sourceNode: ts.Node): ts.TypeNode | undefined {
+  if (
+    ts.isPropertyDeclaration(sourceNode) ||
+    ts.isPropertySignature(sourceNode) ||
+    ts.isParameter(sourceNode) ||
+    ts.isTypeAliasDeclaration(sourceNode)
+  ) {
+    return sourceNode.type;
+  }
+  if (ts.isTypeNode(sourceNode)) {
+    return sourceNode;
+  }
+  return undefined;
+}
+
+function resolveAliasedSymbol(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker
+): ts.Symbol | undefined {
+  if (symbol === undefined) return undefined;
+  return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+}
+
+/**
+ * Resolves a `ts.TypeReferenceNode` to its declaring `ts.TypeAliasDeclaration`,
+ * if the reference names a type alias — following import aliases so that
+ * `import { Foo } from "./types"; field: Foo` resolves through to the
+ * original `type Foo = ...` declaration.
+ *
+ * Returns `undefined` for references to non-alias declarations (interfaces,
+ * classes, modules, etc.).
+ */
+export function getTypeAliasDeclarationFromTypeReference(
+  typeNode: ts.TypeReferenceNode,
+  checker: ts.TypeChecker
+): ts.TypeAliasDeclaration | undefined {
+  const symbol = checker.getSymbolAtLocation(typeNode.typeName);
+  return resolveAliasedSymbol(symbol, checker)?.declarations?.find(ts.isTypeAliasDeclaration);
+}


### PR DESCRIPTION
**Alternative to #287.** Fixes the same bug — path-targeted constraints on extension-registered custom types producing spurious `TYPE_MISMATCH` — but covers all three registration mechanisms and consolidates the duplicated custom-type detection. If you merge this, #287 should be closed.

## Why the more holistic fix

The compiler-backed validator in `tsdoc-parser.ts` had no way to recognize extension-registered custom types, so `@exclusiveMinimum :amount 0` where `amount: Decimal` was rejected as a capability mismatch. `class-analyzer.ts` had a rich three-resolver chain (name / symbol / brand) covering the same question for its own IR-building path, but those resolvers were private and the wrong shape for `ts.Type`-only inputs.

PR #287's minimal fix added a new name-only helper to `tsdoc-parser.ts`. That fix:
- Missed brand-registered custom types (per #273), which are the recommended structural detection mechanism.
- Missed symbol-registered custom types (per #275, `defineCustomType<T>()`).
- Used `hasBroadening` as "is a custom type" rather than "has broadening for this tag" — so `@pattern :amount` on a numeric `Decimal` would silently pass the compiler-backed check.
- Inverted the `aliasSymbol ?? getSymbol()` ordering vs. the codebase convention.

This PR addresses all four issues by sharing the detection logic.

## Design

**New**: `packages/build/src/extensions/resolve-custom-type.ts` owns the canonical `ts.Type`-to-registered-custom-type resolution. It tries all three mechanisms in order (name → symbol → brand), strips nullish unions once, and returns the resolved lookup (or `null`). Composite helpers `hasBroadeningForCustomType` and `isTagBroadenedOnTsType` layer the tag-aware broadening check on top.

**Refactor**: `class-analyzer.ts`'s private resolvers (`resolveRegisteredCustomType`, `resolveSymbolBasedCustomType`, `resolveBrandedCustomType`, plus `resolveCanonicalSymbol` and helpers — ~100 lines) are deleted and replaced with a single call to the shared helper.

**Refactor**: `buildCompilerBackedConstraintDiagnostics` collapses its two branches (path-targeted vs. direct-field) into a symmetric `resolve type → check broadening → capability check` flow. Both branches are tag-aware.

**Infrastructure**: `@formspec/analysis/internal` exports `stripNullishUnion` — the single source of truth used across layers.

## Test matrix

Parametrized via `it.each` to cover the grid this class of bug lives in:

| axis | values |
|---|---|
| Registration | `tsTypeNames` (name) · `brand` · `defineCustomType<T>` (symbol) |
| Tag (positive) | `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, `@multipleOf` |
| Wrapping | bare · `T \| null` · deeply-nested path (`:inner.amount`) |
| Tag (negative) | `@pattern` on numeric `Decimal` (must still reject) |
| Regression | `:currency` path to `string` (must still reject); direct-field capability mismatch (must still reject) |

16 new positive cases + 3 negative regressions. All pass. 742 build tests, 266 e2e, full lint clean.

## Relation to #287

#287 covers the name-based case only and is otherwise correct — the incremental additions here are:
1. Detect brand- and symbol-registered custom types.
2. Make the deferral tag-aware via `findBuiltinConstraintBroadening(customTypeId, tagName)`.
3. Consolidate resolution (class-analyzer's chain + tsdoc-parser's new helper) into one code path.

Closes #287 if merged.