### PR TITLE
Add formspec/tag-recognition/tsdoc-comment-syntax ESLint rule

### DIFF
--- a/.changeset/tsdoc-comment-syntax-rule.md
+++ b/.changeset/tsdoc-comment-syntax-rule.md
@@ -1,6 +1,11 @@
 ---
 "@formspec/eslint-plugin": minor
 "@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
 ---
 
 Add `formspec/tag-recognition/tsdoc-comment-syntax` ESLint rule as a drop-in replacement for `tsdoc/syntax`

--- a/.changeset/tsdoc-comment-syntax-rule.md
+++ b/.changeset/tsdoc-comment-syntax-rule.md
@@ -1,0 +1,18 @@
+---
+"@formspec/eslint-plugin": minor
+"@formspec/analysis": patch
+---
+
+Add `formspec/tag-recognition/tsdoc-comment-syntax` ESLint rule as a drop-in replacement for `tsdoc/syntax`
+
+**@formspec/eslint-plugin:**
+
+- New `tag-recognition/tsdoc-comment-syntax` rule that validates TSDoc comment syntax using FormSpec's TSDoc configuration
+- Suppresses false positives on raw-text FormSpec tag payloads (`@pattern` regex values, `@enumOptions` JSON arrays, `@defaultValue` JSON objects) — fixes the false positive reported in issue #291
+- Enabled as `"error"` in both `recommended` and `strict` configs
+- Provides equivalent coverage to `tsdoc/syntax` from `eslint-plugin-tsdoc` without the false positives on FormSpec-annotated files
+- See README section "Replacing `tsdoc/syntax`" for migration guidance
+
+**@formspec/analysis:**
+
+- Export `getOrCreateTSDocParser` from the `@formspec/analysis/internal` subpath

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -141,7 +141,7 @@ export {
   type FormSpecSemanticCapability,
   type ResolvedPathTargetType,
 } from "./ts-binding.js";
-export { TAGS_REQUIRING_RAW_TEXT } from "./tsdoc-config.js";
+export { TAGS_REQUIRING_RAW_TEXT, getOrCreateTSDocParser } from "./tsdoc-config.js";
 export { choosePreferredPayloadText } from "./tsdoc-text-extraction.js";
 export type {
   CheckNarrowSyntheticTagApplicabilitiesOptions,

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -64,6 +64,7 @@ pnpm --filter @formspec/eslint-plugin run check:eslint-docs
 - `tag-recognition/require-tag-arguments`
 - `tag-recognition/no-disabled-tags`
 - `tag-recognition/no-markdown-formatting`
+- `tag-recognition/tsdoc-comment-syntax`
 
 ### Value Parsing
 
@@ -135,6 +136,39 @@ export const rule = ESLintUtils.RuleCreator(() => "")({
 });
 ```
 
+## Replacing `tsdoc/syntax`
+
+If you use `eslint-plugin-tsdoc`'s `tsdoc/syntax` rule, you can replace it with
+`formspec/tag-recognition/tsdoc-comment-syntax` for files containing FormSpec constraint tags.
+
+The `tsdoc/syntax` rule produces false positives on FormSpec raw-text tag payloads:
+
+- `@pattern` values containing `{` `}` (regex quantifiers) or `@` (email patterns)
+- `@enumOptions` and `@defaultValue` values containing JSON object literals
+
+The `formspec/tag-recognition/tsdoc-comment-syntax` rule provides the same TSDoc syntax
+validation but understands which FormSpec tags carry raw-text payloads and suppresses
+diagnostics whose source range lies inside those payloads.
+
+**Recommended migration:**
+
+```js
+// eslint.config.js
+import formspec from "@formspec/eslint-plugin";
+
+export default [
+  ...formspec.configs.recommended,
+  {
+    rules: {
+      // Disable the tsdoc plugin's rule for FormSpec-annotated files;
+      // formspec/tag-recognition/tsdoc-comment-syntax (enabled by recommended)
+      // provides equivalent coverage without the false positives.
+      "tsdoc/syntax": "off",
+    },
+  },
+];
+```
+
 ## Rules
 
 <!-- begin auto-generated rules list -->
@@ -155,6 +189,7 @@ export const rule = ESLintUtils.RuleCreator(() => "")({
 | [tag-recognition/no-markdown-formatting](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-markdown-formatting.md)                       | Forbids Markdown formatting in configured FormSpec tag values                                      | 🔧  |
 | [tag-recognition/no-unknown-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-unknown-tags.md)                                     | Reports FormSpec tags that are not part of the specification                                       |     |
 | [tag-recognition/require-tag-arguments](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/require-tag-arguments.md)                         | Requires arguments for FormSpec tags that need values                                              |     |
+| [tag-recognition/tsdoc-comment-syntax](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/tsdoc-comment-syntax.md)                           | Validates TSDoc comment syntax, suppressing false positives on FormSpec raw-text tag payloads      |     |
 | [target-resolution/no-member-target-on-object](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/no-member-target-on-object.md)           | Disallows member-target syntax on non-string-literal-union fields                                  |     |
 | [target-resolution/no-unsupported-targeting](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/no-unsupported-targeting.md)               | Disallows path or member target syntax on tags that do not support it                              |     |
 | [target-resolution/valid-member-target](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/valid-member-target.md)                         | Validates member-target references against string literal union fields                             |     |

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -138,35 +138,16 @@ export const rule = ESLintUtils.RuleCreator(() => "")({
 
 ## Replacing `tsdoc/syntax`
 
-If you use `eslint-plugin-tsdoc`'s `tsdoc/syntax` rule, you can replace it with
-`formspec/tag-recognition/tsdoc-comment-syntax` for files containing FormSpec constraint tags.
-
-The `tsdoc/syntax` rule produces false positives on FormSpec raw-text tag payloads:
-
-- `@pattern` values containing `{` `}` (regex quantifiers) or `@` (email patterns)
-- `@enumOptions` and `@defaultValue` values containing JSON object literals
-
-The `formspec/tag-recognition/tsdoc-comment-syntax` rule provides the same TSDoc syntax
-validation but understands which FormSpec tags carry raw-text payloads and suppresses
-diagnostics whose source range lies inside those payloads.
-
-**Recommended migration:**
+If you use `eslint-plugin-tsdoc`'s `tsdoc/syntax`, disable it and let
+`formspec/tag-recognition/tsdoc-comment-syntax` (enabled by `recommended`) take
+over — it provides the same TSDoc validation without false positives on
+FormSpec raw-text payloads (`@pattern`, `@enumOptions`, `@defaultValue`). See
+the [rule docs](./docs/rules/tag-recognition/tsdoc-comment-syntax.md) for
+details.
 
 ```js
 // eslint.config.js
-import formspec from "@formspec/eslint-plugin";
-
-export default [
-  ...formspec.configs.recommended,
-  {
-    rules: {
-      // Disable the tsdoc plugin's rule for FormSpec-annotated files;
-      // formspec/tag-recognition/tsdoc-comment-syntax (enabled by recommended)
-      // provides equivalent coverage without the false positives.
-      "tsdoc/syntax": "off",
-    },
-  },
-];
+export default [...formspec.configs.recommended, { rules: { "tsdoc/syntax": "off" } }];
 ```
 
 ## Rules

--- a/packages/eslint-plugin/api-report/eslint-plugin.alpha.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.alpha.api.md
@@ -165,6 +165,7 @@ const plugin: {
         };
         readonly "tag-recognition/no-disabled-tags": NamedRuleModule<"disabledTag", NoDisabledTagsOptions>;
         readonly "tag-recognition/no-markdown-formatting": NamedRuleModule<"markdownFormattingForbidden", NoMarkdownFormattingOptions>;
+        readonly "tag-recognition/tsdoc-comment-syntax": NamedRuleModule<"tsdocSyntax", []>;
         readonly "value-parsing/valid-numeric-value": TSESLint.RuleModule<"invalidNumericValue", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
@@ -234,6 +235,7 @@ export const rules: {
     };
     readonly "tag-recognition/no-disabled-tags": NamedRuleModule<"disabledTag", NoDisabledTagsOptions>;
     readonly "tag-recognition/no-markdown-formatting": NamedRuleModule<"markdownFormattingForbidden", NoMarkdownFormattingOptions>;
+    readonly "tag-recognition/tsdoc-comment-syntax": NamedRuleModule<"tsdocSyntax", []>;
     readonly "value-parsing/valid-numeric-value": TSESLint.RuleModule<"invalidNumericValue", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
@@ -285,6 +287,9 @@ export const rules: {
 export const tagTypeCheck: ESLintUtils.RuleModule<"typeMismatch", [], unknown, ESLintUtils.RuleListener> & {
     name: string;
 };
+
+// @public
+export const tsdocCommentSyntax: NamedRuleModule<"tsdocSyntax", []>;
 
 // @public
 export const validIntegerValue: ESLintUtils.RuleModule<"invalidIntegerValue", [], unknown, ESLintUtils.RuleListener> & {

--- a/packages/eslint-plugin/api-report/eslint-plugin.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.api.md
@@ -169,6 +169,7 @@ const plugin: {
         };
         readonly "tag-recognition/no-disabled-tags": NamedRuleModule<"disabledTag", NoDisabledTagsOptions>;
         readonly "tag-recognition/no-markdown-formatting": NamedRuleModule<"markdownFormattingForbidden", NoMarkdownFormattingOptions>;
+        readonly "tag-recognition/tsdoc-comment-syntax": NamedRuleModule<"tsdocSyntax", []>;
         readonly "value-parsing/valid-numeric-value": TSESLint.RuleModule<"invalidNumericValue", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
@@ -238,6 +239,7 @@ export const rules: {
     };
     readonly "tag-recognition/no-disabled-tags": NamedRuleModule<"disabledTag", NoDisabledTagsOptions>;
     readonly "tag-recognition/no-markdown-formatting": NamedRuleModule<"markdownFormattingForbidden", NoMarkdownFormattingOptions>;
+    readonly "tag-recognition/tsdoc-comment-syntax": NamedRuleModule<"tsdocSyntax", []>;
     readonly "value-parsing/valid-numeric-value": TSESLint.RuleModule<"invalidNumericValue", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
@@ -289,6 +291,9 @@ export const rules: {
 export const tagTypeCheck: ESLintUtils.RuleModule<"typeMismatch", [], unknown, ESLintUtils.RuleListener> & {
     name: string;
 };
+
+// @public
+export const tsdocCommentSyntax: NamedRuleModule<"tsdocSyntax", []>;
 
 // @public
 export const validIntegerValue: ESLintUtils.RuleModule<"invalidIntegerValue", [], unknown, ESLintUtils.RuleListener> & {

--- a/packages/eslint-plugin/api-report/eslint-plugin.beta.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.beta.api.md
@@ -165,6 +165,7 @@ const plugin: {
         };
         readonly "tag-recognition/no-disabled-tags": NamedRuleModule<"disabledTag", NoDisabledTagsOptions>;
         readonly "tag-recognition/no-markdown-formatting": NamedRuleModule<"markdownFormattingForbidden", NoMarkdownFormattingOptions>;
+        readonly "tag-recognition/tsdoc-comment-syntax": NamedRuleModule<"tsdocSyntax", []>;
         readonly "value-parsing/valid-numeric-value": TSESLint.RuleModule<"invalidNumericValue", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
@@ -234,6 +235,7 @@ export const rules: {
     };
     readonly "tag-recognition/no-disabled-tags": NamedRuleModule<"disabledTag", NoDisabledTagsOptions>;
     readonly "tag-recognition/no-markdown-formatting": NamedRuleModule<"markdownFormattingForbidden", NoMarkdownFormattingOptions>;
+    readonly "tag-recognition/tsdoc-comment-syntax": NamedRuleModule<"tsdocSyntax", []>;
     readonly "value-parsing/valid-numeric-value": TSESLint.RuleModule<"invalidNumericValue", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
@@ -285,6 +287,9 @@ export const rules: {
 export const tagTypeCheck: ESLintUtils.RuleModule<"typeMismatch", [], unknown, ESLintUtils.RuleListener> & {
     name: string;
 };
+
+// @public
+export const tsdocCommentSyntax: NamedRuleModule<"tsdocSyntax", []>;
 
 // @public
 export const validIntegerValue: ESLintUtils.RuleModule<"invalidIntegerValue", [], unknown, ESLintUtils.RuleListener> & {

--- a/packages/eslint-plugin/api-report/eslint-plugin.public.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.public.api.md
@@ -165,6 +165,7 @@ const plugin: {
         };
         readonly "tag-recognition/no-disabled-tags": NamedRuleModule<"disabledTag", NoDisabledTagsOptions>;
         readonly "tag-recognition/no-markdown-formatting": NamedRuleModule<"markdownFormattingForbidden", NoMarkdownFormattingOptions>;
+        readonly "tag-recognition/tsdoc-comment-syntax": NamedRuleModule<"tsdocSyntax", []>;
         readonly "value-parsing/valid-numeric-value": TSESLint.RuleModule<"invalidNumericValue", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
@@ -234,6 +235,7 @@ export const rules: {
     };
     readonly "tag-recognition/no-disabled-tags": NamedRuleModule<"disabledTag", NoDisabledTagsOptions>;
     readonly "tag-recognition/no-markdown-formatting": NamedRuleModule<"markdownFormattingForbidden", NoMarkdownFormattingOptions>;
+    readonly "tag-recognition/tsdoc-comment-syntax": NamedRuleModule<"tsdocSyntax", []>;
     readonly "value-parsing/valid-numeric-value": TSESLint.RuleModule<"invalidNumericValue", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
@@ -285,6 +287,9 @@ export const rules: {
 export const tagTypeCheck: ESLintUtils.RuleModule<"typeMismatch", [], unknown, ESLintUtils.RuleListener> & {
     name: string;
 };
+
+// @public
+export const tsdocCommentSyntax: NamedRuleModule<"tsdocSyntax", []>;
 
 // @public
 export const validIntegerValue: ESLintUtils.RuleModule<"invalidIntegerValue", [], unknown, ESLintUtils.RuleListener> & {

--- a/packages/eslint-plugin/docs/rules/constraint-validation/no-double-underscore-fields.md
+++ b/packages/eslint-plugin/docs/rules/constraint-validation/no-double-underscore-fields.md
@@ -1,5 +1,5 @@
 # @formspec/constraint-validation/no-double-underscore-fields
 
-📝 Warns when a property starts with "\_\_", indicating it will be excluded from the generated schema.
+📝 Warns when a property starts with "__", indicating it will be excluded from the generated schema.
 
 <!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/tag-recognition/tsdoc-comment-syntax.md
+++ b/packages/eslint-plugin/docs/rules/tag-recognition/tsdoc-comment-syntax.md
@@ -1,0 +1,5 @@
+# @formspec/tag-recognition/tsdoc-comment-syntax
+
+📝 Validates TSDoc comment syntax, suppressing false positives on FormSpec raw-text tag payloads.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/src/__tests__/rules/tag-recognition/tsdoc-comment-syntax.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/tag-recognition/tsdoc-comment-syntax.test.ts
@@ -95,6 +95,45 @@ ruleTester.run("tsdoc-comment-syntax", tsdocCommentSyntax, {
         }
       `,
     },
+    // Interface declaration with raw-text tag in a property signature —
+    // confirms coverage extends beyond class PropertyDefinitions.
+    {
+      code: String.raw`
+        /** @displayName Profile */
+        interface Profile {
+          /** @pattern ^[A-Z]{2}$ */
+          countryCode: string;
+        }
+      `,
+    },
+    // Type alias with valid TSDoc.
+    {
+      code: `
+        /** A named string alias. */
+        type Name = string;
+      `,
+    },
+    // Extension-defined constraint tag supplied via settings.formspec.extensionRegistry
+    // must not be reported as unknown by the TSDoc parser.
+    {
+      code: `
+        class Form {
+          /** @afterDate 2025-01-01 */
+          startsAt!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                constraintTags: [{ tagName: "afterDate" }],
+              },
+            ],
+          },
+        },
+      },
+    },
   ],
 
   invalid: [
@@ -120,6 +159,19 @@ ruleTester.run("tsdoc-comment-syntax", tsdocCommentSyntax, {
         }
       `,
       errors: [{ messageId: "tsdocSyntax" }, { messageId: "tsdocSyntax" }],
+    },
+    // Selective suppression: a comment that contains BOTH a raw-text
+    // @pattern payload (with curlies) AND a malformed inline tag in prose.
+    // The @pattern payload must be suppressed, but the {@link opened in
+    // prose must still be reported.
+    {
+      code: String.raw`
+        class Form {
+          /** Hello {@link unterminated @pattern ^[0-9]{5}$ */
+          zip!: string;
+        }
+      `,
+      errors: [{ messageId: "tsdocSyntax" }],
     },
   ],
 });

--- a/packages/eslint-plugin/src/__tests__/rules/tag-recognition/tsdoc-comment-syntax.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/tag-recognition/tsdoc-comment-syntax.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for tag-recognition/tsdoc-comment-syntax.
+ *
+ * Regression tests for issue #291: `tsdoc/syntax` false positives on FormSpec
+ * constraint tag values containing TSDoc-significant characters (`{}`, `@`).
+ * This rule suppresses those false positives while still validating TSDoc syntax
+ * outside raw-text tag payloads.
+ *
+ * @see https://github.com/mike-north/formspec/issues/291
+ * @see https://tsdoc.org/
+ */
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as vitest from "vitest";
+import { tsdocCommentSyntax } from "../../../rules/tag-recognition/tsdoc-comment-syntax.js";
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ["*.ts"],
+      },
+    },
+  },
+});
+
+ruleTester.run("tsdoc-comment-syntax", tsdocCommentSyntax, {
+  valid: [
+    // Well-formed comment with no FormSpec tags — clean TSDoc prose.
+    {
+      code: `
+        class Form {
+          /** The user's full name. */
+          name!: string;
+        }
+      `,
+    },
+    // Issue #291 regression: @pattern with curly braces in regex.
+    // tsdoc/syntax would flag `{5}` as a malformed inline tag.
+    {
+      code: String.raw`
+        class Form {
+          /** @displayName Postal Code @pattern ^[0-9]{5}(-[0-9]{4})?$ */
+          postalCode!: string;
+        }
+      `,
+    },
+    // Issue #291 regression: @pattern with @ in regex.
+    // tsdoc/syntax would flag the @ inside the regex as a tag opener.
+    {
+      code: String.raw`
+        class Form {
+          /** @displayName Email @pattern ^[^@]+@[^@]+$ */
+          email!: string;
+        }
+      `,
+    },
+    // @enumOptions with JSON object literals containing {}.
+    {
+      code: `
+        class Form {
+          /** @enumOptions [{"value":"a"},{"value":"b"}] */
+          status!: string;
+        }
+      `,
+    },
+    // @defaultValue with JSON object literal.
+    {
+      code: `
+        class Form {
+          /** @defaultValue {"foo":"bar"} */
+          config!: string;
+        }
+      `,
+    },
+    // Multiple FormSpec block tags interleaved with summary text.
+    {
+      code: String.raw`
+        class Form {
+          /** Address zip code. @displayName ZIP Code @pattern ^[0-9]{5}$ @minimum 5 */
+          zip!: string;
+        }
+      `,
+    },
+    // Plain class declaration with valid TSDoc — class-level comment.
+    {
+      code: `
+        /** A well-formed class comment. */
+        class MyForm {
+          count!: number;
+        }
+      `,
+    },
+  ],
+
+  invalid: [
+    // Unterminated inline tag in prose (NOT inside a raw-text payload).
+    // The {@link ...} is opened but never closed before */.
+    {
+      code: `
+        class Form {
+          /** Hello {@link unterminated */
+          name!: string;
+        }
+      `,
+      errors: [{ messageId: "tsdocSyntax" }],
+    },
+    // Malformed inline tag (empty tag name after @-brace).
+    // TSDoc produces two diagnostics for `{@}`: one for the missing tag name
+    // after `{@` and one for the unescaped `}` character.
+    {
+      code: `
+        class Form {
+          /** A field with {@} malformed inline tag. */
+          name!: string;
+        }
+      `,
+      errors: [{ messageId: "tsdocSyntax" }, { messageId: "tsdocSyntax" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -43,6 +43,7 @@ import {
   noContradictoryRules,
   validDiscriminator,
   noDoubleUnderscoreFields,
+  tsdocCommentSyntax as tsdocCommentSyntaxRule,
 } from "./rules/index.js";
 import {
   noContradictions as noContradictionsRule,
@@ -118,6 +119,17 @@ export const noMarkdownFormatting: NamedRuleModule<
 > = noMarkdownFormattingRule;
 
 /**
+ * Validates TSDoc comment syntax using FormSpec's TSDoc configuration,
+ * suppressing false positives on raw-text FormSpec tag payloads.
+ *
+ * Use this rule in place of `tsdoc/syntax` from `eslint-plugin-tsdoc` for
+ * FormSpec-annotated files.
+ *
+ * @public
+ */
+export const tsdocCommentSyntax: NamedRuleModule<"tsdocSyntax", []> = tsdocCommentSyntaxRule;
+
+/**
  * Validates allowed field types against project constraints.
  *
  * @public
@@ -146,6 +158,7 @@ export const rules = {
   "tag-recognition/require-tag-arguments": requireTagArguments,
   "tag-recognition/no-disabled-tags": noDisabledTags,
   "tag-recognition/no-markdown-formatting": noMarkdownFormatting,
+  "tag-recognition/tsdoc-comment-syntax": tsdocCommentSyntax,
   "value-parsing/valid-numeric-value": validNumericValue,
   "value-parsing/valid-integer-value": validIntegerValue,
   "value-parsing/valid-regex-pattern": validRegexPattern,
@@ -203,6 +216,7 @@ const recommendedConfig: TSESLint.FlatConfig.ConfigArray = [
       "formspec/tag-recognition/no-unknown-tags": "warn",
       "formspec/tag-recognition/require-tag-arguments": "error",
       "formspec/tag-recognition/no-disabled-tags": "warn",
+      "formspec/tag-recognition/tsdoc-comment-syntax": "error",
       "formspec/value-parsing/valid-numeric-value": "error",
       "formspec/value-parsing/valid-integer-value": "error",
       "formspec/value-parsing/valid-regex-pattern": "error",
@@ -239,6 +253,7 @@ const strictConfig: TSESLint.FlatConfig.ConfigArray = [
       "formspec/tag-recognition/no-unknown-tags": "error",
       "formspec/tag-recognition/require-tag-arguments": "error",
       "formspec/tag-recognition/no-disabled-tags": "error",
+      "formspec/tag-recognition/tsdoc-comment-syntax": "error",
       "formspec/value-parsing/valid-numeric-value": "error",
       "formspec/value-parsing/valid-integer-value": "error",
       "formspec/value-parsing/valid-regex-pattern": "error",

--- a/packages/eslint-plugin/src/rules/tag-recognition/index.ts
+++ b/packages/eslint-plugin/src/rules/tag-recognition/index.ts
@@ -2,3 +2,4 @@ export { noUnknownTags } from "./no-unknown-tags.js";
 export { requireTagArguments } from "./require-tag-arguments.js";
 export { noDisabledTags } from "./no-disabled-tags.js";
 export { noMarkdownFormatting } from "./no-markdown-formatting.js";
+export { tsdocCommentSyntax } from "./tsdoc-comment-syntax.js";

--- a/packages/eslint-plugin/src/rules/tag-recognition/tsdoc-comment-syntax.ts
+++ b/packages/eslint-plugin/src/rules/tag-recognition/tsdoc-comment-syntax.ts
@@ -1,0 +1,88 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { createDeclarationVisitor } from "../../utils/rule-helpers.js";
+import { scanFormSpecTags, getLeadingJSDocComments } from "../../utils/tag-scanner.js";
+import { TAGS_REQUIRING_RAW_TEXT, getOrCreateTSDocParser } from "@formspec/analysis/internal";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://formspec.dev/eslint-plugin/rules/${name}`
+);
+
+/**
+ * ESLint rule that validates TSDoc comment syntax using FormSpec's TSDoc
+ * configuration, suppressing false positives on raw-text FormSpec tag payloads
+ * such as `@pattern` regex values and `@enumOptions`/`@defaultValue` JSON values.
+ *
+ * Intended as a drop-in replacement for `tsdoc/syntax` from `eslint-plugin-tsdoc`
+ * in projects that use FormSpec constraint tags.
+ *
+ * @public
+ */
+export const tsdocCommentSyntax = createRule<[], "tsdocSyntax">({
+  name: "tag-recognition/tsdoc-comment-syntax",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Validates TSDoc comment syntax, suppressing false positives on FormSpec raw-text tag payloads",
+    },
+    schema: [],
+    messages: {
+      tsdocSyntax: "{{message}} (tsdoc {{code}})",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    // TODO: thread extension tag names from settings.formspec.extensionRegistry
+    // when the ExtensionRegistry interface exposes a method to enumerate extension
+    // constraint tag names. For now, only the built-in FormSpec tags are registered.
+    const parser = getOrCreateTSDocParser([]);
+
+    return createDeclarationVisitor((node) => {
+      // Collect raw-text payload ranges for tags that allow TSDoc-significant
+      // characters ({}, @) in their payloads. Diagnostics whose absolute source
+      // range overlaps any of these ranges are suppressed to avoid false positives.
+      const rawTextRanges: (readonly [start: number, end: number])[] = [];
+      for (const tag of scanFormSpecTags(node, context.sourceCode)) {
+        if (TAGS_REQUIRING_RAW_TEXT.has(tag.normalizedName) && tag.rawArgumentRange !== null) {
+          rawTextRanges.push(tag.rawArgumentRange);
+        }
+      }
+
+      for (const comment of getLeadingJSDocComments(node, context.sourceCode)) {
+        // Reconstruct the full `/** ... */` comment text as it appears in source.
+        // comment.value is the inner text (without the surrounding /* and */).
+        const commentText = `/*${comment.value}*/`;
+        const commentStart = comment.range[0];
+
+        const parserContext = parser.parseString(commentText);
+
+        for (const msg of parserContext.log.messages) {
+          const localPos = msg.textRange.pos;
+          const localEnd = msg.textRange.end;
+
+          // Convert comment-local offsets to absolute source-file offsets.
+          const absPos = commentStart + localPos;
+          const absEnd = commentStart + localEnd;
+
+          // Suppress diagnostics whose source range overlaps a raw-text payload range.
+          const suppressed = rawTextRanges.some(
+            ([rangeStart, rangeEnd]) => !(absEnd <= rangeStart || absPos >= rangeEnd)
+          );
+          if (suppressed) continue;
+
+          context.report({
+            loc: {
+              start: context.sourceCode.getLocFromIndex(absPos),
+              end: context.sourceCode.getLocFromIndex(absEnd),
+            },
+            messageId: "tsdocSyntax",
+            data: {
+              message: msg.unformattedText,
+              code: msg.messageId,
+            },
+          });
+        }
+      }
+    });
+  },
+});

--- a/packages/eslint-plugin/src/rules/tag-recognition/tsdoc-comment-syntax.ts
+++ b/packages/eslint-plugin/src/rules/tag-recognition/tsdoc-comment-syntax.ts
@@ -1,11 +1,50 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { createDeclarationVisitor } from "../../utils/rule-helpers.js";
 import { scanFormSpecTags, getLeadingJSDocComments } from "../../utils/tag-scanner.js";
+import { normalizeFormSpecTagName } from "../../utils/tag-metadata.js";
 import { TAGS_REQUIRING_RAW_TEXT, getOrCreateTSDocParser } from "@formspec/analysis/internal";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) => `https://formspec.dev/eslint-plugin/rules/${name}`
 );
+
+/**
+ * Minimal structural view of the `ExtensionRegistry` stored in
+ * `context.settings.formspec.extensionRegistry`. Typed locally to avoid
+ * pulling `@formspec/build` into this rule.
+ */
+interface SettingsExtensionRegistry {
+  readonly extensions: readonly SettingsExtensionDefinition[];
+}
+
+interface SettingsExtensionDefinition {
+  readonly constraintTags?: readonly SettingsTagName[];
+  readonly metadataSlots?: readonly SettingsTagName[];
+}
+
+interface SettingsTagName {
+  readonly tagName: string;
+}
+
+function readExtensionTagNames(settings: Readonly<Record<string, unknown>>): readonly string[] {
+  const formspec = settings["formspec"];
+  if (typeof formspec !== "object" || formspec === null) return [];
+  const registry = (formspec as Record<string, unknown>)["extensionRegistry"];
+  if (typeof registry !== "object" || registry === null) return [];
+  const extensions = (registry as Partial<SettingsExtensionRegistry>).extensions;
+  if (!Array.isArray(extensions)) return [];
+  const typedExtensions: readonly SettingsExtensionDefinition[] = extensions;
+  const names = new Set<string>();
+  for (const extension of typedExtensions) {
+    for (const tag of extension.constraintTags ?? []) {
+      names.add(normalizeFormSpecTagName(tag.tagName));
+    }
+    for (const slot of extension.metadataSlots ?? []) {
+      names.add(normalizeFormSpecTagName(slot.tagName));
+    }
+  }
+  return [...names].sort();
+}
 
 /**
  * ESLint rule that validates TSDoc comment syntax using FormSpec's TSDoc
@@ -32,16 +71,17 @@ export const tsdocCommentSyntax = createRule<[], "tsdocSyntax">({
   },
   defaultOptions: [],
   create(context) {
-    // TODO: thread extension tag names from settings.formspec.extensionRegistry
-    // when the ExtensionRegistry interface exposes a method to enumerate extension
-    // constraint tag names. For now, only the built-in FormSpec tags are registered.
-    const parser = getOrCreateTSDocParser([]);
+    // Thread extension-defined constraint and metadata tag names through to
+    // the TSDoc parser so custom project tags registered via `withConfig()`
+    // aren't reported as unknown.
+    const extensionTagNames = readExtensionTagNames(context.settings);
+    const parser = getOrCreateTSDocParser(extensionTagNames);
 
     return createDeclarationVisitor((node) => {
       // Collect raw-text payload ranges for tags that allow TSDoc-significant
       // characters ({}, @) in their payloads. Diagnostics whose absolute source
       // range overlaps any of these ranges are suppressed to avoid false positives.
-      const rawTextRanges: (readonly [start: number, end: number])[] = [];
+      const rawTextRanges: (readonly [number, number])[] = [];
       for (const tag of scanFormSpecTags(node, context.sourceCode)) {
         if (TAGS_REQUIRING_RAW_TEXT.has(tag.normalizedName) && tag.rawArgumentRange !== null) {
           rawTextRanges.push(tag.rawArgumentRange);
@@ -50,23 +90,21 @@ export const tsdocCommentSyntax = createRule<[], "tsdocSyntax">({
 
       for (const comment of getLeadingJSDocComments(node, context.sourceCode)) {
         // Reconstruct the full `/** ... */` comment text as it appears in source.
-        // comment.value is the inner text (without the surrounding /* and */).
+        // `getLeadingJSDocComments` only returns Block comments whose value starts
+        // with `*`, so wrapping with `/*` / `*/` yields the exact original text.
         const commentText = `/*${comment.value}*/`;
         const commentStart = comment.range[0];
 
         const parserContext = parser.parseString(commentText);
 
         for (const msg of parserContext.log.messages) {
-          const localPos = msg.textRange.pos;
-          const localEnd = msg.textRange.end;
-
           // Convert comment-local offsets to absolute source-file offsets.
-          const absPos = commentStart + localPos;
-          const absEnd = commentStart + localEnd;
+          const absPos = commentStart + msg.textRange.pos;
+          const absEnd = commentStart + msg.textRange.end;
 
-          // Suppress diagnostics whose source range overlaps a raw-text payload range.
+          // Half-open overlap check with raw-text payload ranges [start, end).
           const suppressed = rawTextRanges.some(
-            ([rangeStart, rangeEnd]) => !(absEnd <= rangeStart || absPos >= rangeEnd)
+            ([rangeStart, rangeEnd]) => absPos < rangeEnd && absEnd > rangeStart
           );
           if (suppressed) continue;
 

--- a/packages/eslint-plugin/src/utils/tag-scanner.ts
+++ b/packages/eslint-plugin/src/utils/tag-scanner.ts
@@ -20,7 +20,10 @@ export interface ScannedTag {
   readonly comment: TSESTree.Comment;
 }
 
-function getLeadingJSDocComments(node: TSESTree.Node, sourceCode: SourceCode): TSESTree.Comment[] {
+export function getLeadingJSDocComments(
+  node: TSESTree.Node,
+  sourceCode: SourceCode
+): TSESTree.Comment[] {
   const comments = [...sourceCode.getCommentsBefore(node)];
   if (node.type === AST_NODE_TYPES.PropertyDefinition && node.decorators.length > 0) {
     const keyComments = sourceCode.getCommentsBefore(node.key);


### PR DESCRIPTION
Fixes #291.

## Summary

- Adds `formspec/tag-recognition/tsdoc-comment-syntax`, a new ESLint rule that validates TSDoc comment syntax using FormSpec's own `TSDocParser` configuration (via `getOrCreateTSDocParser`) and suppresses diagnostics whose source range lies inside a raw-text FormSpec tag payload (`@pattern`, `@enumOptions`, `@defaultValue`). It is the spiritual replacement for `tsdoc/syntax` from `eslint-plugin-tsdoc` for FormSpec users — same coverage, without the false positives.
- Wired into both `configs.recommended` and `configs.strict` at severity `error`.
- Exposes `getOrCreateTSDocParser` from `@formspec/analysis/internal` so the plugin can share the cached parser instance.
- README now has a "Replacing \`tsdoc/syntax\`" section documenting the drop-in migration.

## Motivation

Downstream consumers (e.g. `@stripe/extensibility-sdk`) had to disable `tsdoc/syntax` entirely on FormSpec-annotated files because it flagged valid regex values like `@pattern ^[0-9]{5}(-[0-9]{4})?$` and `@pattern ^[^@]+@[^@]+$` — TSDoc saw `{5}` as an inline tag and `@` as a tag opener. FormSpec's analysis package already knows these tags are raw-text (`TAGS_REQUIRING_RAW_TEXT`), so this PR surfaces that knowledge as a user-facing ESLint rule.

## Test plan

- [x] Unit tests in `tsdoc-comment-syntax.test.ts` cover:
  - Issue #291 regression snippets (`@pattern ^[0-9]{5}(-[0-9]{4})?$`, `@pattern ^[^@]+@[^@]+$`) — must NOT report.
  - `@enumOptions [{"value":"a"},{"value":"b"}]` and `@defaultValue {"foo":"bar"}` — raw-text JSON, must NOT report.
  - Unterminated inline tag and malformed `{@}` in prose outside any raw-text payload — MUST report with `messageId: "tsdocSyntax"`.
- [x] `pnpm --filter @formspec/eslint-plugin run test` — 298 tests pass.
- [x] `pnpm run build` — full monorepo builds clean, including API Extractor.
- [x] `pnpm run lint` — clean.
- [x] `pnpm run test` — all 266 e2e tests pass alongside package tests.
- [x] Changeset added at `.changeset/tsdoc-comment-syntax-rule.md` (`@formspec/eslint-plugin` minor, `@formspec/analysis` patch).