### PR TITLE
fix(build): bypass synthetic checker for imported integer-branded types

### DIFF
--- a/.changeset/integer-constraint-cross-file.md
+++ b/.changeset/integer-constraint-cross-file.md
@@ -1,6 +1,8 @@
 ---
 "@formspec/build": patch
 "@formspec/analysis": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
 ---
 
 Fix TYPE_MISMATCH false positives for numeric constraint tags (`@minimum`, `@maximum`, etc.) on integer-branded types imported from another module, including nullable (`Integer | null`) and optional (`score?: Integer`) variants.

--- a/.changeset/integer-constraint-cross-file.md
+++ b/.changeset/integer-constraint-cross-file.md
@@ -1,9 +1,12 @@
 ---
 "@formspec/build": patch
+"@formspec/analysis": patch
 ---
 
-Fix TYPE_MISMATCH false positives for numeric constraint tags (`@minimum`, `@maximum`, etc.) on integer-branded types imported from another module.
+Fix TYPE_MISMATCH false positives for numeric constraint tags (`@minimum`, `@maximum`, etc.) on integer-branded types imported from another module, including nullable (`Integer | null`) and optional (`score?: Integer`) variants.
 
-Previously, when a type structurally matching `number & { [__integerBrand]: true }` (e.g. `Integer` or `PositiveInteger` from `@stripe/extensibility-sdk/stdlib`) was imported from an external module, the compiler-backed constraint validator rejected it as a capability mismatch because the synthetic TypeScript program used for validation could not resolve the imported type name.
+Two independent validation layers needed fixes:
 
-The private `isIntegerBrandedType` function in `class-analyzer.ts` is now exported from `ts-type-utils.ts` and shared with `tsdoc-parser.ts`, which uses it to bypass the synthetic check for integer-branded types — consistent with how the IR classification path already treats them.
+1. **`tsdoc-parser.ts`** (compiler-backed constraint validation): The synthetic TypeScript program used for validation couldn't resolve imported type names. The `isIntegerBrandedType` bypass now strips nullish unions before checking, so `Integer | null` is handled correctly.
+
+2. **`semantic-targets.ts`** (IR-level constraint validation): `checkConstraintOnType` checked capabilities against the raw `effectiveType`, which is a `union` IR node for nullable fields. Now unwraps nullable unions to the non-null member before computing type capabilities.

--- a/.changeset/integer-constraint-cross-file.md
+++ b/.changeset/integer-constraint-cross-file.md
@@ -1,0 +1,9 @@
+---
+"@formspec/build": patch
+---
+
+Fix TYPE_MISMATCH false positives for numeric constraint tags (`@minimum`, `@maximum`, etc.) on integer-branded types imported from another module.
+
+Previously, when a type structurally matching `number & { [__integerBrand]: true }` (e.g. `Integer` or `PositiveInteger` from `@stripe/extensibility-sdk/stdlib`) was imported from an external module, the compiler-backed constraint validator rejected it as a capability mismatch because the synthetic TypeScript program used for validation could not resolve the imported type name.
+
+The private `isIntegerBrandedType` function in `class-analyzer.ts` is now exported from `ts-type-utils.ts` and shared with `tsdoc-parser.ts`, which uses it to bypass the synthetic check for integer-branded types — consistent with how the IR classification path already treats them.

--- a/packages/analysis/src/semantic-targets.ts
+++ b/packages/analysis/src/semantic-targets.ts
@@ -1144,15 +1144,27 @@ function checkConstraintOnType(
   extensionRegistry: ConstraintRegistryLike | undefined
 ): void {
   const effectiveType = dereferenceAnalysisType(type, typeRegistry);
+  // For nullable unions (e.g. Integer | null), unwrap to the non-null member
+  // so that constraint compatibility checks work the same as for the non-null
+  // variant. This mirrors the stripNullishUnion pattern used in ts-binding.ts.
+  const unwrapped =
+    effectiveType.kind === "union"
+      ? (() => {
+          const nonNull = effectiveType.members
+            .map((m) => dereferenceAnalysisType(m, typeRegistry))
+            .filter((m) => !isNullType(m));
+          return nonNull.length === 1 && nonNull[0] !== undefined ? nonNull[0] : effectiveType;
+        })()
+      : effectiveType;
   const isNumber =
-    effectiveType.kind === "primitive" &&
-    ["number", "integer", "bigint"].includes(effectiveType.primitiveKind);
-  const isString = effectiveType.kind === "primitive" && effectiveType.primitiveKind === "string";
-  const isArray = effectiveType.kind === "array";
-  const isEnum = effectiveType.kind === "enum";
+    unwrapped.kind === "primitive" &&
+    ["number", "integer", "bigint"].includes(unwrapped.primitiveKind);
+  const isString = unwrapped.kind === "primitive" && unwrapped.primitiveKind === "string";
+  const isArray = unwrapped.kind === "array";
+  const isEnum = unwrapped.kind === "enum";
   const arrayItemType =
-    effectiveType.kind === "array"
-      ? dereferenceAnalysisType(effectiveType.items, typeRegistry)
+    unwrapped.kind === "array"
+      ? dereferenceAnalysisType(unwrapped.items, typeRegistry)
       : undefined;
   const isStringArray =
     arrayItemType?.kind === "primitive" && arrayItemType.primitiveKind === "string";

--- a/packages/build/src/__tests__/integer-type.test.ts
+++ b/packages/build/src/__tests__/integer-type.test.ts
@@ -41,12 +41,18 @@ function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorRepo
  * `afterAll`.
  */
 let fixturePath: string;
+let importingFixturePath: string;
 let tmpDir: string;
 
 const FIXTURE_SOURCE = [
   // Local unique-symbol brand — structurally identical to @formspec/core's export.
   "declare const __integerBrand: unique symbol;",
   "type Integer = number & { readonly [__integerBrand]: true };",
+  "",
+  // Multi-branded integer — mirrors @stripe/extensibility-sdk/stdlib's Integer/PositiveInteger,
+  // which carry both __integerBrand and a second __stripeType symbol.
+  "declare const __stripeType: unique symbol;",
+  "type MultiBrandedInteger = number & { readonly [__integerBrand]: true; readonly [__stripeType]: 'int' };",
   "",
   // 1. Basic Integer field
   "export interface IntegerFieldsConfig {",
@@ -81,6 +87,40 @@ const FIXTURE_SOURCE = [
   "  integerField: Integer;",
   "  numberField: number;",
   "}",
+  "",
+  // 7. Multi-branded Integer with numeric constraints — mirrors SDK's Integer/PositiveInteger
+  "export interface MultiBrandedConstrainedConfig {",
+  "  /** @minimum 2000 @maximum 2026 */",
+  "  year: MultiBrandedInteger;",
+  "}",
+].join("\n");
+
+/**
+ * Types file that exports MultiBrandedInteger — used by IMPORTING_FIXTURE_SOURCE
+ * to simulate the SDK pattern where Integer/PositiveInteger are imported from an
+ * external module. When the type is imported (not locally declared), its name is
+ * filtered out of supportingDeclarations by buildSupportingDeclarations, so the
+ * synthetic checker cannot resolve it unless isIntegerBrandedType broadens it.
+ */
+const TYPES_SOURCE = [
+  "declare const __integerBrand: unique symbol;",
+  "declare const __stripeType: unique symbol;",
+  "export type MultiBrandedInteger = number & { readonly [__integerBrand]: true; readonly [__stripeType]: 'int' };",
+].join("\n");
+
+/**
+ * Fixture that imports MultiBrandedInteger from a separate module, mirroring the
+ * real-world SDK usage pattern (`import { Integer } from '@stripe/extensibility-sdk/stdlib'`).
+ * The synthetic checker cannot inline-expand the imported type, so without the
+ * isIntegerBrandedType broadening fix this produces a TYPE_MISMATCH diagnostic.
+ */
+const IMPORTING_FIXTURE_SOURCE = [
+  'import type { MultiBrandedInteger } from "./types.js";',
+  "",
+  "export interface CrossFileConstrainedConfig {",
+  "  /** @minimum 2000 @maximum 2026 */",
+  "  year: MultiBrandedInteger;",
+  "}",
 ].join("\n");
 
 beforeAll(() => {
@@ -105,6 +145,10 @@ beforeAll(() => {
 
   fixturePath = path.join(tmpDir, "fixture.ts");
   fs.writeFileSync(fixturePath, FIXTURE_SOURCE);
+
+  fs.writeFileSync(path.join(tmpDir, "types.ts"), TYPES_SOURCE);
+  importingFixturePath = path.join(tmpDir, "importing-fixture.ts");
+  fs.writeFileSync(importingFixturePath, IMPORTING_FIXTURE_SOURCE);
 });
 
 afterAll(() => {
@@ -352,6 +396,51 @@ describe("builtin Integer type", () => {
       // Plain number field → type: "number"
       const numberProp = resolvePropertySchema(result, "numberField");
       expect(numberProp).toHaveProperty("type", "number");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Multi-branded Integer (@minimum / @maximum on a type with extra brand symbols)
+  // -------------------------------------------------------------------------
+  describe("multi-branded Integer (mirrors SDK Integer/PositiveInteger)", () => {
+    it("accepts @minimum and @maximum on a doubly-branded integer type (locally declared)", () => {
+      // MultiBrandedInteger = number & { [__integerBrand]: true } & { [__stripeType]: 'int' }
+      // mirrors @stripe/extensibility-sdk/stdlib Integer and PositiveInteger, which carry
+      // both __integerBrand and __stripeType. The extra brand must not prevent numeric
+      // constraint tags from being accepted.
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "MultiBrandedConstrainedConfig",
+      });
+
+      const properties = result.jsonSchema.properties as Record<string, unknown>;
+      const yearSchema = properties["year"] as Record<string, unknown>;
+
+      expect(yearSchema).toMatchObject({
+        minimum: 2000,
+        maximum: 2026,
+      });
+    });
+
+    it("accepts @minimum and @maximum on a doubly-branded integer type imported from another module", () => {
+      // This is the real-world failure mode: Integer / PositiveInteger come from an
+      // external module (e.g. @stripe/extensibility-sdk/stdlib). buildSupportingDeclarations
+      // filters out any statement that references an imported name, so `MultiBrandedInteger`
+      // is not available in the synthetic TypeScript program. Without the
+      // isIntegerBrandedType broadening fix, the synthetic checker fails to resolve the
+      // type and emits a spurious TYPE_MISMATCH diagnostic, causing generateSchemas to throw.
+      const result = generateSchemasOrThrow({
+        filePath: importingFixturePath,
+        typeName: "CrossFileConstrainedConfig",
+      });
+
+      const properties = result.jsonSchema.properties as Record<string, unknown>;
+      const yearSchema = properties["year"] as Record<string, unknown>;
+
+      expect(yearSchema).toMatchObject({
+        minimum: 2000,
+        maximum: 2026,
+      });
     });
   });
 });

--- a/packages/build/src/__tests__/integer-type.test.ts
+++ b/packages/build/src/__tests__/integer-type.test.ts
@@ -121,6 +121,21 @@ const IMPORTING_FIXTURE_SOURCE = [
   "  /** @minimum 2000 @maximum 2026 */",
   "  year: MultiBrandedInteger;",
   "}",
+  "",
+  "export interface CrossFileNullableConfig {",
+  "  /** @minimum 0 */",
+  "  score: MultiBrandedInteger | null;",
+  "}",
+  "",
+  "export interface CrossFileOptionalConfig {",
+  "  /** @minimum 0 */",
+  "  score?: MultiBrandedInteger;",
+  "}",
+  "",
+  "export interface CrossFilePatternConfig {",
+  "  /** @pattern ^[0-9]+$ */",
+  "  code: MultiBrandedInteger;",
+  "}",
 ].join("\n");
 
 beforeAll(() => {
@@ -404,10 +419,9 @@ describe("builtin Integer type", () => {
   // -------------------------------------------------------------------------
   describe("multi-branded Integer (mirrors SDK Integer/PositiveInteger)", () => {
     it("accepts @minimum and @maximum on a doubly-branded integer type (locally declared)", () => {
-      // MultiBrandedInteger = number & { [__integerBrand]: true } & { [__stripeType]: 'int' }
-      // mirrors @stripe/extensibility-sdk/stdlib Integer and PositiveInteger, which carry
-      // both __integerBrand and __stripeType. The extra brand must not prevent numeric
-      // constraint tags from being accepted.
+      // Documents existing behavior: the class-analyzer path already handles
+      // locally-declared multi-branded integers. This test does NOT guard the
+      // cross-file regression — see the imported variant below.
       const result = generateSchemasOrThrow({
         filePath: fixturePath,
         typeName: "MultiBrandedConstrainedConfig",
@@ -441,6 +455,46 @@ describe("builtin Integer type", () => {
         minimum: 2000,
         maximum: 2026,
       });
+    });
+
+    it("accepts @minimum on a nullable imported integer type", () => {
+      const result = generateSchemasOrThrow({
+        filePath: importingFixturePath,
+        typeName: "CrossFileNullableConfig",
+      });
+
+      const properties = result.jsonSchema.properties as Record<string, unknown>;
+      const scoreSchema = properties["score"] as Record<string, unknown>;
+
+      expect(scoreSchema).toMatchObject({
+        minimum: 0,
+      });
+    });
+
+    it("accepts @minimum on an optional imported integer type", () => {
+      const result = generateSchemasOrThrow({
+        filePath: importingFixturePath,
+        typeName: "CrossFileOptionalConfig",
+      });
+
+      const properties = result.jsonSchema.properties as Record<string, unknown>;
+      const scoreSchema = properties["score"] as Record<string, unknown>;
+
+      expect(scoreSchema).toMatchObject({
+        minimum: 0,
+      });
+    });
+
+    it("rejects @pattern on an imported integer type (not string-like)", () => {
+      // Pins the scope of the integer bypass: only numeric-comparable
+      // constraints are broadened. @pattern requires string-like capability
+      // and must still produce a TYPE_MISMATCH on integer types.
+      expect(() =>
+        generateSchemasOrThrow({
+          filePath: importingFixturePath,
+          typeName: "CrossFilePatternConfig",
+        })
+      ).toThrow(/TYPE_MISMATCH/);
     });
   });
 });

--- a/packages/build/src/analyzer/builtin-brands.ts
+++ b/packages/build/src/analyzer/builtin-brands.ts
@@ -1,0 +1,18 @@
+import * as ts from "typescript";
+import { collectBrandIdentifiers } from "../extensions/ts-type-utils.js";
+
+/**
+ * Returns `true` when `type` is an integer-branded intersection — i.e., it
+ * includes a `number` base and a computed property keyed by `__integerBrand`.
+ *
+ * Used by both `class-analyzer.ts` (IR classification) and `tsdoc-parser.ts`
+ * (constraint validation bypass for imported types whose names the synthetic
+ * program cannot resolve).
+ *
+ * @internal
+ */
+export function isIntegerBrandedType(type: ts.Type): boolean {
+  if (!type.isIntersection()) return false;
+  if (!type.types.some((member) => !!(member.flags & ts.TypeFlags.Number))) return false;
+  return collectBrandIdentifiers(type).includes("__integerBrand");
+}

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -44,6 +44,7 @@ import {
   collectBrandIdentifiers,
   extractTypeNodeFromSource,
   getTypeAliasDeclarationFromTypeReference,
+  isIntegerBrandedType,
 } from "../extensions/ts-type-utils.js";
 import type { MetadataPolicyInput } from "@formspec/core";
 import { getDeclarationMetadataPolicy, normalizeMetadataPolicy } from "../metadata/index.js";
@@ -63,28 +64,6 @@ function isIntersectionType(type: ts.Type): type is ts.IntersectionType {
   return !!(type.flags & ts.TypeFlags.Intersection);
 }
 
-/**
- * Checks whether a type is branded with `__integerBrand` from `@formspec/core`.
- *
- * Integer-branded types are intersections of `number` with a brand object
- * containing the `__integerBrand` unique symbol.
- *
- * Extension-registered custom types (name-, brand-, or symbol-based) are
- * resolved separately via `resolveCustomTypeFromTsType` in
- * `extensions/resolve-custom-type.ts`.
- */
-function isIntegerBrandedType(type: ts.Type): boolean {
-  if (!type.isIntersection()) {
-    return false;
-  }
-
-  const hasNumberBase = type.types.some((member) => !!(member.flags & ts.TypeFlags.Number));
-  if (!hasNumberBase) {
-    return false;
-  }
-
-  return collectBrandIdentifiers(type).includes("__integerBrand");
-}
 
 export function isResolvableObjectLikeAliasTypeNode(typeNode: ts.TypeNode): boolean {
   if (ts.isParenthesizedTypeNode(typeNode)) {

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -43,8 +43,8 @@ import {
 import {
   extractTypeNodeFromSource,
   getTypeAliasDeclarationFromTypeReference,
-  isIntegerBrandedType,
 } from "../extensions/ts-type-utils.js";
+import { isIntegerBrandedType } from "./builtin-brands.js";
 import type { MetadataPolicyInput } from "@formspec/core";
 import { getDeclarationMetadataPolicy, normalizeMetadataPolicy } from "../metadata/index.js";
 

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -41,7 +41,6 @@ import {
   resolveCustomTypeFromTsType,
 } from "../extensions/resolve-custom-type.js";
 import {
-  collectBrandIdentifiers,
   extractTypeNodeFromSource,
   getTypeAliasDeclarationFromTypeReference,
   isIntegerBrandedType,

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -699,7 +699,6 @@ function buildCompilerBackedConstraintDiagnostics(
   const hasBroadening = ((): boolean => {
     if (target === null) {
       if (
-        subjectType !== undefined &&
         isIntegerBrandedType(subjectType) &&
         definition.capabilities.includes("numeric-comparable")
       ) {

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -74,6 +74,7 @@ import {
   customTypeIdFromLookup,
   resolveCustomTypeFromTsType,
 } from "../extensions/resolve-custom-type.js";
+import { isIntegerBrandedType } from "../extensions/ts-type-utils.js";
 
 function sharedTagValueOptions(options?: ParseTSDocOptions) {
   return {
@@ -697,6 +698,13 @@ function buildCompilerBackedConstraintDiagnostics(
   // extension-defined constraint semantics.
   const hasBroadening = ((): boolean => {
     if (target === null) {
+      if (
+        subjectType !== undefined &&
+        isIntegerBrandedType(subjectType) &&
+        definition.capabilities.includes("numeric-comparable")
+      ) {
+        return true;
+      }
       return hasBuiltinConstraintBroadening(tagName, options);
     }
     const registry = options?.extensionRegistry;

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -45,6 +45,7 @@ import {
   getTagDefinition,
   hasTypeSemanticCapability,
   normalizeFormSpecTagName,
+  stripNullishUnion,
   parseConstraintTagValue,
   parseDefaultValueTagValue,
   parseTagSyntax,
@@ -74,7 +75,7 @@ import {
   customTypeIdFromLookup,
   resolveCustomTypeFromTsType,
 } from "../extensions/resolve-custom-type.js";
-import { isIntegerBrandedType } from "../extensions/ts-type-utils.js";
+import { isIntegerBrandedType } from "./builtin-brands.js";
 
 function sharedTagValueOptions(options?: ParseTSDocOptions) {
   return {
@@ -699,7 +700,7 @@ function buildCompilerBackedConstraintDiagnostics(
   const hasBroadening = ((): boolean => {
     if (target === null) {
       if (
-        isIntegerBrandedType(subjectType) &&
+        isIntegerBrandedType(stripNullishUnion(subjectType)) &&
         definition.capabilities.includes("numeric-comparable")
       ) {
         return true;

--- a/packages/build/src/extensions/ts-type-utils.ts
+++ b/packages/build/src/extensions/ts-type-utils.ts
@@ -1,20 +1,6 @@
 import * as ts from "typescript";
 
 /**
- * Returns `true` when `type` is an integer-branded intersection — i.e., it
- * includes a `number` base and a computed property keyed by `__integerBrand`.
- *
- * This structural check mirrors the detection in `class-analyzer.ts` and is
- * used by `tsdoc-parser.ts` to skip the synthetic capability check for imported
- * integer types whose names the synthetic program cannot resolve.
- */
-export function isIntegerBrandedType(type: ts.Type): boolean {
-  if (!type.isIntersection()) return false;
-  if (!type.types.some((member) => !!(member.flags & ts.TypeFlags.Number))) return false;
-  return collectBrandIdentifiers(type).includes("__integerBrand");
-}
-
-/**
  * Collects all brand identifier texts from an intersection type's computed
  * property names.
  *

--- a/packages/build/src/extensions/ts-type-utils.ts
+++ b/packages/build/src/extensions/ts-type-utils.ts
@@ -1,6 +1,20 @@
 import * as ts from "typescript";
 
 /**
+ * Returns `true` when `type` is an integer-branded intersection — i.e., it
+ * includes a `number` base and a computed property keyed by `__integerBrand`.
+ *
+ * This structural check mirrors the detection in `class-analyzer.ts` and is
+ * used by `tsdoc-parser.ts` to skip the synthetic capability check for imported
+ * integer types whose names the synthetic program cannot resolve.
+ */
+export function isIntegerBrandedType(type: ts.Type): boolean {
+  if (!type.isIntersection()) return false;
+  if (!type.types.some((member) => !!(member.flags & ts.TypeFlags.Number))) return false;
+  return collectBrandIdentifiers(type).includes("__integerBrand");
+}
+
+/**
  * Collects all brand identifier texts from an intersection type's computed
  * property names.
  *


### PR DESCRIPTION
## Summary

- Adds `isIntegerBrandedType` to `analyzer/builtin-brands.ts` — a structural check for the `__integerBrand` symbol in intersection types
- In `tsdoc-parser.ts`, `hasBroadening` now returns `true` for integer-branded types (after stripping nullish unions) with `numeric-comparable` capability, bypassing the synthetic type checker
- In `semantic-targets.ts`, `checkConstraintOnType` now unwraps nullable unions before computing type capabilities at the IR level
- Regression tests for cross-file imports: non-nullable, nullable (`Integer | null`), optional (`score?: Integer`), and negative (`@pattern` must still reject)

## Problem

`@minimum`/`@maximum` on `Integer`/`PositiveInteger` fields sourced from an external module (e.g. `@stripe/extensibility-sdk/stdlib`) produced spurious `TYPE_MISMATCH` errors. Two independent validation layers were affected:

1. **`tsdoc-parser.ts`**: The synthetic TypeScript file used for constraint validation couldn't resolve the imported type name, causing the check to fail even though the type is structurally integer-branded.
2. **`semantic-targets.ts`**: The IR-level `checkConstraintOnType` checked capabilities against the raw union type for nullable fields, failing to recognize the integer member.

This was exposed by stripe/extensibility-sdk#449, which removed `Integer`/`PositiveInteger` from the SDK extension registry, relying on formspec's native `__integerBrand` detection — but that detection only existed in the IR classification path, not the constraint validation paths.

## Changes

| File | What |
|---|---|
| `analyzer/builtin-brands.ts` | New module: `isIntegerBrandedType` extracted here from `extensions/ts-type-utils.ts` — `__integerBrand` is a core concept, not an extension |
| `analyzer/tsdoc-parser.ts` | Import `stripNullishUnion`, wrap `subjectType` before `isIntegerBrandedType` check |
| `analyzer/class-analyzer.ts` | Import `isIntegerBrandedType` from new location |
| `analysis/semantic-targets.ts` | Unwrap nullable unions in `checkConstraintOnType` before capability checks |
| `extensions/ts-type-utils.ts` | Remove `isIntegerBrandedType` (moved to `builtin-brands.ts`) |

## Test plan

- [x] New: "accepts @minimum and @maximum on a doubly-branded integer type imported from another module"
- [x] New: "accepts @minimum on a nullable imported integer type"
- [x] New: "accepts @minimum on an optional imported integer type"
- [x] New: "rejects @pattern on an imported integer type (not string-like)" — negative test pinning bypass scope
- [x] Clarified: locally-declared multi-branded test documents existing behavior, not regression guard
- [x] All 748 build tests pass
- [x] All 312 analysis tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)