### PR TITLE
test(build): regression tests for #285 (__result rename under metadata policy)

### DIFF
--- a/.changeset/regression-tests-standalone-apiname.md
+++ b/.changeset/regression-tests-standalone-apiname.md
@@ -1,4 +1,8 @@
 ---
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
 ---
 
 Internal: add regression tests covering the synthetic `__result` wrapper rename under an inferring field-level `apiName` metadata policy (guards the fix in `@formspec/build`'s `toStandaloneJsonSchema`).

--- a/.changeset/regression-tests-standalone-apiname.md
+++ b/.changeset/regression-tests-standalone-apiname.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal: add regression tests covering the synthetic `__result` wrapper rename under an inferring field-level `apiName` metadata policy (guards the fix in `@formspec/build`'s `toStandaloneJsonSchema`).

--- a/packages/build/src/__tests__/signature-schema-generation.test.ts
+++ b/packages/build/src/__tests__/signature-schema-generation.test.ts
@@ -437,14 +437,17 @@ describe("metadata policy that would rename the synthetic __result wrapper (regr
     const method = getMethod(getPaymentService(context), "returnsAny");
 
     // Pre-fix this threw; post-fix it must produce a schema without the
-    // wrapper leaking into properties.
-    expect(() =>
-      generateSchemasFromReturnType({
-        context,
-        declaration: method,
-        metadata: renamingFieldApiNamePolicy,
-      })
-    ).not.toThrow();
+    // synthetic wrapper leaking into properties under either the
+    // original or the policy-renamed key.
+    const schemas = generateSchemasFromReturnType({
+      context,
+      declaration: method,
+      metadata: renamingFieldApiNamePolicy,
+    });
+
+    const properties = (schemas.jsonSchema as { properties?: Record<string, unknown> }).properties;
+    expect(properties?.["__result"]).toBeUndefined();
+    expect(properties?.["result"]).toBeUndefined();
   });
 
   it("handles a type-alias root via generateSchemasFromType", () => {

--- a/packages/build/src/__tests__/signature-schema-generation.test.ts
+++ b/packages/build/src/__tests__/signature-schema-generation.test.ts
@@ -388,3 +388,84 @@ describe("method-signature schema generation", () => {
     });
   });
 });
+
+describe("metadata policy that would rename the synthetic __result wrapper (regression for PR #285)", () => {
+  // Policy that strips leading underscores from field apiNames — the same
+  // behavior (in miniature) as Stripe's toStripeApiCase. Before the fix,
+  // this transformed the internal synthetic "__result" field to "result",
+  // and toStandaloneJsonSchema's schema.properties["__result"] lookup
+  // threw "FormSpec failed to extract the standalone schema root from
+  // the synthetic IR."
+  const renamingFieldApiNamePolicy = {
+    field: {
+      apiName: {
+        mode: "infer-if-missing" as const,
+        infer: ({ logicalName }: { logicalName: string }): string =>
+          logicalName.replace(/^_+/u, ""),
+      },
+    },
+  };
+
+  function getPaymentService(context: ReturnType<typeof createStaticBuildContext>): ts.ClassDeclaration {
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService class not found");
+    }
+    return declaration;
+  }
+
+  it("handles a union-alias return type via generateSchemasFromReturnType", () => {
+    const context = createStaticBuildContext(fixturePath);
+    const method = getMethod(getPaymentService(context), "status");
+
+    const schemas = generateSchemasFromReturnType({
+      context,
+      declaration: method,
+      metadata: renamingFieldApiNamePolicy,
+    });
+
+    // The synthetic wrapper must be unwrapped — the root schema is the
+    // union itself, not an object carrying a "__result" or "result" key.
+    expect(schemas.jsonSchema).toMatchObject({ enum: ["ok", "error"] });
+    const properties = (schemas.jsonSchema as { properties?: Record<string, unknown> }).properties;
+    expect(properties?.["__result"]).toBeUndefined();
+    expect(properties?.["result"]).toBeUndefined();
+  });
+
+  it("handles an `any` return type via generateSchemasFromReturnType", () => {
+    const context = createStaticBuildContext(fixturePath);
+    const method = getMethod(getPaymentService(context), "returnsAny");
+
+    // Pre-fix this threw; post-fix it must produce a schema without the
+    // wrapper leaking into properties.
+    expect(() =>
+      generateSchemasFromReturnType({
+        context,
+        declaration: method,
+        metadata: renamingFieldApiNamePolicy,
+      })
+    ).not.toThrow();
+  });
+
+  it("handles a type-alias root via generateSchemasFromType", () => {
+    const context = createStaticBuildContext(fixturePath);
+    const aliasDeclaration = resolveModuleExportDeclaration(context, "PaymentStatus");
+    if (aliasDeclaration === null || !ts.isTypeAliasDeclaration(aliasDeclaration)) {
+      throw new Error("PaymentStatus type alias not found");
+    }
+
+    const type = context.checker.getTypeAtLocation(aliasDeclaration);
+
+    const schemas = generateSchemasFromType({
+      context,
+      type,
+      sourceNode: aliasDeclaration,
+      metadata: renamingFieldApiNamePolicy,
+    });
+
+    expect(schemas.jsonSchema).toMatchObject({ enum: ["ok", "error"] });
+    const properties = (schemas.jsonSchema as { properties?: Record<string, unknown> }).properties;
+    expect(properties?.["__result"]).toBeUndefined();
+    expect(properties?.["result"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds regression test coverage for the bug fixed in #285 — which shipped without tests.

Before that fix, when a metadata policy with an `infer-if-missing` field-level `apiName` transform was active (e.g. one that strips leading underscores, as Stripe's `toStripeApiCase` does), the synthetic `__result` wrapper inside `toStandaloneJsonSchema` was renamed by the policy and the subsequent `schema.properties["__result"]` lookup threw:

> FormSpec failed to extract the standalone schema root from the synthetic IR.

## Tests added

Three cases in [packages/build/src/__tests__/signature-schema-generation.test.ts](packages/build/src/__tests__/signature-schema-generation.test.ts) covering each public entry point that reaches the standalone path:

1. `generateSchemasFromReturnType` over a union type alias (`PaymentService.status(): PaymentStatus`)
2. `generateSchemasFromReturnType` over an `any` return type (`PaymentService.returnsAny()`)
3. `generateSchemasFromType` over a resolved `ts.Type` for a union alias (`PaymentStatus`)

Each shares one inline `renamingFieldApiNamePolicy` helper that reproduces the original production trigger in miniature (strips leading underscores from field apiNames).

## Verification

- Under the current (post-#285) fix: all 17 tests in the file pass.
- With the fix reverted in-place: all 3 new tests fail with the exact pre-fix error above. The 14 pre-existing tests still pass. Fix was then restored.
- `pnpm run clean && pnpm run build && pnpm run lint && pnpm run test` all green.

## Test plan

- [x] New tests pass against the fixed code
- [x] New tests fail against the pre-fix code (verified by temporary revert)
- [x] Full repo `build + lint + test` green