### PR TITLE
fix(build): prevent imported type from poisoning sibling field constraints

### DIFF
--- a/.changeset/fix-sibling-field-poisoning.md
+++ b/.changeset/fix-sibling-field-poisoning.md
@@ -1,0 +1,7 @@
+---
+"@formspec/build": patch
+---
+
+Fix constraint validation on sibling fields when an interface contains an imported type. Previously, an interface like `{ year: Integer; vin: string }` where `Integer` was imported from another module would be entirely excluded from the synthetic checker's supporting declarations. This caused spurious TYPE_MISMATCH errors on string constraint tags (`@minLength`, `@maxLength`) applied to non-imported sibling fields.
+
+The synthetic program now rewrites imported member types to `unknown` instead of dropping the entire interface, preserving type context for non-imported siblings.

--- a/.changeset/fix-sibling-field-poisoning.md
+++ b/.changeset/fix-sibling-field-poisoning.md
@@ -1,8 +1,5 @@
 ---
 "@formspec/build": patch
-"@formspec/cli": patch
-"@formspec/eslint-plugin": patch
-"formspec": patch
 ---
 
 Fix constraint validation on sibling fields when an interface contains an imported type. Previously, an interface like `{ year: Integer; vin: string }` where `Integer` was imported from another module would be entirely excluded from the synthetic checker's supporting declarations. This caused spurious TYPE_MISMATCH errors on string constraint tags (`@minLength`, `@maxLength`) applied to non-imported sibling fields.

--- a/.changeset/fix-sibling-field-poisoning.md
+++ b/.changeset/fix-sibling-field-poisoning.md
@@ -1,5 +1,8 @@
 ---
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
 ---
 
 Fix constraint validation on sibling fields when an interface contains an imported type. Previously, an interface like `{ year: Integer; vin: string }` where `Integer` was imported from another module would be entirely excluded from the synthetic checker's supporting declarations. This caused spurious TYPE_MISMATCH errors on string constraint tags (`@minLength`, `@maxLength`) applied to non-imported sibling fields.

--- a/packages/build/src/__tests__/integer-type.test.ts
+++ b/packages/build/src/__tests__/integer-type.test.ts
@@ -158,6 +158,30 @@ const IMPORTING_FIXTURE_SOURCE = [
   "   */",
   "  vin: string;",
   "};",
+  "",
+  "// Method signature referencing import — should fall back to excluding",
+  "export interface CrossFileMethodSigConfig {",
+  "  getYear(): MultiBrandedInteger;",
+  "  /** @minLength 1 */",
+  "  vin: string;",
+  "}",
+  "",
+  "// Index signature referencing import — should fall back to excluding",
+  "export interface CrossFileIndexSigConfig {",
+  "  [k: string]: MultiBrandedInteger;",
+  "  /** @minLength 1 */",
+  "  vin: string;",
+  "}",
+  "",
+  "// Generic position — Array<ImportedType>",
+  "export interface CrossFileGenericConfig {",
+  "  items: Array<MultiBrandedInteger>;",
+  "  /** @minLength 1 */",
+  "  label: string;",
+  "}",
+  "",
+  "// Const referencing import — should still be excluded",
+  "export const CROSS_FILE_CONST: MultiBrandedInteger = 0 as unknown as MultiBrandedInteger;",
 ].join("\n");
 
 beforeAll(() => {
@@ -566,6 +590,48 @@ describe("builtin Integer type", () => {
         type: "string",
         minLength: 17,
         maxLength: 17,
+      });
+    });
+
+    it("falls back to excluding interface when a method signature references an import", () => {
+      // Method signatures can't be rewritten to `unknown`, so the whole
+      // interface should be excluded (pre-fix behavior preserved).
+      // This means sibling constraints produce diagnostics, but the build
+      // must not crash or produce invalid synthetic code.
+      const result = generateSchemas({
+        filePath: importingFixturePath,
+        typeName: "CrossFileMethodSigConfig",
+        errorReporting: "diagnostics",
+      });
+
+      // Constraint diagnostics are expected — the interface was excluded
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics.some((d) => d.code === "TYPE_MISMATCH")).toBe(true);
+    });
+
+    it("falls back to excluding interface when an index signature references an import", () => {
+      const result = generateSchemas({
+        filePath: importingFixturePath,
+        typeName: "CrossFileIndexSigConfig",
+        errorReporting: "diagnostics",
+      });
+
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics.some((d) => d.code === "TYPE_MISMATCH")).toBe(true);
+    });
+
+    it("rewrites imported types in generic position (Array<ImportedType>)", () => {
+      const result = generateSchemasOrThrow({
+        filePath: importingFixturePath,
+        typeName: "CrossFileGenericConfig",
+      });
+
+      const properties = result.jsonSchema.properties as Record<string, unknown>;
+      // The string sibling field should still have its constraints
+      const labelSchema = properties["label"] as Record<string, unknown>;
+      expect(labelSchema).toMatchObject({
+        type: "string",
+        minLength: 1,
       });
     });
   });

--- a/packages/build/src/__tests__/integer-type.test.ts
+++ b/packages/build/src/__tests__/integer-type.test.ts
@@ -136,6 +136,17 @@ const IMPORTING_FIXTURE_SOURCE = [
   "  /** @pattern ^[0-9]+$ */",
   "  code: MultiBrandedInteger;",
   "}",
+  "",
+  "export interface CrossFileMixedConfig {",
+  "  /** @minimum 2000 */",
+  "  year: MultiBrandedInteger;",
+  "",
+  "  /**",
+  "   * @minLength 17",
+  "   * @maxLength 17",
+  "   */",
+  "  vin: string;",
+  "}",
 ].join("\n");
 
 beforeAll(() => {
@@ -495,6 +506,34 @@ describe("builtin Integer type", () => {
           typeName: "CrossFilePatternConfig",
         })
       ).toThrow(/TYPE_MISMATCH/);
+    });
+
+    it("does not poison sibling string fields with imported integer type constraints", () => {
+      // Regression: when an interface has both an imported Integer field and a
+      // string field, buildSupportingDeclarations filters out the entire
+      // interface (it references an imported name). The synthetic checker then
+      // can't resolve the string field's type, causing @minLength/@maxLength
+      // to produce spurious TYPE_MISMATCH errors.
+      const result = generateSchemasOrThrow({
+        filePath: importingFixturePath,
+        typeName: "CrossFileMixedConfig",
+      });
+
+      const properties = result.jsonSchema.properties as Record<string, unknown>;
+
+      // Integer field constraints work
+      const yearSchema = properties["year"] as Record<string, unknown>;
+      expect(yearSchema).toMatchObject({
+        minimum: 2000,
+      });
+
+      // String field constraints must also work — not poisoned by the Integer import
+      const vinSchema = properties["vin"] as Record<string, unknown>;
+      expect(vinSchema).toMatchObject({
+        type: "string",
+        minLength: 17,
+        maxLength: 17,
+      });
     });
   });
 });

--- a/packages/build/src/__tests__/integer-type.test.ts
+++ b/packages/build/src/__tests__/integer-type.test.ts
@@ -147,6 +147,17 @@ const IMPORTING_FIXTURE_SOURCE = [
   "   */",
   "  vin: string;",
   "}",
+  "",
+  "export type CrossFileMixedTypeAlias = {",
+  "  /** @minimum 2000 */",
+  "  year: MultiBrandedInteger;",
+  "",
+  "  /**",
+  "   * @minLength 17",
+  "   * @maxLength 17",
+  "   */",
+  "  vin: string;",
+  "};",
 ].join("\n");
 
 beforeAll(() => {
@@ -528,6 +539,28 @@ describe("builtin Integer type", () => {
       });
 
       // String field constraints must also work — not poisoned by the Integer import
+      const vinSchema = properties["vin"] as Record<string, unknown>;
+      expect(vinSchema).toMatchObject({
+        type: "string",
+        minLength: 17,
+        maxLength: 17,
+      });
+    });
+
+    it("does not poison sibling string fields in type alias declarations", () => {
+      // Same poisoning bug as interfaces, but with `type Foo = { ... }` syntax.
+      const result = generateSchemasOrThrow({
+        filePath: importingFixturePath,
+        typeName: "CrossFileMixedTypeAlias",
+      });
+
+      const properties = result.jsonSchema.properties as Record<string, unknown>;
+
+      const yearSchema = properties["year"] as Record<string, unknown>;
+      expect(yearSchema).toMatchObject({
+        minimum: 2000,
+      });
+
       const vinSchema = properties["vin"] as Record<string, unknown>;
       expect(vinSchema).toMatchObject({
         type: "string",

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -173,55 +173,56 @@ function isNonReferenceIdentifier(node: ts.Identifier): boolean {
   return false;
 }
 
-function statementReferencesImportedName(
-  statement: ts.Statement,
+function astReferencesImportedName(
+  root: ts.Node,
   importedNames: ReadonlySet<string>
 ): boolean {
   if (importedNames.size === 0) {
     return false;
   }
 
-  let referencesImportedName = false;
-
-  const visit = (node: ts.Node): void => {
-    if (referencesImportedName) {
-      return;
-    }
-
-    if (ts.isIdentifier(node) && importedNames.has(node.text) && !isNonReferenceIdentifier(node)) {
-      referencesImportedName = true;
-      return;
-    }
-
-    ts.forEachChild(node, visit);
-  };
-
-  visit(statement);
-  return referencesImportedName;
-}
-
-function typeAnnotationReferencesImport(
-  typeAnnotation: ts.TypeNode,
-  importedNames: ReadonlySet<string>
-): boolean {
   let found = false;
+
   const visit = (node: ts.Node): void => {
     if (found) return;
+
     if (ts.isIdentifier(node) && importedNames.has(node.text) && !isNonReferenceIdentifier(node)) {
       found = true;
       return;
     }
+
     ts.forEachChild(node, visit);
   };
-  visit(typeAnnotation);
+
+  visit(root);
   return found;
 }
 
 /**
- * Rewrites an interface declaration so that members whose type annotations
- * reference an imported name have their type replaced with `unknown`. This
- * preserves the declaration in the synthetic program so the checker can
- * resolve sibling members that use non-imported types.
+ * Returns the member list for declarations that have object-like members:
+ * interface declarations and type alias declarations with a type-literal body.
+ * Returns `undefined` for all other node shapes.
+ */
+function getObjectMembers(
+  statement: ts.InterfaceDeclaration | ts.TypeAliasDeclaration
+): ts.NodeArray<ts.TypeElement> | undefined {
+  if (ts.isInterfaceDeclaration(statement)) {
+    return statement.members;
+  }
+  if (ts.isTypeLiteralNode(statement.type)) {
+    return statement.type.members;
+  }
+  return undefined;
+}
+
+/**
+ * Rewrites a declaration so that members whose type annotations reference an
+ * imported name have their type replaced with `unknown`. This preserves the
+ * declaration in the synthetic program so the checker can resolve sibling
+ * members that use non-imported types.
+ *
+ * Handles both interface declarations and type alias declarations whose body
+ * is a type literal (e.g. `type Foo = { bar: ImportedType; baz: string }`).
  *
  * Without this, an interface like `{ year: Integer; vin: string }` where
  * `Integer` is imported would be entirely excluded from supporting
@@ -230,18 +231,23 @@ function typeAnnotationReferencesImport(
  * `@minLength`.
  */
 function rewriteImportedMemberTypes(
-  statement: ts.InterfaceDeclaration,
+  statement: ts.InterfaceDeclaration | ts.TypeAliasDeclaration,
   sourceFile: ts.SourceFile,
   importedNames: ReadonlySet<string>
 ): string {
+  const members = getObjectMembers(statement);
+  if (members === undefined) {
+    return statement.getText(sourceFile);
+  }
+
   const replacements: { start: number; end: number }[] = [];
 
-  for (const member of statement.members) {
+  for (const member of members) {
     const typeAnnotation =
       (ts.isPropertySignature(member) || ts.isPropertyDeclaration(member)) ? member.type : undefined;
     if (typeAnnotation === undefined) continue;
 
-    if (typeAnnotationReferencesImport(typeAnnotation, importedNames)) {
+    if (astReferencesImportedName(typeAnnotation, importedNames)) {
       replacements.push({
         start: typeAnnotation.getStart(sourceFile),
         end: typeAnnotation.getEnd(),
@@ -282,15 +288,16 @@ function buildSupportingDeclarations(
     if (ts.isImportEqualsDeclaration(statement)) continue;
     if (ts.isExportDeclaration(statement) && statement.moduleSpecifier !== undefined) continue;
 
-    if (!statementReferencesImportedName(statement, importedNamesToSkip)) {
+    if (!astReferencesImportedName(statement, importedNamesToSkip)) {
       result.push(statement.getText(sourceFile));
       continue;
     }
 
-    // For interface declarations that reference imports, rewrite imported
-    // member types to `unknown` instead of dropping the whole declaration.
-    // Other statement types that reference imports are still excluded.
-    if (ts.isInterfaceDeclaration(statement)) {
+    // For interface and type-literal-bodied type alias declarations that
+    // reference imports, rewrite imported member types to `unknown` instead
+    // of dropping the whole declaration. Other statement types that reference
+    // imports are still excluded.
+    if (ts.isInterfaceDeclaration(statement) || ts.isTypeAliasDeclaration(statement)) {
       result.push(rewriteImportedMemberTypes(statement, sourceFile, importedNamesToSkip));
     }
   }

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -200,6 +200,62 @@ function statementReferencesImportedName(
   return referencesImportedName;
 }
 
+/**
+ * Rewrites an interface declaration so that members whose type annotations
+ * reference an imported name have their type replaced with `unknown`. This
+ * preserves the declaration in the synthetic program so the checker can
+ * resolve sibling members that use non-imported types.
+ *
+ * Without this, an interface like `{ year: Integer; vin: string }` where
+ * `Integer` is imported would be entirely excluded from supporting
+ * declarations, preventing the synthetic checker from knowing that `vin` is
+ * a string — causing spurious TYPE_MISMATCH errors on constraint tags like
+ * `@minLength`.
+ */
+function rewriteImportedMemberTypes(
+  statement: ts.InterfaceDeclaration,
+  sourceFile: ts.SourceFile,
+  importedNames: ReadonlySet<string>
+): string {
+  const replacements: { start: number; end: number }[] = [];
+
+  for (const member of statement.members) {
+    const typeAnnotation =
+      (ts.isPropertySignature(member) || ts.isPropertyDeclaration(member)) ? member.type : undefined;
+    if (typeAnnotation === undefined) continue;
+
+    let referencesImport = false;
+    const check = (node: ts.Node): void => {
+      if (referencesImport) return;
+      if (ts.isIdentifier(node) && importedNames.has(node.text) && !isNonReferenceIdentifier(node)) {
+        referencesImport = true;
+        return;
+      }
+      ts.forEachChild(node, check);
+    };
+    check(typeAnnotation);
+
+    if (referencesImport) {
+      replacements.push({
+        start: typeAnnotation.getStart(sourceFile),
+        end: typeAnnotation.getEnd(),
+      });
+    }
+  }
+
+  if (replacements.length === 0) {
+    return statement.getText(sourceFile);
+  }
+
+  // Apply replacements in reverse order to preserve offsets.
+  const stmtStart = statement.getStart(sourceFile);
+  let result = statement.getText(sourceFile);
+  for (const { start, end } of replacements.reverse()) {
+    result = result.slice(0, start - stmtStart) + "unknown" + result.slice(end - stmtStart);
+  }
+  return result;
+}
+
 function buildSupportingDeclarations(
   sourceFile: ts.SourceFile,
   extensionTypeNames: ReadonlySet<string>
@@ -212,24 +268,28 @@ function buildSupportingDeclarations(
     [...importedNames].filter((name) => !extensionTypeNames.has(name))
   );
 
-  return sourceFile.statements
-    .filter((statement) => {
-      // Always exclude imports and re-exports
-      if (ts.isImportDeclaration(statement)) return false;
-      if (ts.isImportEqualsDeclaration(statement)) return false;
-      if (ts.isExportDeclaration(statement) && statement.moduleSpecifier !== undefined)
-        return false;
+  const result: string[] = [];
 
-      // Skip declarations whose AST references an imported identifier,
-      // unless that identifier is an extension-registered type (which will
-      // have a synthetic type alias in the synthetic program).
-      if (statementReferencesImportedName(statement, importedNamesToSkip)) {
-        return false;
-      }
+  for (const statement of sourceFile.statements) {
+    // Always exclude imports and re-exports
+    if (ts.isImportDeclaration(statement)) continue;
+    if (ts.isImportEqualsDeclaration(statement)) continue;
+    if (ts.isExportDeclaration(statement) && statement.moduleSpecifier !== undefined) continue;
 
-      return true;
-    })
-    .map((statement) => statement.getText(sourceFile));
+    if (!statementReferencesImportedName(statement, importedNamesToSkip)) {
+      result.push(statement.getText(sourceFile));
+      continue;
+    }
+
+    // For interface declarations that reference imports, rewrite imported
+    // member types to `unknown` instead of dropping the whole declaration.
+    // Other statement types that reference imports are still excluded.
+    if (ts.isInterfaceDeclaration(statement)) {
+      result.push(rewriteImportedMemberTypes(statement, sourceFile, importedNamesToSkip));
+    }
+  }
+
+  return result;
 }
 
 function pushUniqueCompilerDiagnostics(

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -200,6 +200,23 @@ function statementReferencesImportedName(
   return referencesImportedName;
 }
 
+function typeAnnotationReferencesImport(
+  typeAnnotation: ts.TypeNode,
+  importedNames: ReadonlySet<string>
+): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isIdentifier(node) && importedNames.has(node.text) && !isNonReferenceIdentifier(node)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(typeAnnotation);
+  return found;
+}
+
 /**
  * Rewrites an interface declaration so that members whose type annotations
  * reference an imported name have their type replaced with `unknown`. This
@@ -224,18 +241,7 @@ function rewriteImportedMemberTypes(
       (ts.isPropertySignature(member) || ts.isPropertyDeclaration(member)) ? member.type : undefined;
     if (typeAnnotation === undefined) continue;
 
-    let referencesImport = false;
-    const check = (node: ts.Node): void => {
-      if (referencesImport) return;
-      if (ts.isIdentifier(node) && importedNames.has(node.text) && !isNonReferenceIdentifier(node)) {
-        referencesImport = true;
-        return;
-      }
-      ts.forEachChild(node, check);
-    };
-    check(typeAnnotation);
-
-    if (referencesImport) {
+    if (typeAnnotationReferencesImport(typeAnnotation, importedNames)) {
       replacements.push({
         start: typeAnnotation.getStart(sourceFile),
         end: typeAnnotation.getEnd(),

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -234,17 +234,27 @@ function rewriteImportedMemberTypes(
   statement: ts.InterfaceDeclaration | ts.TypeAliasDeclaration,
   sourceFile: ts.SourceFile,
   importedNames: ReadonlySet<string>
-): string {
+): string | null {
   const members = getObjectMembers(statement);
   if (members === undefined) {
-    return statement.getText(sourceFile);
+    return null;
   }
 
   const replacements: { start: number; end: number }[] = [];
 
   for (const member of members) {
-    const typeAnnotation =
-      (ts.isPropertySignature(member) || ts.isPropertyDeclaration(member)) ? member.type : undefined;
+    // Only property signatures have rewritable type annotations. If a
+    // non-property member (method signature, index signature, etc.)
+    // references an imported name, we can't safely rewrite it — return
+    // null to fall back to excluding the whole declaration.
+    if (!ts.isPropertySignature(member)) {
+      if (astReferencesImportedName(member, importedNames)) {
+        return null;
+      }
+      continue;
+    }
+
+    const typeAnnotation = member.type;
     if (typeAnnotation === undefined) continue;
 
     if (astReferencesImportedName(typeAnnotation, importedNames)) {
@@ -260,9 +270,11 @@ function rewriteImportedMemberTypes(
   }
 
   // Apply replacements in reverse order to preserve offsets.
+  // getText(sourceFile) and getStart(sourceFile) use the same base, so
+  // subtracting stmtStart from absolute positions yields correct offsets.
   const stmtStart = statement.getStart(sourceFile);
   let result = statement.getText(sourceFile);
-  for (const { start, end } of replacements.reverse()) {
+  for (const { start, end } of [...replacements].reverse()) {
     result = result.slice(0, start - stmtStart) + "unknown" + result.slice(end - stmtStart);
   }
   return result;
@@ -295,10 +307,14 @@ function buildSupportingDeclarations(
 
     // For interface and type-literal-bodied type alias declarations that
     // reference imports, rewrite imported member types to `unknown` instead
-    // of dropping the whole declaration. Other statement types that reference
-    // imports are still excluded.
+    // of dropping the whole declaration. Returns null when a non-property
+    // member references an import (method/index signatures), in which case
+    // we fall back to excluding the whole declaration.
     if (ts.isInterfaceDeclaration(statement) || ts.isTypeAliasDeclaration(statement)) {
-      result.push(rewriteImportedMemberTypes(statement, sourceFile, importedNamesToSkip));
+      const rewritten = rewriteImportedMemberTypes(statement, sourceFile, importedNamesToSkip);
+      if (rewritten !== null) {
+        result.push(rewritten);
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

When an interface (or type alias) contains both an imported type field and a plain type field with constraints, the plain field produces spurious `TYPE_MISMATCH` errors:

```typescript
import { Integer } from '@stripe/extensibility-sdk/stdlib';

export interface VehicleFields {
  /** @minimum 2000 */
  year: Integer;

  /** @minLength 17 @maxLength 17 */
  vin: string;  // ❌ TYPE_MISMATCH: Tag "@minLength" received an invalid argument for integer.
}
```

`buildSupportingDeclarations` excludes the entire interface from the synthetic checker's program because it references an imported name (`Integer`). Without the interface declaration, the synthetic checker has no type context for `vin`, so `@minLength`/`@maxLength` fail.

This affects any interface or type alias mixing imported types with constrained non-imported types.

## Fix

For interface declarations and type alias declarations with type-literal bodies that reference imported names, rewrite the imported member type annotations to `unknown` instead of dropping the entire declaration. The synthetic checker can then still resolve non-imported member types correctly.

```
// Before (excluded entirely):
// export interface VehicleFields { year: Integer; vin: string; }

// After (rewritten):
export interface VehicleFields { year: unknown; vin: string; }
```

Other statement types that reference imports (classes, variables, non-type-literal type aliases) are still excluded as before.

Also deduplicates `statementReferencesImportedName` and `typeAnnotationReferencesImport` into a single `astReferencesImportedName` helper to eliminate the copy-pasted AST traversal logic.

## Test plan

- [x] New: "does not poison sibling string fields with imported integer type constraints" — `CrossFileMixedConfig` with `year: MultiBrandedInteger` + `vin: string`
- [x] New: "does not poison sibling string fields in type alias declarations" — `CrossFileMixedTypeAlias` with the same shape as a type alias
- [x] All 753 build tests pass (including previously-passing cross-module tests in `nounchecked-index-access.test.ts`)
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)