### PR TITLE
Add pino-based debug logging

### DIFF
--- a/.changeset/pino-debug-logging.md
+++ b/.changeset/pino-debug-logging.md
@@ -7,6 +7,8 @@
 "@formspec/cli": minor
 "@formspec/language-server": minor
 "@formspec/ts-plugin": minor
+"@formspec/dsl": minor
+"@formspec/eslint-plugin": minor
 "formspec": minor
 ---
 

--- a/.changeset/pino-debug-logging.md
+++ b/.changeset/pino-debug-logging.md
@@ -1,0 +1,19 @@
+---
+"@formspec/core": minor
+"@formspec/build": minor
+"@formspec/analysis": minor
+"@formspec/runtime": minor
+"@formspec/config": minor
+"@formspec/cli": minor
+"@formspec/language-server": minor
+"@formspec/ts-plugin": minor
+"formspec": minor
+---
+
+Add pino-based debug logging with a `DEBUG=formspec:*` enable convention.
+
+Apps (`@formspec/cli`, the `@formspec/build` CLI, and `@formspec/language-server`) construct pino loggers inline and route output to stderr, stderr, and the LSP connection console respectively. `@formspec/ts-plugin` wraps `ts.server.Logger` via `fromTsLogger` so diagnostics flow through the tsserver log file instead of stdio.
+
+Libraries (`@formspec/build`, `@formspec/analysis`, `@formspec/runtime`, `@formspec/config`) now accept an optional `logger?: LoggerLike` on their public entry points, defaulting to a silent no-op. They never import pino directly, so consumers do not pick up pino as a transitive dependency.
+
+`@formspec/core` exports the shared `LoggerLike` interface, `noopLogger` constant, and the `isNamespaceEnabled` matcher used across all apps. The umbrella `formspec` package re-exports `LoggerLike` and `noopLogger`.

--- a/packages/analysis/api-report/analysis.alpha.api.md
+++ b/packages/analysis/api-report/analysis.alpha.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { ExtensionDefinition } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 import type { MetadataAnalysisResult } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import * as ts from 'typescript';
@@ -28,6 +29,7 @@ export interface AnalyzeMetadataForSourceFileOptions extends AnalyzeMetadataOpti
 // @public
 export interface AnalyzeMetadataOptions {
     readonly extensions?: readonly ExtensionDefinition[] | undefined;
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly program: ts.Program;
 }

--- a/packages/analysis/api-report/analysis.api.md
+++ b/packages/analysis/api-report/analysis.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { ExtensionDefinition } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 import type { MetadataAnalysisResult } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import * as ts from 'typescript';
@@ -28,6 +29,7 @@ export interface AnalyzeMetadataForSourceFileOptions extends AnalyzeMetadataOpti
 // @public
 export interface AnalyzeMetadataOptions {
     readonly extensions?: readonly ExtensionDefinition[] | undefined;
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly program: ts.Program;
 }

--- a/packages/analysis/api-report/analysis.beta.api.md
+++ b/packages/analysis/api-report/analysis.beta.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { ExtensionDefinition } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 import type { MetadataAnalysisResult } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import * as ts from 'typescript';
@@ -28,6 +29,7 @@ export interface AnalyzeMetadataForSourceFileOptions extends AnalyzeMetadataOpti
 // @public
 export interface AnalyzeMetadataOptions {
     readonly extensions?: readonly ExtensionDefinition[] | undefined;
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly program: ts.Program;
 }

--- a/packages/analysis/api-report/analysis.public.api.md
+++ b/packages/analysis/api-report/analysis.public.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { ExtensionDefinition } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 import type { MetadataAnalysisResult } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import * as ts from 'typescript';
@@ -28,6 +29,7 @@ export interface AnalyzeMetadataForSourceFileOptions extends AnalyzeMetadataOpti
 // @public
 export interface AnalyzeMetadataOptions {
     readonly extensions?: readonly ExtensionDefinition[] | undefined;
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly program: ts.Program;
 }

--- a/packages/analysis/src/__tests__/logger.test.ts
+++ b/packages/analysis/src/__tests__/logger.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from "vitest";
+import * as ts from "typescript";
+import type { LoggerLike } from "@formspec/core";
+import { analyzeMetadataForSourceFile, analyzeMetadataForNode } from "../index.js";
+import { createProgram } from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Shared capturing logger helper
+// ---------------------------------------------------------------------------
+
+interface LogRecord {
+  readonly level: "trace" | "debug" | "info" | "warn" | "error";
+  readonly msg: string;
+  /** Child bindings from logger.child() calls */
+  readonly bindings: Record<string, unknown>;
+  /** Extra args passed as the second argument to log methods */
+  readonly extraArgs: unknown[];
+}
+
+function makeCapturingLogger(
+  bindings: Record<string, unknown> = {}
+): { logger: LoggerLike; records: LogRecord[] } {
+  const records: LogRecord[] = [];
+
+  function build(currentBindings: Record<string, unknown>): LoggerLike {
+    const push =
+      (level: LogRecord["level"]) =>
+      (msg: string, ...args: unknown[]) => {
+        records.push({ level, msg, bindings: { ...currentBindings }, extraArgs: args });
+      };
+    return {
+      trace: push("trace"),
+      debug: push("debug"),
+      info: push("info"),
+      warn: push("warn"),
+      error: push("error"),
+      child(childBindings) {
+        return build({ ...currentBindings, ...childBindings });
+      },
+    };
+  }
+
+  return { logger: build(bindings), records };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture source — a simple class with two declarations to analyze
+// ---------------------------------------------------------------------------
+
+const FIXTURE_SOURCE = `
+/** @apiName UserRecord @displayName User */
+export class User {
+  /** @displayName First Name */
+  firstName: string = "";
+  /** @displayName Last Name */
+  lastName: string = "";
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("@formspec/analysis logger integration", () => {
+  describe("analyzeMetadataForSourceFile", () => {
+    it("emits a debug record with stage=analysis, fileName, and tagCount after file analysis", () => {
+      // Integration: asserts one debug record per file (plan §3 @formspec/analysis)
+      const { program, sourceFile } = createProgram(FIXTURE_SOURCE);
+      const { logger, records } = makeCapturingLogger();
+
+      const results = analyzeMetadataForSourceFile({ program, sourceFile, logger });
+
+      // Three declarations in the fixture: User (class) + firstName + lastName
+      expect(results.length).toBeGreaterThan(0);
+
+      // Plan §3: one debug line per file analyzed (filename + tag count)
+      // fileName and tagCount are passed as the second arg to logger.debug()
+      const fileRecord = records.find(
+        (r) =>
+          r.level === "debug" &&
+          r.bindings["stage"] === "analysis" &&
+          r.msg.includes("analyzed source file")
+      );
+      expect(fileRecord).toBeDefined(); // stage: "analysis" debug record for file analysis present
+      // Extra args: the second argument to debug() is { fileName, tagCount }
+      const extra = fileRecord?.extraArgs[0] as Record<string, unknown> | undefined;
+      expect(extra).toBeDefined();
+      expect(typeof extra?.["fileName"]).toBe("string"); // fileName is a string
+      expect((extra?.["fileName"] as string)).toContain("formspec.ts"); // source file name logged
+      expect(typeof extra?.["tagCount"]).toBe("number"); // tagCount is a number
+      expect(extra?.["tagCount"]).toBeGreaterThan(0); // at least one declaration found
+    });
+  });
+
+  describe("analyzeMetadataForNode", () => {
+    it("emits a debug record with stage=analysis when analyzing a node", () => {
+      // Integration: asserts node-level analysis emits a debug record
+      const { program, sourceFile } = createProgram(FIXTURE_SOURCE);
+      const { logger, records } = makeCapturingLogger();
+
+      // Find the first class declaration node
+      let classNode: ts.Node | undefined;
+      const visit = (node: ts.Node): void => {
+        if (classNode === undefined && ts.isClassDeclaration(node)) {
+          classNode = node;
+        }
+        node.forEachChild(visit);
+      };
+      sourceFile.forEachChild(visit);
+
+      if (classNode === undefined) {
+        throw new Error("Expected to find a class declaration in the fixture");
+      }
+
+      analyzeMetadataForNode({ program, node: classNode, logger });
+
+      const analysisRecord = records.find(
+        (r) => r.level === "debug" && r.bindings["stage"] === "analysis"
+      );
+      expect(analysisRecord).toBeDefined(); // stage: "analysis" binding present
+    });
+
+    it("produces no console output when logger is omitted", () => {
+      const { program, sourceFile } = createProgram(FIXTURE_SOURCE);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { /* silence */ });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => { /* silence */ });
+
+      try {
+        analyzeMetadataForSourceFile({ program, sourceFile });
+      } finally {
+        consoleSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+      }
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/analysis/src/metadata-analysis.ts
+++ b/packages/analysis/src/metadata-analysis.ts
@@ -1,5 +1,6 @@
 import type {
   ExplicitMetadataSource,
+  LoggerLike,
   MetadataAnalysisResult,
   MetadataApplicableSlot,
   MetadataDeclarationKind,
@@ -10,6 +11,7 @@ import type {
   ResolvedScalarMetadata,
   ExtensionDefinition,
 } from "@formspec/core";
+import { noopLogger } from "@formspec/core";
 import * as ts from "typescript";
 import { parseCommentBlock, type ParsedCommentTag } from "./comment-syntax.js";
 import { getTagDefinition, normalizeFormSpecTagName } from "./tag-registry.js";
@@ -27,6 +29,11 @@ export interface AnalyzeMetadataOptions {
   readonly metadata?: MetadataPolicyInput | undefined;
   /** Optional extension definitions contributing additional metadata slots. */
   readonly extensions?: readonly ExtensionDefinition[] | undefined;
+  /**
+   * Optional logger for diagnostic output. Defaults to a no-op logger so
+   * existing callers produce no output.
+   */
+  readonly logger?: LoggerLike | undefined;
 }
 
 /**
@@ -634,6 +641,9 @@ export function analyzeMetadataForNodeWithChecker(
 export function analyzeMetadataForNode(
   options: AnalyzeMetadataForNodeOptions
 ): MetadataAnalysisResult | null {
+  const logger = (options.logger ?? noopLogger).child({ stage: "analysis" });
+  const logicalName = getLogicalName(options.node);
+  logger.debug("analyzing metadata for node", { logicalName: logicalName ?? "(unnamed)" });
   return analyzeMetadataForNodeWithChecker({
     program: options.program,
     checker: options.program.getTypeChecker(),
@@ -651,6 +661,8 @@ export function analyzeMetadataForNode(
 export function analyzeMetadataForSourceFile(
   options: AnalyzeMetadataForSourceFileOptions
 ): readonly MetadataAnalysisResult[] {
+  const logger = (options.logger ?? noopLogger).child({ stage: "analysis" });
+  const fileName = options.sourceFile.fileName;
   const results: MetadataAnalysisResult[] = [];
   const checker = options.program.getTypeChecker();
 
@@ -672,5 +684,7 @@ export function analyzeMetadataForSourceFile(
   };
 
   visit(options.sourceFile);
+  // One debug record per file: filename + tag count — plan §3 @formspec/analysis
+  logger.debug("analyzed source file", { fileName, tagCount: results.length });
   return results;
 }

--- a/packages/build/api-report/build.alpha.api.md
+++ b/packages/build/api-report/build.alpha.api.md
@@ -21,6 +21,7 @@ import { ExtensionDefinition } from '@formspec/core';
 import { FormElement } from '@formspec/core';
 import { FormSpec } from '@formspec/core';
 import { Group } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import { NumberField } from '@formspec/core';
 import { ObjectField } from '@formspec/core';
@@ -41,6 +42,7 @@ export function buildFormSchemas<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
 }
 
 // @public
@@ -209,6 +211,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 // @public
 export interface GenerateJsonSchemaOptions {
     readonly enumSerialization?: "enum" | "oneOf";
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
 }
@@ -337,6 +340,7 @@ export function generateUiSchema<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
 }
 
@@ -615,6 +619,7 @@ export function writeSchemas<E extends readonly FormElement[]>(form: FormSpec<E>
 // @public
 export interface WriteSchemasOptions extends GenerateJsonSchemaOptions {
     readonly indent?: number;
+    readonly logger?: LoggerLike | undefined;
     readonly name?: string;
     readonly outDir: string;
 }

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -21,6 +21,7 @@ import { ExtensionDefinition } from '@formspec/core';
 import { FormElement } from '@formspec/core';
 import { FormSpec } from '@formspec/core';
 import { Group } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import { NumberField } from '@formspec/core';
 import { ObjectField } from '@formspec/core';
@@ -41,6 +42,7 @@ export function buildFormSchemas<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
 }
 
 // @public
@@ -213,6 +215,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 // @public
 export interface GenerateJsonSchemaOptions {
     readonly enumSerialization?: "enum" | "oneOf";
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
 }
@@ -341,6 +344,7 @@ export function generateUiSchema<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
 }
 
@@ -619,6 +623,7 @@ export function writeSchemas<E extends readonly FormElement[]>(form: FormSpec<E>
 // @public
 export interface WriteSchemasOptions extends GenerateJsonSchemaOptions {
     readonly indent?: number;
+    readonly logger?: LoggerLike | undefined;
     readonly name?: string;
     readonly outDir: string;
 }

--- a/packages/build/api-report/build.beta.api.md
+++ b/packages/build/api-report/build.beta.api.md
@@ -21,6 +21,7 @@ import { ExtensionDefinition } from '@formspec/core';
 import { FormElement } from '@formspec/core';
 import { FormSpec } from '@formspec/core';
 import { Group } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import { NumberField } from '@formspec/core';
 import { ObjectField } from '@formspec/core';
@@ -41,6 +42,7 @@ export function buildFormSchemas<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
 }
 
 // @public
@@ -209,6 +211,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 // @public
 export interface GenerateJsonSchemaOptions {
     readonly enumSerialization?: "enum" | "oneOf";
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
 }
@@ -337,6 +340,7 @@ export function generateUiSchema<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
 }
 
@@ -615,6 +619,7 @@ export function writeSchemas<E extends readonly FormElement[]>(form: FormSpec<E>
 // @public
 export interface WriteSchemasOptions extends GenerateJsonSchemaOptions {
     readonly indent?: number;
+    readonly logger?: LoggerLike | undefined;
     readonly name?: string;
     readonly outDir: string;
 }

--- a/packages/build/api-report/build.public.api.md
+++ b/packages/build/api-report/build.public.api.md
@@ -21,6 +21,7 @@ import { ExtensionDefinition } from '@formspec/core';
 import { FormElement } from '@formspec/core';
 import { FormSpec } from '@formspec/core';
 import { Group } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 import type { MetadataPolicyInput } from '@formspec/core';
 import { NumberField } from '@formspec/core';
 import { ObjectField } from '@formspec/core';
@@ -41,6 +42,7 @@ export function buildFormSchemas<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
 }
 
 // @public
@@ -209,6 +211,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 // @public
 export interface GenerateJsonSchemaOptions {
     readonly enumSerialization?: "enum" | "oneOf";
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
 }
@@ -337,6 +340,7 @@ export function generateUiSchema<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
 }
 
@@ -615,6 +619,7 @@ export function writeSchemas<E extends readonly FormElement[]>(form: FormSpec<E>
 // @public
 export interface WriteSchemasOptions extends GenerateJsonSchemaOptions {
     readonly indent?: number;
+    readonly logger?: LoggerLike | undefined;
     readonly name?: string;
     readonly outDir: string;
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -46,11 +46,17 @@
     "@formspec/core": "workspace:*",
     "zod": "^3.25.0"
   },
+  "optionalDependencies": {
+    "pino": "^9.0.0",
+    "pino-pretty": "^11.0.0"
+  },
   "peerDependencies": {
     "typescript": "^5.0.0"
   },
   "devDependencies": {
     "@formspec/dsl": "workspace:*",
+    "pino": "^9.0.0",
+    "pino-pretty": "^11.0.0",
     "vitest": "^3.0.0"
   },
   "publishConfig": {

--- a/packages/build/src/__tests__/logger.test.ts
+++ b/packages/build/src/__tests__/logger.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { LoggerLike } from "@formspec/core";
+import { formspec, field } from "@formspec/dsl";
+import { buildFormSchemas, generateJsonSchema, generateUiSchema, writeSchemas } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Capturing logger — pushes every record to an array so tests can assert shape
+// ---------------------------------------------------------------------------
+
+interface LogRecord {
+  readonly level: "trace" | "debug" | "info" | "warn" | "error";
+  readonly msg: string;
+  readonly bindings: Record<string, unknown>;
+}
+
+function makeCapturingLogger(
+  bindings: Record<string, unknown> = {}
+): { logger: LoggerLike; records: LogRecord[] } {
+  const records: LogRecord[] = [];
+
+  const push =
+    (level: LogRecord["level"]) =>
+    (msg: string, ..._args: unknown[]) => {
+      records.push({ level, msg, bindings: { ...bindings } });
+    };
+
+  const logger: LoggerLike = {
+    trace: push("trace"),
+    debug: push("debug"),
+    info: push("info"),
+    warn: push("warn"),
+    error: push("error"),
+    child(childBindings) {
+      return makeCapturingLogger({ ...bindings, ...childBindings }).logger;
+    },
+  };
+
+  // The child logger shares the same records array via closure trick:
+  // override child to push into *this* records array.
+  const loggerWithSharedRecords: LoggerLike = {
+    trace: push("trace"),
+    debug: push("debug"),
+    info: push("info"),
+    warn: push("warn"),
+    error: push("error"),
+    child(childBindings) {
+      const childPush =
+        (level: LogRecord["level"]) =>
+        (msg: string, ..._args: unknown[]) => {
+          records.push({ level, msg, bindings: { ...bindings, ...childBindings } });
+        };
+      return {
+        trace: childPush("trace"),
+        debug: childPush("debug"),
+        info: childPush("info"),
+        warn: childPush("warn"),
+        error: childPush("error"),
+        child(grandChildBindings) {
+          return makeCapturingLogger({ ...bindings, ...childBindings, ...grandChildBindings })
+            .logger;
+        },
+      };
+    },
+  };
+  void logger; // suppress unused-variable lint warning for naive logger above
+
+  return { logger: loggerWithSharedRecords, records };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("@formspec/build logger integration", () => {
+  const SIMPLE_FORM = formspec(
+    field.text("name", { required: true }),
+    field.number("age", { min: 0 })
+  );
+
+  describe("buildFormSchemas", () => {
+    it("emits at least one debug record with stage=ir when a logger is passed", () => {
+      // Integration test: asserts the IR-construction stage emits a debug record
+      // (plan §3 @formspec/build — IR construction entry)
+      const { logger, records } = makeCapturingLogger();
+
+      buildFormSchemas(SIMPLE_FORM, { logger });
+
+      const irRecord = records.find(
+        (r) => r.level === "debug" && r.bindings["stage"] === "ir"
+      );
+      expect(irRecord).toBeDefined(); // stage: "ir" binding present
+    });
+
+    it("emits at least one debug record with stage=schema when a logger is passed", () => {
+      // Integration test: asserts the schema-emit stage emits a debug record
+      // (plan §3 @formspec/build — schema emit entry)
+      const { logger, records } = makeCapturingLogger();
+
+      buildFormSchemas(SIMPLE_FORM, { logger });
+
+      const schemaRecord = records.find(
+        (r) => r.level === "debug" && r.bindings["stage"] === "schema"
+      );
+      expect(schemaRecord).toBeDefined(); // stage: "schema" binding present
+    });
+
+    it("emits a top-level debug record at buildFormSchemas entry", () => {
+      const { logger, records } = makeCapturingLogger();
+
+      buildFormSchemas(SIMPLE_FORM, { logger });
+
+      // At least one debug record emitted by buildFormSchemas itself (no stage binding)
+      const topLevel = records.find((r) => r.level === "debug" && r.msg.includes("buildFormSchemas"));
+      expect(topLevel).toBeDefined();
+    });
+  });
+
+  describe("generateJsonSchema", () => {
+    it("emits debug records with stage=ir and stage=schema bindings", () => {
+      const { logger, records } = makeCapturingLogger();
+
+      generateJsonSchema(SIMPLE_FORM, { logger });
+
+      const irRecord = records.find(
+        (r) => r.level === "debug" && r.bindings["stage"] === "ir"
+      );
+      const schemaRecord = records.find(
+        (r) => r.level === "debug" && r.bindings["stage"] === "schema"
+      );
+      expect(irRecord).toBeDefined(); // IR stage debug record present
+      expect(schemaRecord).toBeDefined(); // schema stage debug record present
+    });
+  });
+
+  describe("generateUiSchema", () => {
+    it("emits debug records with stage=ir and stage=schema bindings", () => {
+      const { logger, records } = makeCapturingLogger();
+
+      generateUiSchema(SIMPLE_FORM, { logger });
+
+      const irRecord = records.find(
+        (r) => r.level === "debug" && r.bindings["stage"] === "ir"
+      );
+      const schemaRecord = records.find(
+        (r) => r.level === "debug" && r.bindings["stage"] === "schema"
+      );
+      expect(irRecord).toBeDefined(); // IR stage debug record present
+      expect(schemaRecord).toBeDefined(); // schema stage debug record present
+    });
+  });
+
+  describe("writeSchemas", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-logger-test-"));
+    });
+
+    afterEach(() => {
+      if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true });
+      }
+    });
+
+    it("emits debug records with stage=write for each file written", () => {
+      // Integration: asserts one debug entry per file written (plan §3 @formspec/build)
+      const { logger, records } = makeCapturingLogger();
+
+      writeSchemas(SIMPLE_FORM, { outDir: tempDir, name: "test", logger });
+
+      const writeRecords = records.filter(
+        (r) => r.level === "debug" && r.bindings["stage"] === "write"
+      );
+      // Expect exactly 2 write records — one per file (JSON Schema + UI Schema)
+      expect(writeRecords.length).toBeGreaterThanOrEqual(2); // one per file written
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Regression: no console output when logger is absent
+  // ---------------------------------------------------------------------------
+
+  describe("no console output when logger is omitted", () => {
+    it("buildFormSchemas produces no console.log or console.error output without a logger", () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { /* silence */ });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => { /* silence */ });
+
+      try {
+        buildFormSchemas(SIMPLE_FORM);
+      } finally {
+        consoleSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+      }
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it("generateJsonSchema produces no console output without a logger", () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { /* silence */ });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => { /* silence */ });
+
+      try {
+        generateJsonSchema(SIMPLE_FORM);
+      } finally {
+        consoleSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+      }
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/build/src/browser.ts
+++ b/packages/build/src/browser.ts
@@ -16,7 +16,8 @@
  * @packageDocumentation
  */
 
-import type { FormElement, FormSpec } from "@formspec/core";
+import type { FormElement, FormSpec, LoggerLike } from "@formspec/core";
+import { noopLogger } from "@formspec/core";
 import { generateJsonSchema, type GenerateJsonSchemaOptions } from "./json-schema/generator.js";
 import { generateUiSchema } from "./ui-schema/generator.js";
 import { type JsonSchema2020 } from "./json-schema/ir-generator.js";
@@ -116,7 +117,13 @@ export interface BuildResult {
  * Currently identical to `GenerateJsonSchemaOptions`. Defined separately so the
  * browser-safe surface can grow independently in the future if needed.
  */
-export type BuildFormSchemasOptions = GenerateJsonSchemaOptions;
+export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions {
+  /**
+   * Optional logger for diagnostic output. Defaults to a no-op logger so
+   * existing callers produce no output.
+   */
+  readonly logger?: LoggerLike | undefined;
+}
 
 /**
  * Builds both JSON Schema and UI Schema from a FormSpec.
@@ -140,6 +147,8 @@ export function buildFormSchemas<E extends readonly FormElement[]>(
   form: FormSpec<E>,
   options?: BuildFormSchemasOptions
 ): BuildResult {
+  const logger = options?.logger ?? noopLogger;
+  logger.debug("buildFormSchemas (browser): starting schema generation");
   return {
     jsonSchema: generateJsonSchema(form, options),
     uiSchema: generateUiSchema(form, options),

--- a/packages/build/src/cli.ts
+++ b/packages/build/src/cli.ts
@@ -16,6 +16,9 @@
 
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
+import { createLogger } from "./cli/logger.js";
+
+const log = createLogger("formspec:build");
 
 interface CliOptions {
   inputFile: string;
@@ -126,6 +129,8 @@ function parseArgs(args: string[]): CliOptions | null {
     name = path.basename(inputFile, path.extname(inputFile));
   }
 
+  log.debug("Arguments parsed", { inputFile, outDir, name, enumSerialization });
+
   return { inputFile, outDir, name, enumSerialization };
 }
 
@@ -141,17 +146,21 @@ async function main(): Promise<void> {
 
   // Resolve input file path
   const absoluteInput = path.resolve(process.cwd(), inputFile);
+  log.debug("Resolved input file", { absoluteInput });
 
   try {
     // Dynamically import the input file
     // Use file URL for cross-platform compatibility (Windows paths need file:// URLs)
     const fileUrl = pathToFileURL(absoluteInput).href;
+    log.debug("Loading form module", { fileUrl });
+
     const module = (await import(fileUrl)) as Record<string, unknown>;
 
     // Look for the form export
     const form = module["default"] ?? module["form"];
 
     if (!form || typeof form !== "object" || !("elements" in form)) {
+      log.error("Input file does not export a valid FormSpec", { fileUrl });
       console.error("Error: Input file must export a FormSpec as default export or as 'form'");
       console.error("Example:");
       console.error('  export default formspec(field.text("name"));');
@@ -159,6 +168,8 @@ async function main(): Promise<void> {
       console.error('  export const form = formspec(field.text("name"));');
       process.exit(1);
     }
+
+    log.debug("Form module loaded, generating schemas");
 
     // Import writeSchemas dynamically to avoid circular deps
     const { writeSchemas } = await import("./index.js");
@@ -168,13 +179,17 @@ async function main(): Promise<void> {
       { outDir, name, enumSerialization }
     );
 
+    log.debug("Schemas written", { jsonSchemaPath, uiSchemaPath });
+
     console.log("Generated:");
     console.log(`  ${jsonSchemaPath}`);
     console.log(`  ${uiSchemaPath}`);
   } catch (error) {
     if (error instanceof Error) {
+      log.child({ err: error.message }).error("Schema generation failed");
       console.error(`Error: ${error.message}`);
     } else {
+      log.error("Schema generation failed with unknown error");
       console.error("Error:", error);
     }
     process.exit(1);

--- a/packages/build/src/cli/logger.ts
+++ b/packages/build/src/cli/logger.ts
@@ -1,0 +1,50 @@
+/**
+ * Pino-based logger factory for the @formspec/build CLI.
+ *
+ * Reads `process.env.DEBUG` to determine which namespaces are enabled using
+ * the shared matcher in `@formspec/core` — same semantics as the `debug` npm
+ * package (comma-separated patterns, `*` wildcard, `-` prefix for negation,
+ * negations always win).
+ */
+
+import { isNamespaceEnabled, noopLogger } from "@formspec/core";
+import type { LoggerLike } from "@formspec/core";
+
+/**
+ * Creates a logger for the given namespace.
+ *
+ * When the namespace is enabled by `DEBUG`, writes structured JSON to stderr
+ * (with pino-pretty formatting when stderr is a TTY). Otherwise returns the
+ * silent `noopLogger` from `@formspec/core`.
+ *
+ * pino and pino-pretty are loaded lazily via `require()` so that the CLI
+ * pays no load-time cost when logging is disabled, and so the dependencies
+ * can be declared as `optionalDependencies` of `@formspec/build`.
+ */
+export function createLogger(namespace: string): LoggerLike {
+  const debugEnv = process.env["DEBUG"] ?? "";
+  if (!isNamespaceEnabled(debugEnv, namespace)) {
+    return noopLogger;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const pinoModule = require("pino") as { default: typeof import("pino") } | typeof import("pino");
+  const pino = typeof pinoModule === "function" ? pinoModule : pinoModule.default;
+
+  const isTTY = process.stderr.isTTY;
+
+  if (isTTY) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pinoPretty = require("pino-pretty") as { default: unknown };
+    const prettyTransport = (pinoPretty.default ?? pinoPretty) as (
+      opts: Record<string, unknown>,
+    ) => NodeJS.WritableStream;
+    const stream = prettyTransport({ destination: 2, colorize: true, sync: true });
+    return pino({ name: namespace, level: "debug" }, stream) as unknown as LoggerLike;
+  }
+
+  return pino(
+    { name: namespace, level: "debug" },
+    pino.destination({ dest: 2, sync: true }),
+  ) as unknown as LoggerLike;
+}

--- a/packages/build/src/cli/logger.ts
+++ b/packages/build/src/cli/logger.ts
@@ -7,8 +7,11 @@
  * negations always win).
  */
 
+import { createRequire } from "node:module";
 import { isNamespaceEnabled, noopLogger } from "@formspec/core";
 import type { LoggerLike } from "@formspec/core";
+
+const require = createRequire(import.meta.url);
 
 /**
  * Creates a logger for the given namespace.
@@ -27,14 +30,12 @@ export function createLogger(namespace: string): LoggerLike {
     return noopLogger;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const pinoModule = require("pino") as { default: typeof import("pino") } | typeof import("pino");
   const pino = typeof pinoModule === "function" ? pinoModule : pinoModule.default;
 
   const isTTY = process.stderr.isTTY;
 
   if (isTTY) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const pinoPretty = require("pino-pretty") as { default: unknown };
     const prettyTransport = (pinoPretty.default ?? pinoPretty) as (
       opts: Record<string, unknown>,

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -23,7 +23,8 @@
  * @packageDocumentation
  */
 
-import type { FormElement, FormSpec } from "@formspec/core";
+import type { FormElement, FormSpec, LoggerLike } from "@formspec/core";
+import { noopLogger } from "@formspec/core";
 import { generateJsonSchema, type GenerateJsonSchemaOptions } from "./json-schema/generator.js";
 import { generateUiSchema, type GenerateUiSchemaOptions } from "./ui-schema/generator.js";
 import { type JsonSchema2020 } from "./json-schema/ir-generator.js";
@@ -194,8 +195,13 @@ export interface BuildResult {
  *
  * @public
  */
-export interface BuildFormSchemasOptions
-  extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {}
+export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+  /**
+   * Optional logger for diagnostic output. Defaults to a no-op logger so
+   * existing callers produce no output.
+   */
+  readonly logger?: LoggerLike | undefined;
+}
 
 /**
  * Builds both JSON Schema and UI Schema from a FormSpec.
@@ -230,6 +236,8 @@ export function buildFormSchemas<E extends readonly FormElement[]>(
   form: FormSpec<E>,
   options?: BuildFormSchemasOptions
 ): BuildResult {
+  const logger = options?.logger ?? noopLogger;
+  logger.debug("buildFormSchemas: starting schema generation");
   return {
     jsonSchema: generateJsonSchema(form, options),
     uiSchema: generateUiSchema(form, options),
@@ -248,6 +256,11 @@ export interface WriteSchemasOptions extends GenerateJsonSchemaOptions {
   readonly name?: string;
   /** Number of spaces for JSON indentation. Defaults to 2 */
   readonly indent?: number;
+  /**
+   * Optional logger for diagnostic output. Defaults to a no-op logger so
+   * existing callers produce no output.
+   */
+  readonly logger?: LoggerLike | undefined;
 }
 
 /**
@@ -304,16 +317,19 @@ export function writeSchemas<E extends readonly FormElement[]>(
     vendorPrefix,
     enumSerialization,
     metadata,
+    logger: rawLogger,
   } = options;
+  const logger = (rawLogger ?? noopLogger).child({ stage: "write" });
 
   // Build schemas
   const buildOptions =
     vendorPrefix === undefined && enumSerialization === undefined && metadata === undefined
-      ? undefined
+      ? { logger: rawLogger }
       : {
           ...(vendorPrefix !== undefined && { vendorPrefix }),
           ...(enumSerialization !== undefined && { enumSerialization }),
           ...(metadata !== undefined && { metadata }),
+          logger: rawLogger,
         };
 
   const { jsonSchema, uiSchema } = buildFormSchemas(form, buildOptions);
@@ -327,7 +343,9 @@ export function writeSchemas<E extends readonly FormElement[]>(
   const jsonSchemaPath = path.join(outDir, `${name}-schema.json`);
   const uiSchemaPath = path.join(outDir, `${name}-uischema.json`);
 
+  logger.debug("writing JSON Schema", { path: jsonSchemaPath });
   fs.writeFileSync(jsonSchemaPath, JSON.stringify(jsonSchema, null, indent));
+  logger.debug("writing UI Schema", { path: uiSchemaPath });
   fs.writeFileSync(uiSchemaPath, JSON.stringify(uiSchema, null, indent));
 
   return { jsonSchemaPath, uiSchemaPath };

--- a/packages/build/src/json-schema/generator.ts
+++ b/packages/build/src/json-schema/generator.ts
@@ -4,7 +4,8 @@
  * Routes through the canonical IR pipeline: Chain DSL → FormIR → JSON Schema 2020-12.
  */
 
-import type { FormElement, FormSpec, MetadataPolicyInput } from "@formspec/core";
+import type { FormElement, FormSpec, LoggerLike, MetadataPolicyInput } from "@formspec/core";
+import { noopLogger } from "@formspec/core";
 import { canonicalizeChainDSL } from "../canonicalize/index.js";
 import {
   generateJsonSchemaFromIR,
@@ -30,6 +31,11 @@ export interface GenerateJsonSchemaOptions {
   readonly enumSerialization?: "enum" | "oneOf";
   /** Metadata resolution policy for chain DSL generation. */
   readonly metadata?: MetadataPolicyInput | undefined;
+  /**
+   * Optional logger for diagnostic output. Defaults to a no-op logger so
+   * existing callers produce no output.
+   */
+  readonly logger?: LoggerLike | undefined;
 }
 
 /**
@@ -66,10 +72,14 @@ export function generateJsonSchema<E extends readonly FormElement[]>(
   form: FormSpec<E>,
   options?: GenerateJsonSchemaOptions
 ): JsonSchema2020 {
+  const logger = (options?.logger ?? noopLogger).child({ stage: "ir" });
   const metadata = options?.metadata;
   const vendorPrefix = options?.vendorPrefix;
   const enumSerialization = options?.enumSerialization;
+  logger.debug("canonicalizing chain DSL to IR");
   const ir = canonicalizeChainDSL(form, metadata !== undefined ? { metadata } : undefined);
+  const schemaLogger = (options?.logger ?? noopLogger).child({ stage: "schema" });
+  schemaLogger.debug("generating JSON Schema from IR");
   const internalOptions: GenerateJsonSchemaFromIROptions | undefined =
     vendorPrefix === undefined && enumSerialization === undefined
       ? undefined

--- a/packages/build/src/ui-schema/generator.ts
+++ b/packages/build/src/ui-schema/generator.ts
@@ -4,7 +4,8 @@
  * Routes through the canonical IR pipeline: Chain DSL → FormIR → UI Schema.
  */
 
-import type { FormElement, FormSpec, MetadataPolicyInput } from "@formspec/core";
+import type { FormElement, FormSpec, LoggerLike, MetadataPolicyInput } from "@formspec/core";
+import { noopLogger } from "@formspec/core";
 import { canonicalizeChainDSL } from "../canonicalize/index.js";
 import { generateUiSchemaFromIR } from "./ir-generator.js";
 import type { UISchema } from "./types.js";
@@ -17,6 +18,11 @@ import type { UISchema } from "./types.js";
 export interface GenerateUiSchemaOptions {
   /** Metadata resolution policy for chain DSL UI generation. */
   readonly metadata?: MetadataPolicyInput | undefined;
+  /**
+   * Optional logger for diagnostic output. Defaults to a no-op logger so
+   * existing callers produce no output.
+   */
+  readonly logger?: LoggerLike | undefined;
 }
 
 /**
@@ -69,9 +75,13 @@ export function generateUiSchema<E extends readonly FormElement[]>(
   form: FormSpec<E>,
   options?: GenerateUiSchemaOptions
 ): UISchema {
+  const logger = (options?.logger ?? noopLogger).child({ stage: "ir" });
+  logger.debug("canonicalizing chain DSL to IR for UI Schema generation");
   const ir = canonicalizeChainDSL(
     form,
     options?.metadata !== undefined ? { metadata: options.metadata } : undefined
   );
+  const schemaLogger = (options?.logger ?? noopLogger).child({ stage: "schema" });
+  schemaLogger.debug("generating UI Schema from IR");
   return generateUiSchemaFromIR(ir);
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,9 @@
   "dependencies": {
     "typescript": "^5.0.0",
     "@formspec/build": "workspace:*",
-    "@formspec/config": "workspace:*"
+    "@formspec/config": "workspace:*",
+    "pino": "^9.0.0",
+    "pino-pretty": "^11.0.0"
   },
   "devDependencies": {
     "@formspec/core": "workspace:*",

--- a/packages/cli/src/__tests__/logger.test.ts
+++ b/packages/cli/src/__tests__/logger.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the CLI logger module.
+ *
+ * Tests focus on `isNamespaceEnabled`, which implements the `DEBUG` env-var
+ * pattern matching. The rules mirror the `debug` npm package convention:
+ *   - comma-separated patterns
+ *   - `*` wildcard (glob, not regex)
+ *   - `-` prefix negates a pattern; negations take precedence over positive matches
+ *
+ * Spec-first: all expected values are written by hand from the rules above,
+ * not derived from running the implementation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isNamespaceEnabled } from "@formspec/core";
+
+describe("isNamespaceEnabled", () => {
+  // ── empty / undefined-equivalent patterns ──────────────────────────────────
+
+  it("returns false for empty pattern string", () => {
+    expect(isNamespaceEnabled("", "formspec:cli")).toBe(false);
+  });
+
+  it("returns false for whitespace-only pattern", () => {
+    expect(isNamespaceEnabled("   ", "formspec:cli")).toBe(false);
+  });
+
+  // ── exact match ────────────────────────────────────────────────────────────
+
+  it("returns true when pattern exactly matches namespace", () => {
+    expect(isNamespaceEnabled("formspec:cli", "formspec:cli")).toBe(true);
+  });
+
+  it("returns false when pattern does not match namespace", () => {
+    expect(isNamespaceEnabled("formspec:build", "formspec:cli")).toBe(false);
+  });
+
+  it("is case-sensitive: 'Formspec:cli' does not match 'formspec:cli'", () => {
+    expect(isNamespaceEnabled("Formspec:cli", "formspec:cli")).toBe(false);
+  });
+
+  // ── wildcard (*) ───────────────────────────────────────────────────────────
+
+  it("* alone enables any namespace", () => {
+    expect(isNamespaceEnabled("*", "formspec:cli")).toBe(true);
+    expect(isNamespaceEnabled("*", "anything")).toBe(true);
+  });
+
+  it("prefix wildcard formspec:* matches all formspec namespaces", () => {
+    expect(isNamespaceEnabled("formspec:*", "formspec:cli")).toBe(true);
+    expect(isNamespaceEnabled("formspec:*", "formspec:build")).toBe(true);
+    expect(isNamespaceEnabled("formspec:*", "formspec:build:ir")).toBe(true);
+  });
+
+  it("prefix wildcard formspec:* does not match unrelated namespaces", () => {
+    expect(isNamespaceEnabled("formspec:*", "other:lib")).toBe(false);
+  });
+
+  it("suffix wildcard *:cli matches any prefix before :cli", () => {
+    expect(isNamespaceEnabled("*:cli", "formspec:cli")).toBe(true);
+    expect(isNamespaceEnabled("*:cli", "myapp:cli")).toBe(true);
+  });
+
+  it("mid-string wildcard formspec:*:ir matches multi-level names", () => {
+    expect(isNamespaceEnabled("formspec:*:ir", "formspec:build:ir")).toBe(true);
+    expect(isNamespaceEnabled("formspec:*:ir", "formspec:x:ir")).toBe(true);
+    expect(isNamespaceEnabled("formspec:*:ir", "formspec:build:schema")).toBe(false);
+  });
+
+  // ── negation (-) ───────────────────────────────────────────────────────────
+
+  it("negation alone (-formspec:build) does not enable formspec:cli", () => {
+    // Only negation, no positive patterns → nothing is enabled
+    expect(isNamespaceEnabled("-formspec:build", "formspec:cli")).toBe(false);
+  });
+
+  it("negation silences a specific namespace when combined with wildcard", () => {
+    // formspec:* enables everything under formspec, but -formspec:cli:noisy blocks it
+    expect(isNamespaceEnabled("formspec:*,-formspec:cli:noisy", "formspec:cli")).toBe(true);
+    expect(isNamespaceEnabled("formspec:*,-formspec:cli:noisy", "formspec:cli:noisy")).toBe(false);
+    expect(isNamespaceEnabled("formspec:*,-formspec:cli:noisy", "formspec:build")).toBe(true);
+  });
+
+  it("negation wildcard silences a whole subtree", () => {
+    // Everything under formspec except formspec:build:*
+    expect(isNamespaceEnabled("formspec:*,-formspec:build:*", "formspec:cli")).toBe(true);
+    expect(isNamespaceEnabled("formspec:*,-formspec:build:*", "formspec:build:ir")).toBe(false);
+    expect(isNamespaceEnabled("formspec:*,-formspec:build:*", "formspec:build:schema")).toBe(false);
+    // formspec:build itself does not match the -formspec:build:* negation (needs : after build)
+    expect(isNamespaceEnabled("formspec:*,-formspec:build:*", "formspec:build")).toBe(true);
+  });
+
+  it("negation takes precedence regardless of pattern order", () => {
+    // Even though the positive pattern appears after the negation pattern, negations win
+    expect(isNamespaceEnabled("-formspec:cli,formspec:*", "formspec:cli")).toBe(false);
+  });
+
+  // ── comma-separated multiple patterns ──────────────────────────────────────
+
+  it("returns true when any positive pattern matches", () => {
+    expect(isNamespaceEnabled("formspec:cli,formspec:build", "formspec:cli")).toBe(true);
+    expect(isNamespaceEnabled("formspec:cli,formspec:build", "formspec:build")).toBe(true);
+  });
+
+  it("returns false when no positive pattern matches", () => {
+    expect(isNamespaceEnabled("formspec:cli,formspec:build", "formspec:analysis")).toBe(false);
+  });
+
+  it("handles leading/trailing spaces around comma-separated patterns", () => {
+    expect(isNamespaceEnabled("formspec:cli , formspec:build", "formspec:build")).toBe(true);
+  });
+
+  it("ignores empty segments produced by adjacent commas", () => {
+    expect(isNamespaceEnabled("formspec:cli,,formspec:build", "formspec:build")).toBe(true);
+  });
+
+  // ── negative cases: ensure exact semantics ──────────────────────────────────
+
+  it("formspec:build does not match formspec:build:ir (partial match is not enough)", () => {
+    // Exact pattern without wildcard must be an exact match
+    expect(isNamespaceEnabled("formspec:build", "formspec:build:ir")).toBe(false);
+  });
+
+  it("formspec: prefix does not match formspec:cli (colon is literal, not wildcard)", () => {
+    expect(isNamespaceEnabled("formspec:", "formspec:cli")).toBe(false);
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -669,7 +669,7 @@ async function main(): Promise<void> {
     }
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    log.error("CLI error: %s", msg);
+    log.error(`CLI error: ${msg}`);
     console.error("Error:", msg);
     process.exit(1);
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,9 @@ import {
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as ts from "typescript";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("formspec:cli");
 
 /**
  * CLI options parsed from arguments.
@@ -369,9 +372,9 @@ async function main(): Promise<void> {
       console.log(`Using config: ${configResult.configPath}`);
     }
   } catch (error) {
-    console.error(
-      `Error loading config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    const msg = `Error loading config: ${error instanceof Error ? error.message : String(error)}`;
+    log.error(msg);
+    console.error(msg);
     process.exit(1);
   }
 
@@ -468,7 +471,9 @@ async function main(): Promise<void> {
       const classDecl = findClassByName(ctx.sourceFile, options.className);
 
       if (!classDecl) {
-        console.error(`Error: Class "${options.className}" not found in ${options.filePath}`);
+        const msg = `Class "${options.className}" not found in ${options.filePath}`;
+        log.error(msg);
+        console.error(`Error: ${msg}`);
         process.exit(1);
       }
 
@@ -663,7 +668,9 @@ async function main(): Promise<void> {
       console.log("Done!");
     }
   } catch (error) {
-    console.error("Error:", error instanceof Error ? error.message : error);
+    const msg = error instanceof Error ? error.message : String(error);
+    log.error("CLI error: %s", msg);
+    console.error("Error:", msg);
     process.exit(1);
   }
 }

--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -1,0 +1,74 @@
+/**
+ * Pino-backed logger factory for the FormSpec CLI.
+ *
+ * Reads `process.env.DEBUG` to determine which namespaces are enabled.
+ * Enabled namespaces write to `process.stderr` at level `debug`; disabled
+ * namespaces return the silent `noopLogger` so there is zero overhead.
+ *
+ * ## Enable convention
+ *
+ * `DEBUG=formspec:*` — enable all formspec namespaces
+ * `DEBUG=formspec:cli,formspec:build` — enable two specific namespaces
+ * `DEBUG=formspec:*,-formspec:cli:noisy` — wildcard with negation
+ *
+ * @packageDocumentation
+ */
+
+import type { LoggerLike } from "@formspec/core";
+import { isNamespaceEnabled, noopLogger } from "@formspec/core";
+import pino from "pino";
+
+/**
+ * Wraps a pino `Logger` so that `.child()` is typed as returning `LoggerLike`
+ * rather than pino's own `Logger`. pino's child is structurally compatible —
+ * this adapter exists only to satisfy the strict return type.
+ */
+function wrapLogger(logger: pino.Logger): LoggerLike {
+  // pino's Logger overloads use (obj, msg?, ...args) | (msg, ...args).
+  // We forward as (obj={}, msg, ...args) so the overload resolution is
+  // unambiguous regardless of what LoggerLike callers pass as extra args.
+  return {
+    trace: (msg, ...args) => { logger.trace({}, msg, ...args); },
+    debug: (msg, ...args) => { logger.debug({}, msg, ...args); },
+    info:  (msg, ...args) => { logger.info({}, msg, ...args); },
+    warn:  (msg, ...args) => { logger.warn({}, msg, ...args); },
+    error: (msg, ...args) => { logger.error({}, msg, ...args); },
+    child: (bindings) => wrapLogger(logger.child(bindings)),
+  };
+}
+
+/**
+ * Creates a `LoggerLike` for the given namespace.
+ *
+ * When the namespace is enabled via `process.env.DEBUG`, returns a pino logger
+ * writing to `process.stderr` (with pino-pretty when stderr is a TTY).
+ * Otherwise returns `noopLogger`.
+ */
+export function createLogger(namespace: string): LoggerLike {
+  const debugEnv = process.env["DEBUG"] ?? "";
+  if (!isNamespaceEnabled(debugEnv, namespace)) {
+    return noopLogger;
+  }
+
+  const isTty = process.stderr.isTTY;
+
+  const destination: pino.DestinationStream = isTty
+    ? (pino.transport({
+        target: "pino-pretty",
+        options: {
+          destination: 2, // stderr fd
+          colorize: true,
+        },
+      }) as pino.DestinationStream)
+    : process.stderr;
+
+  const baseLogger = pino(
+    {
+      level: "debug",
+      base: { namespace },
+    },
+    destination,
+  );
+
+  return wrapLogger(baseLogger);
+}

--- a/packages/config/api-report/config.alpha.api.md
+++ b/packages/config/api-report/config.alpha.api.md
@@ -250,6 +250,7 @@ export interface LoadConfigNotFoundResult {
 // @public
 export interface LoadConfigOptions {
     configPath?: string;
+    logger?: LoggerLike | undefined;
     searchFrom?: string;
 }
 

--- a/packages/config/api-report/config.alpha.api.md
+++ b/packages/config/api-report/config.alpha.api.md
@@ -260,6 +260,16 @@ export type LoadConfigResult = LoadConfigFoundResult | LoadConfigNotFoundResult;
 // @public
 export function loadFormSpecConfig(options?: LoadConfigOptions): Promise<LoadConfigResult>;
 
+// @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+}
+
 // @beta
 export function mergeWithDefaults(config: ConstraintConfig | undefined): ResolvedConstraintConfig;
 

--- a/packages/config/api-report/config.api.md
+++ b/packages/config/api-report/config.api.md
@@ -252,6 +252,8 @@ export interface LoadConfigNotFoundResult {
 // @public
 export interface LoadConfigOptions {
     configPath?: string;
+    // Warning: (ae-forgotten-export) The symbol "LoggerLike" needs to be exported by the entry point index.d.ts
+    logger?: LoggerLike | undefined;
     searchFrom?: string;
 }
 

--- a/packages/config/api-report/config.api.md
+++ b/packages/config/api-report/config.api.md
@@ -252,7 +252,6 @@ export interface LoadConfigNotFoundResult {
 // @public
 export interface LoadConfigOptions {
     configPath?: string;
-    // Warning: (ae-forgotten-export) The symbol "LoggerLike" needs to be exported by the entry point index.d.ts
     logger?: LoggerLike | undefined;
     searchFrom?: string;
 }
@@ -262,6 +261,16 @@ export type LoadConfigResult = LoadConfigFoundResult | LoadConfigNotFoundResult;
 
 // @public
 export function loadFormSpecConfig(options?: LoadConfigOptions): Promise<LoadConfigResult>;
+
+// @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+}
 
 // @beta
 export function mergeWithDefaults(config: ConstraintConfig | undefined): ResolvedConstraintConfig;

--- a/packages/config/api-report/config.beta.api.md
+++ b/packages/config/api-report/config.beta.api.md
@@ -250,6 +250,7 @@ export interface LoadConfigNotFoundResult {
 // @public
 export interface LoadConfigOptions {
     configPath?: string;
+    logger?: LoggerLike | undefined;
     searchFrom?: string;
 }
 

--- a/packages/config/api-report/config.beta.api.md
+++ b/packages/config/api-report/config.beta.api.md
@@ -260,6 +260,16 @@ export type LoadConfigResult = LoadConfigFoundResult | LoadConfigNotFoundResult;
 // @public
 export function loadFormSpecConfig(options?: LoadConfigOptions): Promise<LoadConfigResult>;
 
+// @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+}
+
 // @beta
 export function mergeWithDefaults(config: ConstraintConfig | undefined): ResolvedConstraintConfig;
 

--- a/packages/config/api-report/config.public.api.md
+++ b/packages/config/api-report/config.public.api.md
@@ -198,6 +198,7 @@ export interface LoadConfigNotFoundResult {
 // @public
 export interface LoadConfigOptions {
     configPath?: string;
+    logger?: LoggerLike | undefined;
     searchFrom?: string;
 }
 

--- a/packages/config/api-report/config.public.api.md
+++ b/packages/config/api-report/config.public.api.md
@@ -209,6 +209,16 @@ export type LoadConfigResult = LoadConfigFoundResult | LoadConfigNotFoundResult;
 export function loadFormSpecConfig(options?: LoadConfigOptions): Promise<LoadConfigResult>;
 
 // @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+}
+
+// @public
 export interface NumberField<N extends string> {
     readonly apiName?: string;
     readonly displayName?: string;

--- a/packages/config/src/__tests__/logger.test.ts
+++ b/packages/config/src/__tests__/logger.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LoggerLike } from "@formspec/core";
+import { loadFormSpecConfig } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Shared capturing logger helper
+// ---------------------------------------------------------------------------
+
+interface LogRecord {
+  readonly level: "trace" | "debug" | "info" | "warn" | "error";
+  readonly msg: string;
+  /** Bindings accumulated via logger.child() calls */
+  readonly bindings: Record<string, unknown>;
+  /** Extra arguments passed to the log method (e.g. second arg to debug()) */
+  readonly extraArgs: unknown[];
+}
+
+function makeCapturingLogger(
+  bindings: Record<string, unknown> = {}
+): { logger: LoggerLike; records: LogRecord[] } {
+  const records: LogRecord[] = [];
+
+  function build(currentBindings: Record<string, unknown>): LoggerLike {
+    const push =
+      (level: LogRecord["level"]) =>
+      (msg: string, ...args: unknown[]) => {
+        records.push({ level, msg, bindings: { ...currentBindings }, extraArgs: args });
+      };
+    return {
+      trace: push("trace"),
+      debug: push("debug"),
+      info: push("info"),
+      warn: push("warn"),
+      error: push("error"),
+      child(childBindings) {
+        return build({ ...currentBindings, ...childBindings });
+      },
+    };
+  }
+
+  return { logger: build(bindings), records };
+}
+
+// ---------------------------------------------------------------------------
+// Temp dir management
+// ---------------------------------------------------------------------------
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const base = join(
+    tmpdir(),
+    `formspec-logger-test-${String(Date.now())}-${Math.random().toString(36).slice(2)}`
+  );
+  await mkdir(base, { recursive: true });
+  tempDirs.push(base);
+  return base;
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("@formspec/config logger integration", () => {
+  describe("loadFormSpecConfig", () => {
+    it("emits a debug record with stage=config and configPath when a config file is found", async () => {
+      // Integration: asserts resolved config path and source are logged (plan §3 @formspec/config)
+      // configPath and source are passed as extra args to logger.debug()
+      const dir = await createTempDir();
+      const filePath = join(dir, "formspec.config.ts");
+      await writeFile(
+        filePath,
+        `export default { vendorPrefix: "x-test" };`,
+        "utf-8"
+      );
+
+      const { logger, records } = makeCapturingLogger();
+
+      const result = await loadFormSpecConfig({ configPath: filePath, logger });
+
+      expect(result.found).toBe(true);
+
+      // Plan §3: log resolved config path and source
+      const configRecord = records.find(
+        (r) =>
+          r.level === "debug" &&
+          r.bindings["stage"] === "config" &&
+          r.msg.includes("loading config file")
+      );
+      expect(configRecord).toBeDefined(); // stage: "config" debug record present for file loading
+      const extra = configRecord?.extraArgs[0] as Record<string, unknown> | undefined;
+      expect(extra?.["configPath"]).toBe(filePath); // resolved config path logged
+    });
+
+    it("emits a debug record indicating the source is 'explicit' when configPath is given", async () => {
+      // Integration: asserts explicit vs discovered config source is logged
+      const dir = await createTempDir();
+      const filePath = join(dir, "formspec.config.ts");
+      await writeFile(filePath, `export default {};`, "utf-8");
+
+      const { logger, records } = makeCapturingLogger();
+
+      await loadFormSpecConfig({ configPath: filePath, logger });
+
+      const configRecord = records.find(
+        (r) =>
+          r.level === "debug" &&
+          r.bindings["stage"] === "config" &&
+          r.msg.includes("loading config file")
+      );
+      const extra = configRecord?.extraArgs[0] as Record<string, unknown> | undefined;
+      expect(extra?.["source"]).toBe("explicit"); // source="explicit" for explicit configPath
+    });
+
+    it("emits a debug record indicating the source is 'discovered' when searching from a dir", async () => {
+      // Integration: asserts discovered config source is logged
+      const dir = await createTempDir();
+      const filePath = join(dir, "formspec.config.ts");
+      await writeFile(filePath, `export default {};`, "utf-8");
+
+      const { logger, records } = makeCapturingLogger();
+
+      await loadFormSpecConfig({ searchFrom: dir, logger });
+
+      const configRecord = records.find(
+        (r) =>
+          r.level === "debug" &&
+          r.bindings["stage"] === "config" &&
+          r.msg.includes("loading config file")
+      );
+      const extra = configRecord?.extraArgs[0] as Record<string, unknown> | undefined;
+      expect(extra?.["source"]).toBe("discovered"); // source="discovered" for auto-discovery
+    });
+
+    it("emits a debug record when no config file is found", async () => {
+      // Integration: no-config case should still emit a debug log
+      const dir = await createTempDir(); // empty — no config file
+
+      const { logger, records } = makeCapturingLogger();
+
+      const result = await loadFormSpecConfig({ searchFrom: dir, logger });
+
+      expect(result.found).toBe(false);
+
+      const notFoundRecord = records.find(
+        (r) => r.level === "debug" && r.bindings["stage"] === "config"
+      );
+      expect(notFoundRecord).toBeDefined(); // debug record emitted even when no config found
+    });
+
+    it("produces no console output when logger is omitted", async () => {
+      const dir = await createTempDir();
+      const filePath = join(dir, "formspec.config.ts");
+      await writeFile(filePath, `export default {};`, "utf-8");
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { /* silence */ });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => { /* silence */ });
+
+      try {
+        await loadFormSpecConfig({ configPath: filePath });
+      } finally {
+        consoleSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+      }
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -73,6 +73,9 @@ export type {
   TextField,
 } from "@formspec/core";
 
+// Logger contract (re-exported so LoadConfigOptions.logger resolves in the API surface)
+export type { LoggerLike } from "@formspec/core";
+
 // Config loading
 export {
   loadFormSpecConfig,

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -6,6 +6,8 @@ async function getJiti() {
   const { createJiti } = await import("jiti");
   return createJiti(import.meta.url);
 }
+import type { LoggerLike } from "@formspec/core";
+import { noopLogger } from "@formspec/core";
 import type { FormSpecConfig, ConstraintConfig, ResolvedConstraintConfig } from "./types.js";
 import { mergeWithDefaults } from "./defaults.js";
 
@@ -36,6 +38,12 @@ export interface LoadConfigOptions {
    * If provided, skips file discovery entirely.
    */
   configPath?: string;
+
+  /**
+   * Optional logger for diagnostic output. Defaults to a no-op logger so
+   * existing callers produce no output.
+   */
+  logger?: LoggerLike | undefined;
 }
 
 /**
@@ -205,7 +213,8 @@ function validateLoadedConfig(config: FormSpecConfig, filePath: string): void {
 export async function loadFormSpecConfig(
   options: LoadConfigOptions = {}
 ): Promise<LoadConfigResult> {
-  const { searchFrom = process.cwd(), configPath } = options;
+  const { searchFrom = process.cwd(), configPath, logger: rawLogger } = options;
+  const logger = (rawLogger ?? noopLogger).child({ stage: "config" });
 
   let resolvedPath: string | null = null;
 
@@ -221,9 +230,11 @@ export async function loadFormSpecConfig(
   }
 
   if (!resolvedPath) {
+    logger.debug("no config file found", { searchFrom });
     return { found: false };
   }
 
+  logger.debug("loading config file", { configPath: resolvedPath, source: configPath ? "explicit" : "discovered" });
   const config = await loadConfigFile(resolvedPath);
 
   return {
@@ -249,6 +260,7 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<{
   configPath: string | null;
   found: boolean;
 }> {
+  // Pass the logger through to the underlying implementation
   const result = await loadFormSpecConfig(options);
 
   if (!result.found) {

--- a/packages/core/api-report/core.alpha.api.md
+++ b/packages/core/api-report/core.alpha.api.md
@@ -515,6 +515,9 @@ export function isField(element: FormElement): element is AnyField;
 export function isGroup(element: FormElement): element is Group<readonly FormElement[]>;
 
 // @public
+export function isNamespaceEnabled(pattern: string, namespace: string): boolean;
+
+// @public
 export function isNumberField(element: FormElement): element is NumberField<string>;
 
 // @public
@@ -541,6 +544,16 @@ export interface LengthConstraintNode {
     readonly path?: PathTarget;
     readonly provenance: Provenance;
     readonly value: number;
+}
+
+// @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
 }
 
 // @public
@@ -687,6 +700,9 @@ export interface MetadataValueRequireExplicitPolicyInput {
     readonly mode: "require-explicit";
     readonly pluralization?: MetadataPluralizationPolicyInput | undefined;
 }
+
+// @public
+export const noopLogger: LoggerLike;
 
 // @public
 export interface NormalizedDeclarationMetadataPolicy {

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -515,6 +515,9 @@ export function isField(element: FormElement): element is AnyField;
 export function isGroup(element: FormElement): element is Group<readonly FormElement[]>;
 
 // @public
+export function isNamespaceEnabled(pattern: string, namespace: string): boolean;
+
+// @public
 export function isNumberField(element: FormElement): element is NumberField<string>;
 
 // @public
@@ -541,6 +544,16 @@ export interface LengthConstraintNode {
     readonly path?: PathTarget;
     readonly provenance: Provenance;
     readonly value: number;
+}
+
+// @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
 }
 
 // @public
@@ -687,6 +700,9 @@ export interface MetadataValueRequireExplicitPolicyInput {
     readonly mode: "require-explicit";
     readonly pluralization?: MetadataPluralizationPolicyInput | undefined;
 }
+
+// @public
+export const noopLogger: LoggerLike;
 
 // @public
 export interface NormalizedDeclarationMetadataPolicy {

--- a/packages/core/api-report/core.beta.api.md
+++ b/packages/core/api-report/core.beta.api.md
@@ -515,6 +515,9 @@ export function isField(element: FormElement): element is AnyField;
 export function isGroup(element: FormElement): element is Group<readonly FormElement[]>;
 
 // @public
+export function isNamespaceEnabled(pattern: string, namespace: string): boolean;
+
+// @public
 export function isNumberField(element: FormElement): element is NumberField<string>;
 
 // @public
@@ -541,6 +544,16 @@ export interface LengthConstraintNode {
     readonly path?: PathTarget;
     readonly provenance: Provenance;
     readonly value: number;
+}
+
+// @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
 }
 
 // @public
@@ -687,6 +700,9 @@ export interface MetadataValueRequireExplicitPolicyInput {
     readonly mode: "require-explicit";
     readonly pluralization?: MetadataPluralizationPolicyInput | undefined;
 }
+
+// @public
+export const noopLogger: LoggerLike;
 
 // @public
 export interface NormalizedDeclarationMetadataPolicy {

--- a/packages/core/api-report/core.public.api.md
+++ b/packages/core/api-report/core.public.api.md
@@ -329,6 +329,9 @@ export function isField(element: FormElement): element is AnyField;
 export function isGroup(element: FormElement): element is Group<readonly FormElement[]>;
 
 // @public
+export function isNamespaceEnabled(pattern: string, namespace: string): boolean;
+
+// @public
 export function isNumberField(element: FormElement): element is NumberField<string>;
 
 // @public
@@ -339,6 +342,16 @@ export function isStaticEnumField(element: FormElement): element is StaticEnumFi
 
 // @public
 export function isTextField(element: FormElement): element is TextField<string>;
+
+// @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+}
 
 // @public
 export interface MetadataAnalysisResult {
@@ -484,6 +497,9 @@ export interface MetadataValueRequireExplicitPolicyInput {
     readonly mode: "require-explicit";
     readonly pluralization?: MetadataPluralizationPolicyInput | undefined;
 }
+
+// @public
+export const noopLogger: LoggerLike;
 
 // @public
 export interface NormalizedDeclarationMetadataPolicy {

--- a/packages/core/src/__tests__/logger.test.ts
+++ b/packages/core/src/__tests__/logger.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the shared logger contract in `@formspec/core`.
+ *
+ * Semantics follow the `debug` npm package convention: comma-separated
+ * patterns, `*` wildcard, `-` prefix for negation, and negations always win
+ * regardless of ordering.
+ *
+ * @see https://github.com/debug-js/debug#wildcards
+ */
+import { describe, expect, it, vi } from "vitest";
+import { isNamespaceEnabled, noopLogger } from "../logger.js";
+
+describe("isNamespaceEnabled", () => {
+  describe("empty and whitespace patterns", () => {
+    it("returns false for empty string", () => {
+      expect(isNamespaceEnabled("", "formspec:cli")).toBe(false);
+    });
+
+    it("returns false for whitespace-only string", () => {
+      expect(isNamespaceEnabled("   ", "formspec:cli")).toBe(false);
+    });
+
+    it("returns false for a list of empty commas", () => {
+      expect(isNamespaceEnabled(",,,", "formspec:cli")).toBe(false);
+    });
+  });
+
+  describe("exact match", () => {
+    it("enables exact namespace match", () => {
+      expect(isNamespaceEnabled("formspec:cli", "formspec:cli")).toBe(true);
+    });
+
+    it("does not enable non-matching namespace", () => {
+      expect(isNamespaceEnabled("formspec:cli", "formspec:build")).toBe(false);
+    });
+
+    it("treats `:` as a literal character", () => {
+      expect(isNamespaceEnabled("formspec:cli", "formspec_cli")).toBe(false);
+    });
+  });
+
+  describe("wildcards", () => {
+    it("matches everything under a prefix with `*`", () => {
+      expect(isNamespaceEnabled("formspec:*", "formspec:cli")).toBe(true);
+      expect(isNamespaceEnabled("formspec:*", "formspec:build:ir")).toBe(true);
+    });
+
+    it("does not match a different prefix", () => {
+      expect(isNamespaceEnabled("formspec:*", "other:cli")).toBe(false);
+    });
+
+    it("matches multi-segment wildcard", () => {
+      expect(isNamespaceEnabled("*:ir", "formspec:build:ir")).toBe(true);
+    });
+
+    it("bare `*` matches anything", () => {
+      expect(isNamespaceEnabled("*", "anything")).toBe(true);
+    });
+  });
+
+  describe("negation", () => {
+    it("disables a specific namespace under a wildcard", () => {
+      expect(isNamespaceEnabled("formspec:*,-formspec:cli", "formspec:cli")).toBe(false);
+    });
+
+    it("still enables non-negated namespaces under the wildcard", () => {
+      expect(isNamespaceEnabled("formspec:*,-formspec:cli", "formspec:build")).toBe(true);
+    });
+
+    it("negation wins regardless of ordering", () => {
+      expect(isNamespaceEnabled("-formspec:cli,formspec:*", "formspec:cli")).toBe(false);
+    });
+
+    it("negation without a positive pattern leaves everything disabled", () => {
+      expect(isNamespaceEnabled("-formspec:cli", "formspec:cli")).toBe(false);
+      expect(isNamespaceEnabled("-formspec:cli", "formspec:build")).toBe(false);
+    });
+
+    it("wildcard negation disables a whole prefix", () => {
+      expect(isNamespaceEnabled("*,-formspec:*", "formspec:cli")).toBe(false);
+      expect(isNamespaceEnabled("*,-formspec:*", "other:foo")).toBe(true);
+    });
+  });
+
+  describe("comma-separated lists", () => {
+    it("enables when any positive pattern matches", () => {
+      expect(isNamespaceEnabled("formspec:cli,formspec:build", "formspec:build")).toBe(true);
+    });
+
+    it("ignores whitespace around patterns", () => {
+      expect(isNamespaceEnabled("  formspec:cli  ,  formspec:build  ", "formspec:cli")).toBe(true);
+    });
+  });
+
+  describe("malformed input does not throw", () => {
+    it("handles lone `-`", () => {
+      expect(() => isNamespaceEnabled("-", "formspec:cli")).not.toThrow();
+      expect(isNamespaceEnabled("-", "formspec:cli")).toBe(false);
+    });
+
+    it("handles regex metacharacters in the pattern", () => {
+      expect(() => isNamespaceEnabled("form(spec", "form(spec")).not.toThrow();
+      expect(isNamespaceEnabled("form(spec", "form(spec")).toBe(true);
+    });
+  });
+});
+
+describe("noopLogger", () => {
+  it("child() returns a LoggerLike", () => {
+    const child = noopLogger.child({ stage: "ir" });
+    expect(typeof child.debug).toBe("function");
+  });
+
+  it("does not write to console", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {
+      /* silence */
+    });
+    try {
+      noopLogger.trace("x");
+      noopLogger.debug("x");
+      noopLogger.info("x");
+      noopLogger.warn("x");
+      noopLogger.error("x");
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,6 +147,10 @@ export {
   defineAnnotation,
 } from "./extensions/index.js";
 
+// Logger contract
+export type { LoggerLike } from "./logger.js";
+export { noopLogger, isNamespaceEnabled } from "./logger.js";
+
 // Re-export type guards
 export {
   isField,

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,0 +1,122 @@
+/**
+ * Minimal structured-logger contract used across FormSpec.
+ *
+ * Libraries accept a `LoggerLike` so callers can route diagnostics through
+ * their own logger (e.g. pino in apps, the tsserver logger inside a TypeScript
+ * language service plugin) without pulling a specific logger implementation
+ * into published packages.
+ *
+ * The shape is a subset of pino's `Logger` and is trivially satisfiable by
+ * most structured loggers.
+ *
+ * @public
+ */
+export interface LoggerLike {
+  /** Writes a record at the finest-grained verbosity. */
+  trace(msg: string, ...args: unknown[]): void;
+  /** Writes a diagnostic record used when investigating behaviour. */
+  debug(msg: string, ...args: unknown[]): void;
+  /** Writes an informational record about normal operation. */
+  info(msg: string, ...args: unknown[]): void;
+  /** Writes a record about a recoverable or unexpected condition. */
+  warn(msg: string, ...args: unknown[]): void;
+  /** Writes a record about a failure that prevented the requested work. */
+  error(msg: string, ...args: unknown[]): void;
+  /**
+   * Returns a child logger that tags every subsequent record with the given
+   * bindings (e.g. `{ stage: "ir" }`).
+   */
+  child(bindings: Record<string, unknown>): LoggerLike;
+}
+
+/**
+ * Silent logger used as the default when no logger is injected. All methods
+ * are no-ops and `child` returns the same instance.
+ *
+ * @public
+ */
+function noop(): void {
+  // Intentionally empty — noopLogger discards all records.
+}
+
+/**
+ * A silent logger used as the default when no logger is injected.
+ *
+ * @remarks
+ * All methods are no-ops, but **arguments are still evaluated** by the caller
+ * before being passed in. Gate expensive argument construction yourself
+ * (e.g. `if (log !== noopLogger) log.debug(expensiveFormat(x))`) when the
+ * work would be significant.
+ *
+ * @public
+ */
+export const noopLogger: LoggerLike = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  child: () => noopLogger,
+};
+
+/**
+ * Tests whether a namespace should be enabled given a `DEBUG` pattern string.
+ *
+ * @remarks
+ * Supports the same convention as the `debug` npm package:
+ *
+ * - Comma-separated list of patterns (whitespace around each pattern is
+ *   ignored).
+ * - `*` matches any sequence of characters (glob-style, not regex). All
+ *   other characters match literally.
+ * - A pattern prefixed with `-` is a **negation**. Any matching negation
+ *   disables the namespace regardless of ordering — negations always win
+ *   over positives.
+ *
+ * Empty or whitespace-only `pattern` returns `false`.
+ *
+ * @example
+ * isNamespaceEnabled("formspec:*", "formspec:cli"); // true
+ * isNamespaceEnabled("formspec:*,-formspec:cli", "formspec:cli"); // false
+ * isNamespaceEnabled("-formspec:cli,formspec:*", "formspec:cli"); // false
+ * isNamespaceEnabled("", "formspec:cli"); // false
+ *
+ * @public
+ */
+export function isNamespaceEnabled(pattern: string, namespace: string): boolean {
+  if (pattern.trim().length === 0) {
+    return false;
+  }
+
+  const patterns = pattern
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  // Negations always win regardless of order.
+  for (const p of patterns) {
+    if (p.startsWith("-") && matchesGlob(p.slice(1), namespace)) {
+      return false;
+    }
+  }
+
+  for (const p of patterns) {
+    if (!p.startsWith("-") && matchesGlob(p, namespace)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function matchesGlob(glob: string, namespace: string): boolean {
+  if (glob.length === 0) {
+    return false;
+  }
+  const regexSource = glob.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  try {
+    return new RegExp(`^${regexSource}$`).test(namespace);
+  } catch {
+    return false;
+  }
+}

--- a/packages/formspec/api-report/formspec.alpha.api.md
+++ b/packages/formspec/api-report/formspec.alpha.api.md
@@ -37,6 +37,7 @@ export function buildFormSchemas<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
 }
 
 // @public
@@ -290,6 +291,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 // @public
 export interface GenerateJsonSchemaOptions {
     readonly enumSerialization?: "enum" | "oneOf";
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
 }
@@ -299,6 +301,7 @@ export function generateUiSchema<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
 }
 
@@ -420,6 +423,16 @@ export interface LabelElement {
 }
 
 // @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+}
+
+// @public
 export function logValidationIssues(result: ValidationResult, formName?: string): void;
 
 // @public
@@ -501,6 +514,9 @@ export interface MetadataValueRequireExplicitPolicyInput {
     readonly mode: "require-explicit";
     readonly pluralization?: MetadataPluralizationPolicyInput | undefined;
 }
+
+// @public
+export const noopLogger: LoggerLike;
 
 // @public
 export interface NumberField<N extends string> {
@@ -667,6 +683,7 @@ export function writeSchemas<E extends readonly FormElement[]>(form: FormSpec<E>
 // @public
 export interface WriteSchemasOptions extends GenerateJsonSchemaOptions {
     readonly indent?: number;
+    readonly logger?: LoggerLike | undefined;
     readonly name?: string;
     readonly outDir: string;
 }

--- a/packages/formspec/api-report/formspec.api.md
+++ b/packages/formspec/api-report/formspec.api.md
@@ -37,6 +37,7 @@ export function buildFormSchemas<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
 }
 
 // @public
@@ -290,6 +291,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 // @public
 export interface GenerateJsonSchemaOptions {
     readonly enumSerialization?: "enum" | "oneOf";
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
 }
@@ -299,6 +301,7 @@ export function generateUiSchema<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
 }
 
@@ -420,6 +423,16 @@ export interface LabelElement {
 }
 
 // @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+}
+
+// @public
 export function logValidationIssues(result: ValidationResult, formName?: string): void;
 
 // @public
@@ -501,6 +514,9 @@ export interface MetadataValueRequireExplicitPolicyInput {
     readonly mode: "require-explicit";
     readonly pluralization?: MetadataPluralizationPolicyInput | undefined;
 }
+
+// @public
+export const noopLogger: LoggerLike;
 
 // @public
 export interface NumberField<N extends string> {
@@ -667,6 +683,7 @@ export function writeSchemas<E extends readonly FormElement[]>(form: FormSpec<E>
 // @public
 export interface WriteSchemasOptions extends GenerateJsonSchemaOptions {
     readonly indent?: number;
+    readonly logger?: LoggerLike | undefined;
     readonly name?: string;
     readonly outDir: string;
 }

--- a/packages/formspec/api-report/formspec.beta.api.md
+++ b/packages/formspec/api-report/formspec.beta.api.md
@@ -37,6 +37,7 @@ export function buildFormSchemas<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
 }
 
 // @public
@@ -290,6 +291,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 // @public
 export interface GenerateJsonSchemaOptions {
     readonly enumSerialization?: "enum" | "oneOf";
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
 }
@@ -299,6 +301,7 @@ export function generateUiSchema<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
 }
 
@@ -420,6 +423,16 @@ export interface LabelElement {
 }
 
 // @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+}
+
+// @public
 export function logValidationIssues(result: ValidationResult, formName?: string): void;
 
 // @public
@@ -501,6 +514,9 @@ export interface MetadataValueRequireExplicitPolicyInput {
     readonly mode: "require-explicit";
     readonly pluralization?: MetadataPluralizationPolicyInput | undefined;
 }
+
+// @public
+export const noopLogger: LoggerLike;
 
 // @public
 export interface NumberField<N extends string> {
@@ -667,6 +683,7 @@ export function writeSchemas<E extends readonly FormElement[]>(form: FormSpec<E>
 // @public
 export interface WriteSchemasOptions extends GenerateJsonSchemaOptions {
     readonly indent?: number;
+    readonly logger?: LoggerLike | undefined;
     readonly name?: string;
     readonly outDir: string;
 }

--- a/packages/formspec/api-report/formspec.public.api.md
+++ b/packages/formspec/api-report/formspec.public.api.md
@@ -37,6 +37,7 @@ export function buildFormSchemas<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
 }
 
 // @public
@@ -290,6 +291,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 // @public
 export interface GenerateJsonSchemaOptions {
     readonly enumSerialization?: "enum" | "oneOf";
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
 }
@@ -299,6 +301,7 @@ export function generateUiSchema<E extends readonly FormElement[]>(form: FormSpe
 
 // @public
 export interface GenerateUiSchemaOptions {
+    readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
 }
 
@@ -420,6 +423,16 @@ export interface LabelElement {
 }
 
 // @public
+export interface LoggerLike {
+    child(bindings: Record<string, unknown>): LoggerLike;
+    debug(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+    info(msg: string, ...args: unknown[]): void;
+    trace(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+}
+
+// @public
 export function logValidationIssues(result: ValidationResult, formName?: string): void;
 
 // @public
@@ -501,6 +514,9 @@ export interface MetadataValueRequireExplicitPolicyInput {
     readonly mode: "require-explicit";
     readonly pluralization?: MetadataPluralizationPolicyInput | undefined;
 }
+
+// @public
+export const noopLogger: LoggerLike;
 
 // @public
 export interface NumberField<N extends string> {
@@ -667,6 +683,7 @@ export function writeSchemas<E extends readonly FormElement[]>(form: FormSpec<E>
 // @public
 export interface WriteSchemasOptions extends GenerateJsonSchemaOptions {
     readonly indent?: number;
+    readonly logger?: LoggerLike | undefined;
     readonly name?: string;
     readonly outDir: string;
 }

--- a/packages/formspec/src/index.ts
+++ b/packages/formspec/src/index.ts
@@ -140,7 +140,8 @@ export type {
   Predicate,
 } from "@formspec/core";
 
-export { createInitialFieldState } from "@formspec/core";
+export { createInitialFieldState, noopLogger } from "@formspec/core";
+export type { LoggerLike } from "@formspec/core";
 
 // Type guards
 export {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -31,6 +31,7 @@
     "@formspec/analysis": "workspace:*",
     "@formspec/config": "workspace:*",
     "@formspec/core": "workspace:*",
+    "pino": "^9.0.0",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12"
   },

--- a/packages/language-server/src/__tests__/logger.test.ts
+++ b/packages/language-server/src/__tests__/logger.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLogger } from "../logger.js";
+
+// Pattern-matcher semantics are covered by @formspec/core's logger test suite.
+
+// ---------------------------------------------------------------------------
+// createLogger — routing
+// ---------------------------------------------------------------------------
+describe("createLogger", () => {
+  const originalDebug = process.env["DEBUG"];
+
+  beforeEach(() => {
+    process.env["DEBUG"] = "formspec:lsp";
+  });
+
+  afterEach(() => {
+    if (originalDebug === undefined) {
+      delete process.env["DEBUG"];
+    } else {
+      process.env["DEBUG"] = originalDebug;
+    }
+  });
+
+  function makeConnection() {
+    return {
+      console: {
+        log: vi.fn<(msg: string) => void>(),
+        info: vi.fn<(msg: string) => void>(),
+        warn: vi.fn<(msg: string) => void>(),
+        error: vi.fn<(msg: string) => void>(),
+      },
+    };
+  }
+
+  it("returns noopLogger when namespace is not enabled", () => {
+    process.env["DEBUG"] = "";
+    const connection = makeConnection();
+    const log = createLogger("formspec:lsp", connection);
+
+    log.info("hello");
+    expect(connection.console.log).not.toHaveBeenCalled();
+    expect(connection.console.warn).not.toHaveBeenCalled();
+    expect(connection.console.error).not.toHaveBeenCalled();
+  });
+
+  it("routes info-level to connection.console.info", () => {
+    const connection = makeConnection();
+    const log = createLogger("formspec:lsp", connection);
+
+    log.info("info message");
+
+    // pino is async by default; flush the Writable
+    // We use setImmediate to let the stream drain within the same tick cycle
+    return new Promise<void>((resolve) => {
+      setImmediate(() => {
+        expect(connection.console.info).toHaveBeenCalled();
+        expect(connection.console.log).not.toHaveBeenCalled();
+        expect(connection.console.warn).not.toHaveBeenCalled();
+        expect(connection.console.error).not.toHaveBeenCalled();
+        resolve();
+      });
+    });
+  });
+
+  it("routes debug-level to connection.console.log", () => {
+    const connection = makeConnection();
+    const log = createLogger("formspec:lsp", connection);
+
+    log.debug("debug message");
+
+    return new Promise<void>((resolve) => {
+      setImmediate(() => {
+        expect(connection.console.log).toHaveBeenCalled();
+        resolve();
+      });
+    });
+  });
+
+  it("routes trace-level to connection.console.log", () => {
+    const connection = makeConnection();
+    const log = createLogger("formspec:lsp", connection);
+
+    log.trace("trace message");
+
+    return new Promise<void>((resolve) => {
+      setImmediate(() => {
+        expect(connection.console.log).toHaveBeenCalled();
+        resolve();
+      });
+    });
+  });
+
+  it("routes warn-level to connection.console.warn", () => {
+    const connection = makeConnection();
+    const log = createLogger("formspec:lsp", connection);
+
+    log.warn("warn message");
+
+    return new Promise<void>((resolve) => {
+      setImmediate(() => {
+        expect(connection.console.warn).toHaveBeenCalled();
+        expect(connection.console.error).not.toHaveBeenCalled();
+        resolve();
+      });
+    });
+  });
+
+  it("routes error-level to connection.console.error", () => {
+    const connection = makeConnection();
+    const log = createLogger("formspec:lsp", connection);
+
+    log.error("error message");
+
+    return new Promise<void>((resolve) => {
+      setImmediate(() => {
+        expect(connection.console.error).toHaveBeenCalled();
+        expect(connection.console.warn).not.toHaveBeenCalled();
+        resolve();
+      });
+    });
+  });
+
+  it("child logger inherits routing behaviour", () => {
+    const connection = makeConnection();
+    const log = createLogger("formspec:lsp", connection);
+    const child = log.child({ stage: "init" });
+
+    child.warn("child warn");
+
+    return new Promise<void>((resolve) => {
+      setImmediate(() => {
+        expect(connection.console.warn).toHaveBeenCalled();
+        resolve();
+      });
+    });
+  });
+});

--- a/packages/language-server/src/logger.ts
+++ b/packages/language-server/src/logger.ts
@@ -1,0 +1,176 @@
+/**
+ * Pino-backed logger factory for the FormSpec language server.
+ *
+ * Reads `process.env.DEBUG` to determine which namespaces are enabled.
+ * When enabled, writes each JSON log line to the LSP connection's console
+ * methods at the appropriate severity. When disabled, returns `noopLogger`.
+ *
+ * ## Enable convention
+ *
+ * `DEBUG=formspec:*` — enable all formspec namespaces
+ * `DEBUG=formspec:lsp` — enable only the language server namespace
+ * `DEBUG=formspec:*,-formspec:lsp:noisy` — wildcard with negation
+ */
+
+import { Writable } from "node:stream";
+import type { LoggerLike } from "@formspec/core";
+import { isNamespaceEnabled, noopLogger } from "@formspec/core";
+import pino from "pino";
+
+/**
+ * Minimal shape of the LSP connection console required by `createLogger`.
+ *
+ * The LSP protocol exposes four severity channels. Pino numeric levels are
+ * routed as: `trace/debug` → `log`, `info` → `info`, `warn` → `warn`,
+ * `error` → `error`.
+ */
+export interface LspConsole {
+  log(msg: string): void;
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+}
+
+/**
+ * Pino numeric log levels.
+ * @see https://github.com/pinojs/pino/blob/main/docs/api.md#loggerlevels
+ */
+const PINO_INFO = 30;
+const PINO_WARN = 40;
+const PINO_ERROR = 50;
+
+/**
+ * Shape of a pino JSON log record (only the fields we need for routing).
+ */
+interface PinoRecord {
+  level: number;
+  msg: string;
+}
+
+function isPinoRecord(value: unknown): value is PinoRecord {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>)["level"] === "number" &&
+    typeof (value as Record<string, unknown>)["msg"] === "string"
+  );
+}
+
+function buildSink(console: LspConsole): Writable {
+  // pino writes one JSON object per line, but Node streams may chunk writes
+  // across newline boundaries. Buffer partial lines across writes.
+  let buffer = "";
+
+  function emit(line: string): void {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    try {
+      const record: unknown = JSON.parse(trimmed);
+      if (!isPinoRecord(record)) {
+        console.log(trimmed);
+        return;
+      }
+      if (record.level >= PINO_ERROR) {
+        console.error(trimmed);
+      } else if (record.level >= PINO_WARN) {
+        console.warn(trimmed);
+      } else if (record.level >= PINO_INFO) {
+        console.info(trimmed);
+      } else {
+        console.log(trimmed);
+      }
+    } catch {
+      // Non-JSON line — forward as-is
+      console.log(trimmed);
+    }
+  }
+
+  return new Writable({
+    write(chunk: unknown, _encoding, callback) {
+      const raw: string =
+        chunk instanceof Buffer
+          ? chunk.toString("utf8")
+          : typeof chunk === "string"
+            ? chunk
+            : String(chunk);
+      buffer += raw;
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        emit(line);
+        newlineIndex = buffer.indexOf("\n");
+      }
+      callback();
+    },
+    final(callback) {
+      if (buffer.length > 0) {
+        emit(buffer);
+        buffer = "";
+      }
+      callback();
+    },
+  });
+}
+
+function wrapLogger(logger: pino.Logger): LoggerLike {
+  return {
+    // pino's log methods accept (msg: string) or (obj: object, msg: string).
+    // LoggerLike carries ...args: unknown[] for future extensibility but the
+    // LSP logger only needs to forward the message string — extra args are
+    // not used in practice here.
+    trace: (msg) => {
+      logger.trace(msg);
+    },
+    debug: (msg) => {
+      logger.debug(msg);
+    },
+    info: (msg) => {
+      logger.info(msg);
+    },
+    warn: (msg) => {
+      logger.warn(msg);
+    },
+    error: (msg) => {
+      logger.error(msg);
+    },
+    child: (bindings) => wrapLogger(logger.child(bindings)),
+  };
+}
+
+/**
+ * Creates a `LoggerLike` for the given namespace that forwards log records
+ * to the LSP connection console.
+ *
+ * When `process.env.DEBUG` enables the namespace, constructs a pino logger
+ * whose output is routed to the LSP connection console at the appropriate
+ * severity (trace/debug/info → `console.log`, warn → `console.warn`,
+ * error → `console.error`).
+ *
+ * When the namespace is not enabled, returns `noopLogger` with zero overhead.
+ *
+ * @param namespace - The debug namespace, e.g. `"formspec:lsp"`
+ * @param connection - An object with a `console` property matching `LspConsole`
+ */
+export function createLogger(
+  namespace: string,
+  connection: { console: LspConsole },
+): LoggerLike {
+  const debugEnv = process.env["DEBUG"] ?? "";
+  if (!isNamespaceEnabled(debugEnv, namespace)) {
+    return noopLogger;
+  }
+
+  const sink = buildSink(connection.console);
+  const baseLogger = pino(
+    {
+      level: "trace",
+      base: { namespace },
+    },
+    sink,
+  );
+
+  return wrapLogger(baseLogger);
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -31,6 +31,7 @@ import {
   getPluginCompletionContextForDocument,
   getPluginHoverForDocument,
 } from "./plugin-client.js";
+import { createLogger } from "./logger.js";
 
 const PLUGIN_QUERY_TIMEOUT_ENV_VAR = "FORMSPEC_PLUGIN_QUERY_TIMEOUT_MS";
 
@@ -110,6 +111,7 @@ export interface CreateServerOptions {
  */
 export function createServer(options: CreateServerOptions = {}): Connection {
   const connection = createConnection(ProposedFeatures.all);
+  const log = createLogger("formspec:lsp", connection);
   const documents = new TextDocuments(TextDocument);
   let workspaceRoots = [...(options.workspaceRoots ?? [])];
   const pluginQueryTimeoutMs = resolvePluginQueryTimeoutMs(options.pluginQueryTimeoutMs);
@@ -119,6 +121,7 @@ export function createServer(options: CreateServerOptions = {}): Connection {
   const effectiveExtensions: readonly ExtensionDefinition[] =
     options.config?.extensions ?? options.extensions ?? [];
 
+  log.info("FormSpec language server initializing");
   documents.listen(connection);
 
   async function publishDiagnosticsForDocument(document: TextDocument): Promise<void> {
@@ -139,6 +142,7 @@ export function createServer(options: CreateServerOptions = {}): Connection {
         pluginQueryTimeoutMs
       )) ?? [];
 
+    log.debug(`Publishing ${String(diagnostics.length)} diagnostic(s) for ${document.uri}`);
     void connection.sendDiagnostics({
       uri: document.uri,
       diagnostics: toLspDiagnostics(document, diagnostics, {
@@ -152,6 +156,7 @@ export function createServer(options: CreateServerOptions = {}): Connection {
       ...getWorkspaceRootsFromInitializeParams(params),
       ...workspaceRoots,
     ]);
+    log.info(`Connection initialized with ${String(workspaceRoots.length)} workspace root(s)`);
 
     return {
       capabilities: {
@@ -222,12 +227,14 @@ export function createServer(options: CreateServerOptions = {}): Connection {
   });
 
   documents.onDidOpen(({ document }) => {
+    log.debug(`Document opened: ${document.uri}`);
     void publishDiagnosticsForDocument(document).catch((error: unknown) => {
       connection.console.error(`[FormSpec] Failed to publish diagnostics: ${String(error)}`);
     });
   });
 
   documents.onDidChangeContent(({ document }) => {
+    log.debug(`Document changed: ${document.uri}`);
     void publishDiagnosticsForDocument(document).catch((error: unknown) => {
       connection.console.error(`[FormSpec] Failed to publish diagnostics: ${String(error)}`);
     });

--- a/packages/runtime/api-report/runtime.alpha.api.md
+++ b/packages/runtime/api-report/runtime.alpha.api.md
@@ -11,9 +11,15 @@ import type { FetchOptionsResponse } from '@formspec/core';
 import type { FormElement } from '@formspec/core';
 import type { FormSpec } from '@formspec/core';
 import type { Group } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 
 // @public
-export function defineResolvers<E extends readonly FormElement[], Sources extends string = ResolverSourcesForForm<E>>(form: FormSpec<E>, resolvers: ResolverMap<Sources>): ResolverRegistry<Sources>;
+export function defineResolvers<E extends readonly FormElement[], Sources extends string = ResolverSourcesForForm<E>>(form: FormSpec<E>, resolvers: ResolverMap<Sources>, options?: DefineResolversOptions): ResolverRegistry<Sources>;
+
+// @public
+export interface DefineResolversOptions {
+    readonly logger?: LoggerLike | undefined;
+}
 
 // @public
 export type ExtractDynamicSources<E> = E extends DynamicEnumField<string, infer S> ? S : E extends Group<infer Elements> ? ExtractDynamicSourcesFromArray<Elements> : E extends Conditional<string, unknown, infer Elements> ? ExtractDynamicSourcesFromArray<Elements> : never;

--- a/packages/runtime/api-report/runtime.api.md
+++ b/packages/runtime/api-report/runtime.api.md
@@ -11,9 +11,15 @@ import type { FetchOptionsResponse } from '@formspec/core';
 import type { FormElement } from '@formspec/core';
 import type { FormSpec } from '@formspec/core';
 import type { Group } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 
 // @public
-export function defineResolvers<E extends readonly FormElement[], Sources extends string = ResolverSourcesForForm<E>>(form: FormSpec<E>, resolvers: ResolverMap<Sources>): ResolverRegistry<Sources>;
+export function defineResolvers<E extends readonly FormElement[], Sources extends string = ResolverSourcesForForm<E>>(form: FormSpec<E>, resolvers: ResolverMap<Sources>, options?: DefineResolversOptions): ResolverRegistry<Sources>;
+
+// @public
+export interface DefineResolversOptions {
+    readonly logger?: LoggerLike | undefined;
+}
 
 // @public
 export type ExtractDynamicSources<E> = E extends DynamicEnumField<string, infer S> ? S : E extends Group<infer Elements> ? ExtractDynamicSourcesFromArray<Elements> : E extends Conditional<string, unknown, infer Elements> ? ExtractDynamicSourcesFromArray<Elements> : never;

--- a/packages/runtime/api-report/runtime.beta.api.md
+++ b/packages/runtime/api-report/runtime.beta.api.md
@@ -11,9 +11,15 @@ import type { FetchOptionsResponse } from '@formspec/core';
 import type { FormElement } from '@formspec/core';
 import type { FormSpec } from '@formspec/core';
 import type { Group } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 
 // @public
-export function defineResolvers<E extends readonly FormElement[], Sources extends string = ResolverSourcesForForm<E>>(form: FormSpec<E>, resolvers: ResolverMap<Sources>): ResolverRegistry<Sources>;
+export function defineResolvers<E extends readonly FormElement[], Sources extends string = ResolverSourcesForForm<E>>(form: FormSpec<E>, resolvers: ResolverMap<Sources>, options?: DefineResolversOptions): ResolverRegistry<Sources>;
+
+// @public
+export interface DefineResolversOptions {
+    readonly logger?: LoggerLike | undefined;
+}
 
 // @public
 export type ExtractDynamicSources<E> = E extends DynamicEnumField<string, infer S> ? S : E extends Group<infer Elements> ? ExtractDynamicSourcesFromArray<Elements> : E extends Conditional<string, unknown, infer Elements> ? ExtractDynamicSourcesFromArray<Elements> : never;

--- a/packages/runtime/api-report/runtime.public.api.md
+++ b/packages/runtime/api-report/runtime.public.api.md
@@ -11,9 +11,15 @@ import type { FetchOptionsResponse } from '@formspec/core';
 import type { FormElement } from '@formspec/core';
 import type { FormSpec } from '@formspec/core';
 import type { Group } from '@formspec/core';
+import type { LoggerLike } from '@formspec/core';
 
 // @public
-export function defineResolvers<E extends readonly FormElement[], Sources extends string = ResolverSourcesForForm<E>>(form: FormSpec<E>, resolvers: ResolverMap<Sources>): ResolverRegistry<Sources>;
+export function defineResolvers<E extends readonly FormElement[], Sources extends string = ResolverSourcesForForm<E>>(form: FormSpec<E>, resolvers: ResolverMap<Sources>, options?: DefineResolversOptions): ResolverRegistry<Sources>;
+
+// @public
+export interface DefineResolversOptions {
+    readonly logger?: LoggerLike | undefined;
+}
 
 // @public
 export type ExtractDynamicSources<E> = E extends DynamicEnumField<string, infer S> ? S : E extends Group<infer Elements> ? ExtractDynamicSourcesFromArray<Elements> : E extends Conditional<string, unknown, infer Elements> ? ExtractDynamicSourcesFromArray<Elements> : never;

--- a/packages/runtime/src/__tests__/logger.test.ts
+++ b/packages/runtime/src/__tests__/logger.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+import type { LoggerLike } from "@formspec/core";
+import { formspec, field } from "@formspec/dsl";
+import { defineResolvers } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Shared capturing logger helper
+// ---------------------------------------------------------------------------
+
+interface LogRecord {
+  readonly level: "trace" | "debug" | "info" | "warn" | "error";
+  readonly msg: string;
+  readonly bindings: Record<string, unknown>;
+}
+
+function makeCapturingLogger(
+  bindings: Record<string, unknown> = {}
+): { logger: LoggerLike; records: LogRecord[] } {
+  const records: LogRecord[] = [];
+
+  function build(currentBindings: Record<string, unknown>): LoggerLike {
+    const push =
+      (level: LogRecord["level"]) =>
+      (msg: string, ..._args: unknown[]) => {
+        records.push({ level, msg, bindings: { ...currentBindings } });
+      };
+    return {
+      trace: push("trace"),
+      debug: push("debug"),
+      info: push("info"),
+      warn: push("warn"),
+      error: push("error"),
+      child(childBindings) {
+        return build({ ...currentBindings, ...childBindings });
+      },
+    };
+  }
+
+  return { logger: build(bindings), records };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("@formspec/runtime logger integration", () => {
+  describe("defineResolvers", () => {
+    it("emits a debug record with stage=runtime when a resolver is invoked via .get()", () => {
+      // Integration: asserts resolver invocation triggers a debug log (plan §3 @formspec/runtime)
+      const { logger, records } = makeCapturingLogger();
+
+      const form = formspec(field.dynamicEnum("country", "countries", { label: "Country" }));
+      const resolvers = defineResolvers(
+        form,
+        {
+          countries: async () => {
+            await Promise.resolve();
+            return { options: [{ value: "us", label: "United States" }], validity: "valid" as const };
+          },
+        },
+        { logger }
+      );
+
+      // Invoke the resolver to trigger the debug log
+      resolvers.get("countries");
+
+      const runtimeRecord = records.find(
+        (r) => r.level === "debug" && r.bindings["stage"] === "runtime"
+      );
+      expect(runtimeRecord).toBeDefined(); // stage: "runtime" binding present
+      // .get() returns the resolver function reference — it does not invoke it
+      expect(runtimeRecord?.msg).toContain("resolver requested");
+    });
+
+    it("emits an error record at .error level when resolver is missing", () => {
+      // Regression: missing resolver should log at error level (plan §3 @formspec/runtime)
+      const { logger, records } = makeCapturingLogger();
+
+      const form = formspec(field.dynamicEnum("country", "countries"));
+      const resolvers = defineResolvers(
+        form,
+        {
+          countries: async () => {
+            await Promise.resolve();
+            return { options: [], validity: "valid" as const };
+          },
+        },
+        { logger }
+      );
+
+      expect(() => resolvers.get("unknown" as "countries")).toThrow(
+        "No resolver found for data source: unknown"
+      );
+
+      const errorRecord = records.find((r) => r.level === "error");
+      expect(errorRecord).toBeDefined(); // error log emitted for missing resolver
+    });
+
+    it("produces no console output when logger is omitted", () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { /* silence */ });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => { /* silence */ });
+
+      const form = formspec(field.dynamicEnum("country", "countries"));
+
+      try {
+        const resolvers = defineResolvers(form, {
+          countries: async () => {
+            await Promise.resolve();
+            return { options: [], validity: "valid" as const };
+          },
+        });
+        resolvers.get("countries");
+      } finally {
+        consoleSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+      }
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -35,6 +35,7 @@
 
 export {
   defineResolvers,
+  type DefineResolversOptions,
   type ExtractDynamicSources,
   type ExtractDynamicSourcesFromArray,
   type Resolver,

--- a/packages/runtime/src/resolvers.ts
+++ b/packages/runtime/src/resolvers.ts
@@ -14,7 +14,9 @@ import type {
   DynamicEnumField,
   Group,
   Conditional,
+  LoggerLike,
 } from "@formspec/core";
+import { noopLogger } from "@formspec/core";
 
 /**
  * A resolver function that fetches options for a data source.
@@ -122,6 +124,19 @@ function extractSources(elements: readonly FormElement[]): Set<string> {
 }
 
 /**
+ * Options for `defineResolvers`.
+ *
+ * @public
+ */
+export interface DefineResolversOptions {
+  /**
+   * Optional logger for diagnostic output. Defaults to a no-op logger so
+   * existing callers produce no output.
+   */
+  readonly logger?: LoggerLike | undefined;
+}
+
+/**
  * Defines resolvers for a form's dynamic data sources.
  *
  * This function provides type-safe resolver definitions that match
@@ -155,6 +170,7 @@ function extractSources(elements: readonly FormElement[]): Set<string> {
  *
  * @param form - The FormSpec containing dynamic enum fields
  * @param resolvers - Map of resolver functions for each data source
+ * @param options - Optional options including a logger
  * @returns A ResolverRegistry for type-safe access to resolvers
  *
  * @public
@@ -162,7 +178,12 @@ function extractSources(elements: readonly FormElement[]): Set<string> {
 export function defineResolvers<
   E extends readonly FormElement[],
   Sources extends string = ResolverSourcesForForm<E>,
->(form: FormSpec<E>, resolvers: ResolverMap<Sources>): ResolverRegistry<Sources> {
+>(
+  form: FormSpec<E>,
+  resolvers: ResolverMap<Sources>,
+  options?: DefineResolversOptions
+): ResolverRegistry<Sources> {
+  const logger = (options?.logger ?? noopLogger).child({ stage: "runtime" });
   const sourceSet = extractSources(form.elements);
   const resolverMap = new Map<string, Resolver<keyof DataSourceRegistry>>(
     Object.entries(resolvers) as [string, Resolver<keyof DataSourceRegistry>][]
@@ -179,8 +200,11 @@ export function defineResolvers<
     get<S extends Sources>(source: S) {
       const resolver = resolverMap.get(source);
       if (resolver === undefined) {
-        throw new Error(`No resolver found for data source: ${source}`);
+        const err = new Error(`No resolver found for data source: ${source}`);
+        logger.error(err.message, { source });
+        throw err;
       }
+      logger.debug("resolver requested", { source });
       return resolver as S extends keyof DataSourceRegistry
         ? Resolver<S>
         : (params?: Record<string, unknown>) => Promise<FetchOptionsResponse>;

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -29,7 +29,8 @@
     "api-documenter": "api-documenter markdown -i temp -o docs && node ../../scripts/normalize-generated-markdown.mjs docs"
   },
   "dependencies": {
-    "@formspec/analysis": "workspace:*"
+    "@formspec/analysis": "workspace:*",
+    "@formspec/core": "workspace:*"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/ts-plugin/src/__tests__/logger.test.ts
+++ b/packages/ts-plugin/src/__tests__/logger.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as tsServer from "typescript/lib/tsserverlibrary.js";
+import { fromTsLogger, isNamespaceEnabled } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// Fake ts.server.Logger
+// ---------------------------------------------------------------------------
+
+function createFakeTsLogger(loggingEnabled = true): {
+  logger: tsServer.server.Logger;
+  msgSpy: ReturnType<typeof vi.fn>;
+  infoSpy: ReturnType<typeof vi.fn>;
+} {
+  const msgSpy = vi.fn();
+  const infoSpy = vi.fn();
+
+  const logger = {
+    close: vi.fn(),
+    hasLevel: vi.fn().mockReturnValue(true),
+    loggingEnabled: vi.fn().mockReturnValue(loggingEnabled),
+    perftrc: vi.fn(),
+    info: infoSpy,
+    startGroup: vi.fn(),
+    endGroup: vi.fn(),
+    msg: msgSpy,
+    getLogFileName: vi.fn().mockReturnValue(undefined),
+  } as unknown as tsServer.server.Logger;
+
+  return { logger, msgSpy, infoSpy };
+}
+
+// ---------------------------------------------------------------------------
+// isNamespaceEnabled
+// ---------------------------------------------------------------------------
+
+describe("isNamespaceEnabled", () => {
+  const originalDebug = process.env["DEBUG"];
+
+  afterEach(() => {
+    if (originalDebug === undefined) {
+      delete process.env["DEBUG"];
+    } else {
+      process.env["DEBUG"] = originalDebug;
+    }
+  });
+
+  it("returns false when DEBUG is not set", () => {
+    delete process.env["DEBUG"];
+    expect(isNamespaceEnabled("formspec:ts-plugin")).toBe(false);
+  });
+
+  it("returns false when DEBUG is an empty string", () => {
+    process.env["DEBUG"] = "";
+    expect(isNamespaceEnabled("formspec:ts-plugin")).toBe(false);
+  });
+
+  it("returns true when DEBUG exactly matches the namespace", () => {
+    process.env["DEBUG"] = "formspec:ts-plugin";
+    expect(isNamespaceEnabled("formspec:ts-plugin")).toBe(true);
+  });
+
+  it("returns true when DEBUG uses a wildcard that covers the namespace", () => {
+    process.env["DEBUG"] = "formspec:*";
+    expect(isNamespaceEnabled("formspec:ts-plugin")).toBe(true);
+    expect(isNamespaceEnabled("formspec:build")).toBe(true);
+  });
+
+  it("returns false when wildcard does not cover the namespace", () => {
+    process.env["DEBUG"] = "formspec:*";
+    expect(isNamespaceEnabled("other:service")).toBe(false);
+  });
+
+  it("returns false when namespace is negated", () => {
+    process.env["DEBUG"] = "-formspec:ts-plugin";
+    expect(isNamespaceEnabled("formspec:ts-plugin")).toBe(false);
+  });
+
+  it("returns true for non-negated namespace when another is negated", () => {
+    process.env["DEBUG"] = "formspec:*,-formspec:build";
+    expect(isNamespaceEnabled("formspec:ts-plugin")).toBe(true);
+    expect(isNamespaceEnabled("formspec:build")).toBe(false);
+  });
+
+  it("returns false for formspec:build when -formspec:build is in comma list", () => {
+    process.env["DEBUG"] = "formspec:cli,-formspec:build";
+    expect(isNamespaceEnabled("formspec:cli")).toBe(true);
+    expect(isNamespaceEnabled("formspec:build")).toBe(false);
+  });
+
+  it("does not throw on malformed DEBUG patterns", () => {
+    process.env["DEBUG"] = "((bad-regex";
+    expect(() => isNamespaceEnabled("formspec:ts-plugin")).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fromTsLogger — level routing
+// ---------------------------------------------------------------------------
+
+describe("fromTsLogger", () => {
+  const originalDebug = process.env["DEBUG"];
+
+  beforeEach(() => {
+    process.env["DEBUG"] = "formspec:ts-plugin";
+  });
+
+  afterEach(() => {
+    if (originalDebug === undefined) {
+      delete process.env["DEBUG"];
+    } else {
+      process.env["DEBUG"] = originalDebug;
+    }
+  });
+
+  it("routes trace to ts.server.Msg.Info", () => {
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    log.trace("hello trace");
+    expect(msgSpy).toHaveBeenCalledOnce();
+    const [message, type] = msgSpy.mock.calls[0] as [string, string];
+    expect(type).toBe("Info");
+    expect(message).toContain("hello trace");
+  });
+
+  it("routes debug to ts.server.Msg.Info", () => {
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    log.debug("hello debug");
+    const [, type] = msgSpy.mock.calls[0] as [string, string];
+    expect(type).toBe("Info");
+  });
+
+  it("routes info to ts.server.Msg.Info", () => {
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    log.info("hello info");
+    const [, type] = msgSpy.mock.calls[0] as [string, string];
+    expect(type).toBe("Info");
+  });
+
+  it("routes warn to ts.server.Msg.Info with [WARN] prefix in message", () => {
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    log.warn("careful");
+    const [message, type] = msgSpy.mock.calls[0] as [string, string];
+    expect(type).toBe("Info");
+    expect(message).toContain("[WARN]");
+    expect(message).toContain("careful");
+  });
+
+  it("routes error to ts.server.Msg.Err", () => {
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    log.error("boom");
+    const [, type] = msgSpy.mock.calls[0] as [string, string];
+    expect(type).toBe("Err");
+  });
+
+  // ---------------------------------------------------------------------------
+  // loggingEnabled gating
+  // ---------------------------------------------------------------------------
+
+  it("does not emit when loggingEnabled() returns false", () => {
+    const { logger, msgSpy } = createFakeTsLogger(false);
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    log.info("silent");
+    log.error("also silent");
+    expect(msgSpy).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Namespace prefix
+  // ---------------------------------------------------------------------------
+
+  it("prefixes messages with the namespace in brackets", () => {
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    log.info("test message");
+    const [message] = msgSpy.mock.calls[0] as [string];
+    expect(message).toMatch(/^\[formspec:ts-plugin\]/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // DEBUG gating
+  // ---------------------------------------------------------------------------
+
+  it("returns noopLogger when namespace is not in DEBUG", () => {
+    process.env["DEBUG"] = "formspec:build";
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    log.info("should be silent");
+    expect(msgSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns noopLogger when DEBUG is unset and namespace is provided", () => {
+    delete process.env["DEBUG"];
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    log.info("silent");
+    expect(msgSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not gate when no namespace is provided (namespace-less adapter always emits)", () => {
+    delete process.env["DEBUG"];
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger);
+    log.info("always on");
+    expect(msgSpy).toHaveBeenCalledOnce();
+  });
+
+  // ---------------------------------------------------------------------------
+  // child logger
+  // ---------------------------------------------------------------------------
+
+  it("child logger includes bindings in the prefix", () => {
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    const child = log.child({ stage: "ir", phase: "2" });
+    child.info("child message");
+    const [message] = msgSpy.mock.calls[0] as [string];
+    expect(message).toContain("stage=ir");
+    expect(message).toContain("phase=2");
+    expect(message).toContain("child message");
+  });
+
+  it("child logger accumulates bindings from parent", () => {
+    const { logger, msgSpy } = createFakeTsLogger();
+    const log = fromTsLogger(logger, { namespace: "formspec:ts-plugin" });
+    const child = log.child({ a: "1" });
+    const grandchild = child.child({ b: "2" });
+    grandchild.info("deep");
+    const [message] = msgSpy.mock.calls[0] as [string];
+    expect(message).toContain("a=1");
+    expect(message).toContain("b=2");
+  });
+});

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -40,6 +40,7 @@ export {
   type FormSpecSerializedTagSignature,
 } from "@formspec/analysis";
 import { createLanguageServiceProxy, FormSpecPluginService } from "./service.js";
+import { fromTsLogger } from "./logger.js";
 export {
   createLanguageServiceProxy,
   FormSpecPluginService,
@@ -83,6 +84,8 @@ function readNumberEnvFlag(name: string): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+const PLUGIN_NAMESPACE = "formspec:ts-plugin";
+
 function getOrCreateService(
   info: tsServer.server.PluginCreateInfo,
   typescriptVersion: string
@@ -95,12 +98,17 @@ function getOrCreateService(
     return existing.service;
   }
 
+  const tsLogger = info.project.projectService.logger;
+  // Build a rich FormSpec LoggerLike that prefixes every line with
+  // [formspec:ts-plugin] and gates on DEBUG=formspec:ts-plugin (or DEBUG=formspec:*).
+  const pluginLogger = fromTsLogger(tsLogger, { namespace: PLUGIN_NAMESPACE });
+
   const performanceLogThresholdMs = readNumberEnvFlag(PERF_LOG_THRESHOLD_ENV_VAR);
   const service = new FormSpecPluginService({
     workspaceRoot,
     typescriptVersion,
     getProgram: () => info.languageService.getProgram(),
-    logger: info.project.projectService.logger,
+    logger: tsLogger,
     enablePerformanceLogging: readBooleanEnvFlag(PERF_LOG_ENV_VAR),
     ...(performanceLogThresholdMs === undefined ? {} : { performanceLogThresholdMs }),
   });
@@ -109,14 +117,24 @@ function getOrCreateService(
     service,
     referenceCount: 1,
   };
-  attachProjectCloseHandler(info, workspaceRoot, serviceEntry);
+  attachProjectCloseHandler(info, workspaceRoot, serviceEntry, pluginLogger);
 
-  service.start().catch((error: unknown) => {
-    info.project.projectService.logger.info(
-      `[FormSpec] Plugin service failed to start for ${workspaceRoot}: ${formatPluginError(error)}`
-    );
-    services.delete(workspaceRoot);
-  });
+  pluginLogger.info(`Plugin activating for workspace: ${workspaceRoot} (TypeScript ${typescriptVersion})`);
+
+  service
+    .start()
+    .then(() => {
+      pluginLogger.info(`IPC socket open for ${workspaceRoot}`);
+    })
+    .catch((error: unknown) => {
+      const msg = `Plugin service failed to start for ${workspaceRoot}: ${formatPluginError(error)}`;
+      pluginLogger.error(msg);
+      // Also write through the raw tsLogger so the error appears even when
+      // DEBUG=formspec:ts-plugin is not set.
+      tsLogger.info(`[FormSpec] ${msg}`);
+      services.delete(workspaceRoot);
+    });
+
   services.set(workspaceRoot, serviceEntry);
   return service;
 }
@@ -124,7 +142,8 @@ function getOrCreateService(
 function attachProjectCloseHandler(
   info: tsServer.server.PluginCreateInfo,
   workspaceRoot: string,
-  serviceEntry: ServiceEntry
+  serviceEntry: ServiceEntry,
+  pluginLogger?: import("@formspec/core").LoggerLike
 ): void {
   const originalClose = info.project.close.bind(info.project);
   let closed = false;
@@ -139,10 +158,14 @@ function attachProjectCloseHandler(
     serviceEntry.referenceCount -= 1;
     if (serviceEntry.referenceCount <= 0) {
       services.delete(workspaceRoot);
+      pluginLogger?.info(`IPC socket closing for ${workspaceRoot}`);
       void serviceEntry.service.stop().catch((error: unknown) => {
-        info.project.projectService.logger.info(
-          `[FormSpec] Failed to stop plugin service for ${workspaceRoot}: ${formatPluginError(error)}`
-        );
+        const msg = `Failed to stop plugin service for ${workspaceRoot}: ${formatPluginError(error)}`;
+        if (pluginLogger !== undefined) {
+          pluginLogger.error(msg);
+        } else {
+          info.project.projectService.logger.info(`[FormSpec] ${msg}`);
+        }
       });
     }
     originalClose();

--- a/packages/ts-plugin/src/logger.ts
+++ b/packages/ts-plugin/src/logger.ts
@@ -33,7 +33,11 @@ function formatBindings(bindings: Record<string, unknown>): string {
 }
 
 function buildPrefix(namespace: string, bindings: Record<string, unknown>): string {
-  const bindingStr = Object.keys(bindings).length > 0 ? ` ${formatBindings(bindings)}` : "";
+  const hasBindings = Object.keys(bindings).length > 0;
+  if (namespace.length === 0 && !hasBindings) {
+    return "";
+  }
+  const bindingStr = hasBindings ? ` ${formatBindings(bindings)}` : "";
   return `[${namespace}${bindingStr}] `;
 }
 

--- a/packages/ts-plugin/src/logger.ts
+++ b/packages/ts-plugin/src/logger.ts
@@ -1,0 +1,126 @@
+/**
+ * Adapter that bridges `ts.server.Logger` to the `LoggerLike` contract used
+ * across FormSpec. All log output flows through tsserver's own log file rather
+ * than stdout/stderr, which is the correct place for plugin diagnostics.
+ *
+ * @packageDocumentation
+ */
+import * as ts from "typescript";
+import type * as tsServer from "typescript/lib/tsserverlibrary.js";
+import {
+  isNamespaceEnabled as isNamespaceEnabledCore,
+  type LoggerLike,
+  noopLogger,
+} from "@formspec/core";
+
+/**
+ * Checks whether a namespace is enabled by the `DEBUG` environment variable.
+ *
+ * Thin wrapper around `@formspec/core`'s matcher that reads `process.env.DEBUG`
+ * for the ts-plugin's gating. Comma-separated patterns, `*` wildcard, and `-`
+ * negation are supported; negations always win regardless of order.
+ *
+ * @internal
+ */
+export function isNamespaceEnabled(namespace: string): boolean {
+  return isNamespaceEnabledCore(process.env["DEBUG"] ?? "", namespace);
+}
+
+function formatBindings(bindings: Record<string, unknown>): string {
+  return Object.entries(bindings)
+    .map(([k, v]) => `${k}=${String(v)}`)
+    .join(" ");
+}
+
+function buildPrefix(namespace: string, bindings: Record<string, unknown>): string {
+  const bindingStr = Object.keys(bindings).length > 0 ? ` ${formatBindings(bindings)}` : "";
+  return `[${namespace}${bindingStr}] `;
+}
+
+function makeAdapter(
+  tsLogger: tsServer.server.Logger,
+  namespace: string,
+  bindings: Record<string, unknown>
+): LoggerLike {
+  const prefix = buildPrefix(namespace, bindings);
+
+  function isEnabled(): boolean {
+    if (!tsLogger.loggingEnabled()) {
+      return false;
+    }
+    return true;
+  }
+
+  // ts.server.Msg has Info and Err string enum members. TS has no native
+  // trace/debug/warn variants.
+  // Mapping: trace→Info, debug→Info, info→Info, warn→Info (prefixed [WARN]),
+  // error→Err.
+  return {
+    trace(msg: string): void {
+      if (!isEnabled()) return;
+      tsLogger.msg(`${prefix}${msg}`, ts.server.Msg.Info);
+    },
+    debug(msg: string): void {
+      if (!isEnabled()) return;
+      tsLogger.msg(`${prefix}${msg}`, ts.server.Msg.Info);
+    },
+    info(msg: string): void {
+      if (!isEnabled()) return;
+      tsLogger.msg(`${prefix}${msg}`, ts.server.Msg.Info);
+    },
+    warn(msg: string): void {
+      if (!isEnabled()) return;
+      tsLogger.msg(`${prefix}[WARN] ${msg}`, ts.server.Msg.Info);
+    },
+    error(msg: string): void {
+      if (!isEnabled()) return;
+      tsLogger.msg(`${prefix}${msg}`, ts.server.Msg.Err);
+    },
+    child(childBindings: Record<string, unknown>): LoggerLike {
+      return makeAdapter(tsLogger, namespace, { ...bindings, ...childBindings });
+    },
+  };
+}
+
+/**
+ * Options for {@link fromTsLogger}.
+ *
+ * @public
+ */
+export interface FromTsLoggerOptions {
+  /**
+   * Namespace prefix added to every log line in the form `[namespace]`.
+   * If omitted, no prefix is added.
+   */
+  readonly namespace?: string;
+}
+
+/**
+ * Wraps a `ts.server.Logger` in the FormSpec `LoggerLike` interface.
+ *
+ * When the `DEBUG` environment variable is set and the given namespace is
+ * matched, log calls are forwarded through tsserver's log file. Otherwise a
+ * no-op logger is returned so that unrelated namespaces stay silent.
+ *
+ * Level mapping (tsserver has only Info and Err):
+ * - `trace` → `ts.server.Msg.Info`
+ * - `debug` → `ts.server.Msg.Info`
+ * - `info`  → `ts.server.Msg.Info`
+ * - `warn`  → `ts.server.Msg.Info` (message prefixed with `[WARN]`)
+ * - `error` → `ts.server.Msg.Err`
+ *
+ * @public
+ */
+export function fromTsLogger(
+  tsLogger: tsServer.server.Logger,
+  options?: FromTsLoggerOptions
+): LoggerLike {
+  const namespace = options?.namespace ?? "";
+
+  // When a namespace is provided, gate on the DEBUG env var.
+  if (namespace.length > 0 && !isNamespaceEnabled(namespace)) {
+    return noopLogger;
+  }
+
+  return makeAdapter(tsLogger, namespace, {});
+}

--- a/packages/ts-plugin/src/semantic-service.ts
+++ b/packages/ts-plugin/src/semantic-service.ts
@@ -33,6 +33,15 @@ import { formatPerformanceEvent } from "./perf-utils.js";
 /**
  * Minimal logger contract used by the semantic service.
  *
+ * @remarks
+ * This interface is intentionally narrower than `LoggerLike` from
+ * `@formspec/core`. The semantic service only emits informational lines (via
+ * `info`) for profiling/refresh-failure messages, so callers can satisfy it
+ * with a plain `{ info(s: string): void }` object — including `ts.server.Logger`
+ * directly without wrapping. The broader `LoggerLike` from `@formspec/core` is
+ * used at the plugin activation layer (`packages/ts-plugin/src/index.ts`) where
+ * structured levels (debug, warn, error) and child-logger bindings are needed.
+ *
  * @public
  */
 export interface LoggerLike {

--- a/packages/ts-plugin/tsup.config.ts
+++ b/packages/ts-plugin/tsup.config.ts
@@ -4,5 +4,5 @@ import { baseConfig } from "../../tsup.config.base.js";
 export default defineConfig({
   ...baseConfig,
   entry: ["src/index.ts"],
-  external: ["typescript", "typescript/lib/tsserverlibrary.js"],
+  external: ["typescript", "typescript/lib/tsserverlibrary.js", "@formspec/core"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,13 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      pino:
+        specifier: ^9.0.0
+        version: 9.14.0
+      pino-pretty:
+        specifier: ^11.0.0
+        version: 11.3.0
 
   packages/cli:
     dependencies:
@@ -152,6 +159,12 @@ importers:
       '@formspec/config':
         specifier: workspace:*
         version: link:../config
+      pino:
+        specifier: ^9.0.0
+        version: 9.14.0
+      pino-pretty:
+        specifier: ^11.0.0
+        version: 11.3.0
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -273,6 +286,9 @@ importers:
       '@formspec/core':
         specifier: workspace:*
         version: link:../core
+      pino:
+        specifier: ^9.0.0
+        version: 9.14.0
       vscode-languageserver:
         specifier: ^9.0.1
         version: 9.0.1
@@ -302,6 +318,9 @@ importers:
       '@formspec/analysis':
         specifier: workspace:*
         version: link:../analysis
+      '@formspec/core':
+        specifier: workspace:*
+        version: link:../core
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -858,6 +877,9 @@ packages:
   '@one-ini/wasm@0.2.1':
     resolution: {integrity: sha512-TUqERXGNTifZ9y2g3wPxQrw3HpHv/02DsW3D90T9x0hhonrL1ZqpSmNrU2XkoIq0fP1N6gZfVQzy2Fw1ZvGBNg==}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@rollup/rollup-android-arm-eabi@4.56.0':
     resolution: {integrity: sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==}
     cpu: [arm]
@@ -1285,6 +1307,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1373,12 +1399,19 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -1397,6 +1430,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1457,6 +1493,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
@@ -1493,6 +1532,9 @@ packages:
 
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1556,6 +1598,9 @@ packages:
 
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1663,12 +1708,23 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1682,6 +1738,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -1778,6 +1837,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -1792,6 +1854,9 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2026,6 +2091,9 @@ packages:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
     engines: {node: '>= 6'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
@@ -2070,6 +2138,13 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2154,6 +2229,20 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-pretty@11.3.0:
+    resolution: {integrity: sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -2209,6 +2298,16 @@ packages:
     resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2218,6 +2317,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
@@ -2242,9 +2344,17 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -2282,8 +2392,18 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -2331,6 +2451,9 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2358,6 +2481,10 @@ packages:
   spdx-license-ids@3.0.22:
     resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -2374,6 +2501,9 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2433,6 +2563,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2728,6 +2861,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -3262,6 +3398,8 @@ snapshots:
 
   '@one-ini/wasm@0.2.1': {}
 
+  '@pinojs/redact@0.4.0': {}
+
   '@rollup/rollup-android-arm-eabi@4.56.0':
     optional: true
 
@@ -3729,6 +3867,10 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3803,9 +3945,13 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -3827,6 +3973,11 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-require@5.1.0(esbuild@0.27.2):
     dependencies:
@@ -3878,6 +4029,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   commander@14.0.3: {}
 
   commander@4.1.1: {}
@@ -3906,6 +4059,8 @@ snapshots:
   csstype@3.2.3: {}
 
   dataloader@1.4.0: {}
+
+  dateformat@4.6.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -3950,6 +4105,10 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emojilib@2.4.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -4141,9 +4300,15 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
+
+  fast-copy@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -4158,6 +4323,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
 
@@ -4256,6 +4423,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  help-me@5.0.0: {}
+
   hosted-git-info@2.8.9: {}
 
   hosted-git-info@4.1.0:
@@ -4267,6 +4436,8 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -4470,6 +4641,8 @@ snapshots:
       is-plain-obj: 1.1.0
       kind-of: 6.0.3
 
+  minimist@1.2.8: {}
+
   mlly@1.8.1:
     dependencies:
       acorn: 8.16.0
@@ -4517,6 +4690,12 @@ snapshots:
       validate-npm-package-license: 3.0.4
 
   object-assign@4.1.1: {}
+
+  on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -4588,6 +4767,43 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@11.3.0:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pump: 3.0.4
+      readable-stream: 4.7.0
+      secure-json-parse: 2.7.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 3.1.1
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
+
   pirates@4.0.7: {}
 
   pkg-types@1.3.1:
@@ -4633,11 +4849,22 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  process-warning@5.0.0: {}
+
+  process@0.11.10: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   quick-lru@4.0.1: {}
 
@@ -4665,7 +4892,17 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
   readdirp@4.1.2: {}
+
+  real-require@0.2.0: {}
 
   redent@3.0.0:
     dependencies:
@@ -4723,7 +4960,13 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
+
+  secure-json-parse@2.7.0: {}
 
   semver@5.7.2: {}
 
@@ -4757,6 +5000,10 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
@@ -4782,6 +5029,8 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
+  split2@4.2.0: {}
+
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
@@ -4795,6 +5044,10 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -4856,6 +5109,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   tinybench@2.9.0: {}
 
@@ -5110,6 +5367,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
 
   yallist@4.0.0: {}
 


### PR DESCRIPTION
## Summary

Adds structured debug logging across the FormSpec stack using pino, gated by a `DEBUG=formspec:*` enable convention modeled on the `debug` npm package (comma-separated patterns, `*` wildcard, `-` negation — negations always win).

## Topology

- **Apps construct pino inline.** `@formspec/cli` writes to stderr (pino-pretty on TTY). The `@formspec/build` CLI does the same, with pino loaded via `require()` so it's declared as `optionalDependencies` and isn't forced on library consumers. `@formspec/language-server` pipes pino JSON through a line-buffering `Writable` sink that routes levels to `connection.console.{log,info,warn,error}`.
- **`@formspec/ts-plugin` never touches stdio.** `fromTsLogger` wraps `ts.server.Logger` so diagnostics land in the tsserver log file — stdio is reserved for the tsserver protocol.
- **Libraries accept an injected `LoggerLike`.** `@formspec/build`, `@formspec/analysis`, `@formspec/runtime`, and `@formspec/config` expose an optional `logger` on their public entry points and default to a silent `noopLogger`. None of them import pino.
- **Shared contract lives in `@formspec/core`.** `LoggerLike`, `noopLogger`, and `isNamespaceEnabled` are exported once and reused everywhere, so the four apps can't drift into divergent matcher semantics. The umbrella `formspec` package re-exports `LoggerLike` and `noopLogger`.

## Namespaces

| Namespace | Owner |
|---|---|
| `formspec:cli` | `@formspec/cli` |
| `formspec:build`, `formspec:build:ir`, `formspec:build:schema` | `@formspec/build` |
| `formspec:analysis` | `@formspec/analysis` |
| `formspec:runtime` | `@formspec/runtime` |
| `formspec:config` | `@formspec/config` |
| `formspec:lsp` | `@formspec/language-server` |
| `formspec:ts-plugin` | `@formspec/ts-plugin` |

## Testing

- Unit tests for `isNamespaceEnabled` in `@formspec/core` covering empty/whitespace patterns, exact match, wildcards, negation (including "negation wins regardless of order"), malformed input, and comma-separated lists.
- Per-app unit tests verifying level routing and DEBUG gating.
- Library integration tests assert that a capturing `LoggerLike` sees the expected `stage` binding so the logger is actually plumbed through, not just a silent parameter.
- `fromTsLogger` level-routing tests against a fake `ts.server.Logger`.

All tests, lint, and clean build pass.