### PR TITLE
feat(core): add extractPayload callback to CustomTypeRegistration

### DIFF
--- a/.changeset/resolve-payload-custom-types.md
+++ b/.changeset/resolve-payload-custom-types.md
@@ -1,0 +1,9 @@
+---
+"@formspec/core": minor
+"@formspec/build": minor
+"@formspec/cli": minor
+"@formspec/eslint-plugin": minor
+"formspec": minor
+---
+
+Add optional `resolvePayload` callback to `CustomTypeRegistration`. When defined, the callback is invoked during type analysis with the TypeScript type and checker, and its return value is stored as the custom type node's `payload`. This payload is then passed to `toJsonSchema` during schema generation, enabling extensions to carry type-level information (e.g., a generic argument's resolved literal value) through to JSON Schema output.

--- a/.changeset/resolve-payload-custom-types.md
+++ b/.changeset/resolve-payload-custom-types.md
@@ -12,4 +12,4 @@
 "formspec": minor
 ---
 
-Add optional `resolvePayload` callback to `CustomTypeRegistration`. When defined, the callback is invoked during type analysis with the TypeScript type and checker, and its return value is stored as the custom type node's `payload`. This payload is then passed to `toJsonSchema` during schema generation, enabling extensions to carry type-level information (e.g., a generic argument's resolved literal value) through to JSON Schema output.
+Add optional `extractPayload` callback to `CustomTypeRegistration`. When defined, the callback is invoked during type analysis with the TypeScript type and checker, and its return value is stored as the custom type node's `payload`. This payload is then passed to `toJsonSchema` during schema generation, enabling extensions to carry type-level information (e.g., a generic argument's resolved literal value) through to JSON Schema output.

--- a/.changeset/resolve-payload-custom-types.md
+++ b/.changeset/resolve-payload-custom-types.md
@@ -3,6 +3,12 @@
 "@formspec/build": minor
 "@formspec/cli": minor
 "@formspec/eslint-plugin": minor
+"@formspec/analysis": minor
+"@formspec/config": minor
+"@formspec/dsl": minor
+"@formspec/language-server": minor
+"@formspec/runtime": minor
+"@formspec/ts-plugin": minor
 "formspec": minor
 ---
 

--- a/packages/build/src/__tests__/resolve-payload.test.ts
+++ b/packages/build/src/__tests__/resolve-payload.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the `resolvePayload` callback on custom type registrations.
+ *
+ * Verifies that:
+ *   1. `resolvePayload` is called during type analysis and its return value
+ *      flows through to `toJsonSchema` as the `payload` argument.
+ *   2. The callback receives the TypeScript type and checker, enabling
+ *      extraction of type-level information (e.g., generic argument literals).
+ *   3. Optional (nullable) fields pass the union type correctly.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { defineCustomType, defineExtension } from "@formspec/core/internals";
+import { generateSchemas, type GenerateSchemasOptions } from "../generators/class-schema.js";
+import { createExtensionRegistry } from "../extensions/index.js";
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({
+    ...options,
+    errorReporting: "throw",
+  });
+}
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-resolve-payload-"));
+});
+
+afterAll(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+function writeFixture(name: string, lines: string[]): string {
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(filePath, lines.join("\n"));
+  return filePath;
+}
+
+describe("resolvePayload", () => {
+  it("passes resolved payload through to toJsonSchema", () => {
+    const toJsonSchema = vi.fn((_payload, _vendorPrefix) => ({
+      type: "string",
+      "x-ref-target": _payload,
+    }));
+
+    const registry = createExtensionRegistry([
+      defineExtension({
+        extensionId: "x-test/ref",
+        types: [
+          defineCustomType({
+            typeName: "TestRef",
+            tsTypeNames: ["TestRef"],
+            resolvePayload: (type: unknown, checker: unknown) => {
+              const tsType = type as { getProperty(name: string): unknown | undefined };
+              const tsChecker = checker as {
+                getTypeOfSymbol(symbol: unknown): {
+                  isStringLiteral(): boolean;
+                  value: string;
+                };
+              };
+              const prop = tsType.getProperty("target");
+              if (!prop) return null;
+              const propType = tsChecker.getTypeOfSymbol(prop);
+              return propType.isStringLiteral() ? propType.value : null;
+            },
+            toJsonSchema,
+          }),
+        ],
+      }),
+    ]);
+
+    const filePath = writeFixture("resolve-payload-basic.ts", [
+      "type TestRef<T extends string> = {",
+      "  id: string;",
+      "  target: T;",
+      "};",
+      "",
+      "export interface Config {",
+      '  ref: TestRef<"customer">;',
+      "}",
+    ]);
+
+    const { jsonSchema } = generateSchemasOrThrow({
+      filePath,
+      typeName: "Config",
+      extensionRegistry: registry,
+    });
+
+    expect(toJsonSchema).toHaveBeenCalledWith("customer", expect.any(String));
+
+    const props = jsonSchema.properties ?? {};
+    expect(props.ref).toMatchObject({
+      type: "string",
+      "x-ref-target": "customer",
+    });
+  });
+
+  it("passes null payload when resolvePayload is not defined", () => {
+    const toJsonSchema = vi.fn((_payload, _vendorPrefix) => ({
+      type: "string",
+    }));
+
+    const registry = createExtensionRegistry([
+      defineExtension({
+        extensionId: "x-test/no-payload",
+        types: [
+          defineCustomType({
+            typeName: "NoPayload",
+            tsTypeNames: ["NoPayload"],
+            toJsonSchema,
+          }),
+        ],
+      }),
+    ]);
+
+    const filePath = writeFixture("resolve-payload-none.ts", [
+      "type NoPayload = string & { readonly __brand: true };",
+      "",
+      "export interface Config {",
+      "  value: NoPayload;",
+      "}",
+    ]);
+
+    generateSchemasOrThrow({
+      filePath,
+      typeName: "Config",
+      extensionRegistry: registry,
+    });
+
+    expect(toJsonSchema).toHaveBeenCalledWith(null, expect.any(String));
+  });
+
+  it("resolvePayload receives the union type for optional fields", () => {
+    const resolvePayload = vi.fn((type: unknown, checker: unknown) => {
+      // Strip nullish union members (same pattern as Ref)
+      const t = type as {
+        isUnion(): boolean;
+        types: Array<{ flags: number; getProperty(name: string): unknown }>;
+        getProperty(name: string): unknown | undefined;
+      };
+      const tsChecker = checker as {
+        getTypeOfSymbol(symbol: unknown): {
+          isStringLiteral(): boolean;
+          value: string;
+        };
+      };
+
+      let resolved = t;
+      if (t.isUnion()) {
+        const nonNullish = t.types.filter(
+          (m) => !(m.flags & (0x10_000 | 0x8_000))
+        );
+        if (nonNullish.length === 1 && nonNullish[0] !== undefined) {
+          resolved = nonNullish[0] as typeof resolved;
+        }
+      }
+
+      const prop = resolved.getProperty("target");
+      if (!prop) return null;
+      const propType = tsChecker.getTypeOfSymbol(prop);
+      return propType.isStringLiteral() ? propType.value : null;
+    });
+
+    const registry = createExtensionRegistry([
+      defineExtension({
+        extensionId: "x-test/optional-ref",
+        types: [
+          defineCustomType({
+            typeName: "OptRef",
+            tsTypeNames: ["OptRef"],
+            resolvePayload,
+            toJsonSchema: (payload, _vendorPrefix) => ({
+              type: "string",
+              "x-target": payload,
+            }),
+          }),
+        ],
+      }),
+    ]);
+
+    const filePath = writeFixture("resolve-payload-optional.ts", [
+      "type OptRef<T extends string> = {",
+      "  id: string;",
+      "  target: T;",
+      "};",
+      "",
+      "export interface Config {",
+      '  optional?: OptRef<"invoice">;',
+      "}",
+    ]);
+
+    const { jsonSchema } = generateSchemasOrThrow({
+      filePath,
+      typeName: "Config",
+      extensionRegistry: registry,
+    });
+
+    expect(resolvePayload).toHaveBeenCalled();
+
+    const props = jsonSchema.properties ?? {};
+    expect(props.optional).toMatchObject({
+      type: "string",
+      "x-target": "invoice",
+    });
+  });
+});

--- a/packages/build/src/__tests__/resolve-payload.test.ts
+++ b/packages/build/src/__tests__/resolve-payload.test.ts
@@ -1,12 +1,13 @@
 /**
- * Tests for the `resolvePayload` callback on custom type registrations.
+ * Tests for the `extractPayload` callback on custom type registrations.
  *
  * Verifies that:
- *   1. `resolvePayload` is called during type analysis and its return value
+ *   1. `extractPayload` is called during type analysis and its return value
  *      flows through to `toJsonSchema` as the `payload` argument.
  *   2. The callback receives the TypeScript type and checker, enabling
  *      extraction of type-level information (e.g., generic argument literals).
  *   3. Optional (nullable) fields pass the union type correctly.
+ *   4. Errors thrown by the callback are attributed to the extension.
  */
 
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
@@ -28,7 +29,7 @@ function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorRepo
 let tmpDir: string;
 
 beforeAll(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-resolve-payload-"));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-extract-payload-"));
 });
 
 afterAll(() => {
@@ -43,8 +44,8 @@ function writeFixture(name: string, lines: string[]): string {
   return filePath;
 }
 
-describe("resolvePayload", () => {
-  it("passes resolved payload through to toJsonSchema", () => {
+describe("extractPayload", () => {
+  it("passes extracted payload through to toJsonSchema", () => {
     const toJsonSchema = vi.fn(
       (payload: unknown, _vendorPrefix: string) => ({
         type: "string",
@@ -59,7 +60,7 @@ describe("resolvePayload", () => {
           defineCustomType({
             typeName: "TestRef",
             tsTypeNames: ["TestRef"],
-            resolvePayload: (type: unknown, checker: unknown) => {
+            extractPayload: (type: unknown, checker: unknown) => {
               const tsType = type as ts.Type;
               const tsChecker = checker as ts.TypeChecker;
               const prop = tsType.getProperty("target");
@@ -73,7 +74,7 @@ describe("resolvePayload", () => {
       }),
     ]);
 
-    const filePath = writeFixture("resolve-payload-basic.ts", [
+    const filePath = writeFixture("extract-payload-basic.ts", [
       "type TestRef<T extends string> = {",
       "  id: string;",
       "  target: T;",
@@ -90,6 +91,7 @@ describe("resolvePayload", () => {
       extensionRegistry: registry,
     });
 
+    // Verify the payload reached toJsonSchema
     expect(toJsonSchema).toHaveBeenCalledWith("customer", expect.any(String));
 
     const props = jsonSchema.properties ?? {};
@@ -99,10 +101,12 @@ describe("resolvePayload", () => {
     });
   });
 
-  it("passes null payload when resolvePayload is not defined", () => {
-    const toJsonSchema = vi.fn((_payload, _vendorPrefix) => ({
-      type: "string",
-    }));
+  it("passes null payload when extractPayload is not defined", () => {
+    const toJsonSchema = vi.fn(
+      (_payload: unknown, _vendorPrefix: string) => ({
+        type: "string",
+      })
+    );
 
     const registry = createExtensionRegistry([
       defineExtension({
@@ -117,7 +121,7 @@ describe("resolvePayload", () => {
       }),
     ]);
 
-    const filePath = writeFixture("resolve-payload-none.ts", [
+    const filePath = writeFixture("extract-payload-none.ts", [
       "type NoPayload = string & { readonly __brand: true };",
       "",
       "export interface Config {",
@@ -134,9 +138,8 @@ describe("resolvePayload", () => {
     expect(toJsonSchema).toHaveBeenCalledWith(null, expect.any(String));
   });
 
-  it("resolvePayload receives the union type for optional fields", () => {
-    const resolvePayload = vi.fn((type: unknown, checker: unknown) => {
-      // Strip nullish union members (same pattern as Ref)
+  it("handles optional fields by passing the union type to extractPayload", () => {
+    const extractPayload = vi.fn((type: unknown, checker: unknown) => {
       let resolved = type as ts.Type;
       const tsChecker = checker as ts.TypeChecker;
 
@@ -162,7 +165,7 @@ describe("resolvePayload", () => {
           defineCustomType({
             typeName: "OptRef",
             tsTypeNames: ["OptRef"],
-            resolvePayload,
+            extractPayload,
             toJsonSchema: (payload, _vendorPrefix) => ({
               type: "string",
               "x-target": payload,
@@ -172,7 +175,7 @@ describe("resolvePayload", () => {
       }),
     ]);
 
-    const filePath = writeFixture("resolve-payload-optional.ts", [
+    const filePath = writeFixture("extract-payload-optional.ts", [
       "type OptRef<T extends string> = {",
       "  id: string;",
       "  target: T;",
@@ -189,12 +192,84 @@ describe("resolvePayload", () => {
       extensionRegistry: registry,
     });
 
-    expect(resolvePayload).toHaveBeenCalled();
+    expect(extractPayload).toHaveBeenCalled();
 
     const props = jsonSchema.properties ?? {};
     expect(props.optional).toMatchObject({
       type: "string",
       "x-target": "invoice",
     });
+  });
+
+  it("attributes errors from extractPayload to the extension", () => {
+    const registry = createExtensionRegistry([
+      defineExtension({
+        extensionId: "x-test/throwing",
+        types: [
+          defineCustomType({
+            typeName: "Throwing",
+            tsTypeNames: ["Throwing"],
+            extractPayload: () => {
+              throw new Error("kaboom");
+            },
+            toJsonSchema: () => ({ type: "string" }),
+          }),
+        ],
+      }),
+    ]);
+
+    const filePath = writeFixture("extract-payload-throwing.ts", [
+      "type Throwing = string & { readonly __brand: true };",
+      "",
+      "export interface Config {",
+      "  value: Throwing;",
+      "}",
+    ]);
+
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath,
+        typeName: "Config",
+        extensionRegistry: registry,
+      })
+    ).toThrow(/extractPayload for custom type "Throwing" in extension "x-test\/throwing" threw/);
+  });
+
+  it("coerces undefined return to null", () => {
+    const toJsonSchema = vi.fn(
+      (_payload: unknown, _vendorPrefix: string) => ({
+        type: "string",
+      })
+    );
+
+    const registry = createExtensionRegistry([
+      defineExtension({
+        extensionId: "x-test/undef-return",
+        types: [
+          defineCustomType({
+            typeName: "UndefReturn",
+            tsTypeNames: ["UndefReturn"],
+            extractPayload: () => undefined as never,
+            toJsonSchema,
+          }),
+        ],
+      }),
+    ]);
+
+    const filePath = writeFixture("extract-payload-undef.ts", [
+      "type UndefReturn = string & { readonly __brand: true };",
+      "",
+      "export interface Config {",
+      "  value: UndefReturn;",
+      "}",
+    ]);
+
+    generateSchemasOrThrow({
+      filePath,
+      typeName: "Config",
+      extensionRegistry: registry,
+    });
+
+    expect(toJsonSchema).toHaveBeenCalledWith(null, expect.any(String));
   });
 });

--- a/packages/build/src/__tests__/resolve-payload.test.ts
+++ b/packages/build/src/__tests__/resolve-payload.test.ts
@@ -13,6 +13,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as ts from "typescript";
 import { defineCustomType, defineExtension } from "@formspec/core/internals";
 import { generateSchemas, type GenerateSchemasOptions } from "../generators/class-schema.js";
 import { createExtensionRegistry } from "../extensions/index.js";
@@ -44,10 +45,12 @@ function writeFixture(name: string, lines: string[]): string {
 
 describe("resolvePayload", () => {
   it("passes resolved payload through to toJsonSchema", () => {
-    const toJsonSchema = vi.fn((_payload, _vendorPrefix) => ({
-      type: "string",
-      "x-ref-target": _payload,
-    }));
+    const toJsonSchema = vi.fn(
+      (payload: unknown, _vendorPrefix: string) => ({
+        type: "string",
+        "x-ref-target": payload,
+      })
+    );
 
     const registry = createExtensionRegistry([
       defineExtension({
@@ -57,13 +60,8 @@ describe("resolvePayload", () => {
             typeName: "TestRef",
             tsTypeNames: ["TestRef"],
             resolvePayload: (type: unknown, checker: unknown) => {
-              const tsType = type as { getProperty(name: string): unknown | undefined };
-              const tsChecker = checker as {
-                getTypeOfSymbol(symbol: unknown): {
-                  isStringLiteral(): boolean;
-                  value: string;
-                };
-              };
+              const tsType = type as ts.Type;
+              const tsChecker = checker as ts.TypeChecker;
               const prop = tsType.getProperty("target");
               if (!prop) return null;
               const propType = tsChecker.getTypeOfSymbol(prop);
@@ -139,25 +137,15 @@ describe("resolvePayload", () => {
   it("resolvePayload receives the union type for optional fields", () => {
     const resolvePayload = vi.fn((type: unknown, checker: unknown) => {
       // Strip nullish union members (same pattern as Ref)
-      const t = type as {
-        isUnion(): boolean;
-        types: Array<{ flags: number; getProperty(name: string): unknown }>;
-        getProperty(name: string): unknown | undefined;
-      };
-      const tsChecker = checker as {
-        getTypeOfSymbol(symbol: unknown): {
-          isStringLiteral(): boolean;
-          value: string;
-        };
-      };
+      let resolved = type as ts.Type;
+      const tsChecker = checker as ts.TypeChecker;
 
-      let resolved = t;
-      if (t.isUnion()) {
-        const nonNullish = t.types.filter(
-          (m) => !(m.flags & (0x10_000 | 0x8_000))
+      if (resolved.isUnion()) {
+        const nonNullish = resolved.types.filter(
+          (m) => !(m.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined))
         );
         if (nonNullish.length === 1 && nonNullish[0] !== undefined) {
-          resolved = nonNullish[0] as typeof resolved;
+          resolved = nonNullish[0];
         }
       }
 

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -1706,10 +1706,23 @@ export function resolveTypeNode(
     sourceNode
   );
   if (customTypeLookup !== null) {
-    const payload = customTypeLookup.registration.resolvePayload?.(type, checker) ?? null;
+    const typeId = customTypeIdFromLookup(customTypeLookup);
+    let payload: import("@formspec/core/internals").ExtensionPayloadValue = null;
+    // extractPayload receives the host program's ts.Type and ts.TypeChecker.
+    if (customTypeLookup.registration.extractPayload !== undefined) {
+      try {
+        payload = customTypeLookup.registration.extractPayload(type, checker) ?? null;
+      } catch (cause) {
+        throw new Error(
+          `extractPayload for custom type "${customTypeLookup.registration.typeName}" ` +
+            `in extension "${customTypeLookup.extensionId}" threw`,
+          { cause }
+        );
+      }
+    }
     return {
       kind: "custom",
-      typeId: customTypeIdFromLookup(customTypeLookup),
+      typeId,
       payload,
     };
   }

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -1706,10 +1706,11 @@ export function resolveTypeNode(
     sourceNode
   );
   if (customTypeLookup !== null) {
+    const payload = customTypeLookup.registration.resolvePayload?.(type, checker) ?? null;
     return {
       kind: "custom",
       typeId: customTypeIdFromLookup(customTypeLookup),
-      payload: null,
+      payload,
     };
   }
   const primitiveAlias = tryResolveNamedPrimitiveAlias(

--- a/packages/core/api-report/core.alpha.api.md
+++ b/packages/core/api-report/core.alpha.api.md
@@ -159,7 +159,7 @@ export interface CustomTypeNode {
 export interface CustomTypeRegistration {
     readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
-    readonly resolvePayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
+    readonly extractPayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     // @deprecated
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.alpha.api.md
+++ b/packages/core/api-report/core.alpha.api.md
@@ -159,6 +159,7 @@ export interface CustomTypeNode {
 export interface CustomTypeRegistration {
     readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
+    readonly resolvePayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     // @deprecated
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -159,7 +159,7 @@ export interface CustomTypeNode {
 export interface CustomTypeRegistration {
     readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
-    readonly resolvePayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
+    readonly extractPayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     // @deprecated
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -159,6 +159,7 @@ export interface CustomTypeNode {
 export interface CustomTypeRegistration {
     readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
+    readonly resolvePayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     // @deprecated
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.beta.api.md
+++ b/packages/core/api-report/core.beta.api.md
@@ -159,7 +159,7 @@ export interface CustomTypeNode {
 export interface CustomTypeRegistration {
     readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
-    readonly resolvePayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
+    readonly extractPayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     // @deprecated
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.beta.api.md
+++ b/packages/core/api-report/core.beta.api.md
@@ -159,6 +159,7 @@ export interface CustomTypeNode {
 export interface CustomTypeRegistration {
     readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
+    readonly resolvePayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     // @deprecated
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.public.api.md
+++ b/packages/core/api-report/core.public.api.md
@@ -93,6 +93,7 @@ export interface CustomConstraintRegistration {
 export interface CustomTypeRegistration {
     readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
+    readonly resolvePayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     // @deprecated
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/api-report/core.public.api.md
+++ b/packages/core/api-report/core.public.api.md
@@ -93,7 +93,7 @@ export interface CustomConstraintRegistration {
 export interface CustomTypeRegistration {
     readonly brand?: string;
     readonly builtinConstraintBroadenings?: readonly BuiltinConstraintBroadeningRegistration[];
-    readonly resolvePayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
+    readonly extractPayload?: (type: unknown, checker: unknown) => ExtensionPayloadValue;
     readonly toJsonSchema: (payload: ExtensionPayloadValue, vendorPrefix: string) => Record<string, unknown>;
     // @deprecated
     readonly tsTypeNames?: readonly string[];

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -114,15 +114,38 @@ export interface CustomTypeRegistration {
    * Use this to carry type-level information (e.g., a generic argument's
    * resolved literal value) through the IR into schema generation.
    *
-   * Parameters are typed as `unknown` because `@formspec/core` does not
+   * **Parameters:** typed as `unknown` because `@formspec/core` does not
    * depend on the TypeScript compiler API. Implementations should cast to
-   * `ts.Type` and `ts.TypeChecker`.
+   * `ts.Type` and `ts.TypeChecker`. Both parameters originate from the
+   * host program's type checker — extensions may rely on host-program
+   * symbol identity.
+   *
+   * **Contract:**
+   * - Must be a pure function of `(type, checker)` — no I/O or shared state.
+   * - May be invoked multiple times for the same type (no memoization is provided).
+   * - Must return a JSON-serializable `ExtensionPayloadValue`. Returning live
+   *   compiler objects (e.g., `ts.Type`) will corrupt any IR caching.
+   * - Errors thrown by the callback are attributed to the extension and
+   *   reported as build diagnostics.
+   * - Returning `undefined` is coerced to `null` at the call site.
    *
    * @param type - The resolved TypeScript type (cast to `ts.Type`).
    * @param checker - The TypeScript type checker (cast to `ts.TypeChecker`).
    * @returns A JSON-serializable payload, or `null` if no payload can be extracted.
+   *
+   * @example
+   * ```typescript
+   * extractPayload: (type: unknown, checker: unknown) => {
+   *   const tsType = type as ts.Type;
+   *   const tsChecker = checker as ts.TypeChecker;
+   *   const prop = tsType.getProperty('target');
+   *   if (!prop) return null;
+   *   const propType = tsChecker.getTypeOfSymbol(prop);
+   *   return propType.isStringLiteral() ? propType.value : null;
+   * }
+   * ```
    */
-  readonly resolvePayload?: (
+  readonly extractPayload?: (
     type: unknown,
     checker: unknown
   ) => ExtensionPayloadValue;

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -107,6 +107,26 @@ export interface CustomTypeRegistration {
    */
   readonly brand?: string;
   /**
+   * Optional callback to extract a payload from the TypeScript type at
+   * analysis time. The returned value is stored on the custom type node
+   * and later passed to `toJsonSchema`.
+   *
+   * Use this to carry type-level information (e.g., a generic argument's
+   * resolved literal value) through the IR into schema generation.
+   *
+   * Parameters are typed as `unknown` because `@formspec/core` does not
+   * depend on the TypeScript compiler API. Implementations should cast to
+   * `ts.Type` and `ts.TypeChecker`.
+   *
+   * @param type - The resolved TypeScript type (cast to `ts.Type`).
+   * @param checker - The TypeScript type checker (cast to `ts.TypeChecker`).
+   * @returns A JSON-serializable payload, or `null` if no payload can be extracted.
+   */
+  readonly resolvePayload?: (
+    type: unknown,
+    checker: unknown
+  ) => ExtensionPayloadValue;
+  /**
    * Converts the custom type's payload into a JSON Schema fragment.
    *
    * @param payload - The opaque JSON payload stored on the custom type node.


### PR DESCRIPTION
## Problem

Extensions that register custom types (via `defineCustomType`) have no way to carry type-level information from TypeScript analysis into JSON Schema generation. The `payload` on custom type nodes is always `null`.

This blocks generic types like `Ref<T>` where the generic argument `T` determines the JSON Schema output (e.g., a referenced type tag). Without the payload, `toJsonSchema` can't produce the correct structured schema.

## Fix

Add an optional `extractPayload` callback to `CustomTypeRegistration`:

```typescript
readonly extractPayload?: (
  type: unknown,   // ts.Type
  checker: unknown // ts.TypeChecker
) => ExtensionPayloadValue;
```

When defined, the class analyzer calls `extractPayload(type, checker)` after matching a custom type and stores the result as the node's `payload`. This payload then flows through to `toJsonSchema(payload, vendorPrefix)` during schema generation. Errors thrown by the callback are attributed to the extension (type name + extension ID).

### Why a callback with `unknown` parameters?

The information needed to extract a payload flows through three layers:

1. **`@formspec/core`** defines `CustomTypeRegistration`. This package has no TypeScript compiler dependency — it can't reference `ts.Type` or `ts.TypeChecker`.
2. **`@formspec/build`** runs the class analyzer and has access to the resolved `ts.Type` for each field. It calls `extractPayload` and passes the TypeScript type and checker.
3. **The extension** (the consumer defining the custom type) knows what specific information to extract. For example, a `Ref<T>` extension knows to look up the `type` property's string literal value from the generic argument.

Without a callback, the class analyzer would need to know what to extract for every possible custom type — which it can't, since custom types are defined by extensions. The `unknown` parameters are the cost of the interface living in `@formspec/core` (lightweight, no TS compiler dependency) while the actual values come from `@formspec/build` (which depends on the TS compiler). Extension authors cast back to `ts.Type` and `ts.TypeChecker` — they know what they're receiving because the contract is documented.

### Contract

The TSDoc on `extractPayload` documents:
- **Purity** — must be a pure function of `(type, checker)`, no I/O or shared state
- **Multiplicity** — may be invoked multiple times for the same type (no memoization)
- **JSON-serializability** — must return `ExtensionPayloadValue`, not live compiler objects
- **Error semantics** — errors are attributed to the extension and reported as build errors
- **`undefined` vs `null`** — `undefined` return is coerced to `null`
- **Host program** — both parameters originate from the host program's type checker

## Test plan

- [x] New: `extractPayload` passes extracted payload through to `toJsonSchema`
- [x] New: `null` payload when `extractPayload` is not defined (backwards compatible)
- [x] New: `extractPayload` receives the union type for optional fields
- [x] New: errors from `extractPayload` are attributed to the extension
- [x] New: `undefined` return is coerced to `null`
- [x] All 764 build tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)