### PR TITLE
perf(e2e): Phase 0-C analysis microbenchmark + baseline

### DIFF
--- a/docs/refactors/phase-0-baseline.md
+++ b/docs/refactors/phase-0-baseline.md
@@ -1,0 +1,64 @@
+# Phase 0-C Analysis Microbenchmark Baseline
+
+Captured during Phase 0-C of the synthetic-checker retirement refactor.
+See [`docs/refactors/synthetic-checker-retirement.md`](./synthetic-checker-retirement.md) §8.2 for performance criteria and §9.2 #8 for the benchmark specification.
+
+## Fixture
+
+**File:** `e2e/benchmarks/analysis-bench-fixture.ts`  
+**Type:** `AnalysisBenchFixture`  
+**Fields:** 20 fields covering the full constraint-tag vocabulary:
+- 8 numeric fields: `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, `@multipleOf`
+- 4 string fields: `@minLength`, `@maxLength`, `@pattern`
+- 2 array fields: `@minItems`, `@maxItems`, `@uniqueItems`
+- 2 enum-ish fields: `@enumOptions`
+- 2 const fields: `@const`
+- 2 path-target fields: nested property constraints via `:propertyName` syntax
+
+## Baseline Measurements
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| `wallTimeMs` (warm median, runs 2–5) | **35.40 ms** | Steady-state `generateSchemasFromProgram` cost; excludes module-load overhead |
+| `wallTimeMs` (cold, run 1) | **1 613 ms** | Includes TypeScript module load + first-run JIT + empty synthetic-batch cache |
+| `peakRssBytes` (warm median) | **955.9 MB** (1 002 307 584 bytes) | Peak RSS across runs 2–5 of `generateSchemasFromProgram` |
+| `syntheticProgramCount` (cold) | **20** | Distinct `ts.createProgram` invocations during constraint-tag validation (one per constraint batch) |
+
+**Commit SHA:** `7288e3b105fa49a23db18eb0dda504b0da898239`  
+**Node version:** v24.14.0  
+**Platform:** darwin / arm64
+
+## Methodology Notes
+
+### Warm vs. cold runs
+
+Run 1 (cold) includes TypeScript module load and JIT compilation. The steady-state wall time (warm median over runs 2–5) is the number that matters for regression detection — it isolates the analysis pipeline cost from process startup overhead.
+
+### Synthetic-program count
+
+TypeScript 5.9+ publishes its exports as non-configurable getter properties. Monkey-patching `ts.createProgram` at runtime is not possible on Node.js 24 (`Cannot redefine property: createProgram`). The count is therefore obtained via `FormSpecSemanticService.getStats().syntheticCompileCount`, which increments on every `ts.createProgram` call inside the `@formspec/analysis` synthetic-checker. The service uses the same synthetic-checker code path as `generateSchemasFromProgram`.
+
+**Cold vs. warm behavior:** `@formspec/analysis` maintains a module-level LRU cache (`syntheticBatchResultCache`, 64 entries). After the first (cold) run, all 20 constraint batches are cached. Subsequent warm runs produce 0 synthetic-program constructions. Only the cold count (20) is meaningful for Phase 4 comparison.
+
+### Phase 4 comparison targets
+
+Per §8.2 of the refactor plan:
+
+- `wallTimeMs` warm: must not regress by more than 5% (≤ **37.17 ms**)
+- `peakRssBytes` warm: must not regress by more than 10% (≤ **1 052 MB**)
+- `syntheticProgramCount` cold: Phase 4 goal is to eliminate all 20 constructions (target: **0**)
+
+## How to Re-run
+
+```bash
+pnpm --filter @formspec/e2e run bench:analysis
+```
+
+The script outputs JSON to stdout and a human-readable table to stderr.
+To capture the JSON for diffing:
+
+```bash
+GIT_COMMIT_SHA=$(git rev-parse HEAD) \
+  pnpm --filter @formspec/e2e run bench:analysis \
+  > bench-results.json 2>/dev/null
+```

--- a/docs/refactors/phase-0-baseline.md
+++ b/docs/refactors/phase-0-baseline.md
@@ -20,7 +20,7 @@ See [`docs/refactors/synthetic-checker-retirement.md`](./synthetic-checker-retir
 | Metric | Value | Notes |
 |--------|-------|-------|
 | `wallTimeMs` (warm median, runs 2–5) | **35.40 ms** | Steady-state `generateSchemasFromProgram` cost; excludes module-load overhead |
-| `wallTimeMs` (cold, run 1) | **1 613 ms** | Includes TypeScript module load + first-run JIT + empty synthetic-batch cache |
+| `wallTimeMs` (cold, run 1) | **1 613 ms** | First invocation of `generateSchemasFromProgram` with an empty synthetic-batch cache (JIT warmup + cold cache); module-load overhead runs before the timer starts |
 | `peakRssBytes` (warm median) | **955.9 MB** (1 002 307 584 bytes) | Peak RSS across runs 2–5 of `generateSchemasFromProgram` |
 | `syntheticProgramCount` (cold) | **20** | Distinct `ts.createProgram` invocations during constraint-tag validation (one per constraint batch) |
 
@@ -32,7 +32,7 @@ See [`docs/refactors/synthetic-checker-retirement.md`](./synthetic-checker-retir
 
 ### Warm vs. cold runs
 
-Run 1 (cold) includes TypeScript module load and JIT compilation. The steady-state wall time (warm median over runs 2–5) is the number that matters for regression detection — it isolates the analysis pipeline cost from process startup overhead.
+Run 1 (cold) measures the first invocation of `generateSchemasFromProgram` — JIT warmup and an empty synthetic-batch cache dominate the number. Module imports happen before the timer starts, so module-load cost is *not* included. The steady-state wall time (warm median over runs 2–5) is the number that matters for regression detection — it isolates the analysis pipeline cost from first-invocation effects.
 
 ### Synthetic-program count
 

--- a/e2e/benchmarks/analysis-bench-fixture.ts
+++ b/e2e/benchmarks/analysis-bench-fixture.ts
@@ -19,7 +19,7 @@ interface MonetaryAmount {
   currency: string;
 }
 
-/** Fulfillment status code (string union). */
+/** Fulfillment status code paired with a human-readable label. */
 interface FulfillmentStatus {
   code: string;
   label: string;
@@ -178,14 +178,14 @@ export interface AnalysisBenchFixture {
   /**
    * Allowed shipping carriers for this order.
    *
-   * @enumOptions [{"value":"fedex","label":"FedEx"},{"value":"ups","label":"UPS"},{"value":"usps","label":"USPS"}]
+   * @enumOptions [{"id":"fedex","label":"FedEx"},{"id":"ups","label":"UPS"},{"id":"usps","label":"USPS"}]
    */
   shippingCarrier: ShippingCarrierOption;
 
   /**
    * Payment method options accepted at checkout.
    *
-   * @enumOptions [{"value":"card","label":"Credit Card"},{"value":"ach","label":"Bank Transfer"},{"value":"wallet","label":"Digital Wallet"}]
+   * @enumOptions [{"id":"card","label":"Credit Card"},{"id":"ach","label":"Bank Transfer"},{"id":"wallet","label":"Digital Wallet"}]
    */
   paymentMethod: PaymentMethodOption;
 

--- a/e2e/benchmarks/analysis-bench-fixture.ts
+++ b/e2e/benchmarks/analysis-bench-fixture.ts
@@ -1,0 +1,233 @@
+/**
+ * Microbenchmark fixture for Phase 0-C: analysis-pipeline baseline.
+ *
+ * 20 fields covering the full constraint-tag vocabulary exercised by the
+ * synthetic-checker retirement refactor (see docs/refactors/synthetic-checker-retirement.md §8.2).
+ *
+ * Field breakdown:
+ *   - 8 numeric fields:  @minimum, @maximum, @exclusiveMinimum, @exclusiveMaximum, @multipleOf
+ *   - 4 string fields:   @minLength, @maxLength, @pattern
+ *   - 2 array fields:    @minItems, @maxItems, @uniqueItems
+ *   - 2 enum-ish fields: @enumOptions
+ *   - 2 const fields:    @const
+ *   - 2 path-target:     @minimum/:minLength :nested.property value
+ */
+
+/** Nested monetary amount used by path-target fields. */
+interface MonetaryAmount {
+  amount: number;
+  currency: string;
+}
+
+/** Fulfillment status code (string union). */
+interface FulfillmentStatus {
+  code: string;
+  label: string;
+}
+
+/** Shipping carrier option. */
+type ShippingCarrierOption = "fedex" | "ups" | "usps";
+
+/** Payment method option. */
+type PaymentMethodOption = "card" | "ach" | "wallet";
+
+/**
+ * Analysis microbenchmark fixture — representative 20-field interface.
+ *
+ * Every builtin constraint tag appears at least once so the synthetic-checker
+ * validation path is exercised in full.
+ */
+export interface AnalysisBenchFixture {
+  // -----------------------------------------------------------------------
+  // Numeric fields (8)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Customer age in years.
+   *
+   * @minimum 0
+   * @maximum 120
+   */
+  age: number;
+
+  /**
+   * Product price in cents.
+   *
+   * @minimum 0
+   * @exclusiveMaximum 1000000
+   */
+  priceInCents: number;
+
+  /**
+   * Discount percentage applied to the order.
+   *
+   * @exclusiveMinimum 0
+   * @maximum 100
+   */
+  discountPercent: number;
+
+  /**
+   * Inventory quantity available for shipping.
+   *
+   * @minimum 0
+   * @maximum 99999
+   * @multipleOf 1
+   */
+  stockQuantity: number;
+
+  /**
+   * Weight of the shipment in kilograms.
+   *
+   * @exclusiveMinimum 0
+   * @exclusiveMaximum 1000
+   * @multipleOf 0.001
+   */
+  weightKg: number;
+
+  /**
+   * Tax rate as a decimal fraction.
+   *
+   * @minimum 0
+   * @maximum 1
+   * @multipleOf 0.0001
+   */
+  taxRate: number;
+
+  /**
+   * Credit limit in whole currency units.
+   *
+   * @minimum 0
+   * @maximum 500000
+   * @multipleOf 100
+   */
+  creditLimit: number;
+
+  /**
+   * Shipping zone index.
+   *
+   * @minimum 1
+   * @maximum 9
+   * @multipleOf 1
+   */
+  shippingZone: number;
+
+  // -----------------------------------------------------------------------
+  // String fields (4)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Customer's full legal name.
+   *
+   * @minLength 1
+   * @maxLength 200
+   */
+  fullName: string;
+
+  /**
+   * Contact email address.
+   *
+   * @minLength 5
+   * @maxLength 254
+   * @pattern ^[^@\s]+@[^@\s]+\.[^@\s]+$
+   */
+  email: string;
+
+  /**
+   * International phone number with country code.
+   *
+   * @minLength 7
+   * @maxLength 20
+   * @pattern ^\+?[0-9\s\-().]{7,20}$
+   */
+  phoneNumber: string;
+
+  /**
+   * ISO 4217 currency code.
+   *
+   * @minLength 3
+   * @maxLength 3
+   * @pattern ^[A-Z]{3}$
+   */
+  currencyCode: string;
+
+  // -----------------------------------------------------------------------
+  // Array fields (2)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Product category tags applied to the order line.
+   *
+   * @minItems 1
+   * @maxItems 10
+   * @uniqueItems
+   */
+  categoryTags: string[];
+
+  /**
+   * Ordered list of warehouse fulfillment steps.
+   *
+   * @minItems 0
+   * @maxItems 50
+   */
+  fulfillmentSteps: string[];
+
+  // -----------------------------------------------------------------------
+  // Enum-ish fields (2)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Allowed shipping carriers for this order.
+   *
+   * @enumOptions [{"value":"fedex","label":"FedEx"},{"value":"ups","label":"UPS"},{"value":"usps","label":"USPS"}]
+   */
+  shippingCarrier: ShippingCarrierOption;
+
+  /**
+   * Payment method options accepted at checkout.
+   *
+   * @enumOptions [{"value":"card","label":"Credit Card"},{"value":"ach","label":"Bank Transfer"},{"value":"wallet","label":"Digital Wallet"}]
+   */
+  paymentMethod: PaymentMethodOption;
+
+  // -----------------------------------------------------------------------
+  // Const fields (2)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Schema version — always "v2" for this fixture.
+   *
+   * @const "v2"
+   */
+  schemaVersion: string;
+
+  /**
+   * Maximum allowed revision depth before archival.
+   *
+   * @const 10
+   */
+  maxRevisionDepth: number;
+
+  // -----------------------------------------------------------------------
+  // Path-target fields (2)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Total order amount with currency.
+   *
+   * @minimum :amount 0
+   * @maximum :amount 9999999.99
+   * @minLength :currency 3
+   * @maxLength :currency 3
+   */
+  totalAmount: MonetaryAmount;
+
+  /**
+   * Refund details with fulfillment status code label.
+   *
+   * @minLength :code 2
+   * @maxLength :code 20
+   * @minLength :label 1
+   * @maxLength :label 100
+   */
+  refundDetails: FulfillmentStatus;
+}

--- a/e2e/benchmarks/analysis-bench.ts
+++ b/e2e/benchmarks/analysis-bench.ts
@@ -11,12 +11,13 @@
  *
  * ### Run model
  *
- * Five runs are collected per metric path. Run 1 is the **cold run** (module
- * load + empty synthetic-batch cache). Runs 2–5 are **warm runs** (TypeScript
- * module already loaded; synthetic-batch cache populated). Median is computed
- * over warm runs (2–5) for wall time and RSS. The cold-run synthetic-program
- * count is reported separately because subsequent runs hit the module-level
- * LRU cache in @formspec/analysis and produce a count of 0.
+ * Five runs are collected per metric path. Run 1 is the **cold run** for the
+ * measured call (first invocation/JIT effects + empty synthetic-batch cache;
+ * module imports run before the timer starts). Runs 2–5 are **warm runs**
+ * (subsequent invocations with the synthetic-batch cache populated). Median is
+ * computed over warm runs (2–5) for wall time and RSS. The cold-run
+ * synthetic-program count is reported separately because subsequent runs hit
+ * the module-level LRU cache in @formspec/analysis and produce a count of 0.
  *
  * ### Synthetic-program count methodology
  *
@@ -223,6 +224,12 @@ async function main(): Promise<void> {
     const warmPeakRssBytes = allPeakRssBytes.slice(1);
 
     // --- TS-plugin-path measurements (syntheticProgramCount) ---
+    // TODO(phase-0c): this loop shares @formspec/analysis's module-level
+    //   synthetic-batch LRU cache with the build-path loop above. If cache
+    //   keys overlap, the plugin-path "cold" run may observe hits from the
+    //   earlier build-path runs. Add a clearSyntheticBatchCache() hook or run
+    //   the plugin path in a fresh process to make the cold count strictly
+    //   comparable across phases.
     const allSyntheticCounts: PluginRunResult[] = [];
 
     process.stderr.write("\n  Plugin-path (FormSpecSemanticService.getDiagnostics):\n");
@@ -271,7 +278,7 @@ async function main(): Promise<void> {
           warmMedian: medianWarmWallTimeMs,
           all: allWallTimeMs,
           path: "generateSchemasFromProgram",
-          note: "Run 1 (cold) includes TypeScript module load + empty synthetic-batch cache. Warm median (runs 2-5) is the steady-state cost.",
+          note: "Run 1 (cold) measures the first invocation of generateSchemasFromProgram with an empty synthetic-batch cache. Module imports run before the timer starts, so module-load overhead is excluded. Warm median (runs 2-5) is the steady-state cost.",
         },
         peakRssBytes: {
           warmMedian: medianWarmPeakRssBytes,
@@ -284,7 +291,7 @@ async function main(): Promise<void> {
           cacheHits: allSyntheticCounts.map((r) => r.syntheticBatchCacheHits),
           cacheMisses: allSyntheticCounts.map((r) => r.syntheticBatchCacheMisses),
           path: "FormSpecSemanticService.getDiagnostics",
-          note: "TypeScript 5.9+ sealed exports prevent direct monkey-patching. Count from FormSpecSemanticService.getStats().syntheticCompileCount. Only run 1 (cold) produces a non-zero count — subsequent runs hit the module-level LRU cache in @formspec/analysis.",
+          note: "TypeScript 5.9+ sealed exports prevent direct monkey-patching. Count from FormSpecSemanticService.getStats().syntheticCompileCount. Run 1 is labeled 'cold' for this path only; because @formspec/analysis maintains a module-level LRU cache that is shared between build-path and plugin-path call sites, any overlap in cache keys from the build-path loop (which runs earlier in this process) may cause the plugin-path cold run to observe cache hits. For a fully isolated cold measurement, run this benchmark in a fresh process or add a cache-clear hook — subsequent runs in the same process hit the module-level LRU cache and produce a count of 0.",
         },
       },
       commitSha,

--- a/e2e/benchmarks/analysis-bench.ts
+++ b/e2e/benchmarks/analysis-bench.ts
@@ -1,0 +1,302 @@
+/**
+ * Phase 0-C microbenchmark: analysis-pipeline baseline.
+ *
+ * Measures three metrics for a single `generateSchemasFromProgram` call
+ * against the 20-field AnalysisBenchFixture:
+ *
+ *   1. wallTimeMs      — end-to-end elapsed time
+ *   2. peakRssBytes    — peak resident set size observed via polling
+ *   3. syntheticProgramCount — ts.createProgram invocations inside the
+ *                             synthetic constraint-checker
+ *
+ * ### Run model
+ *
+ * Five runs are collected per metric path. Run 1 is the **cold run** (module
+ * load + empty synthetic-batch cache). Runs 2–5 are **warm runs** (TypeScript
+ * module already loaded; synthetic-batch cache populated). Median is computed
+ * over warm runs (2–5) for wall time and RSS. The cold-run synthetic-program
+ * count is reported separately because subsequent runs hit the module-level
+ * LRU cache in @formspec/analysis and produce a count of 0.
+ *
+ * ### Synthetic-program count methodology
+ *
+ * TypeScript 5.9+ exports are sealed (non-configurable getters), so
+ * monkey-patching `ts.createProgram` at runtime is not possible on Node.js 24.
+ * Instead the count is obtained via the `FormSpecSemanticService` from
+ * `@formspec/ts-plugin`, which exposes `syntheticCompileCount` in its
+ * `getStats()` method and increments it on every synthetic-checker
+ * `ts.createProgram` call. The service is driven to produce diagnostics for
+ * the fixture file, which exercises the same constraint-validation path as
+ * `generateSchemasFromProgram`.
+ *
+ * Run with:
+ *   pnpm --filter @formspec/e2e run bench:analysis
+ *
+ * Output: JSON to stdout, human-readable table to stderr.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import * as ts from "typescript";
+import { generateSchemasFromProgram } from "@formspec/build";
+import { FormSpecSemanticService } from "@formspec/ts-plugin";
+
+// ---------------------------------------------------------------------------
+// Peak-RSS polling
+// ---------------------------------------------------------------------------
+
+interface RssPoller {
+  stop: () => number;
+}
+
+function startRssPoller(intervalMs = 5): RssPoller {
+  let peak = process.memoryUsage().rss;
+
+  const id = setInterval(() => {
+    const current = process.memoryUsage().rss;
+    if (current > peak) peak = current;
+  }, intervalMs);
+
+  // Ensure the interval doesn't block process exit.
+  if (typeof id.unref === "function") id.unref();
+
+  return {
+    stop: () => {
+      clearInterval(id);
+      // Take one final sample after the work completes.
+      const final = process.memoryUsage().rss;
+      if (final > peak) peak = final;
+      return peak;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture file setup
+// ---------------------------------------------------------------------------
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_SOURCE_PATH = path.join(BENCH_DIR, "analysis-bench-fixture.ts");
+const TYPE_NAME = "AnalysisBenchFixture";
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  strict: true,
+  skipLibCheck: true,
+};
+
+// ---------------------------------------------------------------------------
+// Wall-time + RSS measurement: generateSchemasFromProgram path
+// ---------------------------------------------------------------------------
+
+interface BuildRunResult {
+  readonly wallTimeMs: number;
+  readonly peakRssBytes: number;
+}
+
+function runBuildBenchOnce(filePath: string): BuildRunResult {
+  const program = ts.createProgram([filePath], COMPILER_OPTIONS);
+
+  const rssPoller = startRssPoller();
+  const start = performance.now();
+
+  // Use "diagnostics" so validation errors do not abort the run —
+  // we want to measure the full pipeline cost regardless of fixture validity.
+  generateSchemasFromProgram({
+    program,
+    filePath,
+    typeName: TYPE_NAME,
+    errorReporting: "diagnostics",
+  });
+
+  const wallTimeMs = performance.now() - start;
+  const peakRssBytes = rssPoller.stop();
+
+  return { wallTimeMs, peakRssBytes };
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic-program-count measurement: FormSpecSemanticService path
+//
+// The semantic service drives the same @formspec/analysis synthetic-checker
+// as the build path. It exposes syntheticCompileCount via getStats(), giving
+// us an exact count of ts.createProgram invocations inside the checker.
+//
+// NOTE: @formspec/analysis has a module-level LRU cache for synthetic-batch
+// results. After the first (cold) run, subsequent runs of the same fixture
+// produce cache hits and a compile count of 0. We therefore report the cold
+// and warm counts separately rather than computing a misleading median across
+// all runs.
+// ---------------------------------------------------------------------------
+
+interface PluginRunResult {
+  readonly syntheticProgramCount: number;
+  readonly syntheticBatchCacheHits: number;
+  readonly syntheticBatchCacheMisses: number;
+}
+
+function runPluginBenchOnce(workspaceRoot: string, filePath: string): PluginRunResult {
+  const program = ts.createProgram([filePath], COMPILER_OPTIONS);
+
+  const service = new FormSpecSemanticService({
+    workspaceRoot,
+    typescriptVersion: ts.version,
+    getProgram: () => program,
+  });
+
+  try {
+    const before = service.getStats();
+    service.getDiagnostics(filePath);
+    const after = service.getStats();
+    return {
+      syntheticProgramCount: after.syntheticCompileCount - before.syntheticCompileCount,
+      syntheticBatchCacheHits:
+        after.syntheticBatchCacheHits - before.syntheticBatchCacheHits,
+      syntheticBatchCacheMisses:
+        after.syntheticBatchCacheMisses - before.syntheticBatchCacheMisses,
+    };
+  } finally {
+    service.dispose();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Median helper (over an array of numbers)
+// ---------------------------------------------------------------------------
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("Cannot compute median of empty array");
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (sorted[mid - 1]! + sorted[mid]!) / 2
+    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      sorted[mid]!;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const RUNS = 5;
+
+async function main(): Promise<void> {
+  const workspaceRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "formspec-analysis-bench-")
+  );
+
+  try {
+    // Write the fixture TypeScript file to a temp directory so ts.createProgram
+    // can resolve it as a real file.
+    const source = await fs.readFile(FIXTURE_SOURCE_PATH, "utf8");
+    const fixturePath = path.join(workspaceRoot, "analysis-bench-fixture.ts");
+    await fs.writeFile(fixturePath, source, "utf8");
+
+    process.stderr.write(`Running analysis benchmark (${String(RUNS)} runs, run 1 = cold)...\n`);
+    process.stderr.write(`  fixture: ${FIXTURE_SOURCE_PATH}\n`);
+    process.stderr.write(`  type:    ${TYPE_NAME}\n\n`);
+
+    // --- Build-path measurements (wall time + RSS) ---
+    const allWallTimeMs: number[] = [];
+    const allPeakRssBytes: number[] = [];
+
+    process.stderr.write("  Build-path (generateSchemasFromProgram):\n");
+    for (let i = 0; i < RUNS; i++) {
+      const label = i === 0 ? "cold" : "warm";
+      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
+      const result = runBuildBenchOnce(fixturePath);
+      allWallTimeMs.push(result.wallTimeMs);
+      allPeakRssBytes.push(result.peakRssBytes);
+      process.stderr.write(
+        ` ${result.wallTimeMs.toFixed(1)}ms  RSS=${(result.peakRssBytes / 1024 / 1024).toFixed(1)}MB\n`
+      );
+    }
+
+    // Warm median = median over runs 2..5 (skip run 1 which includes module load)
+    const warmWallTimeMs = allWallTimeMs.slice(1);
+    const warmPeakRssBytes = allPeakRssBytes.slice(1);
+
+    // --- TS-plugin-path measurements (syntheticProgramCount) ---
+    const allSyntheticCounts: PluginRunResult[] = [];
+
+    process.stderr.write("\n  Plugin-path (FormSpecSemanticService.getDiagnostics):\n");
+    for (let i = 0; i < RUNS; i++) {
+      const label = i === 0 ? "cold" : "warm";
+      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
+      const result = runPluginBenchOnce(workspaceRoot, fixturePath);
+      allSyntheticCounts.push(result);
+      process.stderr.write(
+        ` syntheticPrograms=${String(result.syntheticProgramCount)} cacheHits=${String(result.syntheticBatchCacheHits)} cacheMisses=${String(result.syntheticBatchCacheMisses)}\n`
+      );
+    }
+
+    const medianWarmWallTimeMs = median(warmWallTimeMs);
+    const medianWarmPeakRssBytes = median(warmPeakRssBytes);
+    const coldSyntheticProgramCount = allSyntheticCounts[0]?.syntheticProgramCount ?? 0;
+
+    const coldWallTimeMs = allWallTimeMs[0] ?? 0;
+
+    // Human-readable summary to stderr
+    process.stderr.write("\n--- Phase 0-C Analysis Baseline ---\n");
+    process.stderr.write(
+      `  wallTimeMs cold:             ${coldWallTimeMs.toFixed(2)}\n`
+    );
+    process.stderr.write(
+      `  wallTimeMs warm (median):    ${medianWarmWallTimeMs.toFixed(2)}\n`
+    );
+    process.stderr.write(
+      `  peakRssBytes warm (median):  ${String(Math.round(medianWarmPeakRssBytes))} (${(medianWarmPeakRssBytes / 1024 / 1024).toFixed(1)} MB)\n`
+    );
+    process.stderr.write(
+      `  syntheticProgramCount cold:  ${String(coldSyntheticProgramCount)}\n`
+    );
+    process.stderr.write("-----------------------------------\n");
+
+    // Machine-readable JSON to stdout for CI ingestion
+    const commitSha = process.env["GIT_COMMIT_SHA"] ?? "unknown";
+    const output = {
+      phase: "0-C",
+      description: "analysis-pipeline baseline",
+      fixture: TYPE_NAME,
+      runs: RUNS,
+      metrics: {
+        wallTimeMs: {
+          cold: coldWallTimeMs,
+          warmMedian: medianWarmWallTimeMs,
+          all: allWallTimeMs,
+          path: "generateSchemasFromProgram",
+          note: "Run 1 (cold) includes TypeScript module load + empty synthetic-batch cache. Warm median (runs 2-5) is the steady-state cost.",
+        },
+        peakRssBytes: {
+          warmMedian: medianWarmPeakRssBytes,
+          all: allPeakRssBytes,
+          path: "generateSchemasFromProgram",
+        },
+        syntheticProgramCount: {
+          cold: coldSyntheticProgramCount,
+          all: allSyntheticCounts.map((r) => r.syntheticProgramCount),
+          cacheHits: allSyntheticCounts.map((r) => r.syntheticBatchCacheHits),
+          cacheMisses: allSyntheticCounts.map((r) => r.syntheticBatchCacheMisses),
+          path: "FormSpecSemanticService.getDiagnostics",
+          note: "TypeScript 5.9+ sealed exports prevent direct monkey-patching. Count from FormSpecSemanticService.getStats().syntheticCompileCount. Only run 1 (cold) produces a non-zero count — subsequent runs hit the module-level LRU cache in @formspec/analysis.",
+        },
+      },
+      commitSha,
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    };
+
+    process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  } finally {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/e2e/benchmarks/ts-intercept-preload.cjs
+++ b/e2e/benchmarks/ts-intercept-preload.cjs
@@ -1,0 +1,3 @@
+// This file was created during Phase 0-C benchmark development but is no
+// longer used. It is kept as a placeholder to avoid git confusion; the
+// content is intentionally empty.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "vitest run",
     "benchmark:hybrid-tooling": "pnpm --filter @formspec/language-server... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && tsx ./benchmarks/hybrid-tooling-comparison.ts",
-    "bench:analysis": "pnpm --filter @formspec/ts-plugin... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/analysis-bench.ts"
+    "bench:analysis": "pnpm -r --filter @formspec/build... --filter @formspec/ts-plugin... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/analysis-bench.ts"
   },
   "dependencies": {
     "@formspec/analysis": "workspace:*",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "benchmark:hybrid-tooling": "pnpm --filter @formspec/language-server... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && tsx ./benchmarks/hybrid-tooling-comparison.ts"
+    "benchmark:hybrid-tooling": "pnpm --filter @formspec/language-server... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && tsx ./benchmarks/hybrid-tooling-comparison.ts",
+    "bench:analysis": "pnpm --filter @formspec/ts-plugin... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/analysis-bench.ts"
   },
   "dependencies": {
     "@formspec/analysis": "workspace:*",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -75,6 +75,9 @@ export default [
       ".Codex/**",
       ".claude/**",
       "packages/ts-plugin/index.cjs",
+      // Unused CJS artifact from Phase 0-C benchmark development — not part of
+      // the TypeScript project and cannot be linted as such.
+      "e2e/benchmarks/ts-intercept-preload.cjs",
       // CI scripts are plain JS, not part of the TypeScript project.
       ".github/**",
       // Examples have their own eslint.config.js with formspec plugin rules.


### PR DESCRIPTION
## Summary

- Adds a 20-field `AnalysisBenchFixture` TypeScript interface exercising every builtin constraint-tag (numeric, string, array, `enumOptions`, `const`, path-target)
- Adds `e2e/benchmarks/analysis-bench.ts` — runnable via `pnpm --filter @formspec/e2e run bench:analysis` — measuring wall time (`generateSchemasFromProgram`), peak RSS, and synthetic `ts.createProgram` construction count (via `FormSpecSemanticService` stats)
- Adds `docs/refactors/phase-0-baseline.md` with the captured numbers and Phase 4 regression thresholds

Part of the synthetic-checker retirement refactor (#302), Phase 0-C per §9.2 #8.

## Baseline numbers (darwin arm64, Node v24.14.0)

| Metric | Value |
|--------|-------|
| `wallTimeMs` warm median (runs 2–5) | **35.40 ms** |
| `wallTimeMs` cold (run 1, inc. module load) | 1 613 ms |
| `peakRssBytes` warm median | **955.9 MB** |
| `syntheticProgramCount` cold | **20** |

Phase 4 regression gate (from §8.2): warm wall time ≤ 37.17 ms (+5%), peak RSS ≤ 1 052 MB (+10%), syntheticProgramCount → 0.

## Methodology note

TypeScript 5.9+ seals its module exports as non-configurable getters (`configurable: false`), so `ts.createProgram` cannot be monkey-patched on Node.js 24. The synthetic-program count is obtained instead via `FormSpecSemanticService.getStats().syntheticCompileCount`, which tracks the same counter inside the shared `@formspec/analysis` synthetic-checker. The baseline doc explains this and how Phase 4 comparisons should interpret the number.

## Test plan

- [x] `pnpm run build` passes clean
- [x] `pnpm run lint` passes clean
- [x] `pnpm run test` — all 266 tests pass
- [x] `pnpm --filter @formspec/e2e run bench:analysis` executes and produces JSON + console output