### PR TITLE
fix(build): prevent stack overflow on large external type arguments

### DIFF
--- a/.changeset/fix-large-type-argument-overflow.md
+++ b/.changeset/fix-large-type-argument-overflow.md
@@ -1,0 +1,8 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Fix stack overflow when a generic type's type argument references a large external type (e.g., `Ref<Stripe.Customer>` where `Customer` has 100+ nested properties). Type arguments from external modules are now emitted as opaque references instead of being recursively expanded, since they are only used for `$defs` naming and don't contribute to the schema output.

--- a/packages/build/src/__tests__/large-type-argument.test.ts
+++ b/packages/build/src/__tests__/large-type-argument.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests that type arguments referencing large external types don't overflow
+ * the stack during schema generation.
+ *
+ * Regression: Ref<Stripe.Customer> caused a stack overflow because
+ * extractReferenceTypeArguments recursed into Customer's 100+ deeply
+ * nested properties. The type argument is only used for naming and $defs
+ * references — it doesn't need full property expansion.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { generateSchemas, type GenerateSchemasOptions } from "../generators/class-schema.js";
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({
+    ...options,
+    errorReporting: "throw",
+  });
+}
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-large-type-arg-"));
+
+  // A large external type with many properties (simulates Stripe.Customer)
+  fs.writeFileSync(
+    path.join(tmpDir, "large-type.ts"),
+    [
+      "export interface LargeType {",
+      "  readonly object: 'large_thing';",
+      ...Array.from({ length: 100 }, (_, i) => `  prop${i}: string;`),
+      "}",
+    ].join("\n")
+  );
+
+  // A generic wrapper type that references the large type as a type argument
+  fs.writeFileSync(
+    path.join(tmpDir, "wrapper.ts"),
+    [
+      'import type { LargeType } from "./large-type.js";',
+      "",
+      "type Wrapper<T extends { readonly object: string }> = {",
+      "  id: string;",
+      '  type: T["object"];',
+      "};",
+      "",
+      "export interface Config {",
+      "  ref: Wrapper<LargeType>;",
+      "}",
+    ].join("\n")
+  );
+
+  fs.writeFileSync(
+    path.join(tmpDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "nodenext",
+          strict: true,
+          skipLibCheck: true,
+        },
+      },
+      null,
+      2
+    )
+  );
+});
+
+afterAll(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+describe("large external type argument", () => {
+  it("does not overflow the stack when a type argument is a large external type", () => {
+    const result = generateSchemasOrThrow({
+      filePath: path.join(tmpDir, "wrapper.ts"),
+      typeName: "Config",
+    });
+
+    // The build should complete without stack overflow. The wrapper's own
+    // properties (id, type) should appear in the schema output.
+    expect(result.jsonSchema).toBeDefined();
+    expect(result.jsonSchema.properties).toBeDefined();
+  });
+});

--- a/packages/build/src/__tests__/large-type-argument.test.ts
+++ b/packages/build/src/__tests__/large-type-argument.test.ts
@@ -2,14 +2,15 @@
  * Tests for generic wrapper types (like Ref<T>) with type arguments of
  * varying sizes and origins.
  *
+ * Related: packages/build/src/__tests__/discriminator.test.ts:704 covers
+ * a similar large-carrier scenario via @discriminator.
+ *
  * Covers:
- *   1. Small locally-defined type argument — resolves correctly with
- *      the wrapper's own properties preserved.
- *   2. Deeply nested external type argument — doesn't overflow the stack
- *      and doesn't leak into $defs.
- *      Regression: Ref<Stripe.Customer> caused a stack overflow because
- *      extractReferenceTypeArguments recursed into Customer's deeply
- *      nested property tree.
+ *   1. External deeply-nested type argument — doesn't overflow the stack
+ *      and doesn't leak into $defs (regression for Ref<Stripe.Customer>).
+ *   2. External small type argument — same opaque-reference behavior.
+ *   3. Same-file type argument — falls through to normal recursive resolution.
+ *   4. Inline anonymous type argument — falls through to normal resolution.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -40,27 +41,18 @@ beforeAll(() => {
     ].join("\n")
   );
 
-  // Deeply nested type chain (simulates Stripe.Customer's recursive depth).
-  // Each level references the next, creating a chain that would reliably
-  // overflow the stack if recursively expanded.
-  const nestingDepth = 30;
-  const nestedTypeLines: string[] = [
-    "export interface Level0 {",
-    "  readonly object: 'deep_thing';",
-    "  name: string;",
-    "  nested: Level1;",
-    "}",
-  ];
-  for (let i = 1; i < nestingDepth; i++) {
-    const next = i < nestingDepth - 1 ? `Level${String(i + 1)}` : "string";
-    nestedTypeLines.push(
-      `export interface Level${String(i)} {`,
-      `  value${String(i)}: string;`,
-      `  nested: ${next};`,
-      "}",
-    );
+  // Deeply nested type chain (simulates the deeply-recursive shape that caused
+  // the original Ref<Stripe.Customer> overflow). Each type references the next,
+  // so resolving one requires recursing through all ~300 declarations.
+  const depth = 300;
+  const lines: string[] = [];
+  for (let d = 0; d < depth; d++) {
+    lines.push(`export interface Type${String(d)} {`);
+    lines.push(`  readonly object: 'type_${String(d)}';`);
+    if (d + 1 < depth) lines.push(`  nested: Type${String(d + 1)};`);
+    lines.push("}");
   }
-  fs.writeFileSync(path.join(tmpDir, "deep-type.ts"), nestedTypeLines.join("\n"));
+  fs.writeFileSync(path.join(tmpDir, "deep-type.ts"), lines.join("\n"));
 
   // Generic wrapper (simulates Ref<T>)
   fs.writeFileSync(
@@ -75,7 +67,7 @@ beforeAll(() => {
     ].join("\n")
   );
 
-  // Fixture using small local type argument
+  // Fixture using small external type argument
   fs.writeFileSync(
     path.join(tmpDir, "small-ref.ts"),
     [
@@ -92,11 +84,46 @@ beforeAll(() => {
   fs.writeFileSync(
     path.join(tmpDir, "deep-ref.ts"),
     [
-      'import type { Level0 } from "./deep-type.js";',
+      'import type { Type0 } from "./deep-type.js";',
       'import type { Wrapper } from "./wrapper.js";',
       "",
       "export interface DeepRefConfig {",
-      "  ref: Wrapper<Level0>;",
+      "  ref: Wrapper<Type0>;",
+      "}",
+    ].join("\n")
+  );
+
+  // Fixture using same-file type argument (should resolve normally)
+  fs.writeFileSync(
+    path.join(tmpDir, "same-file-ref.ts"),
+    [
+      "type Wrapper<T extends { readonly object: string }> = {",
+      "  id: string;",
+      '  type: T["object"];',
+      "};",
+      "",
+      "interface LocalType {",
+      "  readonly object: 'local_thing';",
+      "  extra: number;",
+      "}",
+      "",
+      "export interface SameFileConfig {",
+      "  ref: Wrapper<LocalType>;",
+      "}",
+    ].join("\n")
+  );
+
+  // Fixture using inline anonymous type argument (should resolve normally)
+  fs.writeFileSync(
+    path.join(tmpDir, "inline-ref.ts"),
+    [
+      "type Wrapper<T extends { readonly object: string }> = {",
+      "  id: string;",
+      '  type: T["object"];',
+      "};",
+      "",
+      "export interface InlineConfig {",
+      "  ref: Wrapper<{ readonly object: 'inline_thing' }>;",
       "}",
     ].join("\n")
   );
@@ -126,34 +153,54 @@ afterAll(() => {
 });
 
 describe("generic wrapper type arguments", () => {
-  it("resolves Wrapper<SmallType> with correct properties", () => {
-    const result = generateSchemasOrThrow({
-      filePath: path.join(tmpDir, "small-ref.ts"),
-      typeName: "SmallRefConfig",
-    });
-
-    const properties = result.jsonSchema.properties as Record<string, unknown>;
-    expect(properties).toBeDefined();
-
-    const refSchema = properties["ref"] as Record<string, unknown>;
-    expect(refSchema).toBeDefined();
-  });
-
-  it("resolves Wrapper<Level0> without stack overflow and without leaking into $defs", () => {
+  it("emits deeply-nested external type as opaque reference without recursing through the chain", () => {
     const result = generateSchemasOrThrow({
       filePath: path.join(tmpDir, "deep-ref.ts"),
       typeName: "DeepRefConfig",
     });
 
-    const properties = result.jsonSchema.properties as Record<string, unknown>;
-    expect(properties).toBeDefined();
+    const defs = (result.jsonSchema.$defs ?? {}) as Record<string, unknown>;
+    const props = result.jsonSchema.properties as Record<string, unknown>;
+    expect(props["ref"]).toBeDefined();
 
-    const refSchema = properties["ref"] as Record<string, unknown>;
-    expect(refSchema).toBeDefined();
+    // Pre-fix, $defs would contain Type0 (and all nested Type1..Type299)
+    // with their properties inlined — and the recursion caused a stack overflow.
+    expect(defs).not.toHaveProperty("Type0");
+    expect(defs).not.toHaveProperty("Type1");
+  });
 
-    // The deeply nested external type argument must NOT be expanded into $defs
-    const defs = result.jsonSchema.$defs ?? {};
-    expect(defs).not.toHaveProperty("Level0");
-    expect(defs).not.toHaveProperty("Level1");
+  it("emits small external type as opaque reference without inlining into $defs", () => {
+    const result = generateSchemasOrThrow({
+      filePath: path.join(tmpDir, "small-ref.ts"),
+      typeName: "SmallRefConfig",
+    });
+
+    const defs = (result.jsonSchema.$defs ?? {}) as Record<string, unknown>;
+    const props = result.jsonSchema.properties as Record<string, unknown>;
+    expect(props["ref"]).toBeDefined();
+
+    // External type arguments are emitted as opaque references regardless
+    // of size. SmallType should not appear in $defs.
+    expect(defs).not.toHaveProperty("SmallType");
+  });
+
+  it("resolves same-file type argument normally (not opaque)", () => {
+    const result = generateSchemasOrThrow({
+      filePath: path.join(tmpDir, "same-file-ref.ts"),
+      typeName: "SameFileConfig",
+    });
+
+    const props = result.jsonSchema.properties as Record<string, unknown>;
+    expect(props["ref"]).toBeDefined();
+  });
+
+  it("resolves inline anonymous type argument normally", () => {
+    const result = generateSchemasOrThrow({
+      filePath: path.join(tmpDir, "inline-ref.ts"),
+      typeName: "InlineConfig",
+    });
+
+    const props = result.jsonSchema.properties as Record<string, unknown>;
+    expect(props["ref"]).toBeDefined();
   });
 });

--- a/packages/build/src/__tests__/large-type-argument.test.ts
+++ b/packages/build/src/__tests__/large-type-argument.test.ts
@@ -1,11 +1,15 @@
 /**
- * Tests that type arguments referencing large external types don't overflow
- * the stack during schema generation.
+ * Tests for generic wrapper types (like Ref<T>) with type arguments of
+ * varying sizes and origins.
  *
- * Regression: Ref<Stripe.Customer> caused a stack overflow because
- * extractReferenceTypeArguments recursed into Customer's 100+ deeply
- * nested properties. The type argument is only used for naming and $defs
- * references — it doesn't need full property expansion.
+ * Covers:
+ *   1. Small locally-defined type argument — resolves correctly with
+ *      the wrapper's own properties preserved.
+ *   2. Deeply nested external type argument — doesn't overflow the stack
+ *      and doesn't leak into $defs.
+ *      Regression: Ref<Stripe.Customer> caused a stack overflow because
+ *      extractReferenceTypeArguments recursed into Customer's deeply
+ *      nested property tree.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -24,32 +28,75 @@ function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorRepo
 let tmpDir: string;
 
 beforeAll(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-large-type-arg-"));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-type-arg-"));
 
-  // A large external type with many properties (simulates Stripe.Customer)
+  // Small type defined in a separate file
   fs.writeFileSync(
-    path.join(tmpDir, "large-type.ts"),
+    path.join(tmpDir, "small-type.ts"),
     [
-      "export interface LargeType {",
-      "  readonly object: 'large_thing';",
-      ...Array.from({ length: 100 }, (_, i) => `  prop${i}: string;`),
+      "export interface SmallType {",
+      "  readonly object: 'small_thing';",
       "}",
     ].join("\n")
   );
 
-  // A generic wrapper type that references the large type as a type argument
+  // Deeply nested type chain (simulates Stripe.Customer's recursive depth).
+  // Each level references the next, creating a chain that would reliably
+  // overflow the stack if recursively expanded.
+  const nestingDepth = 30;
+  const nestedTypeLines: string[] = [
+    "export interface Level0 {",
+    "  readonly object: 'deep_thing';",
+    "  name: string;",
+    "  nested: Level1;",
+    "}",
+  ];
+  for (let i = 1; i < nestingDepth; i++) {
+    const next = i < nestingDepth - 1 ? `Level${String(i + 1)}` : "string";
+    nestedTypeLines.push(
+      `export interface Level${String(i)} {`,
+      `  value${String(i)}: string;`,
+      `  nested: ${next};`,
+      "}",
+    );
+  }
+  fs.writeFileSync(path.join(tmpDir, "deep-type.ts"), nestedTypeLines.join("\n"));
+
+  // Generic wrapper (simulates Ref<T>)
   fs.writeFileSync(
     path.join(tmpDir, "wrapper.ts"),
     [
-      'import type { LargeType } from "./large-type.js";',
-      "",
       "type Wrapper<T extends { readonly object: string }> = {",
       "  id: string;",
       '  type: T["object"];',
       "};",
       "",
-      "export interface Config {",
-      "  ref: Wrapper<LargeType>;",
+      "export { type Wrapper };",
+    ].join("\n")
+  );
+
+  // Fixture using small local type argument
+  fs.writeFileSync(
+    path.join(tmpDir, "small-ref.ts"),
+    [
+      'import type { SmallType } from "./small-type.js";',
+      'import type { Wrapper } from "./wrapper.js";',
+      "",
+      "export interface SmallRefConfig {",
+      "  ref: Wrapper<SmallType>;",
+      "}",
+    ].join("\n")
+  );
+
+  // Fixture using deeply nested external type argument
+  fs.writeFileSync(
+    path.join(tmpDir, "deep-ref.ts"),
+    [
+      'import type { Level0 } from "./deep-type.js";',
+      'import type { Wrapper } from "./wrapper.js";',
+      "",
+      "export interface DeepRefConfig {",
+      "  ref: Wrapper<Level0>;",
       "}",
     ].join("\n")
   );
@@ -78,16 +125,35 @@ afterAll(() => {
   }
 });
 
-describe("large external type argument", () => {
-  it("does not overflow the stack when a type argument is a large external type", () => {
+describe("generic wrapper type arguments", () => {
+  it("resolves Wrapper<SmallType> with correct properties", () => {
     const result = generateSchemasOrThrow({
-      filePath: path.join(tmpDir, "wrapper.ts"),
-      typeName: "Config",
+      filePath: path.join(tmpDir, "small-ref.ts"),
+      typeName: "SmallRefConfig",
     });
 
-    // The build should complete without stack overflow. The wrapper's own
-    // properties (id, type) should appear in the schema output.
-    expect(result.jsonSchema).toBeDefined();
-    expect(result.jsonSchema.properties).toBeDefined();
+    const properties = result.jsonSchema.properties as Record<string, unknown>;
+    expect(properties).toBeDefined();
+
+    const refSchema = properties["ref"] as Record<string, unknown>;
+    expect(refSchema).toBeDefined();
+  });
+
+  it("resolves Wrapper<Level0> without stack overflow and without leaking into $defs", () => {
+    const result = generateSchemasOrThrow({
+      filePath: path.join(tmpDir, "deep-ref.ts"),
+      typeName: "DeepRefConfig",
+    });
+
+    const properties = result.jsonSchema.properties as Record<string, unknown>;
+    expect(properties).toBeDefined();
+
+    const refSchema = properties["ref"] as Record<string, unknown>;
+    expect(refSchema).toBeDefined();
+
+    // The deeply nested external type argument must NOT be expanded into $defs
+    const defs = result.jsonSchema.$defs ?? {};
+    expect(defs).not.toHaveProperty("Level0");
+    expect(defs).not.toHaveProperty("Level1");
   });
 });

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -1294,30 +1294,30 @@ function extractReferenceTypeArguments(
   return referenceTypeNode.typeArguments.map((argumentNode) => {
     const argumentType = checker.getTypeFromTypeNode(argumentNode);
 
-    // If the type argument is a named type from an external module (not
-    // declared in the current file), register it as an opaque reference
-    // rather than resolving its full property tree. This prevents stack
-    // overflows on deeply nested external types (e.g. Stripe.Customer)
-    // that are only used as phantom type parameters (e.g. Ref<T>).
-    const rawSymbol = argumentType.aliasSymbol ?? argumentType.getSymbol();
-    // Resolve through import aliases to the canonical declaration so that
-    // the source-file comparison checks the external module, not the local
-    // import specifier.
+    // If the type argument is a named type declared outside the current
+    // analysis root file, emit a synthetic opaque reference TypeNode
+    // instead of recursing into its declaration. This preserves the name
+    // for buildInstantiatedReferenceName while avoiding stack overflows on
+    // deeply-nested types (e.g. Stripe.Customer) used as phantom parameters
+    // (e.g. Ref<T>). Note: this path does NOT populate typeRegistry —
+    // callers that need a resolved $defs entry must get it via the parent
+    // type's property walk.
+    const baseSymbol = argumentType.aliasSymbol ?? argumentType.getSymbol();
     const argumentSymbol =
-      rawSymbol !== undefined && (rawSymbol.flags & ts.SymbolFlags.Alias) !== 0
-        ? checker.getAliasedSymbol(rawSymbol)
-        : rawSymbol;
+      baseSymbol !== undefined && baseSymbol.flags & ts.SymbolFlags.Alias
+        ? checker.getAliasedSymbol(baseSymbol)
+        : baseSymbol;
     const argumentDecl = argumentSymbol?.declarations?.[0];
     if (
       argumentDecl !== undefined &&
-      argumentDecl.getSourceFile().fileName !== sourceNode?.getSourceFile().fileName
+      argumentDecl.getSourceFile().fileName !== file
     ) {
-      const argumentName = argumentSymbol?.getName() ?? rawSymbol?.getName();
+      const argumentName = argumentSymbol?.getName() ?? baseSymbol?.getName();
       if (argumentName !== undefined) {
         return {
           tsType: argumentType,
           typeNode: {
-            kind: "reference" as const,
+            kind: "reference",
             name: argumentName,
             typeArguments: [],
           },

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -1293,6 +1293,31 @@ function extractReferenceTypeArguments(
 
   return referenceTypeNode.typeArguments.map((argumentNode) => {
     const argumentType = checker.getTypeFromTypeNode(argumentNode);
+
+    // If the type argument is a named type from an external module (not
+    // declared in the current file), register it as an opaque reference
+    // rather than resolving its full property tree. This prevents stack
+    // overflows on deeply nested external types (e.g. Stripe.Customer)
+    // that are only used as phantom type parameters (e.g. Ref<T>).
+    const argumentSymbol = argumentType.aliasSymbol ?? argumentType.getSymbol();
+    const argumentDecl = argumentSymbol?.declarations?.[0];
+    if (
+      argumentDecl !== undefined &&
+      argumentDecl.getSourceFile().fileName !== sourceNode?.getSourceFile().fileName
+    ) {
+      const argumentName = argumentSymbol?.getName();
+      if (argumentName !== undefined) {
+        return {
+          tsType: argumentType,
+          typeNode: {
+            kind: "reference" as const,
+            name: argumentName,
+            typeArguments: [] as TypeNode[],
+          },
+        };
+      }
+    }
+
     return {
       tsType: argumentType,
       typeNode: resolveTypeNode(

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -1299,20 +1299,27 @@ function extractReferenceTypeArguments(
     // rather than resolving its full property tree. This prevents stack
     // overflows on deeply nested external types (e.g. Stripe.Customer)
     // that are only used as phantom type parameters (e.g. Ref<T>).
-    const argumentSymbol = argumentType.aliasSymbol ?? argumentType.getSymbol();
+    const rawSymbol = argumentType.aliasSymbol ?? argumentType.getSymbol();
+    // Resolve through import aliases to the canonical declaration so that
+    // the source-file comparison checks the external module, not the local
+    // import specifier.
+    const argumentSymbol =
+      rawSymbol !== undefined && (rawSymbol.flags & ts.SymbolFlags.Alias) !== 0
+        ? checker.getAliasedSymbol(rawSymbol)
+        : rawSymbol;
     const argumentDecl = argumentSymbol?.declarations?.[0];
     if (
       argumentDecl !== undefined &&
       argumentDecl.getSourceFile().fileName !== sourceNode?.getSourceFile().fileName
     ) {
-      const argumentName = argumentSymbol?.getName();
+      const argumentName = argumentSymbol?.getName() ?? rawSymbol?.getName();
       if (argumentName !== undefined) {
         return {
           tsType: argumentType,
           typeNode: {
             kind: "reference" as const,
             name: argumentName,
-            typeArguments: [] as TypeNode[],
+            typeArguments: [],
           },
         };
       }


### PR DESCRIPTION
## Problem

`Ref<Stripe.Customer>` in a custom object field definition causes a stack overflow during schema generation. `Stripe.Customer` has 100+ deeply nested properties, and `extractReferenceTypeArguments` recursively calls `resolveTypeNode` on the type argument, which expands the full property tree and overflows the stack.

## Fix

When resolving type arguments in `extractReferenceTypeArguments`, if the argument is a named type declared in an external module (not the current file), emit it as an opaque reference node instead of recursively expanding it. Type arguments are only used for `$defs` naming and reference node `typeArguments` arrays — they don't contribute to the parent type's property schema. The parent type's properties (e.g., `id` and `type` on `Ref`) are resolved separately in the property loop, where `__` prefixed members like `__type?: T` are already skipped by `shouldEmitResolvedObjectProperty`.

This preserves the existing discriminator/prefix pipeline (`@discriminator :type T` + `apiNamePrefix`) that handles `Ref<OtherCustomObject>` correctly.

## Test plan

- [x] New: schema generation completes without overflow when a type argument is a large external type (100+ properties)
- [x] All 770 build tests pass
- [x] Manually tested: `pnpm image` in demo app produces `OBJECT_REFERENCE_TYPE` with `referencedType: "customer"` for `Ref<Customer>` using `@stripe/extensibility-api-objects`

🤖 Generated with [Claude Code](https://claude.com/claude-code)