### PR TITLE
fix(build): omit redundant title in oneOf enum serialization (#310)

### DIFF
--- a/.changeset/omit-redundant-oneof-title.md
+++ b/.changeset/omit-redundant-oneof-title.md
@@ -1,0 +1,9 @@
+---
+"@formspec/build": patch
+---
+
+Omit redundant `title` in `oneOf` enum serialization when title equals the `const` value.
+
+When using `enumSerialization: "oneOf"`, members with no `@displayName` (or a `@displayName` identical to the value) previously emitted `{ "const": "USD", "title": "USD" }`. The `title` is now omitted in those cases, producing the more compact `{ "const": "USD" }`. A `title` is still emitted when an explicit `@displayName` differs from the value (e.g. `{ "const": "EUR", "title": "Euro" }`).
+
+This reduces serialized schema size significantly for large enums — approximately 13 characters saved per member (~2,000 characters for a 157-member ISO 4217 currency enum).

--- a/.changeset/omit-redundant-oneof-title.md
+++ b/.changeset/omit-redundant-oneof-title.md
@@ -1,5 +1,8 @@
 ---
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
 ---
 
 Omit redundant `title` in `oneOf` enum serialization when title equals the `const` value.

--- a/packages/build/src/__tests__/ir-json-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-json-schema-generator.test.ts
@@ -485,26 +485,6 @@ describe("generateJsonSchemaFromIR", () => {
       });
     });
 
-    // Tests for #310: omit redundant title in oneOf enum serialization
-    it("omits title when displayName equals the const value (issue #310)", () => {
-      // When displayName is set but identical to the value, title is still redundant.
-      const ir = makeIR([
-        makeField("currency", {
-          kind: "enum",
-          members: [
-            { value: "USD", displayName: "USD" },
-            { value: "EUR", displayName: "EUR" },
-          ],
-        }),
-      ]);
-      const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "oneOf" });
-      const prop = (schema.properties as Record<string, unknown>)["currency"];
-
-      expect(prop).toEqual({
-        oneOf: [{ const: "USD" }, { const: "EUR" }],
-      });
-    });
-
     it("emits title only for members whose displayName differs from the value (issue #310)", () => {
       // Mixed: some members have a meaningful displayName, others do not (or it matches).
       const ir = makeIR([
@@ -528,6 +508,54 @@ describe("generateJsonSchemaFromIR", () => {
         ],
       });
     });
+
+    // Parameterized edge cases for #310: displayName === String(m.value) comparison semantics.
+    // EnumMember.value is `string | number` — boolean values are not part of the IR type,
+    // so there is no boolean edge case to test.
+    it.each([
+      {
+        label: "numeric const matching stringified value — omit title",
+        value: 42 as string | number,
+        displayName: "42",
+        expectedTitle: false,
+      },
+      {
+        label: "numeric const with different displayName — emit title",
+        value: 1 as string | number,
+        displayName: "One",
+        expectedTitle: true,
+      },
+      {
+        label: "empty-string displayName matching empty-string value — omit title",
+        value: "" as string | number,
+        displayName: "",
+        expectedTitle: false,
+      },
+      {
+        label: "case-differing displayName — emit title (strict !== semantics, issue #310)",
+        value: "USD" as string | number,
+        displayName: "usd",
+        expectedTitle: true,
+      },
+    ])(
+      "oneOf title omission edge case: $label",
+      ({ value, displayName, expectedTitle }) => {
+        const ir = makeIR([
+          makeField("f", {
+            kind: "enum",
+            members: [{ value, displayName }],
+          }),
+        ]);
+        const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "oneOf" });
+        const prop = (schema.properties as Record<string, unknown>)["f"];
+
+        if (expectedTitle) {
+          expect(prop).toEqual({ oneOf: [{ const: value, title: displayName }] });
+        } else {
+          expect(prop).toEqual({ oneOf: [{ const: value }] });
+        }
+      },
+    );
 
     it("uses the configured vendorPrefix for the display-name extension", () => {
       const ir = makeIR([

--- a/packages/build/src/__tests__/ir-json-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-json-schema-generator.test.ts
@@ -441,6 +441,10 @@ describe("generateJsonSchemaFromIR", () => {
     });
 
     it("supports oneOf serialization with explicit and fallback titles", () => {
+      // Updated for #310: title is only emitted when displayName differs from the const value.
+      // "sent" has no displayName, so its title is omitted (was redundant).
+      // "draft" has displayName "Draft" (differs from value) → title emitted.
+      // "paid" has displayName "Paid in Full" (differs from value) → title emitted.
       const ir = makeIR([
         makeField("status", {
           kind: "enum",
@@ -457,13 +461,16 @@ describe("generateJsonSchemaFromIR", () => {
       expect(prop).toEqual({
         oneOf: [
           { const: "draft", title: "Draft" },
-          { const: "sent", title: "sent" },
+          { const: "sent" },
           { const: "paid", title: "Paid in Full" },
         ],
       });
     });
 
     it("supports oneOf serialization when no member has a displayName", () => {
+      // Updated for #310: when no member has a displayName, no titles are emitted.
+      // Previously emitted title equal to const (e.g. { const: "draft", title: "draft" }),
+      // which was redundant.
       const ir = makeIR([
         makeField("status", {
           kind: "enum",
@@ -474,9 +481,50 @@ describe("generateJsonSchemaFromIR", () => {
       const prop = (schema.properties as Record<string, unknown>)["status"];
 
       expect(prop).toEqual({
+        oneOf: [{ const: "draft" }, { const: "sent" }],
+      });
+    });
+
+    // Tests for #310: omit redundant title in oneOf enum serialization
+    it("omits title when displayName equals the const value (issue #310)", () => {
+      // When displayName is set but identical to the value, title is still redundant.
+      const ir = makeIR([
+        makeField("currency", {
+          kind: "enum",
+          members: [
+            { value: "USD", displayName: "USD" },
+            { value: "EUR", displayName: "EUR" },
+          ],
+        }),
+      ]);
+      const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "oneOf" });
+      const prop = (schema.properties as Record<string, unknown>)["currency"];
+
+      expect(prop).toEqual({
+        oneOf: [{ const: "USD" }, { const: "EUR" }],
+      });
+    });
+
+    it("emits title only for members whose displayName differs from the value (issue #310)", () => {
+      // Mixed: some members have a meaningful displayName, others do not (or it matches).
+      const ir = makeIR([
+        makeField("currency", {
+          kind: "enum",
+          members: [
+            { value: "USD" },
+            { value: "EUR", displayName: "Euro" },
+            { value: "GBP", displayName: "GBP" }, // displayName === value → omit title
+          ],
+        }),
+      ]);
+      const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "oneOf" });
+      const prop = (schema.properties as Record<string, unknown>)["currency"];
+
+      expect(prop).toEqual({
         oneOf: [
-          { const: "draft", title: "draft" },
-          { const: "sent", title: "sent" },
+          { const: "USD" },
+          { const: "EUR", title: "Euro" },
+          { const: "GBP" },
         ],
       });
     });

--- a/packages/build/src/__tests__/ir-json-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-json-schema-generator.test.ts
@@ -440,7 +440,7 @@ describe("generateJsonSchemaFromIR", () => {
       expect(prop).toEqual({ enum: [1, 2, 3] });
     });
 
-    it("supports oneOf serialization with explicit and fallback titles", () => {
+    it("supports oneOf serialization and omits title when it matches the value (issue #310)", () => {
       // Updated for #310: title is only emitted when displayName differs from the const value.
       // "sent" has no displayName, so its title is omitted (was redundant).
       // "draft" has displayName "Draft" (differs from value) → title emitted.

--- a/packages/build/src/__tests__/ref-type-schema.test.ts
+++ b/packages/build/src/__tests__/ref-type-schema.test.ts
@@ -344,14 +344,15 @@ describe("Ref<T> JSON Schema serialization", () => {
       const refProps = expectRecord(refSchema["properties"], "Missing Ref properties");
       const typeSchema = expectRecord(refProps["type"], "Missing type property");
 
-      // oneOf serialization: singleton enum → oneOf with const + title
+      // oneOf serialization: singleton enum → oneOf with const only (no title when
+      // displayName equals the value; #310 — omit redundant title).
       expect(typeSchema).not.toHaveProperty("enum");
       const oneOf = typeSchema["oneOf"] as unknown[];
       expect(oneOf).toBeDefined();
       expect(oneOf).toHaveLength(1);
       const member = oneOf[0] as Record<string, unknown>;
       expect(member["const"]).toBe("customer");
-      expect(member["title"]).toBe("customer");
+      expect(member).not.toHaveProperty("title");
     });
 
     it("multiple Ref fields each get oneOf discriminators with correct const values", () => {

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -575,16 +575,20 @@ function generatePrimitiveType(type: PrimitiveTypeNode): JsonSchema2020 {
  *
  * Enum emission is caller-configurable. The default `enum` mode keeps the
  * compact keyword and adds a complete vendor-prefixed display-name map when
- * any member label is available. The `oneOf` mode always emits per-member
- * `const`/`title` entries so downstream consumers can rely on `title`.
+ * any member label is available. The `oneOf` mode emits per-member `const`
+ * entries, and includes `title` only when the member has an explicit
+ * `@displayName` that differs from the value — omitting redundant titles
+ * such as `{ "const": "USD", "title": "USD" }` (#310).
  */
 function generateEnumType(type: EnumTypeNode, ctx: GeneratorContext): JsonSchema2020 {
   if (ctx.enumSerialization === "oneOf") {
     return {
-      oneOf: type.members.map((m) => ({
-        const: m.value,
-        title: m.displayName ?? String(m.value),
-      })),
+      oneOf: type.members.map((m) => {
+        const stringValue = String(m.value);
+        const title =
+          m.displayName !== undefined && m.displayName !== stringValue ? m.displayName : undefined;
+        return title !== undefined ? { const: m.value, title } : { const: m.value };
+      }),
     };
   }
 

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -129,17 +129,13 @@ describe("generators", () => {
         enumSerialization: "oneOf",
       });
 
+      // Updated for #310: no title emitted when there is no @displayName
+      // (the fallback title equalling the value is redundant).
       expect(methodSchemas.params?.jsonSchema).toEqual({
-        oneOf: [
-          { const: "draft", title: "draft" },
-          { const: "sent", title: "sent" },
-        ],
+        oneOf: [{ const: "draft" }, { const: "sent" }],
       });
       expect(methodSchemas.returnType).toEqual({
-        oneOf: [
-          { const: "draft", title: "draft" },
-          { const: "sent", title: "sent" },
-        ],
+        oneOf: [{ const: "draft" }, { const: "sent" }],
       });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Closes #310.

- In `generateEnumType` (IR → JSON Schema), omit `title` from a `oneOf` enum member when it would equal the stringified `const` value. Previously, members without a `displayName` always got `title: String(m.value)`, bloating schemas for large enums with no UI benefit (JSON Forms falls back to the `const` when `title` is absent).
- A 157-member enum saves ~1.6-2KB of JSON in the serialized schema.

## Behavior change

- `{ value: "USD" }` (no displayName) → was `{ const: "USD", title: "USD" }`, now `{ const: "USD" }`.
- `{ value: "USD", displayName: "USD" }` → was `{ const: "USD", title: "USD" }`, now `{ const: "USD" }`.
- `{ value: "EUR", displayName: "Euro" }` → unchanged: `{ const: "EUR", title: "Euro" }`.

## Test plan

- [x] Regression tests added referencing #310 (mixed-member case + parameterized edge cases for numeric const, empty strings, and case-differing displayName).
- [x] Updated existing tests that had encoded the old (wrong) behavior.
- [x] `pnpm --filter @formspec/build test` — 774 passed.
- [x] `pnpm --filter @formspec/cli test` — green.
- [x] `pnpm run lint` / `pnpm run typecheck` — clean.
- [x] Changeset added (`patch` for `@formspec/build`).