### PR TITLE
test(analysis): @const raw-fallback edge-case coverage (0.5e)

### DIFF
--- a/.changeset/phase-0.5e-const-raw-fallback.md
+++ b/.changeset/phase-0.5e-const-raw-fallback.md
@@ -1,5 +1,11 @@
 ---
 "@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
 ---
 
 Add edge-case behavior-pin tests for `@const` raw-string fallback (Phase 0.5e). Covers invalid number-like input, multi-line JSON truncation, trailing-comma arrays, Unicode escape sequences, and empty-after-trim payloads.

--- a/.changeset/phase-0.5e-const-raw-fallback.md
+++ b/.changeset/phase-0.5e-const-raw-fallback.md
@@ -1,0 +1,5 @@
+---
+"@formspec/analysis": patch
+---
+
+Add edge-case behavior-pin tests for `@const` raw-string fallback (Phase 0.5e). Covers invalid number-like input, multi-line JSON truncation, trailing-comma arrays, Unicode escape sequences, and empty-after-trim payloads.

--- a/packages/analysis/src/__tests__/tag-value-parser.test.ts
+++ b/packages/analysis/src/__tests__/tag-value-parser.test.ts
@@ -94,13 +94,92 @@ describe("tag-value-parser", () => {
   });
 
   it("falls back to a raw string for non-JSON @const payloads", () => {
+    // Regression pin for §9.1 #5: bare word "not-json" is not valid JSON and must
+    // produce a raw-string const node, not null and not a parse error.
     const parsed = parseConstraintTagValue("const", "not-json", PROVENANCE);
 
+    expect(parsed).not.toBeNull();
     expect(parsed).toEqual({
       kind: "constraint",
       constraintKind: "const",
       value: "not-json",
       provenance: PROVENANCE,
+    });
+  });
+
+  describe("@const raw-string fallback edge cases (§9.1 #5)", () => {
+    // These tests pin the current behavior of the @const parser so that Phase 1's
+    // typed parser can be validated against identical fallback rules.
+    // See docs/refactors/synthetic-checker-retirement.md §9.1 #5.
+
+    it("falls back to raw string for invalid number-like input (@const 1.2.3)", () => {
+      // "1.2.3" is not valid JSON — JSON.parse throws — so the catch branch
+      // must return the trimmed text verbatim as the const value.
+      const parsed = parseConstraintTagValue("const", "1.2.3", PROVENANCE);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed).toEqual({
+        kind: "constraint",
+        constraintKind: "const",
+        value: "1.2.3",
+        provenance: PROVENANCE,
+      });
+    });
+
+    it("truncates multi-line JSON to first line and raw-string falls back (@const [\\n1,\\n2\\n])", () => {
+      // parseTagSyntax operates on the first line only — newlines are treated as
+      // tag-block terminators. The text reaching the JSON.parse try is "[" (just
+      // the opening bracket), which fails to parse, so the catch branch returns
+      // the trimmed first-line text verbatim as the const value.
+      // TODO: Phase 1 typed parser should decide whether to propagate this
+      // truncation or to accept multi-line spans. See
+      // docs/refactors/synthetic-checker-retirement.md §9.1 #5.
+      const parsed = parseConstraintTagValue("const", "[\n1,\n2\n]", PROVENANCE);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed).toEqual({
+        kind: "constraint",
+        constraintKind: "const",
+        value: "[",
+        provenance: PROVENANCE,
+      });
+    });
+
+    it("falls back to raw string for trailing-comma array (@const [1,2,])", () => {
+      // Trailing commas are not valid JSON — JSON.parse throws — so the catch
+      // branch returns the text verbatim.
+      const parsed = parseConstraintTagValue("const", "[1,2,]", PROVENANCE);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed).toEqual({
+        kind: "constraint",
+        constraintKind: "const",
+        value: "[1,2,]",
+        provenance: PROVENANCE,
+      });
+    });
+
+    it("successfully parses Unicode escape sequences in strings (@const \"\\u00e9\")", () => {
+      // JSON.parse resolves \u00e9 to "é", so the try branch wins.
+      // The stored value must be the resolved character, not the escape sequence.
+      const parsed = parseConstraintTagValue("const", '"\\u00e9"', PROVENANCE);
+
+      expect(parsed).not.toBeNull();
+      expect(parsed).toEqual({
+        kind: "constraint",
+        constraintKind: "const",
+        value: "é",
+        provenance: PROVENANCE,
+      });
+    });
+
+    it("returns null for empty-after-trim @const payload (@const <whitespace>)", () => {
+      // When trimmedText === "" the implementation returns null (no diagnostic
+      // is emitted at this layer). Pinning this so Phase 1 preserves the same
+      // early-return rather than treating it as an empty-string const.
+      const parsed = parseConstraintTagValue("const", "   ", PROVENANCE);
+
+      expect(parsed).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Expands negative coverage for the `@const` raw-string fallback per §9.1 #5 of the synthetic-checker retirement plan.

Six behavior-pin tests are added to `packages/analysis/src/__tests__/tag-value-parser.test.ts`:

- **Invalid number-like input** (`1.2.3`) → raw-string fallback
- **Multi-line JSON truncation** (`[\n1,\n2\n]`) → `parseTagSyntax` truncates to the first line (`"["`), which fails JSON parsing → raw-string `"["` (current behavior pinned with a TODO for Phase 1 to decide whether to propagate the truncation)
- **Trailing-comma array** (`[1,2,]`) → raw-string fallback
- **Unicode escape sequences** (`"\u00e9"`) → JSON.parse resolves to `"é"` (try branch wins)
- **Empty-after-trim payload** (`"   "`) → `null` (no const node emitted)
- **Bare-word regression tightening** (`not-json`) — existing test strengthened with `expect(parsed).not.toBeNull()` assertion

All assertions trace directly to the implementation logic at `tag-value-parser.ts:151-176`. No source code changes.

Relates to: `docs/refactors/synthetic-checker-retirement.md §9.1 #5`

## Test plan

- [x] `pnpm install` — clean install passes
- [x] `pnpm run build` — full build passes
- [x] `pnpm --filter @formspec/analysis run test` — all 320 tests pass
- [x] `pnpm run lint` — no lint errors