### PR TITLE
test(analysis): parity-harness log schema + diff helper (0.5m)

### DIFF
--- a/.changeset/analysis-parity-log-schema.md
+++ b/.changeset/analysis-parity-log-schema.md
@@ -1,5 +1,11 @@
 ---
 "@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
 ---
 
 Add parity-harness log schema and diffing helper (Phase 0.5m)

--- a/.changeset/analysis-parity-log-schema.md
+++ b/.changeset/analysis-parity-log-schema.md
@@ -1,0 +1,14 @@
+---
+"@formspec/analysis": patch
+---
+
+Add parity-harness log schema and diffing helper (Phase 0.5m)
+
+Introduces two new test-internal helpers in `packages/analysis/src/__tests__/helpers/`:
+
+- `parity-log-entry.ts` — the `ParityLogEntry` TypeScript type (with `RoleOutcome` union) and an `isParityLogEntry` runtime type-guard that validates the full shape including the optional `diagnostic` sub-object.
+- `diff-parity-logs.ts` — `diffParityLogs(buildEntries, snapshotEntries): ParityDivergence[]`, a deterministic diffing function that normalizes entries by `tag + placement + subjectTypeKind` and reports three categories of divergence: one-sided missing entries, differing `roleOutcome` values, and differing diagnostic `code` values.
+
+These helpers are not exported from the package; they are consumed by the cross-consumer parity harness (Phase 0.5a).
+
+Implements §8.3e and §9.4 item 0.5m of `docs/refactors/synthetic-checker-retirement.md`.

--- a/packages/analysis/src/__tests__/helpers/diff-parity-logs.test.ts
+++ b/packages/analysis/src/__tests__/helpers/diff-parity-logs.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Unit tests for the parity-harness log diffing helper.
+ *
+ * @see docs/refactors/synthetic-checker-retirement.md §8.3e, §9.1 #1
+ */
+
+import { describe, expect, it } from "vitest";
+import { diffParityLogs } from "./diff-parity-logs.js";
+import { isParityLogEntry } from "./parity-log-entry.js";
+import type { ParityLogEntry } from "./parity-log-entry.js";
+
+// ---------------------------------------------------------------------------
+// Test-data factories
+// ---------------------------------------------------------------------------
+
+function makeEntry(
+  overrides: Partial<ParityLogEntry> & {
+    consumer: "build" | "snapshot";
+    tag: string;
+    placement: string;
+    subjectTypeKind: string;
+    roleOutcome: ParityLogEntry["roleOutcome"];
+  },
+): ParityLogEntry {
+  return {
+    elapsedMicros: 10,
+    ...overrides,
+  };
+}
+
+function buildEntry(
+  tag: string,
+  placement: string,
+  subjectTypeKind: string,
+  roleOutcome: ParityLogEntry["roleOutcome"],
+  extra?: Partial<ParityLogEntry>,
+): ParityLogEntry {
+  return makeEntry({ consumer: "build", tag, placement, subjectTypeKind, roleOutcome, ...extra });
+}
+
+function snapshotEntry(
+  tag: string,
+  placement: string,
+  subjectTypeKind: string,
+  roleOutcome: ParityLogEntry["roleOutcome"],
+  extra?: Partial<ParityLogEntry>,
+): ParityLogEntry {
+  return makeEntry({
+    consumer: "snapshot",
+    tag,
+    placement,
+    subjectTypeKind,
+    roleOutcome,
+    ...extra,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// isParityLogEntry — runtime type-guard
+// ---------------------------------------------------------------------------
+
+describe("isParityLogEntry", () => {
+  it("accepts a fully valid build entry", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+        elapsedMicros: 42,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a valid entry with an optional diagnostic", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "snapshot",
+        tag: "pattern",
+        placement: "class-field",
+        subjectTypeKind: "string",
+        roleOutcome: "A-reject",
+        elapsedMicros: 5,
+        diagnostic: { code: "INVALID_TAG_PLACEMENT", message: "tag not valid here" },
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts every valid roleOutcome value", () => {
+    const outcomes: ParityLogEntry["roleOutcome"][] = [
+      "A-pass",
+      "A-reject",
+      "B-pass",
+      "B-reject",
+      "C-pass",
+      "C-reject",
+      "D1",
+      "D2",
+      "bypass",
+    ];
+
+    for (const roleOutcome of outcomes) {
+      expect(
+        isParityLogEntry({
+          consumer: "build",
+          tag: "minimum",
+          placement: "class-field",
+          subjectTypeKind: "number",
+          roleOutcome,
+          elapsedMicros: 1,
+        }),
+        `expected isParityLogEntry to return true for roleOutcome="${roleOutcome}"`,
+      ).toBe(true);
+    }
+  });
+
+  it("rejects null", () => {
+    expect(isParityLogEntry(null)).toBe(false);
+  });
+
+  it("rejects a primitive", () => {
+    expect(isParityLogEntry("not-an-object")).toBe(false);
+    expect(isParityLogEntry(42)).toBe(false);
+  });
+
+  it("rejects an array", () => {
+    expect(isParityLogEntry([])).toBe(false);
+  });
+
+  it("rejects an invalid consumer value", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "unknown",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+        elapsedMicros: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects an invalid roleOutcome value", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "E-pass",
+        elapsedMicros: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects when elapsedMicros is missing", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects when diagnostic is present but malformed (missing code)", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+        elapsedMicros: 1,
+        diagnostic: { message: "missing code field" },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects when diagnostic is an array instead of an object", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+        elapsedMicros: 1,
+        diagnostic: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a class instance (not a plain object)", () => {
+    class Fake {
+      consumer = "build";
+      tag = "minimum";
+      placement = "class-field";
+      subjectTypeKind = "number";
+      roleOutcome = "C-pass";
+      elapsedMicros = 1;
+    }
+    expect(isParityLogEntry(new Fake())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// diffParityLogs
+// ---------------------------------------------------------------------------
+
+describe("diffParityLogs", () => {
+  describe("empty inputs", () => {
+    it("returns no divergences when both sides are empty", () => {
+      expect(diffParityLogs([], [])).toEqual([]);
+    });
+
+    it("returns missing-in-snapshot divergences when build side is non-empty and snapshot is empty", () => {
+      const entries = [buildEntry("minimum", "class-field", "number", "C-pass")];
+      const result = diffParityLogs(entries, []);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        kind: "missing-in-snapshot",
+        key: "minimum::class-field::number",
+      });
+    });
+
+    it("returns missing-in-build divergences when snapshot side is non-empty and build is empty", () => {
+      const entries = [snapshotEntry("minimum", "class-field", "number", "C-pass")];
+      const result = diffParityLogs([], entries);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        kind: "missing-in-build",
+        key: "minimum::class-field::number",
+      });
+    });
+  });
+
+  describe("happy-path equality", () => {
+    it("returns no divergences when build and snapshot entries match exactly", () => {
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+        buildEntry("maxLength", "class-field", "string", "A-pass"),
+      ];
+      const s = [
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+        snapshotEntry("maxLength", "class-field", "string", "A-pass"),
+      ];
+
+      expect(diffParityLogs(b, s)).toEqual([]);
+    });
+
+    it("ignores differences in elapsedMicros when outcomes and codes match", () => {
+      const b = [buildEntry("minimum", "class-field", "number", "C-pass")];
+      const s = [
+        snapshotEntry("minimum", "class-field", "number", "C-pass", { elapsedMicros: 9999 }),
+      ];
+
+      expect(diffParityLogs(b, s)).toEqual([]);
+    });
+
+    it("ignores differences in diagnostic message text when codes match", () => {
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-reject", {
+          diagnostic: { code: "TYPE_MISMATCH", message: "build message" },
+        }),
+      ];
+      const s = [
+        snapshotEntry("minimum", "class-field", "number", "C-reject", {
+          diagnostic: { code: "TYPE_MISMATCH", message: "snapshot message differs" },
+        }),
+      ];
+
+      // Messages differ but codes match — no divergence expected
+      expect(diffParityLogs(b, s)).toEqual([]);
+    });
+  });
+
+  describe("one-sided missing entries", () => {
+    it("emits missing-in-snapshot for an entry present only in build", () => {
+      const b = [buildEntry("pattern", "class-field", "string", "C-pass")];
+      const result = diffParityLogs(b, []);
+
+      expect(result).toHaveLength(1);
+      const div = result[0];
+      expect(div.kind).toBe("missing-in-snapshot");
+      if (div.kind === "missing-in-snapshot") {
+        expect(div.key).toBe("pattern::class-field::string");
+        expect(div.buildEntry).toBe(b[0]);
+      }
+    });
+
+    it("emits missing-in-build for an entry present only in snapshot", () => {
+      const s = [snapshotEntry("pattern", "class-field", "string", "C-pass")];
+      const result = diffParityLogs([], s);
+
+      expect(result).toHaveLength(1);
+      const div = result[0];
+      expect(div.kind).toBe("missing-in-build");
+      if (div.kind === "missing-in-build") {
+        expect(div.key).toBe("pattern::class-field::string");
+        expect(div.snapshotEntry).toBe(s[0]);
+      }
+    });
+
+    it("handles multiple one-sided misses and returns them sorted by key", () => {
+      const b = [
+        buildEntry("zzz", "class-field", "string", "C-pass"),
+        buildEntry("aaa", "class-field", "number", "C-pass"),
+      ];
+      const result = diffParityLogs(b, []);
+
+      expect(result).toHaveLength(2);
+      // Sorted ascending by key: aaa < zzz
+      expect(result[0]).toMatchObject({ kind: "missing-in-snapshot", key: "aaa::class-field::number" });
+      expect(result[1]).toMatchObject({ kind: "missing-in-snapshot", key: "zzz::class-field::string" });
+    });
+  });
+
+  describe("role-outcome divergence", () => {
+    it("emits role-outcome-divergence when build and snapshot have different roleOutcome for the same key", () => {
+      const b = [buildEntry("minimum", "class-field", "number", "C-pass")];
+      const s = [snapshotEntry("minimum", "class-field", "number", "C-reject")];
+
+      const result = diffParityLogs(b, s);
+
+      expect(result).toHaveLength(1);
+      const div = result[0];
+      expect(div.kind).toBe("role-outcome-divergence");
+      if (div.kind === "role-outcome-divergence") {
+        expect(div.buildOutcome).toBe("C-pass");
+        expect(div.snapshotOutcome).toBe("C-reject");
+        expect(div.buildEntry).toBe(b[0]);
+        expect(div.snapshotEntry).toBe(s[0]);
+      }
+    });
+  });
+
+  describe("diagnostic-code divergence", () => {
+    it("emits diagnostic-code-divergence when outcomes match but diagnostic codes differ", () => {
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-reject", {
+          diagnostic: { code: "TYPE_MISMATCH", message: "..." },
+        }),
+      ];
+      const s = [
+        snapshotEntry("minimum", "class-field", "number", "C-reject", {
+          diagnostic: { code: "INVALID_TAG_ARGUMENT", message: "..." },
+        }),
+      ];
+
+      const result = diffParityLogs(b, s);
+
+      expect(result).toHaveLength(1);
+      const div = result[0];
+      expect(div.kind).toBe("diagnostic-code-divergence");
+      if (div.kind === "diagnostic-code-divergence") {
+        expect(div.buildCode).toBe("TYPE_MISMATCH");
+        expect(div.snapshotCode).toBe("INVALID_TAG_ARGUMENT");
+      }
+    });
+
+    it("emits diagnostic-code-divergence when one side has a diagnostic and the other does not", () => {
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-reject", {
+          diagnostic: { code: "TYPE_MISMATCH", message: "type mismatch" },
+        }),
+      ];
+      const s = [snapshotEntry("minimum", "class-field", "number", "C-reject")];
+
+      const result = diffParityLogs(b, s);
+
+      expect(result).toHaveLength(1);
+      const div = result[0];
+      expect(div.kind).toBe("diagnostic-code-divergence");
+      if (div.kind === "diagnostic-code-divergence") {
+        expect(div.buildCode).toBe("TYPE_MISMATCH");
+        expect(div.snapshotCode).toBeUndefined();
+      }
+    });
+  });
+
+  describe("determinism and ordering", () => {
+    it("returns results sorted ascending by composite key regardless of input order", () => {
+      const b = [
+        buildEntry("zzz-tag", "class-field", "string", "C-pass"),
+        buildEntry("aaa-tag", "class-field", "number", "C-pass"),
+        buildEntry("mmm-tag", "class-field", "boolean", "C-pass"),
+      ];
+
+      const result = diffParityLogs(b, []);
+
+      expect(result.map((d) => d.kind === "missing-in-snapshot" ? d.key : "")).toEqual([
+        "aaa-tag::class-field::number",
+        "mmm-tag::class-field::boolean",
+        "zzz-tag::class-field::string",
+      ]);
+    });
+
+    it("produces the same result when called twice with the same inputs", () => {
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-reject", {
+          diagnostic: { code: "TYPE_MISMATCH", message: "..." },
+        }),
+        buildEntry("maxLength", "class-field", "string", "C-pass"),
+      ];
+      const s = [
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+        snapshotEntry("maxLength", "class-field", "string", "C-pass"),
+      ];
+
+      expect(diffParityLogs(b, s)).toEqual(diffParityLogs(b, s));
+    });
+  });
+});

--- a/packages/analysis/src/__tests__/helpers/diff-parity-logs.test.ts
+++ b/packages/analysis/src/__tests__/helpers/diff-parity-logs.test.ts
@@ -115,6 +115,32 @@ describe("isParityLogEntry", () => {
     }
   });
 
+  it("accepts elapsedMicros of 0 (boundary)", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+        elapsedMicros: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a positive finite elapsedMicros", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+        elapsedMicros: 12345.67,
+      }),
+    ).toBe(true);
+  });
+
   it("rejects null", () => {
     expect(isParityLogEntry(null)).toBe(false);
   });
@@ -162,6 +188,45 @@ describe("isParityLogEntry", () => {
         placement: "class-field",
         subjectTypeKind: "number",
         roleOutcome: "C-pass",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects elapsedMicros of NaN", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+        elapsedMicros: NaN,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects elapsedMicros of Infinity", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+        elapsedMicros: Infinity,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects negative elapsedMicros", () => {
+    expect(
+      isParityLogEntry({
+        consumer: "build",
+        tag: "minimum",
+        placement: "class-field",
+        subjectTypeKind: "number",
+        roleOutcome: "C-pass",
+        elapsedMicros: -1,
       }),
     ).toBe(false);
   });
@@ -332,6 +397,7 @@ describe("diffParityLogs", () => {
       const div = result[0];
       expect(div.kind).toBe("role-outcome-divergence");
       if (div.kind === "role-outcome-divergence") {
+        expect(div.index).toBe(0);
         expect(div.buildOutcome).toBe("C-pass");
         expect(div.snapshotOutcome).toBe("C-reject");
         expect(div.buildEntry).toBe(b[0]);
@@ -359,6 +425,7 @@ describe("diffParityLogs", () => {
       const div = result[0];
       expect(div.kind).toBe("diagnostic-code-divergence");
       if (div.kind === "diagnostic-code-divergence") {
+        expect(div.index).toBe(0);
         expect(div.buildCode).toBe("TYPE_MISMATCH");
         expect(div.snapshotCode).toBe("INVALID_TAG_ARGUMENT");
       }
@@ -378,6 +445,7 @@ describe("diffParityLogs", () => {
       const div = result[0];
       expect(div.kind).toBe("diagnostic-code-divergence");
       if (div.kind === "diagnostic-code-divergence") {
+        expect(div.index).toBe(0);
         expect(div.buildCode).toBe("TYPE_MISMATCH");
         expect(div.snapshotCode).toBeUndefined();
       }
@@ -414,6 +482,146 @@ describe("diffParityLogs", () => {
       ];
 
       expect(diffParityLogs(b, s)).toEqual(diffParityLogs(b, s));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Duplicate-key handling
+  // -------------------------------------------------------------------------
+
+  describe("duplicate-key entries (multiple fixtures / fields sharing a tag+placement+type)", () => {
+    it("produces no divergences when both sides have the same count and matching entries for a duplicate key", () => {
+      // Two fixtures both produce a "minimum::class-field::number" entry; both pass.
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+      ];
+      const s = [
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+      ];
+
+      expect(diffParityLogs(b, s)).toEqual([]);
+    });
+
+    it("emits array-length-divergence when build has more entries for a key than snapshot", () => {
+      // Build produced 2 entries for the key; snapshot only produced 1.
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+      ];
+      const s = [snapshotEntry("minimum", "class-field", "number", "C-pass")];
+
+      const result = diffParityLogs(b, s);
+
+      expect(result).toHaveLength(1);
+      const div = result[0];
+      expect(div.kind).toBe("array-length-divergence");
+      if (div.kind === "array-length-divergence") {
+        expect(div.key).toBe("minimum::class-field::number");
+        expect(div.buildCount).toBe(2);
+        expect(div.snapshotCount).toBe(1);
+        expect(div.buildEntries).toHaveLength(2);
+        expect(div.snapshotEntries).toHaveLength(1);
+      }
+    });
+
+    it("emits array-length-divergence when snapshot has more entries for a key than build", () => {
+      const b = [buildEntry("minimum", "class-field", "number", "C-pass")];
+      const s = [
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+      ];
+
+      const result = diffParityLogs(b, s);
+
+      expect(result).toHaveLength(1);
+      const div = result[0];
+      expect(div.kind).toBe("array-length-divergence");
+      if (div.kind === "array-length-divergence") {
+        expect(div.buildCount).toBe(1);
+        expect(div.snapshotCount).toBe(2);
+      }
+    });
+
+    it("skips positional comparison entirely when array lengths differ for a key", () => {
+      // The first entries would match perfectly, but the length divergence should
+      // prevent any role-outcome or diagnostic-code divergence from being emitted.
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+        buildEntry("minimum", "class-field", "number", "C-reject", {
+          diagnostic: { code: "TYPE_MISMATCH", message: "..." },
+        }),
+      ];
+      const s = [
+        // Only one snapshot entry — lengths differ.
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+      ];
+
+      const result = diffParityLogs(b, s);
+
+      // Exactly one divergence: the array-length-divergence; no positional divergences.
+      expect(result).toHaveLength(1);
+      const onlyDiv = result[0];
+      expect(onlyDiv?.kind).toBe("array-length-divergence");
+    });
+
+    it("emits role-outcome-divergence at the correct index when the mismatch is at position 1", () => {
+      // Position 0 matches; position 1 diverges.
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+      ];
+      const s = [
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+        snapshotEntry("minimum", "class-field", "number", "C-reject"), // mismatch at index 1
+      ];
+
+      const result = diffParityLogs(b, s);
+
+      expect(result).toHaveLength(1);
+      const div = result[0];
+      expect(div.kind).toBe("role-outcome-divergence");
+      if (div.kind === "role-outcome-divergence") {
+        expect(div.index).toBe(1);
+        expect(div.buildOutcome).toBe("C-pass");
+        expect(div.snapshotOutcome).toBe("C-reject");
+      }
+    });
+
+    it("emits missing-in-snapshot for each entry when the key is entirely absent from snapshot (multiple entries)", () => {
+      // Key appears twice on the build side but not at all on the snapshot side.
+      const b = [
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+        buildEntry("minimum", "class-field", "number", "C-pass"),
+      ];
+
+      const result = diffParityLogs(b, []);
+
+      expect(result).toHaveLength(2);
+      for (const div of result) {
+        expect(div.kind).toBe("missing-in-snapshot");
+        if (div.kind === "missing-in-snapshot") {
+          expect(div.key).toBe("minimum::class-field::number");
+        }
+      }
+    });
+
+    it("emits missing-in-build for each entry when the key is entirely absent from build (multiple entries)", () => {
+      const s = [
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+        snapshotEntry("minimum", "class-field", "number", "C-pass"),
+      ];
+
+      const result = diffParityLogs([], s);
+
+      expect(result).toHaveLength(2);
+      for (const div of result) {
+        expect(div.kind).toBe("missing-in-build");
+        if (div.kind === "missing-in-build") {
+          expect(div.key).toBe("minimum::class-field::number");
+        }
+      }
     });
   });
 });

--- a/packages/analysis/src/__tests__/helpers/diff-parity-logs.ts
+++ b/packages/analysis/src/__tests__/helpers/diff-parity-logs.ts
@@ -1,0 +1,175 @@
+/**
+ * Diffing helper for cross-consumer parity-harness log comparison.
+ *
+ * {@link diffParityLogs} normalizes entries by their `tag + placement +
+ * subjectTypeKind` composite key and returns structured divergence records
+ * distinguishing:
+ *
+ *   (a) entries present on one side only,
+ *   (b) entries with matching keys but different `roleOutcome`, and
+ *   (c) entries with matching keys and outcomes but different diagnostic
+ *       codes (message text is intentionally excluded from parity checking
+ *       because it may vary across consumers without representing semantic
+ *       divergence).
+ *
+ * The result is deterministic: entries are sorted by natural string order of
+ * their composite key before diffing.
+ *
+ * @see docs/refactors/synthetic-checker-retirement.md §8.3e, §9.1 #1
+ */
+
+import type { ParityLogEntry } from "./parity-log-entry.js";
+
+// ---------------------------------------------------------------------------
+// Composite key
+// ---------------------------------------------------------------------------
+
+/** Stable, human-readable key used to correlate entries across consumers. */
+type CompositeKey = `${string}::${string}::${string}`;
+
+function toKey(entry: ParityLogEntry): CompositeKey {
+  return `${entry.tag}::${entry.placement}::${entry.subjectTypeKind}`;
+}
+
+// ---------------------------------------------------------------------------
+// Divergence kinds
+// ---------------------------------------------------------------------------
+
+/** An entry present in the build consumer log but absent from the snapshot log. */
+export interface MissingInSnapshot {
+  readonly kind: "missing-in-snapshot";
+  readonly key: CompositeKey;
+  readonly buildEntry: ParityLogEntry;
+}
+
+/** An entry present in the snapshot consumer log but absent from the build log. */
+export interface MissingInBuild {
+  readonly kind: "missing-in-build";
+  readonly key: CompositeKey;
+  readonly snapshotEntry: ParityLogEntry;
+}
+
+/** Entries that share a key but produced different `roleOutcome` values. */
+export interface RoleOutcomeDivergence {
+  readonly kind: "role-outcome-divergence";
+  readonly key: CompositeKey;
+  readonly buildEntry: ParityLogEntry;
+  readonly snapshotEntry: ParityLogEntry;
+  readonly buildOutcome: ParityLogEntry["roleOutcome"];
+  readonly snapshotOutcome: ParityLogEntry["roleOutcome"];
+}
+
+/**
+ * Entries that share a key and outcome but emitted diagnostics with different
+ * `code` values.  Message text is NOT compared — codes are the stable
+ * contract; messages may vary.
+ */
+export interface DiagnosticCodeDivergence {
+  readonly kind: "diagnostic-code-divergence";
+  readonly key: CompositeKey;
+  readonly buildEntry: ParityLogEntry;
+  readonly snapshotEntry: ParityLogEntry;
+  readonly buildCode: string | undefined;
+  readonly snapshotCode: string | undefined;
+}
+
+/** Union of all possible parity divergence records. */
+export type ParityDivergence =
+  | MissingInSnapshot
+  | MissingInBuild
+  | RoleOutcomeDivergence
+  | DiagnosticCodeDivergence;
+
+// ---------------------------------------------------------------------------
+// diffParityLogs
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare build-consumer entries against snapshot-consumer entries and return
+ * an ordered list of divergences.
+ *
+ * The algorithm:
+ *  1. Build a key→entry map for each side (last-write-wins if duplicates exist
+ *     within the same side, which is unexpected but handled gracefully).
+ *  2. Collect the union of all keys, sorted ascending.
+ *  3. For each key: emit a divergence when the entry is absent on one side,
+ *     the `roleOutcome` differs, or the diagnostic `code` differs.
+ *
+ * Entries that are fully equivalent (same key, same outcome, same diagnostic
+ * code or both undefined) produce no output.
+ *
+ * @param buildEntries   - Entries collected from the build consumer.
+ * @param snapshotEntries - Entries collected from the snapshot consumer.
+ * @returns Deterministically ordered divergence records (sorted by key).
+ */
+export function diffParityLogs(
+  buildEntries: readonly ParityLogEntry[],
+  snapshotEntries: readonly ParityLogEntry[],
+): ParityDivergence[] {
+  // Index by composite key.  Within one slice, if multiple entries share a
+  // key the last one wins — the caller is responsible for deduplication if
+  // needed, but we must not throw on duplicates.
+  const buildMap = new Map<CompositeKey, ParityLogEntry>();
+  for (const entry of buildEntries) {
+    buildMap.set(toKey(entry), entry);
+  }
+
+  const snapshotMap = new Map<CompositeKey, ParityLogEntry>();
+  for (const entry of snapshotEntries) {
+    snapshotMap.set(toKey(entry), entry);
+  }
+
+  // Union of all keys, sorted for determinism.
+  const allKeys = Array.from(new Set([...buildMap.keys(), ...snapshotMap.keys()])).sort();
+
+  const divergences: ParityDivergence[] = [];
+
+  for (const key of allKeys) {
+    const buildEntry = buildMap.get(key);
+    const snapshotEntry = snapshotMap.get(key);
+
+    if (buildEntry === undefined && snapshotEntry !== undefined) {
+      divergences.push({ kind: "missing-in-build", key, snapshotEntry });
+      continue;
+    }
+
+    if (buildEntry !== undefined && snapshotEntry === undefined) {
+      divergences.push({ kind: "missing-in-snapshot", key, buildEntry });
+      continue;
+    }
+
+    // TypeScript narrowing: both are defined here (union of both maps covers
+    // the only case where both could be undefined — an empty key — which
+    // can't happen since keys come from one of the two maps).
+    if (buildEntry === undefined || snapshotEntry === undefined) continue;
+
+    if (buildEntry.roleOutcome !== snapshotEntry.roleOutcome) {
+      divergences.push({
+        kind: "role-outcome-divergence",
+        key,
+        buildEntry,
+        snapshotEntry,
+        buildOutcome: buildEntry.roleOutcome,
+        snapshotOutcome: snapshotEntry.roleOutcome,
+      });
+      continue;
+    }
+
+    // Same outcome — check diagnostic codes (messages are not compared).
+    const buildCode = buildEntry.diagnostic?.code;
+    const snapshotCode = snapshotEntry.diagnostic?.code;
+
+    if (buildCode !== snapshotCode) {
+      divergences.push({
+        kind: "diagnostic-code-divergence",
+        key,
+        buildEntry,
+        snapshotEntry,
+        buildCode,
+        snapshotCode,
+      });
+    }
+  }
+
+  return divergences;
+}

--- a/packages/analysis/src/__tests__/helpers/diff-parity-logs.ts
+++ b/packages/analysis/src/__tests__/helpers/diff-parity-logs.ts
@@ -6,14 +6,16 @@
  * distinguishing:
  *
  *   (a) entries present on one side only,
- *   (b) entries with matching keys but different `roleOutcome`, and
- *   (c) entries with matching keys and outcomes but different diagnostic
- *       codes (message text is intentionally excluded from parity checking
- *       because it may vary across consumers without representing semantic
- *       divergence).
+ *   (b) keys where the two sides produced a different number of entries,
+ *   (c) entries with matching keys (and same positional index) but different
+ *       `roleOutcome`, and
+ *   (d) entries with matching keys, same positional index, and same outcome
+ *       but different diagnostic codes (message text is intentionally excluded
+ *       from parity checking because it may vary across consumers without
+ *       representing semantic divergence).
  *
- * The result is deterministic: entries are sorted by natural string order of
- * their composite key before diffing.
+ * The result is deterministic: entries are sorted by lexicographic /
+ * Unicode code unit order of their composite key before diffing.
  *
  * @see docs/refactors/synthetic-checker-retirement.md §8.3e, §9.1 #1
  */
@@ -49,10 +51,25 @@ export interface MissingInBuild {
   readonly snapshotEntry: ParityLogEntry;
 }
 
-/** Entries that share a key but produced different `roleOutcome` values. */
+/**
+ * The same composite key produced a different number of entries on each side.
+ * When counts differ the positional comparison is skipped entirely for that key.
+ */
+export interface ArrayLengthDivergence {
+  readonly kind: "array-length-divergence";
+  readonly key: CompositeKey;
+  readonly buildEntries: readonly ParityLogEntry[];
+  readonly snapshotEntries: readonly ParityLogEntry[];
+  readonly buildCount: number;
+  readonly snapshotCount: number;
+}
+
+/** Entries that share a key and positional index but produced different `roleOutcome` values. */
 export interface RoleOutcomeDivergence {
   readonly kind: "role-outcome-divergence";
   readonly key: CompositeKey;
+  /** Zero-based index within the per-key entry array. */
+  readonly index: number;
   readonly buildEntry: ParityLogEntry;
   readonly snapshotEntry: ParityLogEntry;
   readonly buildOutcome: ParityLogEntry["roleOutcome"];
@@ -60,13 +77,15 @@ export interface RoleOutcomeDivergence {
 }
 
 /**
- * Entries that share a key and outcome but emitted diagnostics with different
- * `code` values.  Message text is NOT compared — codes are the stable
- * contract; messages may vary.
+ * Entries that share a key, positional index, and outcome but emitted
+ * diagnostics with different `code` values.  Message text is NOT compared —
+ * codes are the stable contract; messages may vary.
  */
 export interface DiagnosticCodeDivergence {
   readonly kind: "diagnostic-code-divergence";
   readonly key: CompositeKey;
+  /** Zero-based index within the per-key entry array. */
+  readonly index: number;
   readonly buildEntry: ParityLogEntry;
   readonly snapshotEntry: ParityLogEntry;
   readonly buildCode: string | undefined;
@@ -77,6 +96,7 @@ export interface DiagnosticCodeDivergence {
 export type ParityDivergence =
   | MissingInSnapshot
   | MissingInBuild
+  | ArrayLengthDivergence
   | RoleOutcomeDivergence
   | DiagnosticCodeDivergence;
 
@@ -89,11 +109,16 @@ export type ParityDivergence =
  * an ordered list of divergences.
  *
  * The algorithm:
- *  1. Build a key→entry map for each side (last-write-wins if duplicates exist
- *     within the same side, which is unexpected but handled gracefully).
- *  2. Collect the union of all keys, sorted ascending.
- *  3. For each key: emit a divergence when the entry is absent on one side,
- *     the `roleOutcome` differs, or the diagnostic `code` differs.
+ *  1. Build a key→entries[] map for each side, preserving all entries per key.
+ *  2. Collect the union of all keys, sorted ascending (lexicographic order).
+ *  3. For each key:
+ *     a. If the key is absent on one side, emit a missing-in-{snapshot,build}
+ *        divergence for each entry on the present side.
+ *     b. If both sides have the key but different entry counts, emit a single
+ *        array-length-divergence and skip positional comparison for that key.
+ *     c. If counts match, compare entries positionally (build[i] vs
+ *        snapshot[i]):  emit role-outcome-divergence or
+ *        diagnostic-code-divergence for each mismatching pair.
  *
  * Entries that are fully equivalent (same key, same outcome, same diagnostic
  * code or both undefined) produce no output.
@@ -106,17 +131,27 @@ export function diffParityLogs(
   buildEntries: readonly ParityLogEntry[],
   snapshotEntries: readonly ParityLogEntry[],
 ): ParityDivergence[] {
-  // Index by composite key.  Within one slice, if multiple entries share a
-  // key the last one wins — the caller is responsible for deduplication if
-  // needed, but we must not throw on duplicates.
-  const buildMap = new Map<CompositeKey, ParityLogEntry>();
+  // Index by composite key — all entries per key are preserved in order.
+  const buildMap = new Map<CompositeKey, ParityLogEntry[]>();
   for (const entry of buildEntries) {
-    buildMap.set(toKey(entry), entry);
+    const key = toKey(entry);
+    const existing = buildMap.get(key);
+    if (existing !== undefined) {
+      existing.push(entry);
+    } else {
+      buildMap.set(key, [entry]);
+    }
   }
 
-  const snapshotMap = new Map<CompositeKey, ParityLogEntry>();
+  const snapshotMap = new Map<CompositeKey, ParityLogEntry[]>();
   for (const entry of snapshotEntries) {
-    snapshotMap.set(toKey(entry), entry);
+    const key = toKey(entry);
+    const existing = snapshotMap.get(key);
+    if (existing !== undefined) {
+      existing.push(entry);
+    } else {
+      snapshotMap.set(key, [entry]);
+    }
   }
 
   // Union of all keys, sorted for determinism.
@@ -125,49 +160,79 @@ export function diffParityLogs(
   const divergences: ParityDivergence[] = [];
 
   for (const key of allKeys) {
-    const buildEntry = buildMap.get(key);
-    const snapshotEntry = snapshotMap.get(key);
+    const buildArr = buildMap.get(key);
+    const snapshotArr = snapshotMap.get(key);
 
-    if (buildEntry === undefined && snapshotEntry !== undefined) {
-      divergences.push({ kind: "missing-in-build", key, snapshotEntry });
+    if (buildArr === undefined && snapshotArr !== undefined) {
+      // Key entirely absent from build side — one missing-in-build per entry.
+      for (const snapshotEntry of snapshotArr) {
+        divergences.push({ kind: "missing-in-build", key, snapshotEntry });
+      }
       continue;
     }
 
-    if (buildEntry !== undefined && snapshotEntry === undefined) {
-      divergences.push({ kind: "missing-in-snapshot", key, buildEntry });
+    if (buildArr !== undefined && snapshotArr === undefined) {
+      // Key entirely absent from snapshot side — one missing-in-snapshot per entry.
+      for (const buildEntry of buildArr) {
+        divergences.push({ kind: "missing-in-snapshot", key, buildEntry });
+      }
       continue;
     }
 
-    // TypeScript narrowing: both are defined here (union of both maps covers
-    // the only case where both could be undefined — an empty key — which
-    // can't happen since keys come from one of the two maps).
-    if (buildEntry === undefined || snapshotEntry === undefined) continue;
+    // TypeScript narrowing: both are defined here (keys come from one of the
+    // two maps, so the only way both could be undefined is an empty key, which
+    // can't happen).
+    if (buildArr === undefined || snapshotArr === undefined) continue;
 
-    if (buildEntry.roleOutcome !== snapshotEntry.roleOutcome) {
+    // Both sides have entries for this key — check array lengths first.
+    if (buildArr.length !== snapshotArr.length) {
       divergences.push({
-        kind: "role-outcome-divergence",
+        kind: "array-length-divergence",
         key,
-        buildEntry,
-        snapshotEntry,
-        buildOutcome: buildEntry.roleOutcome,
-        snapshotOutcome: snapshotEntry.roleOutcome,
+        buildEntries: buildArr,
+        snapshotEntries: snapshotArr,
+        buildCount: buildArr.length,
+        snapshotCount: snapshotArr.length,
       });
       continue;
     }
 
-    // Same outcome — check diagnostic codes (messages are not compared).
-    const buildCode = buildEntry.diagnostic?.code;
-    const snapshotCode = snapshotEntry.diagnostic?.code;
+    // Same length — compare positionally.
+    for (const [i, buildEntry] of buildArr.entries()) {
+      // snapshotArr has the same length (verified above), so snapshotArr[i] is
+      // always defined.  The type-only cast is safe here; validated by the
+      // length check above.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length equality verified above
+      const snapshotEntry = snapshotArr[i]!;
 
-    if (buildCode !== snapshotCode) {
-      divergences.push({
-        kind: "diagnostic-code-divergence",
-        key,
-        buildEntry,
-        snapshotEntry,
-        buildCode,
-        snapshotCode,
-      });
+      if (buildEntry.roleOutcome !== snapshotEntry.roleOutcome) {
+        divergences.push({
+          kind: "role-outcome-divergence",
+          key,
+          index: i,
+          buildEntry,
+          snapshotEntry,
+          buildOutcome: buildEntry.roleOutcome,
+          snapshotOutcome: snapshotEntry.roleOutcome,
+        });
+        continue;
+      }
+
+      // Same outcome — check diagnostic codes (messages are not compared).
+      const buildCode = buildEntry.diagnostic?.code;
+      const snapshotCode = snapshotEntry.diagnostic?.code;
+
+      if (buildCode !== snapshotCode) {
+        divergences.push({
+          kind: "diagnostic-code-divergence",
+          key,
+          index: i,
+          buildEntry,
+          snapshotEntry,
+          buildCode,
+          snapshotCode,
+        });
+      }
     }
   }
 

--- a/packages/analysis/src/__tests__/helpers/parity-log-entry.ts
+++ b/packages/analysis/src/__tests__/helpers/parity-log-entry.ts
@@ -13,17 +13,27 @@
 // Role-outcome literals
 // ---------------------------------------------------------------------------
 
+/**
+ * Canonical ordered list of all valid `roleOutcome` values.
+ * `RoleOutcome` is derived from this array so the two never diverge.
+ */
+export const ROLE_OUTCOMES = [
+  "A-pass",
+  "A-reject",
+  "B-pass",
+  "B-reject",
+  "C-pass",
+  "C-reject",
+  "D1",
+  "D2",
+  "bypass",
+] as const;
+
 /** All possible values for the `roleOutcome` field of a {@link ParityLogEntry}. */
-export type RoleOutcome =
-  | "A-pass"
-  | "A-reject"
-  | "B-pass"
-  | "B-reject"
-  | "C-pass"
-  | "C-reject"
-  | "D1"
-  | "D2"
-  | "bypass";
+export type RoleOutcome = (typeof ROLE_OUTCOMES)[number];
+
+/** Fast membership test for runtime type-guard use. */
+const ROLE_OUTCOMES_SET: ReadonlySet<string> = new Set<string>(ROLE_OUTCOMES);
 
 // ---------------------------------------------------------------------------
 // Main entry type
@@ -58,7 +68,11 @@ export interface ParityLogEntry {
 // Runtime type-guard
 // ---------------------------------------------------------------------------
 
-/** Returns true when `value` is a plain string-keyed object with no prototype extras. */
+/**
+ * Returns true when `value` is a plain string-keyed object with no prototype
+ * extras.  Excludes null-prototype objects (created via `Object.create(null)`)
+ * because parsed JSON always yields objects with `Object.prototype`.
+ */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return (
     typeof value === "object" &&
@@ -68,18 +82,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
     Object.getOwnPropertySymbols(value).length === 0
   );
 }
-
-const ROLE_OUTCOMES: ReadonlySet<string> = new Set<RoleOutcome>([
-  "A-pass",
-  "A-reject",
-  "B-pass",
-  "B-reject",
-  "C-pass",
-  "C-reject",
-  "D1",
-  "D2",
-  "bypass",
-]);
 
 /**
  * Type-guard: returns true when `value` is a well-formed {@link ParityLogEntry}.
@@ -96,8 +98,13 @@ export function isParityLogEntry(value: unknown): value is ParityLogEntry {
   if (typeof tag !== "string") return false;
   if (typeof placement !== "string") return false;
   if (typeof subjectTypeKind !== "string") return false;
-  if (typeof roleOutcome !== "string" || !ROLE_OUTCOMES.has(roleOutcome)) return false;
-  if (typeof elapsedMicros !== "number") return false;
+  if (typeof roleOutcome !== "string" || !ROLE_OUTCOMES_SET.has(roleOutcome)) return false;
+  if (
+    typeof elapsedMicros !== "number" ||
+    !Number.isFinite(elapsedMicros) ||
+    elapsedMicros < 0
+  )
+    return false;
 
   if (diagnostic !== undefined) {
     if (!isPlainObject(diagnostic)) return false;

--- a/packages/analysis/src/__tests__/helpers/parity-log-entry.ts
+++ b/packages/analysis/src/__tests__/helpers/parity-log-entry.ts
@@ -1,0 +1,109 @@
+/**
+ * Type definition and runtime type-guard for a single parity-harness log entry.
+ *
+ * Each entry records one constraint-tag application observed by a consumer
+ * (build or snapshot), along with the role outcome and optional diagnostic
+ * details.  The diffing helper {@link diffParityLogs} compares slices of
+ * these entries across the two consumers.
+ *
+ * @see docs/refactors/synthetic-checker-retirement.md §8.3b, §8.3e
+ */
+
+// ---------------------------------------------------------------------------
+// Role-outcome literals
+// ---------------------------------------------------------------------------
+
+/** All possible values for the `roleOutcome` field of a {@link ParityLogEntry}. */
+export type RoleOutcome =
+  | "A-pass"
+  | "A-reject"
+  | "B-pass"
+  | "B-reject"
+  | "C-pass"
+  | "C-reject"
+  | "D1"
+  | "D2"
+  | "bypass";
+
+// ---------------------------------------------------------------------------
+// Main entry type
+// ---------------------------------------------------------------------------
+
+/**
+ * One structured log entry emitted per constraint-tag application.
+ *
+ * Fields mirror the §8.3b specification:
+ *   - `consumer` — which pipeline produced this entry
+ *   - `tag` — the TSDoc tag name (without `@`), e.g. `"minimum"`
+ *   - `placement` — the placement kind string, e.g. `"class-field"`
+ *   - `subjectTypeKind` — the TypeScript type kind of the subject, e.g. `"number"`
+ *   - `roleOutcome` — which role accepted/rejected the application
+ *   - `elapsedMicros` — elapsed time in microseconds for this application
+ *   - `diagnostic` — present when a rejection diagnostic was emitted
+ */
+export interface ParityLogEntry {
+  readonly consumer: "build" | "snapshot";
+  readonly tag: string;
+  readonly placement: string;
+  readonly subjectTypeKind: string;
+  readonly roleOutcome: RoleOutcome;
+  readonly elapsedMicros: number;
+  readonly diagnostic?: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runtime type-guard
+// ---------------------------------------------------------------------------
+
+/** Returns true when `value` is a plain string-keyed object with no prototype extras. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype &&
+    Object.getOwnPropertySymbols(value).length === 0
+  );
+}
+
+const ROLE_OUTCOMES: ReadonlySet<string> = new Set<RoleOutcome>([
+  "A-pass",
+  "A-reject",
+  "B-pass",
+  "B-reject",
+  "C-pass",
+  "C-reject",
+  "D1",
+  "D2",
+  "bypass",
+]);
+
+/**
+ * Type-guard: returns true when `value` is a well-formed {@link ParityLogEntry}.
+ *
+ * Validates all required fields and the optional `diagnostic` sub-object.
+ */
+export function isParityLogEntry(value: unknown): value is ParityLogEntry {
+  if (!isPlainObject(value)) return false;
+
+  const { consumer, tag, placement, subjectTypeKind, roleOutcome, elapsedMicros, diagnostic } =
+    value;
+
+  if (consumer !== "build" && consumer !== "snapshot") return false;
+  if (typeof tag !== "string") return false;
+  if (typeof placement !== "string") return false;
+  if (typeof subjectTypeKind !== "string") return false;
+  if (typeof roleOutcome !== "string" || !ROLE_OUTCOMES.has(roleOutcome)) return false;
+  if (typeof elapsedMicros !== "number") return false;
+
+  if (diagnostic !== undefined) {
+    if (!isPlainObject(diagnostic)) return false;
+    if (typeof diagnostic["code"] !== "string") return false;
+    if (typeof diagnostic["message"] !== "string") return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary

Phase 0.5m of the synthetic-checker retirement plan (§8.3e, §9.4). Adds the parity-harness log schema and a deterministic diff helper that Phase 0.5a will consume.

- Entry type + runtime type guard (`parity-log-entry.ts`)
- `diffParityLogs(build, snapshot)` — normalized by `(tag, placement, subjectTypeKind)`, reports one-sided missing, role-outcome divergence, and diagnostic-code divergence
- 26 unit tests

Internal test helper only; not exported from \`@formspec/analysis\`.

## Test plan

- [x] \`pnpm --filter @formspec/analysis run build\` — green
- [x] \`pnpm --filter @formspec/analysis run test\` — 26 new tests pass
- [x] \`pnpm run lint\` — clean

## Refactor-plan reference

- docs/refactors/synthetic-checker-retirement.md §8.3e, §9.4 item 0.5m