### PR TITLE
test(e2e): Ref<Customer> stress-test fixture + baseline (0.5l)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,7 +10,7 @@ Run the end-to-end suite from the monorepo root:
 pnpm run test:e2e
 ```
 
-Run the analysis microbenchmark fixture:
+Run the hybrid-tooling comparison benchmark:
 
 ```bash
 pnpm --filter @formspec/e2e run benchmark:hybrid-tooling

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,12 +10,78 @@ Run the end-to-end suite from the monorepo root:
 pnpm run test:e2e
 ```
 
-Run the benchmark fixture directly:
+Run the analysis microbenchmark fixture:
 
 ```bash
 pnpm --filter @formspec/e2e run benchmark:hybrid-tooling
 ```
 
+## Benchmarks
+
+### Analysis pipeline baseline (Phase 0-C)
+
+**Script:** `benchmarks/analysis-bench.ts`
+**Fixture:** `benchmarks/analysis-bench-fixture.ts` — 20-field `AnalysisBenchFixture` interface
+**Baseline:** `docs/refactors/phase-0-baseline.md`
+
+Measures `generateSchemasFromProgram` wall time, peak RSS, and synthetic `ts.createProgram`
+invocation count. Used as the Phase 0-C baseline for the synthetic-checker retirement refactor.
+
+```bash
+pnpm --filter @formspec/e2e run bench:analysis
+```
+
+### Stripe Ref\<Customer\> stress test (Phase 0 / §8.4a)
+
+**Script:** `benchmarks/stripe-ref-customer-bench.ts`
+**Fixture:** `fixtures/stripe-ref-customer/` — 30-field `CustomerRefForm` class with `Ref<T>` fields
+**Baseline:** `bench/baselines/stripe-ref-customer-baseline.json`
+
+This is the named acceptance gate for generic-reference handling in the synthetic-checker
+retirement refactor (see `docs/refactors/synthetic-checker-retirement.md` §8.4).
+
+Measures wall time, peak RSS, and OOM behaviour when the full FormSpec build pipeline
+processes a form class containing `Ref<Customer>`, `Ref<PaymentMethod>`, `Ref<Subscription>`,
+and `Ref<Invoice>` fields backed by Stripe-like types declared in a sibling file.
+
+```bash
+pnpm --filter @formspec/e2e run bench:stripe-ref-customer
+```
+
+To capture baseline JSON:
+
+```bash
+GIT_COMMIT_SHA=$(git rev-parse HEAD) \
+  pnpm --filter @formspec/e2e run bench:stripe-ref-customer \
+  > stripe-ref-baseline.json 2>/dev/null
+```
+
+#### Phase 0 baseline numbers (arm64 darwin, Node v24.14.0)
+
+| Metric | Value |
+|--------|-------|
+| `wallTime_ms` warm median | **44.8 ms** |
+| `wallTime_ms` cold (run 1) | **1 657 ms** |
+| `peakRSS_MB` warm median | **921.8 MB** |
+| `didOOM` (512 MB cap) | **false** |
+
+#### Phase comparison gates
+
+- **Phase 4** (after host-checker migration): `peakRSS_MB` ≤ **460.9 MB**, zero OOM on 1 GB runner.
+- **Phase 6** (after full synthetic deletion): `syntheticProgramCount` = 0 — no `ts.createProgram`
+  calls recorded in debug logs for the whole run.
+
+#### resolvePayload / extractPayload
+
+PR #300 (`resolvePayload` on `CustomTypeRegistration`) was superseded by PR #308 and removed in
+PR #313. This fixture uses the existing `generateSchemasFromProgram` API directly — no custom
+type registration is required because PR #308 added the external-type bypass in
+`extractReferenceTypeArguments` that prevents stack overflows on large SDK types. The baseline
+JSON records `resolvePayloadAvailable: false` to document this. See
+`fixtures/stripe-ref-customer/STUB_NOTE.md` for migration guidance if a `resolvePayload`
+equivalent ever lands.
+
 ## License
 
-This workspace is part of the FormSpec monorepo and is released under the MIT License. See [LICENSE](./LICENSE) for details.
+This workspace is part of the FormSpec monorepo and is released under the MIT License. See
+[LICENSE](./LICENSE) for details.

--- a/e2e/bench/baselines/stripe-ref-customer-baseline.json
+++ b/e2e/bench/baselines/stripe-ref-customer-baseline.json
@@ -1,0 +1,33 @@
+{
+  "phase": "0",
+  "description": "Stripe Ref<Customer> stress-test — Phase 0 pre-refactor baseline (§8.4a)",
+  "fixture": "e2e/fixtures/stripe-ref-customer/customer-ref-form.ts",
+  "typeName": "CustomerRefForm",
+  "fieldCount": 30,
+  "runs": 5,
+  "resolvePayloadAvailable": false,
+  "metrics": {
+    "peakRSS_MB": 921.8,
+    "wallTime_ms": 44.8,
+    "didOOM": false,
+    "warmWallTimes_ms": [
+      44.51,
+      53.64,
+      45.08,
+      43.75
+    ],
+    "allPeakRSS_MB": [
+      901.8,
+      909.8,
+      918,
+      925.6,
+      933.3
+    ],
+    "coldWallTime_ms": 1657.05
+  },
+  "gitSha": "57437ffa65381db44876480a79482f8e6edf78ac",
+  "timestamp": "2026-04-20T00:20:47.493Z",
+  "nodeVersion": "v24.14.0",
+  "platform": "darwin",
+  "arch": "arm64"
+}

--- a/e2e/benchmarks/stripe-ref-customer-bench.ts
+++ b/e2e/benchmarks/stripe-ref-customer-bench.ts
@@ -1,0 +1,406 @@
+/**
+ * Phase 0 baseline: Stripe `Ref<Customer>` stress-test benchmark (§8.4a / 0.5l).
+ *
+ * Measures three metrics for a single `generateSchemasFromProgram` call
+ * against the 30-field `CustomerRefForm` fixture that includes `Ref<T>`-typed
+ * fields backed by Stripe-like types declared in a sibling file.
+ *
+ *   1. wallTimeMs      — end-to-end elapsed time
+ *   2. peakRSS_MB      — peak resident set size (megabytes) observed via polling
+ *   3. didOOM          — whether the process ran out of memory
+ *
+ * ### Why this benchmark matters
+ *
+ * The synthetic `ts.Program` inside `@formspec/analysis` has historically been
+ * the OOM risk in FormSpec — it instantiates a parallel type graph that the host
+ * checker has already computed once. The Stripe `Ref<T>` fixture exercises
+ * generic-reference resolution across two source files, triggering the external-type
+ * bypass in `extractReferenceTypeArguments` (PR #308). This is the path that was
+ * historically prone to stack overflows and memory exhaustion on large SDK types.
+ *
+ * ### Phase comparison gates (§8.4b and §8.4c)
+ *
+ *   - **Phase 4** (after host-checker migration): peakRSS_MB ≤ 50% of this baseline,
+ *     zero OOM on a 1 GB runner.
+ *   - **Phase 6** (after full synthetic deletion): same fixture, zero `ts.createProgram`
+ *     calls in debug logs (`syntheticProgramCount` reads 0).
+ *
+ * ### resolvePayload availability
+ *
+ * PR #300 (`resolvePayload` / `extractPayload` on `CustomTypeRegistration`) was
+ * superseded by PR #308 and removed in PR #313. This benchmark uses the existing
+ * `generateSchemasFromProgram` API directly — no custom type registration is needed
+ * because the external-type bypass already handles `Ref<T>` correctly.
+ *
+ * See `e2e/fixtures/stripe-ref-customer/STUB_NOTE.md` for migration guidance.
+ *
+ * ### Run model
+ *
+ * Five runs are collected. Run 1 is the **cold run** (first invocation; module imports
+ * run before the timer starts). Runs 2–5 are **warm runs**. Median is computed over
+ * warm runs for wall time and RSS. OOM detection uses a subprocess with a 512 MB
+ * `--max-old-space-size` limit; if the subprocess exits non-zero with `ENOMEM` or
+ * JavaScript heap OOM messages, `didOOM` is set to `true`.
+ *
+ * ### Output
+ *
+ * Writes baseline JSON to `e2e/bench/baselines/stripe-ref-customer-baseline.json`
+ * and emits human-readable output to stderr and JSON to stdout.
+ *
+ * ### How to run
+ *
+ *   pnpm --filter @formspec/e2e run bench:stripe-ref-customer
+ *
+ * To capture JSON:
+ *
+ *   GIT_COMMIT_SHA=$(git rev-parse HEAD) \
+ *     pnpm --filter @formspec/e2e run bench:stripe-ref-customer \
+ *     > stripe-ref-baseline.json 2>/dev/null
+ */
+
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import * as ts from "typescript";
+import { generateSchemasFromProgram } from "@formspec/build";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+const E2E_ROOT = path.resolve(BENCH_DIR, "..");
+const FIXTURE_DIR = path.join(E2E_ROOT, "fixtures", "stripe-ref-customer");
+const BASELINE_DIR = path.join(E2E_ROOT, "bench", "baselines");
+const BASELINE_PATH = path.join(BASELINE_DIR, "stripe-ref-customer-baseline.json");
+const TYPE_NAME = "CustomerRefForm";
+const RUNS = 5;
+
+// TODO: migrate to real `import Stripe from "stripe"` + resolvePayload once
+//       a resolvePayload-equivalent lands on CustomTypeRegistration.
+//       See e2e/fixtures/stripe-ref-customer/STUB_NOTE.md for context.
+const RESOLVE_PAYLOAD_AVAILABLE = false;
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  strict: true,
+  skipLibCheck: true,
+};
+
+// ---------------------------------------------------------------------------
+// Peak-RSS polling
+// ---------------------------------------------------------------------------
+
+interface RssPoller {
+  stop: () => number;
+}
+
+function startRssPoller(intervalMs = 5): RssPoller {
+  let peak = process.memoryUsage().rss;
+
+  const id = setInterval(() => {
+    const current = process.memoryUsage().rss;
+    if (current > peak) peak = current;
+  }, intervalMs);
+
+  // Ensure the interval does not block process exit.
+  if (typeof id.unref === "function") id.unref();
+
+  return {
+    stop: () => {
+      clearInterval(id);
+      const final = process.memoryUsage().rss;
+      if (final > peak) peak = final;
+      return peak;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Single benchmark run
+// ---------------------------------------------------------------------------
+
+interface BuildRunResult {
+  readonly wallTimeMs: number;
+  readonly peakRssBytes: number;
+}
+
+function runBuildBenchOnce(fixturePath: string, extraFiles: string[]): BuildRunResult {
+  const allFiles = [fixturePath, ...extraFiles];
+  const program = ts.createProgram(allFiles, COMPILER_OPTIONS);
+
+  const rssPoller = startRssPoller();
+  const start = performance.now();
+
+  generateSchemasFromProgram({
+    program,
+    filePath: fixturePath,
+    typeName: TYPE_NAME,
+    errorReporting: "diagnostics",
+  });
+
+  const wallTimeMs = performance.now() - start;
+  const peakRssBytes = rssPoller.stop();
+
+  return { wallTimeMs, peakRssBytes };
+}
+
+// ---------------------------------------------------------------------------
+// OOM detection via subprocess with memory cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a single schema-generation pass in a child Node.js process capped at
+ * `maxOldSpaceMb` MB of V8 old-space. Returns `true` if the process ran out
+ * of memory (exit code non-zero and stderr contains OOM indicators).
+ *
+ * This is a best-effort check: on some OS/Node combinations, OOM may result
+ * in a SIGKILL without the expected stderr message. In those cases, any
+ * non-zero exit from the child is conservatively reported as OOM.
+ */
+function detectOom(fixturePath: string, extraFiles: string[], maxOldSpaceMb = 512): boolean {
+  // Write an inline runner script to a temp file that the child process executes.
+  // We intentionally keep the script minimal — its only job is to call
+  // generateSchemasFromProgram and exit 0 on success or 1 on failure.
+  // Numeric enum values embedded directly — avoids template-expression type errors.
+  const scriptTarget = String(ts.ScriptTarget.ES2022);
+  const moduleKind = String(ts.ModuleKind.NodeNext);
+  const moduleResolution = String(ts.ModuleResolutionKind.NodeNext);
+
+  const runnerScript = [
+    `import { createProgram } from "typescript";`,
+    `import { generateSchemasFromProgram } from "@formspec/build";`,
+    `const program = createProgram(${JSON.stringify([fixturePath, ...extraFiles])}, {`,
+    `  target: ${scriptTarget},`,
+    `  module: ${moduleKind},`,
+    `  moduleResolution: ${moduleResolution},`,
+    `  strict: true,`,
+    `  skipLibCheck: true,`,
+    `});`,
+    `generateSchemasFromProgram({`,
+    `  program,`,
+    `  filePath: ${JSON.stringify(fixturePath)},`,
+    `  typeName: ${JSON.stringify(TYPE_NAME)},`,
+    `  errorReporting: "diagnostics",`,
+    `});`,
+    `process.exit(0);`,
+  ].join("\n");
+
+  // Write the runner script to a temp file so the child can import it as ESM.
+  const tmpDir = os.tmpdir();
+  const runnerPath = path.join(tmpDir, `formspec-oom-probe-${String(process.pid)}.mjs`);
+  try {
+    // Sync write — this runs before the child is spawned.
+    fsSync.writeFileSync(runnerPath, runnerScript, "utf8");
+  } catch {
+    // If we can't write the probe script, conservatively report no OOM.
+    return false;
+  }
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [`--max-old-space-size=${String(maxOldSpaceMb)}`, runnerPath],
+      {
+        encoding: "utf8",
+        timeout: 120_000,
+        env: { ...process.env },
+      }
+    );
+
+    if (result.status === 0) return false;
+
+    // Check for OOM indicators in output.
+    const output = `${result.stdout}${result.stderr}`;
+    const oomIndicators = [
+      "ENOMEM",
+      "out of memory",
+      "JavaScript heap out of memory",
+      "Allocation failed",
+    ];
+    if (oomIndicators.some((indicator) => output.toLowerCase().includes(indicator.toLowerCase()))) {
+      return true;
+    }
+
+    // Non-zero exit without OOM message: likely a different error (e.g. fixture
+    // compilation failure). Do not count this as OOM.
+    return false;
+  } finally {
+    try {
+      fsSync.unlinkSync(runnerPath);
+    } catch {
+      // Best effort cleanup.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Median helper
+// ---------------------------------------------------------------------------
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("Cannot compute median of empty array");
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (sorted[mid - 1]! + sorted[mid]!) / 2
+    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      sorted[mid]!;
+}
+
+// ---------------------------------------------------------------------------
+// Baseline JSON shape
+// ---------------------------------------------------------------------------
+
+interface StripeRefCustomerBaseline {
+  readonly phase: "0";
+  readonly description: string;
+  readonly fixture: string;
+  readonly typeName: string;
+  readonly fieldCount: number;
+  readonly runs: number;
+  readonly resolvePayloadAvailable: boolean;
+  readonly metrics: {
+    readonly peakRSS_MB: number;
+    readonly wallTime_ms: number;
+    readonly didOOM: boolean;
+    readonly warmWallTimes_ms: readonly number[];
+    readonly allPeakRSS_MB: readonly number[];
+    readonly coldWallTime_ms: number;
+  };
+  readonly gitSha: string;
+  readonly timestamp: string;
+  readonly nodeVersion: string;
+  readonly platform: string;
+  readonly arch: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  // Ensure baseline directory exists.
+  await fs.mkdir(BASELINE_DIR, { recursive: true });
+
+  // Copy fixture source files to a temp directory so ts.createProgram can
+  // resolve them as real files from the filesystem.
+  const workspaceRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "formspec-stripe-ref-bench-")
+  );
+
+  try {
+    // Copy both fixture files into the temp workspace.
+    const fixtureFile = "customer-ref-form.ts";
+    const supportFile = "stripe-like-types.ts";
+
+    const fixtureSrc = await fs.readFile(path.join(FIXTURE_DIR, fixtureFile), "utf8");
+    const supportSrc = await fs.readFile(path.join(FIXTURE_DIR, supportFile), "utf8");
+
+    const fixturePath = path.join(workspaceRoot, fixtureFile);
+    const supportPath = path.join(workspaceRoot, supportFile);
+
+    await fs.writeFile(fixturePath, fixtureSrc, "utf8");
+    await fs.writeFile(supportPath, supportSrc, "utf8");
+
+    const extraFiles = [supportPath];
+
+    process.stderr.write(`\n=== Stripe Ref<Customer> Stress-Test Benchmark (Phase 0 baseline) ===\n\n`);
+    process.stderr.write(`  fixture type: ${TYPE_NAME}\n`);
+    process.stderr.write(`  fixture file: ${fixtureFile}\n`);
+    process.stderr.write(`  support file: ${supportFile}\n`);
+    process.stderr.write(`  runs:         ${String(RUNS)} (run 1 = cold)\n`);
+    process.stderr.write(`  resolvePayloadAvailable: ${String(RESOLVE_PAYLOAD_AVAILABLE)}\n\n`);
+
+    // --- Build-path measurements ---
+    const allWallTimeMs: number[] = [];
+    const allPeakRssBytes: number[] = [];
+
+    process.stderr.write(`  Build-path (generateSchemasFromProgram):\n`);
+    for (let i = 0; i < RUNS; i++) {
+      const label = i === 0 ? "cold" : "warm";
+      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
+      const result = runBuildBenchOnce(fixturePath, extraFiles);
+      allWallTimeMs.push(result.wallTimeMs);
+      allPeakRssBytes.push(result.peakRssBytes);
+      process.stderr.write(
+        ` ${result.wallTimeMs.toFixed(1)}ms  RSS=${(result.peakRssBytes / 1024 / 1024).toFixed(1)}MB\n`
+      );
+    }
+
+    const warmWallTimeMs = allWallTimeMs.slice(1);
+    const warmPeakRssBytes = allPeakRssBytes.slice(1);
+
+    const medianWarmWallTimeMs = median(warmWallTimeMs);
+    const medianWarmPeakRssBytes = median(warmPeakRssBytes);
+    const coldWallTimeMs = allWallTimeMs[0] ?? 0;
+    const peakRSSMB = medianWarmPeakRssBytes / 1024 / 1024;
+
+    // --- OOM detection ---
+    process.stderr.write(`\n  OOM probe (512 MB cap)...\n`);
+    const didOOM = detectOom(fixturePath, extraFiles, 512);
+    process.stderr.write(`    didOOM: ${String(didOOM)}\n`);
+
+    // --- Human-readable summary ---
+    process.stderr.write(`\n--- Phase 0 Stripe Ref<Customer> Baseline ---\n`);
+    process.stderr.write(
+      `  wallTime_ms cold:             ${coldWallTimeMs.toFixed(2)}\n`
+    );
+    process.stderr.write(
+      `  wallTime_ms warm (median):    ${medianWarmWallTimeMs.toFixed(2)}\n`
+    );
+    process.stderr.write(
+      `  peakRSS_MB warm (median):    ${peakRSSMB.toFixed(1)} MB\n`
+    );
+    process.stderr.write(`  didOOM (512 MB cap):         ${String(didOOM)}\n`);
+    process.stderr.write(`  resolvePayloadAvailable:     ${String(RESOLVE_PAYLOAD_AVAILABLE)}\n`);
+    process.stderr.write(`---------------------------------------------\n`);
+
+    // --- Phase 4 / Phase 6 gate notes ---
+    process.stderr.write(`\n  Phase 4 gate: peakRSS_MB ≤ ${(peakRSSMB * 0.5).toFixed(1)} MB, zero OOM on 1 GB runner\n`);
+    process.stderr.write(`  Phase 6 gate: syntheticProgramCount = 0 (no ts.createProgram calls in debug logs)\n\n`);
+
+    // --- Write baseline JSON ---
+    const commitSha = process.env["GIT_COMMIT_SHA"] ?? "unknown";
+
+    const baseline: StripeRefCustomerBaseline = {
+      phase: "0",
+      description: "Stripe Ref<Customer> stress-test — Phase 0 pre-refactor baseline (§8.4a)",
+      fixture: "e2e/fixtures/stripe-ref-customer/customer-ref-form.ts",
+      typeName: TYPE_NAME,
+      fieldCount: 30,
+      runs: RUNS,
+      resolvePayloadAvailable: RESOLVE_PAYLOAD_AVAILABLE,
+      metrics: {
+        peakRSS_MB: Math.round(peakRSSMB * 10) / 10,
+        wallTime_ms: Math.round(medianWarmWallTimeMs * 100) / 100,
+        didOOM,
+        warmWallTimes_ms: warmWallTimeMs.map((v) => Math.round(v * 100) / 100),
+        allPeakRSS_MB: allPeakRssBytes.map((v) => Math.round((v / 1024 / 1024) * 10) / 10),
+        coldWallTime_ms: Math.round(coldWallTimeMs * 100) / 100,
+      },
+      gitSha: commitSha,
+      timestamp: new Date().toISOString(),
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    };
+
+    await fs.writeFile(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+    process.stderr.write(`  Baseline written: ${BASELINE_PATH}\n\n`);
+
+    // Machine-readable JSON to stdout.
+    process.stdout.write(`${JSON.stringify(baseline, null, 2)}\n`);
+  } finally {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/e2e/benchmarks/stripe-ref-customer-bench.ts
+++ b/e2e/benchmarks/stripe-ref-customer-bench.ts
@@ -158,11 +158,20 @@ function runBuildBenchOnce(fixturePath: string, extraFiles: string[]): BuildRunR
 /**
  * Runs a single schema-generation pass in a child Node.js process capped at
  * `maxOldSpaceMb` MB of V8 old-space. Returns `true` if the process ran out
- * of memory (exit code non-zero and stderr contains OOM indicators).
+ * of memory.
  *
- * This is a best-effort check: on some OS/Node combinations, OOM may result
- * in a SIGKILL without the expected stderr message. In those cases, any
- * non-zero exit from the child is conservatively reported as OOM.
+ * Detection strategy (in priority order):
+ * 1. Known OOM stderr indicators (`JavaScript heap out of memory`, `ENOMEM`, etc.)
+ * 2. SIGKILL termination (`result.signal === "SIGKILL"`) — the OS kills the
+ *    process before Node.js can write diagnostic output when heap allocation
+ *    fails at the OS level.
+ * 3. Null exit status with any signal — treated as OOM because the only child
+ *    task is schema generation; a signal-terminated run that succeeded would
+ *    have exited 0.
+ *
+ * Non-signal non-zero exits (e.g. fixture compilation failure, uncaught
+ * exception from the runner script) are returned as `false` because they
+ * indicate a different class of error rather than memory exhaustion.
  */
 function detectOom(fixturePath: string, extraFiles: string[], maxOldSpaceMb = 512): boolean {
   // Write an inline runner script to a temp file that the child process executes.
@@ -228,8 +237,14 @@ function detectOom(fixturePath: string, extraFiles: string[], maxOldSpaceMb = 51
       return true;
     }
 
-    // Non-zero exit without OOM message: likely a different error (e.g. fixture
-    // compilation failure). Do not count this as OOM.
+    // SIGKILL (or any signal with a null status) means the OS terminated the
+    // process before Node.js could write OOM diagnostics — treat as OOM.
+    if (result.status === null && result.signal !== null) {
+      return true;
+    }
+
+    // Non-zero exit without a signal and without known OOM output: likely a
+    // different error (e.g. fixture compilation failure, uncaught exception).
     return false;
   } finally {
     try {

--- a/e2e/fixtures/stripe-ref-customer/STUB_NOTE.md
+++ b/e2e/fixtures/stripe-ref-customer/STUB_NOTE.md
@@ -1,0 +1,44 @@
+# Stub Note: resolvePayload / extractPayload not available
+
+## Status
+
+`resolvePayload` / `extractPayload` **does not exist** on `CustomTypeRegistration` in
+`@formspec/core`. PR #300 was superseded by PR #308 and removed in PR #313.
+
+## Impact on this fixture
+
+The Phase 0.5l instructions originally contemplated using `resolvePayload` to register a
+`Ref<T>` custom type that inspects the TypeScript `ts.Type` of the type argument at
+build time. That path is no longer available.
+
+## What PR #308 provides instead
+
+PR #308 added the external-type bypass in `extractReferenceTypeArguments`
+(`packages/build/src/analyzer/class-analyzer.ts`). When the type argument to `Ref<T>` is
+a type declared in a *different* source file from the current analysis root, the analyzer
+emits an opaque `{ kind: "reference", name: "<TypeName>", typeArguments: [] }` node
+instead of recursing into the full declaration. This prevents the stack overflows observed
+on deeply nested types like `Stripe.Customer`.
+
+## What the fixture does
+
+`customer-ref-form.ts` uses locally declared `Ref<T>` and `Customer`, `PaymentMethod`,
+`Subscription`, and `Invoice` types from `stripe-like-types.ts` (a sibling file in this
+fixture directory). The `stripe-like-types.ts` file is _not_ the analysis root, so the
+external-type bypass fires for every `Ref<T>` field — exactly the path being benchmarked.
+
+## Migration path (when/if resolvePayload lands)
+
+If a future PR re-introduces `resolvePayload` or a functionally equivalent callback on
+`CustomTypeRegistration`:
+
+1. Remove `stripe-like-types.ts` (or keep it alongside a real `stripe` import).
+2. Register `Ref<T>` via `defineCustomType<Ref<unknown>>({ ... resolvePayload: ... })`.
+3. Update `stripe-ref-customer-bench.ts` to set `resolvePayloadAvailable: true`.
+4. Re-run the benchmark and commit updated baseline numbers.
+5. Delete or update this file.
+
+## TODO
+
+<!-- TODO: migrate to real `import Stripe from "stripe"` + resolvePayload once PR #300
+     (or equivalent) re-lands. See STUB_NOTE.md for context. -->

--- a/e2e/fixtures/stripe-ref-customer/customer-ref-form.ts
+++ b/e2e/fixtures/stripe-ref-customer/customer-ref-form.ts
@@ -1,0 +1,314 @@
+/**
+ * Stripe Ref<Customer> stress-test fixture for Phase 0 baseline (§8.4 / 0.5l).
+ *
+ * This file is the acceptance gate for generic-reference handling in Phase 4
+ * of the synthetic-checker retirement refactor.
+ *
+ * See `docs/refactors/synthetic-checker-retirement.md` §8.4 for full criteria.
+ * See `STUB_NOTE.md` in this directory for the resolvePayload stub rationale.
+ *
+ * Field summary (30 total):
+ *   - 1  Ref<Customer>          — core generic-reference field
+ *   - 2  Ref<PaymentMethod>     — expandable payment method references
+ *   - 1  Ref<Subscription>      — expandable subscription reference
+ *   - 1  Ref<Invoice>           — expandable invoice reference (with @description)
+ *   - 1  nested object (shipping address) with its own Ref<Customer> field
+ *   - 6  constrained strings    — @minLength, @maxLength, @pattern
+ *   - 6  constrained numbers    — @minimum, @maximum, @multipleOf
+ *   - 4  optional / nullable fields
+ *   - 4  enum / literal-union fields
+ *   - 3  boolean flags
+ *   - 1  Record<string, string> metadata
+ */
+
+import type {
+  Ref,
+  Customer,
+  PaymentMethod,
+  Subscription,
+  Invoice,
+  TaxExemptStatus,
+  SubscriptionStatus,
+  CardBrand,
+} from "./stripe-like-types.js";
+
+// =============================================================================
+// Inline supporting types — used for nested-object fields
+// =============================================================================
+
+/** Shipping address fields collected at checkout time. */
+interface CheckoutAddress {
+  /** @minLength 1 @maxLength 200 */
+  line1: string;
+  /** @maxLength 200 */
+  line2?: string;
+  /** @minLength 1 @maxLength 100 */
+  city: string;
+  /** @minLength 2 @maxLength 2 @pattern ^[A-Z]{2}$ */
+  countryCode: string;
+  /** @minLength 3 @maxLength 10 @pattern ^[A-Za-z0-9 \-]{3,10}$ */
+  postalCode: string;
+  /**
+   * Reference to the customer who owns this address — demonstrates a nested
+   * Ref<T> field inside an object, exercising the type-argument bypass path
+   * in `extractReferenceTypeArguments`.
+   */
+  ownerRef: Ref<Customer>;
+}
+
+// =============================================================================
+// Main fixture class — 30 fields
+// =============================================================================
+
+/**
+ * Stripe `Ref<Customer>` stress-test form fixture.
+ *
+ * Used by `e2e/benchmarks/stripe-ref-customer-bench.ts` to measure
+ * peak RSS, wall time, and OOM behaviour under the full FormSpec build
+ * pipeline with generic-reference resolution active.
+ *
+ * See §8.4 of `docs/refactors/synthetic-checker-retirement.md` for
+ * acceptance gates and phase comparison targets.
+ */
+export class CustomerRefForm {
+  // =========================================================================
+  // Generic reference fields (5) — these are the primary stress drivers
+  // =========================================================================
+
+  /**
+   * The primary Stripe customer being referenced.
+   *
+   * This field exercises the `extractReferenceTypeArguments` external-type
+   * bypass introduced in PR #308: `Customer` is declared in
+   * `stripe-like-types.ts` (a different analysis file), so the analyzer emits
+   * an opaque `{ kind: "reference", name: "Customer", typeArguments: [] }`
+   * node instead of recursing into the full Customer declaration.
+   */
+  customer!: Ref<Customer>;
+
+  /**
+   * Primary payment method on file.
+   *
+   * @description The default payment method attached to this customer.
+   */
+  defaultPaymentMethod!: Ref<PaymentMethod>;
+
+  /**
+   * Backup payment method for retry logic.
+   */
+  backupPaymentMethod?: Ref<PaymentMethod>;
+
+  /**
+   * Active subscription, if any.
+   */
+  activeSubscription?: Ref<Subscription>;
+
+  /**
+   * Most recent invoice.
+   *
+   * @description The latest invoice generated for this customer, including
+   * any pending charges.
+   */
+  latestInvoice?: Ref<Invoice>;
+
+  // =========================================================================
+  // Constrained string fields (6)
+  // =========================================================================
+
+  /**
+   * Internal reference code for the customer record.
+   *
+   * @minLength 3
+   * @maxLength 64
+   * @pattern ^[A-Za-z0-9_\-]+$
+   */
+  referenceCode!: string;
+
+  /**
+   * Customer's display name as shown in the dashboard.
+   *
+   * @minLength 1
+   * @maxLength 200
+   */
+  displayName!: string;
+
+  /**
+   * Primary contact email address.
+   *
+   * @minLength 5
+   * @maxLength 254
+   * @pattern ^[^@\s]+@[^@\s]+\.[^@\s]+$
+   */
+  email!: string;
+
+  /**
+   * E.164-formatted phone number.
+   *
+   * @minLength 7
+   * @maxLength 20
+   * @pattern ^\+?[0-9\s\-().]{7,20}$
+   */
+  phone?: string;
+
+  /**
+   * ISO 3166-1 alpha-2 country code for the billing address.
+   *
+   * @minLength 2
+   * @maxLength 2
+   * @pattern ^[A-Z]{2}$
+   */
+  billingCountry!: string;
+
+  /**
+   * ISO 4217 currency code (lowercase).
+   *
+   * @minLength 3
+   * @maxLength 3
+   * @pattern ^[a-z]{3}$
+   */
+  currency!: string;
+
+  // =========================================================================
+  // Constrained numeric fields (6)
+  // =========================================================================
+
+  /**
+   * Customer's outstanding balance in the smallest currency unit (e.g. cents).
+   * Negative values indicate credits.
+   *
+   * @minimum -999999999
+   * @maximum 999999999
+   */
+  balanceCents!: number;
+
+  /**
+   * Credit limit extended to this customer, in cents.
+   *
+   * @minimum 0
+   * @maximum 5000000
+   * @multipleOf 100
+   */
+  creditLimitCents!: number;
+
+  /**
+   * Number of successful charges recorded for this customer.
+   *
+   * @minimum 0
+   * @maximum 99999
+   * @multipleOf 1
+   */
+  successfulChargeCount!: number;
+
+  /**
+   * Number of failed charge attempts, used for risk scoring.
+   *
+   * @minimum 0
+   * @maximum 999
+   * @multipleOf 1
+   */
+  failedChargeCount!: number;
+
+  /**
+   * Lifetime value of the customer in cents.
+   *
+   * @minimum 0
+   * @maximum 999999999
+   * @multipleOf 1
+   */
+  lifetimeValueCents!: number;
+
+  /**
+   * Risk score computed by the fraud-detection model (0.00–1.00).
+   *
+   * @minimum 0
+   * @maximum 1
+   * @multipleOf 0.0001
+   */
+  riskScore!: number;
+
+  // =========================================================================
+  // Enum / literal-union fields (4)
+  // =========================================================================
+
+  /** Tax-exempt status for the customer. */
+  taxExempt!: TaxExemptStatus;
+
+  /** Status of the customer's active subscription. */
+  subscriptionStatus?: SubscriptionStatus;
+
+  /** Preferred card brand for display purposes. */
+  preferredCardBrand?: CardBrand;
+
+  /**
+   * How the customer prefers to be contacted.
+   *
+   * @enumOptions [{"id":"email","label":"Email"},{"id":"sms","label":"SMS"},{"id":"phone","label":"Phone"},{"id":"none","label":"None"}]
+   */
+  contactPreference!: "email" | "sms" | "phone" | "none";
+
+  // =========================================================================
+  // Boolean flags (3)
+  // =========================================================================
+
+  /** Whether the customer account is currently delinquent. */
+  isDelinquent!: boolean;
+
+  /** Whether the customer has opted in to marketing communications. */
+  marketingOptIn!: boolean;
+
+  /** Whether the customer has completed identity verification. */
+  identityVerified!: boolean;
+
+  // =========================================================================
+  // Nested object field (1) — exercises Ref<T> inside a nested object
+  // =========================================================================
+
+  /**
+   * Primary shipping address for this customer, including a back-reference
+   * to the owning customer (Ref<Customer> inside a nested object).
+   */
+  shippingAddress?: CheckoutAddress;
+
+  // =========================================================================
+  // Metadata / freeform (1)
+  // =========================================================================
+
+  /**
+   * Arbitrary key-value metadata attached to this customer record.
+   * Values must be strings; keys must be non-empty.
+   */
+  metadata!: Record<string, string>;
+
+  // =========================================================================
+  // Optional / nullable supplemental fields (4)
+  // =========================================================================
+
+  /**
+   * Internal CRM account ID for cross-system linking.
+   *
+   * @minLength 1
+   * @maxLength 128
+   */
+  crmAccountId?: string;
+
+  /**
+   * Unix timestamp of when the customer was first created.
+   *
+   * @minimum 0
+   */
+  createdAt?: number;
+
+  /**
+   * Unix timestamp of the most recent update.
+   *
+   * @minimum 0
+   */
+  updatedAt?: number;
+
+  /**
+   * Human-readable note left by a support agent.
+   *
+   * @maxLength 1000
+   */
+  supportNote?: string;
+}

--- a/e2e/fixtures/stripe-ref-customer/stripe-like-types.ts
+++ b/e2e/fixtures/stripe-ref-customer/stripe-like-types.ts
@@ -232,10 +232,12 @@ export interface Customer {
  * When expanded, the field contains the full resource object.
  *
  * FormSpec treats Ref<T> as an opaque wrapper type. The generic
- * parameter `T` is carried as a phantom type argument and does NOT
- * trigger full expansion of the external type — this is the path
+ * parameter `T` is carried via the `__type` phantom property and does
+ * NOT trigger full expansion of the external type — this is the path
  * guarded by the `extractReferenceTypeArguments` external-type bypass
  * (PR #308, `e2e/fixtures/stripe-ref-customer/STUB_NOTE.md`).
+ * The `__` prefix on `__type` is load-bearing: `class-analyzer.ts`
+ * skips all `__`-prefixed properties during IR emission.
  */
 export interface Ref<T> {
   /**
@@ -249,9 +251,12 @@ export interface Ref<T> {
    */
   readonly expanded: boolean;
   /**
-   * The expanded resource, or undefined when only the ID is available.
-   * This phantom field drives generic-reference resolution in the
-   * FormSpec analyzer.
+   * Phantom field carrying the generic type argument for FormSpec's
+   * external-type bypass (`extractReferenceTypeArguments`, PR #308).
+   * The `__` prefix is load-bearing: `class-analyzer.ts` excludes all
+   * `__`-prefixed properties from Canonical IR emission, so this field
+   * never appears in generated JSON Schema while still making `T`
+   * visible to generic-reference resolution.
    */
-  readonly resource?: T;
+  readonly __type?: T;
 }

--- a/e2e/fixtures/stripe-ref-customer/stripe-like-types.ts
+++ b/e2e/fixtures/stripe-ref-customer/stripe-like-types.ts
@@ -1,0 +1,257 @@
+/**
+ * Self-contained Stripe-like type definitions for the Ref<Customer> stress-test fixture.
+ *
+ * These types mirror the structure of the real `stripe` npm SDK — deeply nested objects,
+ * optional fields, discriminated-union metadata, and expandable-field polymorphism —
+ * without importing the SDK itself. This keeps the fixture self-contained and avoids
+ * adding `stripe` as a production dependency of `@formspec/e2e`.
+ *
+ * When the real `stripe` SDK becomes available as a peer dep (see STUB_NOTE.md), replace
+ * these hand-authored types with the corresponding `Stripe.*` imports and verify the
+ * baseline numbers are still in range.
+ *
+ * Field count: ~80 properties across the type graph. The form fixture selects a
+ * representative cross-section of ~30 fields through `CustomerRefForm`.
+ */
+
+// =============================================================================
+// Core Stripe primitives
+// =============================================================================
+
+/** Unix epoch timestamp (seconds since 1970-01-01T00:00:00Z). */
+export type Timestamp = number;
+
+/** ISO 4217 currency code, lowercase (e.g. "usd", "eur"). */
+export type Currency = string;
+
+/** Stripe object ID prefix for customers (cus_*). */
+export type CustomerId = string;
+
+/** Stripe object ID prefix for payment methods (pm_*). */
+export type PaymentMethodId = string;
+
+/** Stripe object ID prefix for addresses. */
+export type AddressId = string;
+
+/** Stripe object ID prefix for invoices (in_*). */
+export type InvoiceId = string;
+
+/** Stripe object ID prefix for subscriptions (sub_*). */
+export type SubscriptionId = string;
+
+// =============================================================================
+// Nested supporting types (simulate complex SDK sub-objects)
+// =============================================================================
+
+/** ISO 3166-1 alpha-2 country code. */
+export interface Country {
+  /** Two-letter country code. */
+  readonly code: string;
+  /** Human-readable country name. */
+  readonly name: string;
+}
+
+/** A physical or billing address, as returned by the Stripe API. */
+export interface StripeAddress {
+  /** Address line 1 (street address, PO box, company name). */
+  readonly line1: string | null;
+  /** Address line 2 (apartment, suite, unit, building, floor). */
+  readonly line2: string | null;
+  /** City, district, suburb, town, or village. */
+  readonly city: string | null;
+  /** State, county, province, or region. */
+  readonly state: string | null;
+  /** ZIP or postal code. */
+  readonly postalCode: string | null;
+  /** Two-letter country code (ISO 3166-1 alpha-2). */
+  readonly country: Country;
+}
+
+/** A card funding source. */
+export type CardBrand = "visa" | "mastercard" | "amex" | "discover" | "jcb" | "unionpay" | "unknown";
+
+/** Card payment method details. */
+export interface CardPaymentMethod {
+  readonly brand: CardBrand;
+  /** Two-digit expiry month (1–12). */
+  readonly expMonth: number;
+  /** Four-digit expiry year. */
+  readonly expYear: number;
+  /** Last four digits of the card number. */
+  readonly last4: string;
+  /** Three-letter ISO code for the country of the card issuer. */
+  readonly country: string | null;
+  /** Card fingerprint — unique per card number. */
+  readonly fingerprint: string | null;
+}
+
+/** Bank account payment method details. */
+export interface BankAccountPaymentMethod {
+  readonly bankName: string | null;
+  readonly routingNumber: string | null;
+  readonly last4: string;
+  readonly country: string;
+  readonly currency: Currency;
+}
+
+/** A polymorphic payment method — either a card or a bank account. */
+export type PaymentMethodDetails =
+  | { readonly type: "card"; readonly card: CardPaymentMethod }
+  | { readonly type: "us_bank_account"; readonly usBankAccount: BankAccountPaymentMethod };
+
+/** A stored payment method on a customer. */
+export interface PaymentMethod {
+  readonly id: PaymentMethodId;
+  readonly object: "payment_method";
+  readonly created: Timestamp;
+  readonly livemode: boolean;
+  readonly details: PaymentMethodDetails;
+  readonly billingDetails: {
+    readonly address: StripeAddress | null;
+    readonly email: string | null;
+    readonly name: string | null;
+    readonly phone: string | null;
+  };
+}
+
+/** Subscription status. */
+export type SubscriptionStatus =
+  | "active"
+  | "canceled"
+  | "incomplete"
+  | "incomplete_expired"
+  | "past_due"
+  | "paused"
+  | "trialing"
+  | "unpaid";
+
+/** A recurring subscription. */
+export interface Subscription {
+  readonly id: SubscriptionId;
+  readonly object: "subscription";
+  readonly status: SubscriptionStatus;
+  readonly currentPeriodStart: Timestamp;
+  readonly currentPeriodEnd: Timestamp;
+  readonly canceledAt: Timestamp | null;
+  readonly cancelAtPeriodEnd: boolean;
+  readonly currency: Currency;
+  readonly livemode: boolean;
+}
+
+/** Invoice status. */
+export type InvoiceStatus = "draft" | "open" | "paid" | "uncollectible" | "void";
+
+/** A Stripe invoice. */
+export interface Invoice {
+  readonly id: InvoiceId;
+  readonly object: "invoice";
+  readonly status: InvoiceStatus | null;
+  readonly amountDue: number;
+  readonly amountPaid: number;
+  readonly amountRemaining: number;
+  readonly currency: Currency;
+  readonly created: Timestamp;
+  readonly dueDate: Timestamp | null;
+  readonly periodStart: Timestamp;
+  readonly periodEnd: Timestamp;
+}
+
+/** Customer tax-exempt status. */
+export type TaxExemptStatus = "exempt" | "none" | "reverse";
+
+/** Tax ID type. */
+export type TaxIdType =
+  | "ad_nrt"
+  | "ae_trn"
+  | "au_abn"
+  | "au_arn"
+  | "eu_vat"
+  | "gb_vat"
+  | "us_ein"
+  | "unknown";
+
+/** A tax identifier. */
+export interface TaxId {
+  readonly type: TaxIdType;
+  readonly value: string;
+  readonly country: string | null;
+}
+
+/** Key-value metadata attached to Stripe objects. */
+export type StripeMetadata = Record<string, string>;
+
+/** Discount applied to a customer. */
+export interface Discount {
+  readonly id: string;
+  readonly object: "discount";
+  readonly couponId: string;
+  readonly start: Timestamp;
+  readonly end: Timestamp | null;
+  readonly percentOff: number | null;
+  readonly amountOff: number | null;
+}
+
+/** A Stripe customer object — the core entity in the type graph. */
+export interface Customer {
+  readonly id: CustomerId;
+  readonly object: "customer";
+  readonly created: Timestamp;
+  readonly livemode: boolean;
+  readonly name: string | null;
+  readonly email: string | null;
+  readonly phone: string | null;
+  readonly description: string | null;
+  readonly currency: Currency | null;
+  readonly address: StripeAddress | null;
+  readonly shipping: {
+    readonly address: StripeAddress;
+    readonly name: string;
+    readonly phone: string | null;
+  } | null;
+  readonly balance: number;
+  readonly delinquent: boolean | null;
+  readonly taxExempt: TaxExemptStatus;
+  readonly taxIds: readonly TaxId[];
+  readonly metadata: StripeMetadata;
+  readonly preferredLocales: readonly string[];
+  readonly defaultSource: string | null;
+  readonly invoicePrefix: string | null;
+  readonly nextInvoiceSequence: number | null;
+  readonly discount: Discount | null;
+  readonly testClock: string | null;
+}
+
+// =============================================================================
+// Ref<T> wrapper — phantom type for expandable-field polymorphism
+// =============================================================================
+
+/**
+ * Ref<T> represents an expandable field in the Stripe API.
+ *
+ * When unexpanded, the field contains only the resource ID string.
+ * When expanded, the field contains the full resource object.
+ *
+ * FormSpec treats Ref<T> as an opaque wrapper type. The generic
+ * parameter `T` is carried as a phantom type argument and does NOT
+ * trigger full expansion of the external type — this is the path
+ * guarded by the `extractReferenceTypeArguments` external-type bypass
+ * (PR #308, `e2e/fixtures/stripe-ref-customer/STUB_NOTE.md`).
+ */
+export interface Ref<T> {
+  /**
+   * The Stripe object ID when the field is unexpanded.
+   * When expanded, this is the full resource object.
+   */
+  readonly id: string;
+  /**
+   * True when the full resource object has been loaded; false when only
+   * the ID is present.
+   */
+  readonly expanded: boolean;
+  /**
+   * The expanded resource, or undefined when only the ID is available.
+   * This phantom field drives generic-reference resolution in the
+   * FormSpec analyzer.
+   */
+  readonly resource?: T;
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,8 @@
     "test": "vitest run",
     "benchmark:hybrid-tooling": "pnpm --filter @formspec/language-server... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && tsx ./benchmarks/hybrid-tooling-comparison.ts",
     "bench:analysis": "pnpm -r --filter @formspec/build... --filter @formspec/ts-plugin... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/analysis-bench.ts",
-    "bench:synthetic-checker": "pnpm -r --filter @formspec/analysis... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/synthetic-checker-baseline.bench.ts"
+    "bench:synthetic-checker": "pnpm -r --filter @formspec/analysis... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/synthetic-checker-baseline.bench.ts",
+    "bench:stripe-ref-customer": "pnpm -r --filter @formspec/build... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-ref-customer-bench.ts"
   },
   "dependencies": {
     "@formspec/analysis": "workspace:*",


### PR DESCRIPTION
## Summary

Implements §8.4 / 0.5l of the synthetic-checker retirement plan ([`docs/refactors/synthetic-checker-retirement.md`](docs/refactors/synthetic-checker-retirement.md)).

- Adds the Stripe `Ref<Customer>` stress-test fixture with 30 fields and `Ref<T>`-typed fields backed by self-contained Stripe-like types
- Adds the Phase 0 benchmark runner that measures wall time, peak RSS, and OOM behaviour
- Commits the Phase 0 baseline JSON (`e2e/bench/baselines/stripe-ref-customer-baseline.json`)
- Documents that `resolvePayload` (PR #300) was superseded by PR #308 and removed in #313 (`STUB_NOTE.md`)

## Phase 0 Baseline Numbers (arm64 darwin, Node v24.14.0)

| Metric | Value |
|--------|-------|
| `wallTime_ms` warm median | **44.8 ms** |
| `wallTime_ms` cold (run 1) | **1 657 ms** |
| `peakRSS_MB` warm median | **921.8 MB** |
| `didOOM` (512 MB cap) | **false** |

**Phase 4 gate (§8.4b):** `peakRSS_MB` ≤ 460.9 MB, zero OOM on a 1 GB runner.
**Phase 6 gate (§8.4c):** `syntheticProgramCount` = 0 in debug logs (no `ts.createProgram` calls).

## resolvePayload availability

`resolvePayload` / `extractPayload` does not exist in `@formspec/core` — PR #300 was superseded by PR #308 and removed in PR #313. The fixture uses `generateSchemasFromProgram` directly. The external-type bypass in `extractReferenceTypeArguments` (PR #308) handles `Ref<T>` without requiring custom type registration: when `Customer`, `PaymentMethod`, etc. are declared in a sibling file, the analyzer emits opaque reference nodes instead of recursing into the full declaration. `resolvePayloadAvailable: false` is recorded in the baseline JSON. Migration guidance is in `e2e/fixtures/stripe-ref-customer/STUB_NOTE.md`.

## Fixture structure

```
e2e/fixtures/stripe-ref-customer/
  stripe-like-types.ts     ← ~80-prop Stripe-like type graph (Customer, Ref<T>, etc.)
  customer-ref-form.ts     ← 30-field CustomerRefForm class (5 Ref<T> fields + constraints)
  STUB_NOTE.md             ← resolvePayload stub rationale + migration path

e2e/benchmarks/
  stripe-ref-customer-bench.ts   ← stress runner (wall time, RSS, OOM detection)

e2e/bench/baselines/
  stripe-ref-customer-baseline.json   ← committed Phase 0 baseline
```

## Test plan

- [x] `pnpm run build` — passes
- [x] `pnpm run lint` — passes (0 errors)
- [x] `pnpm --filter @formspec/e2e run test` — 269 tests pass
- [x] Benchmark ran to completion, baseline JSON committed
- [x] OOM probe returned `false` at 512 MB cap on development machine