### PR TITLE
test(e2e): real-SDK stress fixture for Ref<Stripe.Customer> OOM

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -81,6 +81,65 @@ JSON records `resolvePayloadAvailable: false` to document this. See
 `fixtures/stripe-ref-customer/STUB_NOTE.md` for migration guidance if a `resolvePayload`
 equivalent ever lands.
 
+### Real Stripe SDK stress test (Phase 0 / OOM investigation)
+
+**Script:** `benchmarks/stripe-real-sdk-bench.ts`
+**Fixture:** `fixtures/stripe-real-sdk/` — `RealSdkCustomerRefForm` class with `Ref<Stripe.*>` fields backed by **real** `stripe` npm SDK types
+**Baseline:** `bench/baselines/stripe-real-sdk-baseline.json`
+
+#### Motivation
+
+Users reported OOM when building schemas for classes with `Ref<Stripe.Customer>`-style fields
+referencing types from the actual `stripe` npm package. The synthetic `stripe-ref-customer`
+fixture uses hand-authored Stripe-like types (~80 properties) and does NOT reproduce the
+bug — the real SDK ships types orders of magnitude larger (`Stripe.Invoice` alone is ~4 000
+lines of declarations). This fixture closes the gap by importing from the real `stripe`
+package.
+
+The external-type bypass in `extractReferenceTypeArguments`
+(`packages/build/src/analyzer/class-analyzer.ts`, PR #308) should fire for every
+`Ref<Stripe.*>` field because the Stripe types are declared in `node_modules/stripe/...` —
+a different file from the analysis root. This fixture verifies that the bypass engages
+end-to-end on real SDK types and captures a baseline for Phase 4 comparison.
+
+#### How to run
+
+```bash
+pnpm --filter @formspec/e2e run bench:stripe-real-sdk
+```
+
+To capture JSON output:
+
+```bash
+GIT_COMMIT_SHA=$(git rev-parse HEAD) \
+  pnpm --filter @formspec/e2e run bench:stripe-real-sdk \
+  > stripe-real-sdk-baseline.json 2>/dev/null
+```
+
+#### Phase 0 baseline numbers (arm64 darwin, Node v24.14.0, stripe 22.0.2)
+
+| Metric | Value |
+|--------|-------|
+| `wallTime_ms` warm median | **82 ms** |
+| `wallTime_ms` cold (run 1) | **1 519 ms** |
+| `peakRSS_MB` warm median | **946.5 MB** |
+| `didOOM` (1 GB cap) | **false** |
+
+The bypass engages correctly at Phase 0: no OOM, but peak RSS is 946.5 MB — within ~80 MB
+of the 1 GB cap. This confirms the external-type bypass is load-bearing for real SDK types
+and that Phase 4 (host-checker migration) must bring RSS below 512 MB.
+
+#### Phase 4 acceptance gate
+
+- `didOOM: false` on a 1 GB runner
+- `peakRSS_MB` ≤ **512 MB**
+
+#### Caveat: stripe version dependency
+
+This benchmark depends on the version of the `stripe` npm package installed in `e2e/`.
+Bumping Stripe may shift the baseline — check `bench/baselines/stripe-real-sdk-baseline.json`
+and re-run if the Stripe version changes.
+
 ## License
 
 This workspace is part of the FormSpec monorepo and is released under the MIT License. See

--- a/e2e/bench/baselines/stripe-real-sdk-baseline.json
+++ b/e2e/bench/baselines/stripe-real-sdk-baseline.json
@@ -1,0 +1,29 @@
+{
+  "phase": "0",
+  "description": "Real Stripe SDK Ref<Customer> stress-test — Phase 0 pre-refactor baseline",
+  "fixture": "e2e/fixtures/stripe-real-sdk/customer-ref-form.ts",
+  "typeName": "RealSdkCustomerRefForm",
+  "runs": 3,
+  "stripeVersion": "22.0.2",
+  "metrics": {
+    "peakRSS_MB": 946.5,
+    "wallTime_ms": 81.96,
+    "didOOM": false,
+    "warmWallTimes_ms": [
+      83.47,
+      80.45
+    ],
+    "allPeakRSS_MB": [
+      927,
+      940.4,
+      952.6
+    ],
+    "coldWallTime_ms": 1518.56,
+    "oomHeapCapMb": 1024
+  },
+  "gitSha": "aadddc8d12c4d1af14cd8dd0cdef42b713c9ff2a",
+  "timestamp": "2026-04-20T00:53:38.878Z",
+  "nodeVersion": "v24.14.0",
+  "platform": "darwin",
+  "arch": "arm64"
+}

--- a/e2e/bench/baselines/stripe-real-sdk-baseline.json
+++ b/e2e/bench/baselines/stripe-real-sdk-baseline.json
@@ -6,23 +6,23 @@
   "runs": 3,
   "stripeVersion": "22.0.2",
   "metrics": {
-    "peakRSS_MB": 946.5,
-    "wallTime_ms": 81.96,
+    "peakRSS_MB": 965.7,
+    "wallTime_ms": 10.51,
     "didOOM": false,
     "warmWallTimes_ms": [
-      83.47,
-      80.45
+      9.77,
+      11.24
     ],
     "allPeakRSS_MB": [
-      927,
-      940.4,
-      952.6
+      946.5,
+      959.7,
+      971.7
     ],
-    "coldWallTime_ms": 1518.56,
+    "coldWallTime_ms": 1403.68,
     "oomHeapCapMb": 1024
   },
-  "gitSha": "aadddc8d12c4d1af14cd8dd0cdef42b713c9ff2a",
-  "timestamp": "2026-04-20T00:53:38.878Z",
+  "gitSha": "9431bf2872e12dde026745840f4dcc871c45301d",
+  "timestamp": "2026-04-20T01:12:17.624Z",
   "nodeVersion": "v24.14.0",
   "platform": "darwin",
   "arch": "arm64"

--- a/e2e/benchmarks/stripe-real-sdk-bench.ts
+++ b/e2e/benchmarks/stripe-real-sdk-bench.ts
@@ -66,7 +66,6 @@
 
 import fs from "node:fs/promises";
 import fsSync from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -227,8 +226,13 @@ function detectOom(fixturePath: string, maxOldSpaceMb = OOM_PROBE_HEAP_MB): bool
     `process.exit(0);`,
   ].join("\n");
 
-  const tmpDir = os.tmpdir();
-  const runnerPath = path.join(tmpDir, `formspec-oom-probe-real-sdk-${String(process.pid)}.mjs`);
+  // The runner script must live inside E2E_ROOT (not OS tmpdir) so that
+  // Node.js ESM package resolution can walk up to E2E_ROOT/node_modules and
+  // find `typescript`, `@formspec/build`, and `stripe`. ESM bare-specifier
+  // resolution walks the directory tree from the **script file's location**,
+  // not from `cwd`, so placing the file in OS tmpdir would fail to find any
+  // of those packages even with cwd set correctly.
+  const runnerPath = path.join(E2E_ROOT, `formspec-oom-probe-real-sdk-${String(process.pid)}.mjs`);
   try {
     fsSync.writeFileSync(runnerPath, runnerScript, "utf8");
   } catch {

--- a/e2e/benchmarks/stripe-real-sdk-bench.ts
+++ b/e2e/benchmarks/stripe-real-sdk-bench.ts
@@ -1,0 +1,423 @@
+/**
+ * Phase 0 baseline: real Stripe SDK `Ref<Customer>` stress-test benchmark.
+ *
+ * Measures three metrics for a single `generateSchemasFromProgram` call
+ * against the `RealSdkCustomerRefForm` fixture, which uses REAL types from the
+ * `stripe` npm package instead of hand-authored stubs.
+ *
+ *   1. wallTime_ms   — end-to-end elapsed time (cold + warm median over 3 runs)
+ *   2. peakRSS_MB    — peak resident set size (megabytes) observed via polling
+ *   3. didOOM        — whether the process ran out of memory
+ *
+ * ### Why this benchmark matters
+ *
+ * The synthetic `stripe-ref-customer` fixture uses hand-authored Stripe-like
+ * types (~80 properties across the type graph). The REAL `stripe` npm package
+ * ships thousands of types, deeply nested, with large discriminated unions (e.g.
+ * `Stripe.Invoice` is ~4 000 lines of TypeScript declarations). If the
+ * external-type bypass in `extractReferenceTypeArguments` (PR #308,
+ * `packages/build/src/analyzer/class-analyzer.ts`) does NOT engage on types
+ * from `node_modules/stripe/...`, the analyzer recurses into the full SDK type
+ * graph and may exhaust memory — reproducing the user-reported OOM.
+ *
+ * ### OOM detection strategy
+ *
+ * The OOM probe runs in a subprocess capped at `--max-old-space-size=1024`
+ * (1 GB heap). Detection uses three tiers (in priority order):
+ *   1. Known OOM stderr indicators (`JavaScript heap out of memory`, `ENOMEM`, etc.)
+ *   2. SIGKILL termination (`result.signal === "SIGKILL"`) — OS kills process
+ *      before Node.js can write diagnostic output.
+ *   3. Null exit status with any non-null signal — treated as OOM because the
+ *      only child task is schema generation; a signal-terminated success would
+ *      have exited 0.
+ *
+ * ### Phase 4 acceptance gate (§8.4)
+ *
+ * After the host-checker migration:
+ *   - `didOOM: false` on a 1 GB runner
+ *   - `peakRSS_MB` ≤ 512 MB
+ *
+ * If this baseline records `didOOM: true`, the OOM has been reproduced and the
+ * Phase 4 gate is the bug fix. If it records `didOOM: false` with low RSS, the
+ * external-type bypass is working correctly for real SDK types and the
+ * user-reported OOM is about something else.
+ *
+ * ### Run model
+ *
+ * Three runs are collected. Run 1 is the **cold run** (first invocation; module
+ * imports run before the timer starts). Runs 2–3 are **warm runs**. Median is
+ * computed over warm runs for wall time and RSS.
+ *
+ * ### How to run
+ *
+ *   pnpm --filter @formspec/e2e run bench:stripe-real-sdk
+ *
+ * To capture JSON:
+ *
+ *   GIT_COMMIT_SHA=$(git rev-parse HEAD) \
+ *     pnpm --filter @formspec/e2e run bench:stripe-real-sdk \
+ *     > stripe-real-sdk-baseline.json 2>/dev/null
+ *
+ * ### Output
+ *
+ * Writes baseline JSON to `e2e/bench/baselines/stripe-real-sdk-baseline.json`
+ * and emits human-readable output to stderr and JSON to stdout.
+ */
+
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import * as ts from "typescript";
+import { generateSchemasFromProgram } from "@formspec/build";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+const E2E_ROOT = path.resolve(BENCH_DIR, "..");
+const FIXTURE_DIR = path.join(E2E_ROOT, "fixtures", "stripe-real-sdk");
+const BASELINE_DIR = path.join(E2E_ROOT, "bench", "baselines");
+const BASELINE_PATH = path.join(BASELINE_DIR, "stripe-real-sdk-baseline.json");
+const TYPE_NAME = "RealSdkCustomerRefForm";
+const FIXTURE_FILE = "customer-ref-form.ts";
+const RUNS = 3;
+
+// Heap cap for OOM probe (§8.4: 1 GB).
+const OOM_PROBE_HEAP_MB = 1024;
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  strict: true,
+  skipLibCheck: true,
+};
+
+// ---------------------------------------------------------------------------
+// Peak-RSS polling
+// ---------------------------------------------------------------------------
+
+interface RssPoller {
+  stop: () => number;
+}
+
+function startRssPoller(intervalMs = 5): RssPoller {
+  let peak = process.memoryUsage().rss;
+
+  const id = setInterval(() => {
+    const current = process.memoryUsage().rss;
+    if (current > peak) peak = current;
+  }, intervalMs);
+
+  // Ensure the interval does not block process exit.
+  if (typeof id.unref === "function") id.unref();
+
+  return {
+    stop: () => {
+      clearInterval(id);
+      const final = process.memoryUsage().rss;
+      if (final > peak) peak = final;
+      return peak;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Single benchmark run
+// ---------------------------------------------------------------------------
+
+interface BuildRunResult {
+  readonly wallTimeMs: number;
+  readonly peakRssBytes: number;
+}
+
+function runBuildBenchOnce(fixturePath: string): BuildRunResult {
+  // The fixture imports from "stripe" — we need the stripe node_modules to
+  // be on the path so ts.createProgram can resolve the type declarations.
+  const program = ts.createProgram([fixturePath], COMPILER_OPTIONS);
+
+  const rssPoller = startRssPoller();
+  const start = performance.now();
+
+  generateSchemasFromProgram({
+    program,
+    filePath: fixturePath,
+    typeName: TYPE_NAME,
+    errorReporting: "diagnostics",
+  });
+
+  const wallTimeMs = performance.now() - start;
+  const peakRssBytes = rssPoller.stop();
+
+  return { wallTimeMs, peakRssBytes };
+}
+
+// ---------------------------------------------------------------------------
+// OOM detection via subprocess with memory cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a single schema-generation pass in a child Node.js process capped at
+ * `maxOldSpaceMb` MB of V8 old-space. Returns `true` if the process ran out
+ * of memory.
+ *
+ * Detection strategy (in priority order):
+ * 1. Known OOM stderr indicators (`JavaScript heap out of memory`, `ENOMEM`, etc.)
+ * 2. SIGKILL termination (`result.signal === "SIGKILL"`) — the OS kills the
+ *    process before Node.js can write diagnostic output when heap allocation
+ *    fails at the OS level.
+ * 3. Null exit status with any signal — treated as OOM because the only child
+ *    task is schema generation; a signal-terminated run that succeeded would
+ *    have exited 0.
+ *
+ * Non-signal non-zero exits (e.g. fixture compilation failure, uncaught
+ * exception from the runner script) are returned as `false` because they
+ * indicate a different class of error rather than memory exhaustion.
+ */
+function detectOom(fixturePath: string, maxOldSpaceMb = OOM_PROBE_HEAP_MB): boolean {
+  // Numeric enum values embedded directly — avoids template-expression type errors.
+  const scriptTarget = String(ts.ScriptTarget.ES2022);
+  const moduleKind = String(ts.ModuleKind.NodeNext);
+  const moduleResolution = String(ts.ModuleResolutionKind.NodeNext);
+
+  const runnerScript = [
+    `import { createProgram } from "typescript";`,
+    `import { generateSchemasFromProgram } from "@formspec/build";`,
+    `const program = createProgram(${JSON.stringify([fixturePath])}, {`,
+    `  target: ${scriptTarget},`,
+    `  module: ${moduleKind},`,
+    `  moduleResolution: ${moduleResolution},`,
+    `  strict: true,`,
+    `  skipLibCheck: true,`,
+    `});`,
+    `generateSchemasFromProgram({`,
+    `  program,`,
+    `  filePath: ${JSON.stringify(fixturePath)},`,
+    `  typeName: ${JSON.stringify(TYPE_NAME)},`,
+    `  errorReporting: "diagnostics",`,
+    `});`,
+    `process.exit(0);`,
+  ].join("\n");
+
+  const tmpDir = os.tmpdir();
+  const runnerPath = path.join(tmpDir, `formspec-oom-probe-real-sdk-${String(process.pid)}.mjs`);
+  try {
+    fsSync.writeFileSync(runnerPath, runnerScript, "utf8");
+  } catch {
+    // If we can't write the probe script, conservatively report no OOM.
+    return false;
+  }
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [`--max-old-space-size=${String(maxOldSpaceMb)}`, runnerPath],
+      {
+        encoding: "utf8",
+        timeout: 300_000, // 5 min — real SDK types may take longer
+        env: { ...process.env },
+      }
+    );
+
+    if (result.status === 0) return false;
+
+    // Check for OOM indicators in output.
+    const output = `${result.stdout}${result.stderr}`;
+    const oomIndicators = [
+      "ENOMEM",
+      "out of memory",
+      "JavaScript heap out of memory",
+      "Allocation failed",
+    ];
+    if (oomIndicators.some((indicator) => output.toLowerCase().includes(indicator.toLowerCase()))) {
+      return true;
+    }
+
+    // SIGKILL (or any signal with a null status) means the OS terminated the
+    // process before Node.js could write OOM diagnostics — treat as OOM.
+    if (result.status === null && result.signal !== null) {
+      return true;
+    }
+
+    // Non-zero exit without a signal and without known OOM output: likely a
+    // different error (e.g. fixture compilation failure, uncaught exception).
+    return false;
+  } finally {
+    try {
+      fsSync.unlinkSync(runnerPath);
+    } catch {
+      // Best effort cleanup.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Median helper
+// ---------------------------------------------------------------------------
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("Cannot compute median of empty array");
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (sorted[mid - 1]! + sorted[mid]!) / 2
+    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      sorted[mid]!;
+}
+
+// ---------------------------------------------------------------------------
+// Baseline JSON shape
+// ---------------------------------------------------------------------------
+
+interface StripeRealSdkBaseline {
+  readonly phase: "0";
+  readonly description: string;
+  readonly fixture: string;
+  readonly typeName: string;
+  readonly runs: number;
+  readonly stripeVersion: string;
+  readonly metrics: {
+    readonly peakRSS_MB: number;
+    readonly wallTime_ms: number;
+    readonly didOOM: boolean;
+    readonly warmWallTimes_ms: readonly number[];
+    readonly allPeakRSS_MB: readonly number[];
+    readonly coldWallTime_ms: number;
+    readonly oomHeapCapMb: number;
+  };
+  readonly gitSha: string;
+  readonly timestamp: string;
+  readonly nodeVersion: string;
+  readonly platform: string;
+  readonly arch: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  // Ensure baseline directory exists.
+  await fs.mkdir(BASELINE_DIR, { recursive: true });
+
+  // The fixture imports from "stripe". Rather than copying it to a temp
+  // directory (which would break the "stripe" import resolution), we run
+  // directly against the fixture file in its original location so TypeScript
+  // can resolve `node_modules/stripe` from the e2e workspace.
+  const fixturePath = path.join(FIXTURE_DIR, FIXTURE_FILE);
+
+  // Verify stripe version for the baseline record.
+  const stripePackageJsonPath = path.join(
+    E2E_ROOT,
+    "node_modules",
+    "stripe",
+    "package.json"
+  );
+  const stripeVersion = await fs
+    .readFile(stripePackageJsonPath, "utf8")
+    .then((raw) => {
+      const parsed = JSON.parse(raw) as { version?: string };
+      return parsed.version ?? "unknown";
+    })
+    .catch(() => "unknown");
+
+  process.stderr.write(`\n=== Real Stripe SDK Ref<Customer> Stress-Test Benchmark (Phase 0 baseline) ===\n\n`);
+  process.stderr.write(`  fixture type:   ${TYPE_NAME}\n`);
+  process.stderr.write(`  fixture file:   ${fixturePath}\n`);
+  process.stderr.write(`  stripe version: ${stripeVersion}\n`);
+  process.stderr.write(`  runs:           ${String(RUNS)} (run 1 = cold)\n`);
+  process.stderr.write(`  OOM heap cap:   ${String(OOM_PROBE_HEAP_MB)} MB\n\n`);
+
+  // --- Build-path measurements ---
+  const allWallTimeMs: number[] = [];
+  const allPeakRssBytes: number[] = [];
+
+  process.stderr.write(`  Build-path (generateSchemasFromProgram):\n`);
+  for (let i = 0; i < RUNS; i++) {
+    const label = i === 0 ? "cold" : "warm";
+    process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
+    const result = runBuildBenchOnce(fixturePath);
+    allWallTimeMs.push(result.wallTimeMs);
+    allPeakRssBytes.push(result.peakRssBytes);
+    process.stderr.write(
+      ` ${result.wallTimeMs.toFixed(1)}ms  RSS=${(result.peakRssBytes / 1024 / 1024).toFixed(1)}MB\n`
+    );
+  }
+
+  const warmWallTimeMs = allWallTimeMs.slice(1);
+  const warmPeakRssBytes = allPeakRssBytes.slice(1);
+
+  const medianWarmWallTimeMs = warmWallTimeMs.length > 0 ? median(warmWallTimeMs) : (allWallTimeMs[0] ?? 0);
+  const medianWarmPeakRssBytes = warmPeakRssBytes.length > 0 ? median(warmPeakRssBytes) : (allPeakRssBytes[0] ?? 0);
+  const coldWallTimeMs = allWallTimeMs[0] ?? 0;
+  const peakRSSMB = medianWarmPeakRssBytes / 1024 / 1024;
+
+  // --- OOM detection ---
+  process.stderr.write(`\n  OOM probe (${String(OOM_PROBE_HEAP_MB)} MB heap cap, timeout 5 min)...\n`);
+  const didOOM = detectOom(fixturePath, OOM_PROBE_HEAP_MB);
+  process.stderr.write(`    didOOM: ${String(didOOM)}\n`);
+
+  // --- Human-readable summary ---
+  process.stderr.write(`\n--- Phase 0 Real Stripe SDK Baseline ---\n`);
+  process.stderr.write(`  stripe version:              ${stripeVersion}\n`);
+  process.stderr.write(
+    `  wallTime_ms cold:            ${coldWallTimeMs.toFixed(2)}\n`
+  );
+  process.stderr.write(
+    `  wallTime_ms warm (median):   ${medianWarmWallTimeMs.toFixed(2)}\n`
+  );
+  process.stderr.write(
+    `  peakRSS_MB warm (median):    ${peakRSSMB.toFixed(1)} MB\n`
+  );
+  process.stderr.write(`  didOOM (${String(OOM_PROBE_HEAP_MB)} MB cap):          ${String(didOOM)}\n`);
+  process.stderr.write(`----------------------------------------\n`);
+
+  // --- Interpretation note ---
+  if (didOOM) {
+    process.stderr.write(`\n  *** OOM REPRODUCED — real SDK types exceed heap cap ***\n`);
+    process.stderr.write(`  *** Phase 4 gate: fix must achieve didOOM:false + peakRSS_MB <= 512 MB ***\n\n`);
+  } else {
+    process.stderr.write(`\n  External-type bypass engaging correctly for real SDK types.\n`);
+    process.stderr.write(`  Phase 4 gate: peakRSS_MB <= 512 MB, didOOM: false.\n\n`);
+  }
+
+  // --- Write baseline JSON ---
+  const commitSha = process.env["GIT_COMMIT_SHA"] ?? "unknown";
+
+  const baseline: StripeRealSdkBaseline = {
+    phase: "0",
+    description: "Real Stripe SDK Ref<Customer> stress-test — Phase 0 pre-refactor baseline",
+    fixture: "e2e/fixtures/stripe-real-sdk/customer-ref-form.ts",
+    typeName: TYPE_NAME,
+    runs: RUNS,
+    stripeVersion,
+    metrics: {
+      peakRSS_MB: Math.round(peakRSSMB * 10) / 10,
+      wallTime_ms: Math.round(medianWarmWallTimeMs * 100) / 100,
+      didOOM,
+      warmWallTimes_ms: warmWallTimeMs.map((v) => Math.round(v * 100) / 100),
+      allPeakRSS_MB: allPeakRssBytes.map((v) => Math.round((v / 1024 / 1024) * 10) / 10),
+      coldWallTime_ms: Math.round(coldWallTimeMs * 100) / 100,
+      oomHeapCapMb: OOM_PROBE_HEAP_MB,
+    },
+    gitSha: commitSha,
+    timestamp: new Date().toISOString(),
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+  };
+
+  await fs.writeFile(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+  process.stderr.write(`  Baseline written: ${BASELINE_PATH}\n\n`);
+
+  // Machine-readable JSON to stdout.
+  process.stdout.write(`${JSON.stringify(baseline, null, 2)}\n`);
+}
+
+await main();

--- a/e2e/benchmarks/stripe-real-sdk-bench.ts
+++ b/e2e/benchmarks/stripe-real-sdk-bench.ts
@@ -141,6 +141,26 @@ function runBuildBenchOnce(fixturePath: string): BuildRunResult {
   // be on the path so ts.createProgram can resolve the type declarations.
   const program = ts.createProgram([fixturePath], COMPILER_OPTIONS);
 
+  // Verify the program resolves cleanly before measuring. If Stripe imports
+  // fail to resolve (wrong version, missing dev-dep) we would measure against
+  // an incomplete type graph and produce a meaningless baseline.
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  if (diagnostics.length > 0) {
+    const formatted = ts.formatDiagnosticsWithColorAndContext(
+      [...diagnostics],
+      {
+        getCurrentDirectory: () => E2E_ROOT,
+        getCanonicalFileName: (f) => f,
+        getNewLine: () => "\n",
+      }
+    );
+    throw new Error(
+      `TypeScript diagnostics found for fixture "${fixturePath}" — ` +
+        "baseline measurements would be invalid:\n" +
+        formatted
+    );
+  }
+
   const rssPoller = startRssPoller();
   const start = performance.now();
 
@@ -171,13 +191,16 @@ function runBuildBenchOnce(fixturePath: string): BuildRunResult {
  * 2. SIGKILL termination (`result.signal === "SIGKILL"`) — the OS kills the
  *    process before Node.js can write diagnostic output when heap allocation
  *    fails at the OS level.
- * 3. Null exit status with any signal — treated as OOM because the only child
- *    task is schema generation; a signal-terminated run that succeeded would
- *    have exited 0.
+ * 3. ETIMEDOUT (`result.error?.code === "ETIMEDOUT"`) — `spawnSync` exceeded its
+ *    `timeout` option and sent SIGTERM. This is NOT OOM; the function throws so
+ *    the caller can record a distinct timeout outcome.
+ * 4. Null exit status with SIGKILL — treated as OOM (OS killed before Node.js
+ *    could write diagnostic output).
+ * 5. Other non-zero exits without a signal and without known OOM output — logged
+ *    as a warning (e.g. fixture compilation failure, uncaught exception) and
+ *    returned as `false` so the baseline is not invalidated silently.
  *
- * Non-signal non-zero exits (e.g. fixture compilation failure, uncaught
- * exception from the runner script) are returned as `false` because they
- * indicate a different class of error rather than memory exhaustion.
+ * @throws {Error} If `spawnSync` timed out (`ETIMEDOUT`). Timeout is not OOM.
  */
 function detectOom(fixturePath: string, maxOldSpaceMb = OOM_PROBE_HEAP_MB): boolean {
   // Numeric enum values embedded directly — avoids template-expression type errors.
@@ -220,13 +243,27 @@ function detectOom(fixturePath: string, maxOldSpaceMb = OOM_PROBE_HEAP_MB): bool
       {
         encoding: "utf8",
         timeout: 300_000, // 5 min — real SDK types may take longer
+        // cwd must be E2E_ROOT so Node.js resolves `@formspec/build`, `typescript`,
+        // and `stripe` from the e2e workspace node_modules rather than from the OS
+        // tmpdir (which has none of those packages).
+        cwd: E2E_ROOT,
         env: { ...process.env },
       }
     );
 
     if (result.status === 0) return false;
 
-    // Check for OOM indicators in output.
+    // Tier 0: spawnSync timed out — ETIMEDOUT is NOT OOM.
+    // Throw so the caller records a distinct timeout outcome instead of
+    // silently returning didOOM: false and continuing with an invalid baseline.
+    if ((result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT") {
+      throw new Error(
+        `OOM probe timed out after ${String(300_000 / 60_000)} minutes — ` +
+          "consider raising the timeout if the real SDK is slower than expected."
+      );
+    }
+
+    // Tier 1: Known OOM indicators in stdout/stderr.
     const output = `${result.stdout}${result.stderr}`;
     const oomIndicators = [
       "ENOMEM",
@@ -238,14 +275,27 @@ function detectOom(fixturePath: string, maxOldSpaceMb = OOM_PROBE_HEAP_MB): bool
       return true;
     }
 
-    // SIGKILL (or any signal with a null status) means the OS terminated the
-    // process before Node.js could write OOM diagnostics — treat as OOM.
+    // Tier 2: SIGKILL with null status — OS terminated before Node.js could
+    // write OOM diagnostics.
+    if (result.status === null && result.signal === "SIGKILL") {
+      return true;
+    }
+
+    // Tier 3: Any other null-status signal — treated as OOM because the only
+    // child task is schema generation; a signal-terminated success exits 0.
     if (result.status === null && result.signal !== null) {
       return true;
     }
 
-    // Non-zero exit without a signal and without known OOM output: likely a
-    // different error (e.g. fixture compilation failure, uncaught exception).
+    // Tier 4: Non-signal non-zero exit (fixture compilation failure, uncaught
+    // exception, etc.). This is a distinct class of error — log a warning so
+    // the operator is not left wondering why didOOM is false.
+    process.stderr.write(
+      `\n  WARNING: OOM probe exited with status ${String(result.status)} (not a signal, not OOM indicators found).\n` +
+        `  This may indicate a fixture load error or uncaught exception.\n` +
+        `  stdout: ${result.stdout.slice(0, 500)}\n` +
+        `  stderr: ${result.stderr.slice(0, 500)}\n`
+    );
     return false;
   } finally {
     try {

--- a/e2e/fixtures/stripe-real-sdk/customer-ref-form.ts
+++ b/e2e/fixtures/stripe-real-sdk/customer-ref-form.ts
@@ -1,0 +1,293 @@
+/**
+ * Real-SDK Stripe stress-test fixture for the Ref<Customer> OOM investigation.
+ *
+ * This fixture uses REAL types from the `stripe` npm package (not hand-authored
+ * stubs) to verify whether the external-type bypass in `extractReferenceTypeArguments`
+ * (PR #308, `packages/build/src/analyzer/class-analyzer.ts`) engages correctly
+ * when type arguments reference types from `node_modules/stripe/...`.
+ *
+ * Motivation: Users reported OOM when building schemas for classes with
+ * `Ref<Stripe.Customer>`-style fields backed by real SDK types. The synthetic
+ * fixture in `e2e/fixtures/stripe-ref-customer/` uses hand-authored Stripe-like
+ * types (tiny compared to the real SDK) and does NOT reproduce the bug. This
+ * fixture closes that gap.
+ *
+ * The `Ref<T>` wrapper below uses the same `__type` phantom-property convention
+ * as the synthetic fixture (see `stripe-ref-customer/stripe-like-types.ts`). The
+ * `__` prefix is load-bearing: `class-analyzer.ts` skips all `__`-prefixed
+ * properties during IR emission, so `__type` never appears in generated JSON
+ * Schema while still making `T` visible to generic-reference resolution.
+ *
+ * Field summary (~15 primitive fields + 5 Ref<T> fields + 1 nested object):
+ *   - 1  Ref<Stripe.Customer>         — primary trigger; largest real SDK type
+ *   - 1  Ref<Stripe.PaymentMethod>    — large discriminated-union type
+ *   - 1  Ref<Stripe.Subscription>     — also large
+ *   - 1  Ref<Stripe.Invoice>          — largest type in the SDK type graph
+ *   - 1  Ref<Stripe.TaxId>            — moderate size
+ *   - 1  nested object (RealSdkBillingAddress) with its own Ref<Stripe.Customer>
+ *   - ~15 primitive fields with standard constraint tags
+ *
+ * @see e2e/benchmarks/stripe-real-sdk-bench.ts — runner and OOM detection
+ * @see e2e/fixtures/stripe-ref-customer/STUB_NOTE.md — rationale for Ref<T> approach
+ * @see packages/build/src/analyzer/class-analyzer.ts extractReferenceTypeArguments
+ */
+
+import type Stripe from "stripe";
+
+// =============================================================================
+// Ref<T> — phantom wrapper for expandable-field polymorphism
+// =============================================================================
+
+/**
+ * Ref<T> represents an expandable field in the Stripe API.
+ *
+ * The `__type` phantom property carries the generic type argument for
+ * FormSpec's external-type bypass in `extractReferenceTypeArguments` (PR #308).
+ * The `__` prefix is load-bearing — `class-analyzer.ts` excludes `__`-prefixed
+ * properties from Canonical IR emission.
+ */
+export interface Ref<T> {
+  /**
+   * The Stripe object ID when the field is unexpanded.
+   */
+  readonly id: string;
+  /**
+   * True when the full resource object has been loaded.
+   */
+  readonly expanded: boolean;
+  /**
+   * Phantom field. Carries the generic type argument T to make it visible to
+   * `extractReferenceTypeArguments` without triggering full type-graph recursion
+   * on the (large) SDK type. The `__` prefix causes class-analyzer.ts to skip
+   * this field during IR emission.
+   */
+  readonly __type?: T;
+}
+
+// =============================================================================
+// Nested supporting type — exercises Ref<T> inside an object field
+// =============================================================================
+
+/**
+ * Billing address collected at checkout time. Contains a nested Ref<Stripe.Customer>
+ * to exercise the external-type bypass path inside a nested object walk.
+ */
+interface RealSdkBillingAddress {
+  /** @minLength 1 @maxLength 200 */
+  line1: string;
+  /** @maxLength 200 */
+  line2?: string;
+  /** @minLength 1 @maxLength 100 */
+  city: string;
+  /** @minLength 2 @maxLength 2 @pattern ^[A-Z]{2}$ */
+  countryCode: string;
+  /** @minLength 3 @maxLength 10 @pattern ^[A-Za-z0-9 \-]{3,10}$ */
+  postalCode: string;
+  /**
+   * Back-reference to the owning customer. Tests the bypass path inside nested
+   * object analysis — mirrors the `CheckoutAddress.ownerRef` field in the
+   * synthetic fixture.
+   */
+  ownerRef: Ref<Stripe.Customer>;
+}
+
+// =============================================================================
+// Main fixture class
+// =============================================================================
+
+/**
+ * Real-SDK Stripe stress-test form fixture.
+ *
+ * Used by `e2e/benchmarks/stripe-real-sdk-bench.ts` to measure peak RSS,
+ * wall time, and OOM behaviour under the full FormSpec build pipeline when
+ * `Ref<T>` fields reference REAL types from the `stripe` npm package.
+ *
+ * The external-type bypass in `extractReferenceTypeArguments` (PR #308) should
+ * fire for every `Ref<Stripe.*>` field because the Stripe types are declared in
+ * `node_modules/stripe/...` — a different file from the analysis root. If the
+ * bypass does NOT fire, the analyzer walks the full Stripe type graph and may
+ * exhaust memory.
+ *
+ * See `e2e/benchmarks/stripe-real-sdk-bench.ts` §Phase 4 gate for acceptance
+ * criteria.
+ */
+export class RealSdkCustomerRefForm {
+  // =========================================================================
+  // Ref<Stripe.*> fields — primary stress drivers (5)
+  // =========================================================================
+
+  /**
+   * The primary Stripe customer. `Stripe.Customer` is one of the largest types
+   * in the SDK — deeply nested with many optional sub-objects.
+   */
+  customer!: Ref<Stripe.Customer>;
+
+  /**
+   * Primary payment method. `Stripe.PaymentMethod` is a large discriminated
+   * union over many payment method types (card, bank_transfer, sepa_debit, etc.).
+   */
+  paymentMethod?: Ref<Stripe.PaymentMethod>;
+
+  /**
+   * Active subscription. `Stripe.Subscription` includes nested items list,
+   * plan, price, and schedule references.
+   */
+  subscription?: Ref<Stripe.Subscription>;
+
+  /**
+   * Most recent invoice. `Stripe.Invoice` is the largest type in the SDK with
+   * deeply nested line items, charge, and payment intent references.
+   */
+  invoice?: Ref<Stripe.Invoice>;
+
+  /**
+   * Tax identifier on the customer record. `Stripe.TaxId` is moderate-sized.
+   */
+  taxId?: Ref<Stripe.TaxId>;
+
+  // =========================================================================
+  // Constrained string fields (6)
+  // =========================================================================
+
+  /**
+   * Internal reference code.
+   *
+   * @minLength 3
+   * @maxLength 64
+   * @pattern ^[A-Za-z0-9_\-]+$
+   */
+  referenceCode!: string;
+
+  /**
+   * Customer display name.
+   *
+   * @minLength 1
+   * @maxLength 200
+   */
+  displayName!: string;
+
+  /**
+   * Contact email.
+   *
+   * @minLength 5
+   * @maxLength 254
+   * @pattern ^[^@\s]+@[^@\s]+\.[^@\s]+$
+   */
+  email!: string;
+
+  /**
+   * E.164 phone number.
+   *
+   * @minLength 7
+   * @maxLength 20
+   * @pattern ^\+?[0-9\s\-().]{7,20}$
+   */
+  phone?: string;
+
+  /**
+   * ISO 3166-1 alpha-2 billing country.
+   *
+   * @minLength 2
+   * @maxLength 2
+   * @pattern ^[A-Z]{2}$
+   */
+  billingCountry!: string;
+
+  /**
+   * ISO 4217 currency code (lowercase).
+   *
+   * @minLength 3
+   * @maxLength 3
+   * @pattern ^[a-z]{3}$
+   */
+  currency!: string;
+
+  // =========================================================================
+  // Constrained numeric fields (5)
+  // =========================================================================
+
+  /**
+   * Outstanding balance in smallest currency unit (cents). Negative = credit.
+   *
+   * @minimum -999999999
+   * @maximum 999999999
+   */
+  balanceCents!: number;
+
+  /**
+   * Credit limit in cents.
+   *
+   * @minimum 0
+   * @maximum 5000000
+   * @multipleOf 100
+   */
+  creditLimitCents!: number;
+
+  /**
+   * Number of successful charges.
+   *
+   * @minimum 0
+   * @maximum 99999
+   */
+  successfulChargeCount!: number;
+
+  /**
+   * Lifetime value in cents.
+   *
+   * @minimum 0
+   * @maximum 999999999
+   */
+  lifetimeValueCents!: number;
+
+  /**
+   * Fraud risk score (0.00–1.00).
+   *
+   * @minimum 0
+   * @maximum 1
+   * @multipleOf 0.0001
+   */
+  riskScore!: number;
+
+  // =========================================================================
+  // Enum / literal-union fields (2)
+  // =========================================================================
+
+  /**
+   * How the customer prefers to be contacted.
+   *
+   * @enumOptions [{"id":"email","label":"Email"},{"id":"sms","label":"SMS"},{"id":"phone","label":"Phone"},{"id":"none","label":"None"}]
+   */
+  contactPreference!: "email" | "sms" | "phone" | "none";
+
+  /** Account status. */
+  accountStatus!: "active" | "suspended" | "closed";
+
+  // =========================================================================
+  // Boolean flags (2)
+  // =========================================================================
+
+  /** Whether the customer account is delinquent. */
+  isDelinquent!: boolean;
+
+  /** Whether the customer has completed identity verification. */
+  identityVerified!: boolean;
+
+  // =========================================================================
+  // Nested object with Ref<Stripe.Customer> inside (1)
+  // =========================================================================
+
+  /**
+   * Primary billing address, including a back-reference to the owning customer.
+   * Exercises the external-type bypass path inside a nested object walk.
+   */
+  billingAddress?: RealSdkBillingAddress;
+
+  // =========================================================================
+  // Freeform metadata (1)
+  // =========================================================================
+
+  /**
+   * Arbitrary key-value metadata.
+   */
+  metadata!: Record<string, string>;
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,8 @@
     "benchmark:hybrid-tooling": "pnpm --filter @formspec/language-server... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && tsx ./benchmarks/hybrid-tooling-comparison.ts",
     "bench:analysis": "pnpm -r --filter @formspec/build... --filter @formspec/ts-plugin... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/analysis-bench.ts",
     "bench:synthetic-checker": "pnpm -r --filter @formspec/analysis... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/synthetic-checker-baseline.bench.ts",
-    "bench:stripe-ref-customer": "pnpm -r --filter @formspec/build... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-ref-customer-bench.ts"
+    "bench:stripe-ref-customer": "pnpm -r --filter @formspec/build... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-ref-customer-bench.ts",
+    "bench:stripe-real-sdk": "pnpm -r --filter @formspec/build... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-real-sdk-bench.ts"
   },
   "dependencies": {
     "@formspec/analysis": "workspace:*",
@@ -22,6 +23,7 @@
     "@formspec/validator": "workspace:*"
   },
   "devDependencies": {
+    "stripe": "^22.0.2",
     "tsx": "^4.21.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0",

--- a/e2e/tsconfig.benchmarks.json
+++ b/e2e/tsconfig.benchmarks.json
@@ -9,5 +9,5 @@
       "@formspec/language-server": ["packages/language-server/src/index.ts"]
     }
   },
-  "include": ["benchmarks", "tests/hybrid-tooling-benchmark.test.ts"]
+  "include": ["benchmarks", "fixtures/stripe-real-sdk", "tests/hybrid-tooling-benchmark.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
         specifier: workspace:*
         version: link:../packages/validator
     devDependencies:
+      stripe:
+        specifier: ^22.0.2
+        version: 22.0.2(@types/node@22.19.7)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -2530,6 +2533,15 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  stripe@22.0.2:
+    resolution: {integrity: sha512-2/BLrQ3oB1zlNfeL/LfHFjTGx6EQn0j+ztrrTJHuDjV5VVIpk92oSDaxyKLUr3pG3dnee2LZqhFUv2Bf0G1/3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -5071,6 +5083,10 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  stripe@22.0.2(@types/node@22.19.7):
+    optionalDependencies:
+      '@types/node': 22.19.7
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `e2e/fixtures/stripe-real-sdk/customer-ref-form.ts` — a FormSpec class with `Ref<T>` fields backed by **real** types from the `stripe` npm package (v22.0.2), not hand-authored stubs
- Adds `e2e/benchmarks/stripe-real-sdk-bench.ts` — benchmark runner with OOM detection, wall-time measurement, and baseline JSON output (mirrors `stripe-ref-customer-bench.ts`)
- Installs `stripe` as a devDependency of `@formspec/e2e`
- Adds `bench:stripe-real-sdk` script to `e2e/package.json`

## Motivation

Users reported OOM when building schemas for classes with `Ref<Stripe.Customer>`-style fields referencing types from the real `stripe` npm package. The synthetic `stripe-ref-customer` fixture (#333) uses hand-authored types (~80 properties) and does NOT reproduce the bug — it measures ~922 MB peak RSS with no OOM. The real SDK is far larger: `Stripe.Invoice` alone is ~4 000 lines of TypeScript declarations, `Stripe.PaymentMethod` is a wide discriminated union over ~20 payment method types.

The external-type bypass in `extractReferenceTypeArguments` (PR #308) should prevent full type-graph recursion by emitting an opaque `{ kind: "reference", name: "...", typeArguments: [] }` node whenever a `Ref<T>` type argument is declared in a different file. This fixture verifies that the bypass engages on `node_modules/stripe/...` paths end-to-end.

## Phase 0 baseline (arm64 darwin, Node v24.14.0, stripe 22.0.2)

| Metric | Value |
|--------|-------|
| `peakRSS_MB` warm median | **946.5 MB** |
| `wallTime_ms` warm median | **82 ms** |
| `wallTime_ms` cold (run 1) | **1 519 ms** |
| `didOOM` (1 GB heap cap) | **false** |

The bypass fires correctly at Phase 0: no OOM at 1 GB, but peak RSS is 946.5 MB — within ~80 MB of the 1 GB cap. This is ~25 MB higher than the synthetic fixture baseline (921.8 MB), confirming the real SDK adds meaningful pressure.

**Interpretation:** The external-type bypass is load-bearing for real SDK types. Without it, walking `Stripe.Customer` and `Stripe.Invoice` would recurse into thousands of type nodes and almost certainly OOM. The current ~947 MB RSS is the cost of the TypeScript `ts.Program` itself (one `ts.createProgram` call that loads all of `node_modules/stripe`), not the FormSpec IR walk.

## Phase 4 acceptance gate

After the host-checker migration (`synthetic-checker-retirement.md` §8.4):
- `didOOM: false` on a 1 GB runner
- `peakRSS_MB` ≤ **512 MB**

## Notes

- `stripe` is ~18 MB on disk; type declarations only (`esm/*.d.ts` / `cjs/*.d.ts`); no production code is bundled
- The benchmark does NOT modify production source code
- `e2e/` changes are excluded from the changeset denylist — no changeset needed