### PR TITLE
test(e2e): realistic Stripe-integration OOM sweep across 4 consumer surfaces

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -193,8 +193,10 @@ pnpm --filter @formspec/e2e run bench:stripe-realistic-eslint
 
 #### Surface 4 — tsserver plugin (`FormSpecSemanticService.getDiagnostics`)
 
-Instantiates `FormSpecSemanticService` directly (same code path tsserver loads) and calls
-`getDiagnostics` once cold + twice warm to mimic: open file, first keystroke, second keystroke.
+Instantiates `FormSpecSemanticService` directly (same code path tsserver loads) and reuses the
+same service to call `getDiagnostics` three times: once cold (open-file) and twice warm
+(first keystroke, second keystroke). This models a real editor session rather than cold-starting
+a new service per call.
 
 **Script:** `benchmarks/stripe-realistic-tsserver-bench.ts`
 **Baseline:** `bench/baselines/stripe-realistic-tsserver-baseline.json`
@@ -205,19 +207,23 @@ pnpm --filter @formspec/e2e run bench:stripe-realistic-tsserver
 
 #### Phase 0 baseline numbers (arm64 darwin, Node v24.14.0, 1 GB OOM cap)
 
-| Surface | `peakRSS_MB` warm median | `wallTime_ms` cold | `wallTime_ms` warm median | `didOOM` (1 GB) |
-|---------|--------------------------|-------------------|--------------------------|-----------------|
-| **build** | **861.3 MB** | 432.7 ms | 81.5 ms | **false** |
-| **snapshot** | **843.8 MB** | 290.4 ms | 7.1 ms | **false** |
-| **eslint** | **519.1 MB** | 420.2 ms | 2.8 ms | **false** |
-| **tsserver-plugin** | **846.6 MB** | 370.1 ms | 77.9 ms | **false** |
+| Surface | `peakRSS_MB` | `wallTime_ms` cold | `wallTime_ms` warm median | `didOOM` (1 GB) |
+|---------|--------------|-------------------|--------------------------|-----------------|
+| **build** | **861.3 MB** (warm median) | 432.7 ms | 81.5 ms | **false** |
+| **snapshot** | **843.8 MB** (warm median) | 290.4 ms | 7.1 ms | **false** |
+| **eslint** | **519.1 MB** (warm median) | 420.2 ms | 2.8 ms | **false** |
+| **tsserver-plugin** | **567.4 MB** (session) | 373.8 ms | ~0 ms | **false** |
+
+Notes on tsserver-plugin: the bench creates one service and calls `getDiagnostics` 3× (open-file
++ 2 keystrokes) on the same instance. Session RSS is measured across all three calls. Warm
+wall-time is near-zero because the service caches analysis results across calls.
 
 All four surfaces came in under 1 GB — none OOMed on this machine (M-series arm64, Node v24.14.0).
-However, build / snapshot / tsserver-plugin are all within 160 MB of the 1 GB cap. A machine with
-less available RSS headroom, or a stripe SDK version with larger type graphs, would push these over.
-The ESLint surface is cheaper (~519 MB) because the `@typescript-eslint/parser` creates its own
-TypeScript program and the ESLint rule only inspects the checked file rather than walking the full
-schema emission pipeline.
+Build / snapshot are above 840 MB, within 180 MB of the 1 GB cap. A machine with less available
+RSS headroom, or a stripe SDK version with larger type graphs, would push these over. The ESLint
+surface is cheaper (~519 MB) because the `@typescript-eslint/parser` creates its own TypeScript
+program and the ESLint rule only inspects the checked file rather than walking the full schema
+emission pipeline.
 
 **Interpretation for Phase 4:**
 These numbers are the acceptance-gate baselines. After the host-checker migration (Phase 4),
@@ -229,11 +235,11 @@ still `false` at 1 GB cap.
 | Fixture | Approach | `peakRSS_MB` | `didOOM` (512 MB cap) |
 |---------|---------|--------------|----------------------|
 | `stripe-ref-customer` | `Ref<T>` wrapper, build only | 921.8 MB | false |
-| `stripe-realistic-oom` (this) | Direct Stripe types, 4 surfaces | 843–861 MB | false |
+| `stripe-realistic-oom` (this) | Direct Stripe types, 4 surfaces | 567–861 MB | false |
 
 The `Ref<T>` fixture engaged the external-type bypass (PR #308) which prevented walking Stripe's
-internal type graph. The realistic fixture forces the full walk and lands at similar RSS levels —
-confirming the bypass is not what prevented OOM in prior measurements; it was already under 1 GB.
+internal type graph. The realistic fixture forces the full walk and lands at similar RSS levels for
+build/snapshot — confirming the bypass is not what prevented OOM in prior measurements.
 
 ## License
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -140,6 +140,101 @@ This benchmark depends on the version of the `stripe` npm package installed in `
 Bumping Stripe may shift the baseline — check `bench/baselines/stripe-real-sdk-baseline.json`
 and re-run if the Stripe version changes.
 
+---
+
+### Stripe realistic OOM sweep — all four consumer surfaces (Phase 0)
+
+**Motivation:** Users report OOM when building forms that import types from the `stripe` npm SDK
+directly. Prior fixtures (`stripe-ref-customer`, `stripe-real-sdk`) used a `Ref<T>` wrapper with
+a `__type` phantom property that deliberately bypasses walking into Stripe types (PR #308's
+external-type bypass). They never exercised the OOM path.
+
+This sweep covers the code path real users hit: `Stripe.Customer`, `Stripe.Invoice`, etc.
+embedded **directly** in the form class — no wrapper — across **all four** consumer surfaces
+(build, LSP snapshot, ESLint, tsserver plugin). One command per surface; all four write their own
+baseline JSON so Phase 4 gate progress can be tracked individually.
+
+**Fixture:** `fixtures/stripe-realistic-oom/checkout-form.ts` — `CheckoutForm` class with
+11 fields including `Stripe.Customer`, `Stripe.PaymentMethod`, `Stripe.Subscription`,
+`Stripe.Invoice`, and `Stripe.TaxId` plus primitive fields with TSDoc constraints.
+
+#### Surface 1 — build (`generateSchemasFromProgram`)
+
+**Script:** `benchmarks/stripe-realistic-build-bench.ts`
+**Baseline:** `bench/baselines/stripe-realistic-build-baseline.json`
+
+```bash
+pnpm --filter @formspec/e2e run bench:stripe-realistic-build
+```
+
+#### Surface 2 — snapshot (`buildFormSpecAnalysisFileSnapshot`)
+
+Models the LSP/editor analysis hot path.
+
+**Script:** `benchmarks/stripe-realistic-snapshot-bench.ts`
+**Baseline:** `bench/baselines/stripe-realistic-snapshot-baseline.json`
+
+```bash
+pnpm --filter @formspec/e2e run bench:stripe-realistic-snapshot
+```
+
+#### Surface 3 — ESLint (`type-compatibility/tag-type-check` rule)
+
+Uses the ESLint JS API with `@typescript-eslint/parser` and `parserOptions.project`. The
+`tag-type-check` rule has its own TypeChecker creation path — separate from the build and
+snapshot surfaces.
+
+**Script:** `benchmarks/stripe-realistic-eslint-bench.ts`
+**Baseline:** `bench/baselines/stripe-realistic-eslint-baseline.json`
+
+```bash
+pnpm --filter @formspec/e2e run bench:stripe-realistic-eslint
+```
+
+#### Surface 4 — tsserver plugin (`FormSpecSemanticService.getDiagnostics`)
+
+Instantiates `FormSpecSemanticService` directly (same code path tsserver loads) and calls
+`getDiagnostics` once cold + twice warm to mimic: open file, first keystroke, second keystroke.
+
+**Script:** `benchmarks/stripe-realistic-tsserver-bench.ts`
+**Baseline:** `bench/baselines/stripe-realistic-tsserver-baseline.json`
+
+```bash
+pnpm --filter @formspec/e2e run bench:stripe-realistic-tsserver
+```
+
+#### Phase 0 baseline numbers (arm64 darwin, Node v24.14.0, 1 GB OOM cap)
+
+| Surface | `peakRSS_MB` warm median | `wallTime_ms` cold | `wallTime_ms` warm median | `didOOM` (1 GB) |
+|---------|--------------------------|-------------------|--------------------------|-----------------|
+| **build** | **861.3 MB** | 432.7 ms | 81.5 ms | **false** |
+| **snapshot** | **843.8 MB** | 290.4 ms | 7.1 ms | **false** |
+| **eslint** | **519.1 MB** | 420.2 ms | 2.8 ms | **false** |
+| **tsserver-plugin** | **846.6 MB** | 370.1 ms | 77.9 ms | **false** |
+
+All four surfaces came in under 1 GB — none OOMed on this machine (M-series arm64, Node v24.14.0).
+However, build / snapshot / tsserver-plugin are all within 160 MB of the 1 GB cap. A machine with
+less available RSS headroom, or a stripe SDK version with larger type graphs, would push these over.
+The ESLint surface is cheaper (~519 MB) because the `@typescript-eslint/parser` creates its own
+TypeScript program and the ESLint rule only inspects the checked file rather than walking the full
+schema emission pipeline.
+
+**Interpretation for Phase 4:**
+These numbers are the acceptance-gate baselines. After the host-checker migration (Phase 4),
+all four surfaces must show `peakRSS_MB` ≤ 50% of the corresponding value above, with `didOOM`
+still `false` at 1 GB cap.
+
+**Reference contrast — prior synthetic-fixture baselines:**
+
+| Fixture | Approach | `peakRSS_MB` | `didOOM` (512 MB cap) |
+|---------|---------|--------------|----------------------|
+| `stripe-ref-customer` | `Ref<T>` wrapper, build only | 921.8 MB | false |
+| `stripe-realistic-oom` (this) | Direct Stripe types, 4 surfaces | 843–861 MB | false |
+
+The `Ref<T>` fixture engaged the external-type bypass (PR #308) which prevented walking Stripe's
+internal type graph. The realistic fixture forces the full walk and lands at similar RSS levels —
+confirming the bypass is not what prevented OOM in prior measurements; it was already under 1 GB.
+
 ## License
 
 This workspace is part of the FormSpec monorepo and is released under the MIT License. See

--- a/e2e/bench/baselines/stripe-realistic-build-baseline.json
+++ b/e2e/bench/baselines/stripe-realistic-build-baseline.json
@@ -1,0 +1,29 @@
+{
+  "phase": "0",
+  "surface": "build",
+  "description": "Stripe realistic OOM sweep — build surface (generateSchemasFromProgram, direct Stripe types, no Ref<T> wrapper)",
+  "fixture": "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
+  "typeName": "CheckoutForm",
+  "runs": 3,
+  "oomHeapCapMB": 1024,
+  "metrics": {
+    "peakRSS_MB": 861.3,
+    "wallTime_ms": 81.53,
+    "didOOM": false,
+    "warmWallTimes_ms": [
+      84,
+      79.05
+    ],
+    "allPeakRSS_MB": [
+      593.7,
+      776.8,
+      945.7
+    ],
+    "coldWallTime_ms": 432.71
+  },
+  "gitSha": "unknown",
+  "timestamp": "2026-04-20T01:12:09.040Z",
+  "nodeVersion": "v24.14.0",
+  "platform": "darwin",
+  "arch": "arm64"
+}

--- a/e2e/bench/baselines/stripe-realistic-eslint-baseline.json
+++ b/e2e/bench/baselines/stripe-realistic-eslint-baseline.json
@@ -1,0 +1,30 @@
+{
+  "phase": "0",
+  "surface": "eslint",
+  "description": "Stripe realistic OOM sweep — ESLint surface (tag-type-check rule, direct Stripe types, no Ref<T> wrapper)",
+  "fixture": "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
+  "runs": 3,
+  "oomHeapCapMB": 1024,
+  "metrics": {
+    "peakRSS_MB": 519.1,
+    "wallTime_ms": 2.78,
+    "didOOM": false,
+    "warmWallTimes_ms": [
+      3.37,
+      2.18
+    ],
+    "allPeakRSS_MB": [
+      518.8,
+      519,
+      519.1
+    ],
+    "coldWallTime_ms": 420.19,
+    "errorCount": 0,
+    "warningCount": 0
+  },
+  "gitSha": "unknown",
+  "timestamp": "2026-04-20T01:14:38.081Z",
+  "nodeVersion": "v24.14.0",
+  "platform": "darwin",
+  "arch": "arm64"
+}

--- a/e2e/bench/baselines/stripe-realistic-snapshot-baseline.json
+++ b/e2e/bench/baselines/stripe-realistic-snapshot-baseline.json
@@ -1,0 +1,28 @@
+{
+  "phase": "0",
+  "surface": "snapshot",
+  "description": "Stripe realistic OOM sweep — snapshot surface (buildFormSpecAnalysisFileSnapshot, direct Stripe types, no Ref<T> wrapper)",
+  "fixture": "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
+  "runs": 3,
+  "oomHeapCapMB": 1024,
+  "metrics": {
+    "peakRSS_MB": 843.8,
+    "wallTime_ms": 7.1,
+    "didOOM": false,
+    "warmWallTimes_ms": [
+      7.7,
+      6.5
+    ],
+    "allPeakRSS_MB": [
+      567.2,
+      753.7,
+      933.9
+    ],
+    "coldWallTime_ms": 290.38
+  },
+  "gitSha": "unknown",
+  "timestamp": "2026-04-20T01:12:13.794Z",
+  "nodeVersion": "v24.14.0",
+  "platform": "darwin",
+  "arch": "arm64"
+}

--- a/e2e/bench/baselines/stripe-realistic-tsserver-baseline.json
+++ b/e2e/bench/baselines/stripe-realistic-tsserver-baseline.json
@@ -1,0 +1,33 @@
+{
+  "phase": "0",
+  "surface": "tsserver-plugin",
+  "description": "Stripe realistic OOM sweep — tsserver-plugin surface (FormSpecSemanticService.getDiagnostics, direct Stripe types, no Ref<T> wrapper)",
+  "fixture": "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
+  "runs": 3,
+  "oomHeapCapMB": 1024,
+  "metrics": {
+    "peakRSS_MB": 846.6,
+    "wallTime_ms": 77.91,
+    "didOOM": false,
+    "warmWallTimes_ms": [
+      77.09,
+      78.73
+    ],
+    "allPeakRSS_MB": [
+      570.7,
+      756.7,
+      936.5
+    ],
+    "coldWallTime_ms": 370.1,
+    "syntheticCompileCounts": [
+      5,
+      0,
+      0
+    ]
+  },
+  "gitSha": "unknown",
+  "timestamp": "2026-04-20T01:14:43.043Z",
+  "nodeVersion": "v24.14.0",
+  "platform": "darwin",
+  "arch": "arm64"
+}

--- a/e2e/bench/baselines/stripe-realistic-tsserver-baseline.json
+++ b/e2e/bench/baselines/stripe-realistic-tsserver-baseline.json
@@ -1,24 +1,22 @@
 {
   "phase": "0",
   "surface": "tsserver-plugin",
-  "description": "Stripe realistic OOM sweep — tsserver-plugin surface (FormSpecSemanticService.getDiagnostics, direct Stripe types, no Ref<T> wrapper)",
+  "description": "Stripe realistic OOM sweep — tsserver-plugin surface (FormSpecSemanticService.getDiagnostics, 1 service × 3 getDiagnostics calls, direct Stripe types, no Ref<T> wrapper)",
   "fixture": "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
   "runs": 3,
   "oomHeapCapMB": 1024,
   "metrics": {
-    "peakRSS_MB": 846.6,
-    "wallTime_ms": 77.91,
+    "peakRSS_MB": 567.4,
+    "wallTime_ms": 0.02,
     "didOOM": false,
     "warmWallTimes_ms": [
-      77.09,
-      78.73
+      0.03,
+      0.02
     ],
     "allPeakRSS_MB": [
-      570.7,
-      756.7,
-      936.5
+      567.4
     ],
-    "coldWallTime_ms": 370.1,
+    "coldWallTime_ms": 373.83,
     "syntheticCompileCounts": [
       5,
       0,
@@ -26,7 +24,7 @@
     ]
   },
   "gitSha": "unknown",
-  "timestamp": "2026-04-20T01:14:43.043Z",
+  "timestamp": "2026-04-20T01:46:32.187Z",
   "nodeVersion": "v24.14.0",
   "platform": "darwin",
   "arch": "arm64"

--- a/e2e/benchmarks/stripe-realistic-build-bench.ts
+++ b/e2e/benchmarks/stripe-realistic-build-bench.ts
@@ -1,0 +1,369 @@
+/**
+ * Phase 0 baseline: Stripe realistic OOM sweep — build surface.
+ *
+ * Measures `generateSchemasFromProgram` (from `@formspec/build/internals`)
+ * against a fixture that embeds Stripe types DIRECTLY — no Ref<T> wrapper.
+ * This is the code path reported to OOM in real user projects.
+ *
+ * Unlike `e2e/fixtures/stripe-ref-customer/` (which uses a Ref<T> wrapper
+ * to engage the external-type bypass in PR #308), this fixture forces the
+ * analyzer to walk real Stripe.Customer / Stripe.Invoice / etc.
+ *
+ * ### Metrics captured
+ *
+ *   1. wallTimeMs   — end-to-end elapsed time (cold + warm median over 3 runs)
+ *   2. peakRSS_MB   — peak resident set size (polling, warm median)
+ *   3. didOOM       — whether the process OOMs at a 1 GB heap cap
+ *
+ * ### OOM detection
+ *
+ * The OOM probe spawns a subprocess with `--max-old-space-size=1024`.
+ * Detection checks (in priority order):
+ *   1. Known OOM stderr indicators
+ *   2. SIGKILL termination (OS kills before Node.js writes diagnostics)
+ *   3. Null exit status with any signal
+ *
+ * ### Phase 4 gate
+ *
+ * After host-checker migration: peakRSS_MB ≤ 50% of this baseline,
+ * zero OOM at 1 GB cap across all four surfaces.
+ *
+ * ### How to run
+ *
+ *   pnpm --filter @formspec/e2e run bench:stripe-realistic-build
+ *
+ * Surface label: "build"
+ * Baseline: e2e/bench/baselines/stripe-realistic-build-baseline.json
+ */
+
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import * as ts from "typescript";
+import { generateSchemasFromProgram } from "@formspec/build";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+const E2E_ROOT = path.resolve(BENCH_DIR, "..");
+const FIXTURE_DIR = path.join(E2E_ROOT, "fixtures", "stripe-realistic-oom");
+const BASELINE_DIR = path.join(E2E_ROOT, "bench", "baselines");
+const BASELINE_PATH = path.join(BASELINE_DIR, "stripe-realistic-build-baseline.json");
+const FIXTURE_FILE = "checkout-form.ts";
+const TYPE_NAME = "CheckoutForm";
+const RUNS = 3;
+const OOM_HEAP_CAP_MB = 1024;
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  strict: true,
+  skipLibCheck: true,
+};
+
+// ---------------------------------------------------------------------------
+// Peak-RSS polling
+// ---------------------------------------------------------------------------
+
+interface RssPoller {
+  stop: () => number;
+}
+
+function startRssPoller(intervalMs = 5): RssPoller {
+  let peak = process.memoryUsage().rss;
+
+  const id = setInterval(() => {
+    const current = process.memoryUsage().rss;
+    if (current > peak) peak = current;
+  }, intervalMs);
+
+  if (typeof id.unref === "function") id.unref();
+
+  return {
+    stop: () => {
+      clearInterval(id);
+      const final = process.memoryUsage().rss;
+      if (final > peak) peak = final;
+      return peak;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Single benchmark run
+// ---------------------------------------------------------------------------
+
+interface BuildRunResult {
+  readonly wallTimeMs: number;
+  readonly peakRssBytes: number;
+}
+
+function runBuildBenchOnce(fixturePath: string): BuildRunResult {
+  const program = ts.createProgram([fixturePath], COMPILER_OPTIONS);
+
+  const rssPoller = startRssPoller();
+  const start = performance.now();
+
+  generateSchemasFromProgram({
+    program,
+    filePath: fixturePath,
+    typeName: TYPE_NAME,
+    errorReporting: "diagnostics",
+  });
+
+  const wallTimeMs = performance.now() - start;
+  const peakRssBytes = rssPoller.stop();
+
+  return { wallTimeMs, peakRssBytes };
+}
+
+// ---------------------------------------------------------------------------
+// OOM detection via subprocess with memory cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a single schema-generation pass in a child Node.js process capped at
+ * `maxOldSpaceMb` MB. Returns `true` if the process ran out of memory.
+ */
+function detectOom(fixturePath: string, maxOldSpaceMb: number): boolean {
+  const scriptTarget = String(ts.ScriptTarget.ES2022);
+  const moduleKind = String(ts.ModuleKind.NodeNext);
+  const moduleResolution = String(ts.ModuleResolutionKind.NodeNext);
+
+  const runnerScript = [
+    `import { createProgram } from "typescript";`,
+    `import { generateSchemasFromProgram } from "@formspec/build";`,
+    `const program = createProgram(${JSON.stringify([fixturePath])}, {`,
+    `  target: ${scriptTarget},`,
+    `  module: ${moduleKind},`,
+    `  moduleResolution: ${moduleResolution},`,
+    `  strict: true,`,
+    `  skipLibCheck: true,`,
+    `});`,
+    `generateSchemasFromProgram({`,
+    `  program,`,
+    `  filePath: ${JSON.stringify(fixturePath)},`,
+    `  typeName: ${JSON.stringify(TYPE_NAME)},`,
+    `  errorReporting: "diagnostics",`,
+    `});`,
+    `process.exit(0);`,
+  ].join("\n");
+
+  const tmpDir = os.tmpdir();
+  const runnerPath = path.join(tmpDir, `formspec-oom-probe-build-${String(process.pid)}.mjs`);
+
+  try {
+    fsSync.writeFileSync(runnerPath, runnerScript, "utf8");
+  } catch {
+    return false;
+  }
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [`--max-old-space-size=${String(maxOldSpaceMb)}`, runnerPath],
+      {
+        encoding: "utf8",
+        timeout: 300_000,
+        env: { ...process.env },
+      }
+    );
+
+    if (result.status === 0) return false;
+
+    const output = `${result.stdout}${result.stderr}`;
+    const oomIndicators = [
+      "ENOMEM",
+      "out of memory",
+      "JavaScript heap out of memory",
+      "Allocation failed",
+    ];
+    if (oomIndicators.some((indicator) => output.toLowerCase().includes(indicator.toLowerCase()))) {
+      return true;
+    }
+
+    if (result.status === null && result.signal !== null) {
+      return true;
+    }
+
+    return false;
+  } finally {
+    try {
+      fsSync.unlinkSync(runnerPath);
+    } catch {
+      // Best effort cleanup.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Median helper
+// ---------------------------------------------------------------------------
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("Cannot compute median of empty array");
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (sorted[mid - 1]! + sorted[mid]!) / 2
+    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      sorted[mid]!;
+}
+
+// ---------------------------------------------------------------------------
+// Baseline JSON shape
+// ---------------------------------------------------------------------------
+
+interface StripeRealisticBuildBaseline {
+  readonly phase: "0";
+  readonly surface: "build";
+  readonly description: string;
+  readonly fixture: string;
+  readonly typeName: string;
+  readonly runs: number;
+  readonly oomHeapCapMB: number;
+  readonly metrics: {
+    readonly peakRSS_MB: number;
+    readonly wallTime_ms: number;
+    readonly didOOM: boolean;
+    readonly warmWallTimes_ms: readonly number[];
+    readonly allPeakRSS_MB: readonly number[];
+    readonly coldWallTime_ms: number;
+  };
+  readonly gitSha: string;
+  readonly timestamp: string;
+  readonly nodeVersion: string;
+  readonly platform: string;
+  readonly arch: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  await fs.mkdir(BASELINE_DIR, { recursive: true });
+
+  // Copy the fixture file to a temp directory so ts.createProgram can
+  // resolve it as a real file from the filesystem and can resolve the
+  // stripe package from the e2e node_modules.
+  const workspaceRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "formspec-stripe-realistic-build-")
+  );
+
+  try {
+    const fixtureSrc = await fs.readFile(path.join(FIXTURE_DIR, FIXTURE_FILE), "utf8");
+    const fixturePath = path.join(workspaceRoot, FIXTURE_FILE);
+    await fs.writeFile(fixturePath, fixtureSrc, "utf8");
+
+    // Write a tsconfig so the TypeScript compiler can resolve stripe types
+    // from the e2e package's node_modules.
+    const tsconfig = {
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        skipLibCheck: true,
+        baseUrl: workspaceRoot,
+        paths: {},
+      },
+    };
+    await fs.writeFile(
+      path.join(workspaceRoot, "tsconfig.json"),
+      JSON.stringify(tsconfig, null, 2),
+      "utf8"
+    );
+
+    // Copy the e2e node_modules stripe types into the temp workspace via symlink
+    // so ts.createProgram can find them.
+    const e2eNodeModules = path.join(E2E_ROOT, "node_modules");
+    const tmpNodeModules = path.join(workspaceRoot, "node_modules");
+    await fs.symlink(e2eNodeModules, tmpNodeModules, "dir");
+
+    process.stderr.write(`\n=== Stripe Realistic OOM Sweep — Build Surface (Phase 0 baseline) ===\n\n`);
+    process.stderr.write(`  fixture type: ${TYPE_NAME}\n`);
+    process.stderr.write(`  fixture file: ${FIXTURE_FILE}\n`);
+    process.stderr.write(`  runs:         ${String(RUNS)} (run 1 = cold)\n`);
+    process.stderr.write(`  OOM cap:      ${String(OOM_HEAP_CAP_MB)} MB\n\n`);
+
+    const allWallTimeMs: number[] = [];
+    const allPeakRssBytes: number[] = [];
+
+    process.stderr.write(`  Build-path (generateSchemasFromProgram):\n`);
+    for (let i = 0; i < RUNS; i++) {
+      const label = i === 0 ? "cold" : "warm";
+      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
+      const result = runBuildBenchOnce(fixturePath);
+      allWallTimeMs.push(result.wallTimeMs);
+      allPeakRssBytes.push(result.peakRssBytes);
+      process.stderr.write(
+        ` ${result.wallTimeMs.toFixed(1)}ms  RSS=${(result.peakRssBytes / 1024 / 1024).toFixed(1)}MB\n`
+      );
+    }
+
+    const warmWallTimeMs = allWallTimeMs.slice(1);
+    const warmPeakRssBytes = allPeakRssBytes.slice(1);
+
+    const medianWarmWallTimeMs = warmWallTimeMs.length > 0 ? median(warmWallTimeMs) : (allWallTimeMs[0] ?? 0);
+    const medianWarmPeakRssBytes = warmPeakRssBytes.length > 0 ? median(warmPeakRssBytes) : (allPeakRssBytes[0] ?? 0);
+    const coldWallTimeMs = allWallTimeMs[0] ?? 0;
+    const peakRSSMB = medianWarmPeakRssBytes / 1024 / 1024;
+
+    process.stderr.write(`\n  OOM probe (${String(OOM_HEAP_CAP_MB)} MB cap)...\n`);
+    const didOOM = detectOom(fixturePath, OOM_HEAP_CAP_MB);
+    process.stderr.write(`    didOOM: ${String(didOOM)}\n`);
+
+    process.stderr.write(`\n--- Phase 0 Stripe Realistic Build Baseline ---\n`);
+    process.stderr.write(`  surface:                     build\n`);
+    process.stderr.write(`  wallTime_ms cold:             ${coldWallTimeMs.toFixed(2)}\n`);
+    process.stderr.write(`  wallTime_ms warm (median):    ${medianWarmWallTimeMs.toFixed(2)}\n`);
+    process.stderr.write(`  peakRSS_MB warm (median):    ${peakRSSMB.toFixed(1)} MB\n`);
+    process.stderr.write(`  didOOM (${String(OOM_HEAP_CAP_MB)} MB cap):       ${String(didOOM)}\n`);
+    process.stderr.write(`----------------------------------------------\n`);
+    process.stderr.write(`\n  Phase 4 gate: peakRSS_MB ≤ ${(peakRSSMB * 0.5).toFixed(1)} MB, zero OOM at 1 GB cap\n\n`);
+
+    const commitSha = process.env["GIT_COMMIT_SHA"] ?? "unknown";
+
+    const baseline: StripeRealisticBuildBaseline = {
+      phase: "0",
+      surface: "build",
+      description:
+        "Stripe realistic OOM sweep — build surface (generateSchemasFromProgram, direct Stripe types, no Ref<T> wrapper)",
+      fixture: "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
+      typeName: TYPE_NAME,
+      runs: RUNS,
+      oomHeapCapMB: OOM_HEAP_CAP_MB,
+      metrics: {
+        peakRSS_MB: Math.round(peakRSSMB * 10) / 10,
+        wallTime_ms: Math.round(medianWarmWallTimeMs * 100) / 100,
+        didOOM,
+        warmWallTimes_ms: warmWallTimeMs.map((v) => Math.round(v * 100) / 100),
+        allPeakRSS_MB: allPeakRssBytes.map((v) => Math.round((v / 1024 / 1024) * 10) / 10),
+        coldWallTime_ms: Math.round(coldWallTimeMs * 100) / 100,
+      },
+      gitSha: commitSha,
+      timestamp: new Date().toISOString(),
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    };
+
+    await fs.writeFile(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+    process.stderr.write(`  Baseline written: ${BASELINE_PATH}\n\n`);
+
+    process.stdout.write(`${JSON.stringify(baseline, null, 2)}\n`);
+  } finally {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/e2e/benchmarks/stripe-realistic-build-bench.ts
+++ b/e2e/benchmarks/stripe-realistic-build-bench.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 0 baseline: Stripe realistic OOM sweep — build surface.
  *
- * Measures `generateSchemasFromProgram` (from `@formspec/build/internals`)
+ * Measures `generateSchemasFromProgram` (from `@formspec/build`)
  * against a fixture that embeds Stripe types DIRECTLY — no Ref<T> wrapper.
  * This is the code path reported to OOM in real user projects.
  *
@@ -264,27 +264,9 @@ async function main(): Promise<void> {
     const fixturePath = path.join(workspaceRoot, FIXTURE_FILE);
     await fs.writeFile(fixturePath, fixtureSrc, "utf8");
 
-    // Write a tsconfig so the TypeScript compiler can resolve stripe types
-    // from the e2e package's node_modules.
-    const tsconfig = {
-      compilerOptions: {
-        target: "ES2022",
-        module: "NodeNext",
-        moduleResolution: "NodeNext",
-        strict: true,
-        skipLibCheck: true,
-        baseUrl: workspaceRoot,
-        paths: {},
-      },
-    };
-    await fs.writeFile(
-      path.join(workspaceRoot, "tsconfig.json"),
-      JSON.stringify(tsconfig, null, 2),
-      "utf8"
-    );
-
-    // Copy the e2e node_modules stripe types into the temp workspace via symlink
-    // so ts.createProgram can find them.
+    // Symlink e2e node_modules so ts.createProgram can find stripe types.
+    // ts.createProgram is called directly with COMPILER_OPTIONS (not via the
+    // tsconfig on disk), so no tsconfig.json is needed in the temp workspace.
     const e2eNodeModules = path.join(E2E_ROOT, "node_modules");
     const tmpNodeModules = path.join(workspaceRoot, "node_modules");
     await fs.symlink(e2eNodeModules, tmpNodeModules, "dir");

--- a/e2e/benchmarks/stripe-realistic-eslint-bench.ts
+++ b/e2e/benchmarks/stripe-realistic-eslint-bench.ts
@@ -1,0 +1,410 @@
+/**
+ * Phase 0 baseline: Stripe realistic OOM sweep — ESLint surface.
+ *
+ * Runs `@formspec/eslint-plugin`'s `type-compatibility/tag-type-check` rule against a fixture
+ * that embeds Stripe types DIRECTLY — no Ref<T> wrapper. This surface
+ * exercises the ESLint rule's own TypeChecker path, which is separate from
+ * the build/snapshot surfaces and may have different memory behavior.
+ *
+ * The ESLint `tag-type-check` rule uses `@typescript-eslint/parser` to
+ * create a TypeChecker, then calls into `@formspec/analysis` to validate
+ * constraint tag types. If this surface takes significantly more memory than
+ * the build surface, that's a distinct user-facing finding.
+ *
+ * ### Metrics captured
+ *
+ *   1. wallTimeMs   — end-to-end elapsed time (cold + warm median over 3 runs)
+ *   2. peakRSS_MB   — peak resident set size (polling, warm median)
+ *   3. didOOM       — whether the process OOMs at a 1 GB heap cap
+ *
+ * ### OOM detection
+ *
+ * The OOM probe spawns a subprocess with `--max-old-space-size=1024`.
+ * Detection checks (in priority order):
+ *   1. Known OOM stderr indicators
+ *   2. SIGKILL termination (OS kills before Node.js writes diagnostics)
+ *   3. Null exit status with any signal
+ *
+ * ### Phase 4 gate
+ *
+ * After host-checker migration: peakRSS_MB ≤ 50% of this baseline,
+ * zero OOM at 1 GB cap across all four surfaces.
+ *
+ * ### How to run
+ *
+ *   pnpm --filter @formspec/e2e run bench:stripe-realistic-eslint
+ *
+ * Surface label: "eslint"
+ * Baseline: e2e/bench/baselines/stripe-realistic-eslint-baseline.json
+ */
+
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import { ESLint } from "eslint";
+import * as typescriptEslintParser from "@typescript-eslint/parser";
+import eslintPlugin from "@formspec/eslint-plugin";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+const E2E_ROOT = path.resolve(BENCH_DIR, "..");
+const FIXTURE_DIR = path.join(E2E_ROOT, "fixtures", "stripe-realistic-oom");
+const BASELINE_DIR = path.join(E2E_ROOT, "bench", "baselines");
+const BASELINE_PATH = path.join(BASELINE_DIR, "stripe-realistic-eslint-baseline.json");
+const FIXTURE_FILE = "checkout-form.ts";
+const RUNS = 3;
+const OOM_HEAP_CAP_MB = 1024;
+
+// ---------------------------------------------------------------------------
+// Peak-RSS polling
+// ---------------------------------------------------------------------------
+
+interface RssPoller {
+  stop: () => number;
+}
+
+function startRssPoller(intervalMs = 5): RssPoller {
+  let peak = process.memoryUsage().rss;
+
+  const id = setInterval(() => {
+    const current = process.memoryUsage().rss;
+    if (current > peak) peak = current;
+  }, intervalMs);
+
+  if (typeof id.unref === "function") id.unref();
+
+  return {
+    stop: () => {
+      clearInterval(id);
+      const final = process.memoryUsage().rss;
+      if (final > peak) peak = final;
+      return peak;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Single benchmark run (ESLint path)
+// ---------------------------------------------------------------------------
+
+interface EslintRunResult {
+  readonly wallTimeMs: number;
+  readonly peakRssBytes: number;
+  readonly errorCount: number;
+  readonly warningCount: number;
+}
+
+async function runEslintBenchOnce(
+  workspaceRoot: string,
+  fixturePath: string,
+  tsconfigPath: string
+): Promise<EslintRunResult> {
+  const eslint = new ESLint({
+    // Set cwd to the temp workspace so files within it are not ignored by ESLint's
+    // flat-config base-path logic ("File ignored because outside of base path").
+    cwd: workspaceRoot,
+    overrideConfigFile: true,
+    overrideConfig: [
+      {
+        files: ["**/*.ts"],
+        languageOptions: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          parser: typescriptEslintParser as any,
+          parserOptions: {
+            project: tsconfigPath,
+          },
+        },
+        plugins: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+          "formspec": eslintPlugin as any,
+        },
+        rules: {
+          "formspec/type-compatibility/tag-type-check": "error",
+        },
+      },
+    ],
+  });
+
+  const rssPoller = startRssPoller();
+  const start = performance.now();
+
+  const results = await eslint.lintFiles([fixturePath]);
+
+  const wallTimeMs = performance.now() - start;
+  const peakRssBytes = rssPoller.stop();
+
+  const errorCount = results.reduce((sum, r) => sum + r.errorCount, 0);
+  const warningCount = results.reduce((sum, r) => sum + r.warningCount, 0);
+
+  return { wallTimeMs, peakRssBytes, errorCount, warningCount };
+}
+
+// ---------------------------------------------------------------------------
+// OOM detection via subprocess with memory cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a single ESLint pass in a child Node.js process capped at
+ * `maxOldSpaceMb` MB. Returns `true` if the process ran out of memory.
+ *
+ * The probe script replicates the main bench setup: copies the fixture to
+ * a temp workspace, symlinks e2e node_modules, writes a tsconfig, then
+ * runs ESLint with cwd set to the workspace root.
+ */
+function detectOom(_fixturePath: string, _tsconfigPath: string, maxOldSpaceMb: number): boolean {
+  const e2eRoot = E2E_ROOT;
+  const fixtureFile = FIXTURE_FILE;
+
+  const runnerScript = [
+    `import { ESLint } from "eslint";`,
+    `import * as typescriptEslintParser from "@typescript-eslint/parser";`,
+    `import eslintPlugin from "@formspec/eslint-plugin";`,
+    `import fs from "node:fs/promises";`,
+    `import fsSync from "node:fs";`,
+    `import os from "node:os";`,
+    `import path from "node:path";`,
+    `const e2eRoot = ${JSON.stringify(e2eRoot)};`,
+    `const fixtureFile = ${JSON.stringify(fixtureFile)};`,
+    `const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "formspec-oom-eslint-probe-"));`,
+    `const fixtureSrc = await fs.readFile(path.join(e2eRoot, "fixtures", "stripe-realistic-oom", fixtureFile), "utf8");`,
+    `const fixturePath = path.join(workspaceRoot, fixtureFile);`,
+    `await fs.writeFile(fixturePath, fixtureSrc, "utf8");`,
+    `const tsconfigPath = path.join(workspaceRoot, "tsconfig.json");`,
+    `await fs.writeFile(tsconfigPath, JSON.stringify({ compilerOptions: { target: "ES2022", module: "NodeNext", moduleResolution: "NodeNext", strict: true, skipLibCheck: true } }), "utf8");`,
+    `await fs.symlink(path.join(e2eRoot, "node_modules"), path.join(workspaceRoot, "node_modules"), "dir");`,
+    `const eslint = new ESLint({`,
+    `  cwd: workspaceRoot,`,
+    `  overrideConfigFile: true,`,
+    `  overrideConfig: [{`,
+    `    files: ["**/*.ts"],`,
+    `    languageOptions: {`,
+    `      parser: typescriptEslintParser,`,
+    `      parserOptions: { project: tsconfigPath },`,
+    `    },`,
+    `    plugins: { "formspec": eslintPlugin },`,
+    `    rules: { "formspec/type-compatibility/tag-type-check": "error" },`,
+    `  }],`,
+    `});`,
+    `await eslint.lintFiles([fixturePath]);`,
+    `await fs.rm(workspaceRoot, { recursive: true, force: true });`,
+    `process.exit(0);`,
+  ].join("\n");
+
+  const tmpDir = os.tmpdir();
+  const runnerPath = path.join(tmpDir, `formspec-oom-probe-eslint-${String(process.pid)}.mjs`);
+
+  try {
+    fsSync.writeFileSync(runnerPath, runnerScript, "utf8");
+  } catch {
+    return false;
+  }
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [`--max-old-space-size=${String(maxOldSpaceMb)}`, runnerPath],
+      {
+        encoding: "utf8",
+        timeout: 300_000,
+        env: { ...process.env },
+      }
+    );
+
+    if (result.status === 0) return false;
+
+    const output = `${result.stdout}${result.stderr}`;
+    const oomIndicators = [
+      "ENOMEM",
+      "out of memory",
+      "JavaScript heap out of memory",
+      "Allocation failed",
+    ];
+    if (oomIndicators.some((indicator) => output.toLowerCase().includes(indicator.toLowerCase()))) {
+      return true;
+    }
+
+    if (result.status === null && result.signal !== null) {
+      return true;
+    }
+
+    return false;
+  } finally {
+    try {
+      fsSync.unlinkSync(runnerPath);
+    } catch {
+      // Best effort cleanup.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Median helper
+// ---------------------------------------------------------------------------
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("Cannot compute median of empty array");
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (sorted[mid - 1]! + sorted[mid]!) / 2
+    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      sorted[mid]!;
+}
+
+// ---------------------------------------------------------------------------
+// Baseline JSON shape
+// ---------------------------------------------------------------------------
+
+interface StripeRealisticEslintBaseline {
+  readonly phase: "0";
+  readonly surface: "eslint";
+  readonly description: string;
+  readonly fixture: string;
+  readonly runs: number;
+  readonly oomHeapCapMB: number;
+  readonly metrics: {
+    readonly peakRSS_MB: number;
+    readonly wallTime_ms: number;
+    readonly didOOM: boolean;
+    readonly warmWallTimes_ms: readonly number[];
+    readonly allPeakRSS_MB: readonly number[];
+    readonly coldWallTime_ms: number;
+    readonly errorCount: number;
+    readonly warningCount: number;
+  };
+  readonly gitSha: string;
+  readonly timestamp: string;
+  readonly nodeVersion: string;
+  readonly platform: string;
+  readonly arch: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  await fs.mkdir(BASELINE_DIR, { recursive: true });
+
+  const workspaceRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "formspec-stripe-realistic-eslint-")
+  );
+
+  try {
+    const fixtureSrc = await fs.readFile(path.join(FIXTURE_DIR, FIXTURE_FILE), "utf8");
+    const fixturePath = path.join(workspaceRoot, FIXTURE_FILE);
+    await fs.writeFile(fixturePath, fixtureSrc, "utf8");
+
+    // Create a tsconfig.json in the temp workspace pointing to e2e node_modules
+    // so @typescript-eslint/parser can resolve the stripe types.
+    const tsconfig = {
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        skipLibCheck: true,
+      },
+      include: [FIXTURE_FILE],
+    };
+    const tsconfigPath = path.join(workspaceRoot, "tsconfig.json");
+    await fs.writeFile(tsconfigPath, JSON.stringify(tsconfig, null, 2), "utf8");
+
+    // Symlink e2e node_modules so the TypeScript parser can find stripe types.
+    const e2eNodeModules = path.join(E2E_ROOT, "node_modules");
+    const tmpNodeModules = path.join(workspaceRoot, "node_modules");
+    await fs.symlink(e2eNodeModules, tmpNodeModules, "dir");
+
+    process.stderr.write(`\n=== Stripe Realistic OOM Sweep — ESLint Surface (Phase 0 baseline) ===\n\n`);
+    process.stderr.write(`  fixture file: ${FIXTURE_FILE}\n`);
+    process.stderr.write(`  rule:         formspec/type-compatibility/tag-type-check\n`);
+    process.stderr.write(`  runs:         ${String(RUNS)} (run 1 = cold)\n`);
+    process.stderr.write(`  OOM cap:      ${String(OOM_HEAP_CAP_MB)} MB\n\n`);
+
+    const allWallTimeMs: number[] = [];
+    const allPeakRssBytes: number[] = [];
+    let lastErrorCount = 0;
+    let lastWarningCount = 0;
+
+    process.stderr.write(`  ESLint-path (tag-type-check rule):\n`);
+    for (let i = 0; i < RUNS; i++) {
+      const label = i === 0 ? "cold" : "warm";
+      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
+      const result = await runEslintBenchOnce(workspaceRoot, fixturePath, tsconfigPath);
+      allWallTimeMs.push(result.wallTimeMs);
+      allPeakRssBytes.push(result.peakRssBytes);
+      lastErrorCount = result.errorCount;
+      lastWarningCount = result.warningCount;
+      process.stderr.write(
+        ` ${result.wallTimeMs.toFixed(1)}ms  RSS=${(result.peakRssBytes / 1024 / 1024).toFixed(1)}MB errors=${String(result.errorCount)} warnings=${String(result.warningCount)}\n`
+      );
+    }
+
+    const warmWallTimeMs = allWallTimeMs.slice(1);
+    const warmPeakRssBytes = allPeakRssBytes.slice(1);
+
+    const medianWarmWallTimeMs = warmWallTimeMs.length > 0 ? median(warmWallTimeMs) : (allWallTimeMs[0] ?? 0);
+    const medianWarmPeakRssBytes = warmPeakRssBytes.length > 0 ? median(warmPeakRssBytes) : (allPeakRssBytes[0] ?? 0);
+    const coldWallTimeMs = allWallTimeMs[0] ?? 0;
+    const peakRSSMB = medianWarmPeakRssBytes / 1024 / 1024;
+
+    process.stderr.write(`\n  OOM probe (${String(OOM_HEAP_CAP_MB)} MB cap)...\n`);
+    const didOOM = detectOom(fixturePath, tsconfigPath, OOM_HEAP_CAP_MB);
+    process.stderr.write(`    didOOM: ${String(didOOM)}\n`);
+
+    process.stderr.write(`\n--- Phase 0 Stripe Realistic ESLint Baseline ---\n`);
+    process.stderr.write(`  surface:                     eslint\n`);
+    process.stderr.write(`  wallTime_ms cold:             ${coldWallTimeMs.toFixed(2)}\n`);
+    process.stderr.write(`  wallTime_ms warm (median):    ${medianWarmWallTimeMs.toFixed(2)}\n`);
+    process.stderr.write(`  peakRSS_MB warm (median):    ${peakRSSMB.toFixed(1)} MB\n`);
+    process.stderr.write(`  didOOM (${String(OOM_HEAP_CAP_MB)} MB cap):       ${String(didOOM)}\n`);
+    process.stderr.write(`  lint errors:                 ${String(lastErrorCount)}\n`);
+    process.stderr.write(`  lint warnings:               ${String(lastWarningCount)}\n`);
+    process.stderr.write(`-------------------------------------------------\n`);
+    process.stderr.write(`\n  Phase 4 gate: peakRSS_MB ≤ ${(peakRSSMB * 0.5).toFixed(1)} MB, zero OOM at 1 GB cap\n\n`);
+
+    const commitSha = process.env["GIT_COMMIT_SHA"] ?? "unknown";
+
+    const baseline: StripeRealisticEslintBaseline = {
+      phase: "0",
+      surface: "eslint",
+      description:
+        "Stripe realistic OOM sweep — ESLint surface (tag-type-check rule, direct Stripe types, no Ref<T> wrapper)",
+      fixture: "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
+      runs: RUNS,
+      oomHeapCapMB: OOM_HEAP_CAP_MB,
+      metrics: {
+        peakRSS_MB: Math.round(peakRSSMB * 10) / 10,
+        wallTime_ms: Math.round(medianWarmWallTimeMs * 100) / 100,
+        didOOM,
+        warmWallTimes_ms: warmWallTimeMs.map((v) => Math.round(v * 100) / 100),
+        allPeakRSS_MB: allPeakRssBytes.map((v) => Math.round((v / 1024 / 1024) * 10) / 10),
+        coldWallTime_ms: Math.round(coldWallTimeMs * 100) / 100,
+        errorCount: lastErrorCount,
+        warningCount: lastWarningCount,
+      },
+      gitSha: commitSha,
+      timestamp: new Date().toISOString(),
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    };
+
+    await fs.writeFile(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+    process.stderr.write(`  Baseline written: ${BASELINE_PATH}\n\n`);
+
+    process.stdout.write(`${JSON.stringify(baseline, null, 2)}\n`);
+  } finally {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/e2e/benchmarks/stripe-realistic-snapshot-bench.ts
+++ b/e2e/benchmarks/stripe-realistic-snapshot-bench.ts
@@ -1,0 +1,344 @@
+/**
+ * Phase 0 baseline: Stripe realistic OOM sweep — snapshot surface.
+ *
+ * Measures `buildFormSpecAnalysisFileSnapshot` (from `@formspec/analysis/internal`)
+ * against a fixture that embeds Stripe types DIRECTLY — no Ref<T> wrapper.
+ * This surface models the LSP/editor analysis hot path.
+ *
+ * Unlike `e2e/fixtures/stripe-ref-customer/` (which uses a Ref<T> wrapper
+ * to engage the external-type bypass in PR #308), this fixture forces the
+ * analyzer to walk real Stripe.Customer / Stripe.Invoice / etc.
+ *
+ * ### Metrics captured
+ *
+ *   1. wallTimeMs   — end-to-end elapsed time (cold + warm median over 3 runs)
+ *   2. peakRSS_MB   — peak resident set size (polling, warm median)
+ *   3. didOOM       — whether the process OOMs at a 1 GB heap cap
+ *
+ * ### OOM detection
+ *
+ * The OOM probe spawns a subprocess with `--max-old-space-size=1024`.
+ * Detection checks (in priority order):
+ *   1. Known OOM stderr indicators
+ *   2. SIGKILL termination (OS kills before Node.js writes diagnostics)
+ *   3. Null exit status with any signal
+ *
+ * ### Phase 4 gate
+ *
+ * After host-checker migration: peakRSS_MB ≤ 50% of this baseline,
+ * zero OOM at 1 GB cap across all four surfaces.
+ *
+ * ### How to run
+ *
+ *   pnpm --filter @formspec/e2e run bench:stripe-realistic-snapshot
+ *
+ * Surface label: "snapshot"
+ * Baseline: e2e/bench/baselines/stripe-realistic-snapshot-baseline.json
+ */
+
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import * as ts from "typescript";
+import { buildFormSpecAnalysisFileSnapshot } from "@formspec/analysis/internal";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+const E2E_ROOT = path.resolve(BENCH_DIR, "..");
+const FIXTURE_DIR = path.join(E2E_ROOT, "fixtures", "stripe-realistic-oom");
+const BASELINE_DIR = path.join(E2E_ROOT, "bench", "baselines");
+const BASELINE_PATH = path.join(BASELINE_DIR, "stripe-realistic-snapshot-baseline.json");
+const FIXTURE_FILE = "checkout-form.ts";
+const RUNS = 3;
+const OOM_HEAP_CAP_MB = 1024;
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  strict: true,
+  skipLibCheck: true,
+};
+
+// ---------------------------------------------------------------------------
+// Peak-RSS polling
+// ---------------------------------------------------------------------------
+
+interface RssPoller {
+  stop: () => number;
+}
+
+function startRssPoller(intervalMs = 5): RssPoller {
+  let peak = process.memoryUsage().rss;
+
+  const id = setInterval(() => {
+    const current = process.memoryUsage().rss;
+    if (current > peak) peak = current;
+  }, intervalMs);
+
+  if (typeof id.unref === "function") id.unref();
+
+  return {
+    stop: () => {
+      clearInterval(id);
+      const final = process.memoryUsage().rss;
+      if (final > peak) peak = final;
+      return peak;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Single benchmark run (snapshot path)
+// ---------------------------------------------------------------------------
+
+interface SnapshotRunResult {
+  readonly wallTimeMs: number;
+  readonly peakRssBytes: number;
+}
+
+function runSnapshotBenchOnce(fixturePath: string): SnapshotRunResult {
+  const program = ts.createProgram([fixturePath], COMPILER_OPTIONS);
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(fixturePath);
+
+  if (sourceFile === undefined) {
+    throw new Error(`Could not find source file: ${fixturePath}`);
+  }
+
+  const rssPoller = startRssPoller();
+  const start = performance.now();
+
+  // buildFormSpecAnalysisFileSnapshot is the core LSP/editor analysis hot path.
+  // It walks the AST and resolves types via the TypeChecker, which is where
+  // the Stripe type expansion happens.
+  buildFormSpecAnalysisFileSnapshot(sourceFile, { checker });
+
+  const wallTimeMs = performance.now() - start;
+  const peakRssBytes = rssPoller.stop();
+
+  return { wallTimeMs, peakRssBytes };
+}
+
+// ---------------------------------------------------------------------------
+// OOM detection via subprocess with memory cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a single snapshot pass in a child Node.js process capped at
+ * `maxOldSpaceMb` MB. Returns `true` if the process ran out of memory.
+ */
+function detectOom(fixturePath: string, maxOldSpaceMb: number): boolean {
+  const scriptTarget = String(ts.ScriptTarget.ES2022);
+  const moduleKind = String(ts.ModuleKind.NodeNext);
+  const moduleResolution = String(ts.ModuleResolutionKind.NodeNext);
+
+  const runnerScript = [
+    `import { createProgram } from "typescript";`,
+    `import { buildFormSpecAnalysisFileSnapshot } from "@formspec/analysis/internal";`,
+    `const program = createProgram(${JSON.stringify([fixturePath])}, {`,
+    `  target: ${scriptTarget},`,
+    `  module: ${moduleKind},`,
+    `  moduleResolution: ${moduleResolution},`,
+    `  strict: true,`,
+    `  skipLibCheck: true,`,
+    `});`,
+    `const checker = program.getTypeChecker();`,
+    `const sourceFile = program.getSourceFile(${JSON.stringify(fixturePath)});`,
+    `if (!sourceFile) { process.stderr.write("Source file not found\\n"); process.exit(1); }`,
+    `buildFormSpecAnalysisFileSnapshot(sourceFile, { checker });`,
+    `process.exit(0);`,
+  ].join("\n");
+
+  const tmpDir = os.tmpdir();
+  const runnerPath = path.join(tmpDir, `formspec-oom-probe-snapshot-${String(process.pid)}.mjs`);
+
+  try {
+    fsSync.writeFileSync(runnerPath, runnerScript, "utf8");
+  } catch {
+    return false;
+  }
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [`--max-old-space-size=${String(maxOldSpaceMb)}`, runnerPath],
+      {
+        encoding: "utf8",
+        timeout: 300_000,
+        env: { ...process.env },
+      }
+    );
+
+    if (result.status === 0) return false;
+
+    const output = `${result.stdout}${result.stderr}`;
+    const oomIndicators = [
+      "ENOMEM",
+      "out of memory",
+      "JavaScript heap out of memory",
+      "Allocation failed",
+    ];
+    if (oomIndicators.some((indicator) => output.toLowerCase().includes(indicator.toLowerCase()))) {
+      return true;
+    }
+
+    if (result.status === null && result.signal !== null) {
+      return true;
+    }
+
+    return false;
+  } finally {
+    try {
+      fsSync.unlinkSync(runnerPath);
+    } catch {
+      // Best effort cleanup.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Median helper
+// ---------------------------------------------------------------------------
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("Cannot compute median of empty array");
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (sorted[mid - 1]! + sorted[mid]!) / 2
+    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      sorted[mid]!;
+}
+
+// ---------------------------------------------------------------------------
+// Baseline JSON shape
+// ---------------------------------------------------------------------------
+
+interface StripeRealisticSnapshotBaseline {
+  readonly phase: "0";
+  readonly surface: "snapshot";
+  readonly description: string;
+  readonly fixture: string;
+  readonly runs: number;
+  readonly oomHeapCapMB: number;
+  readonly metrics: {
+    readonly peakRSS_MB: number;
+    readonly wallTime_ms: number;
+    readonly didOOM: boolean;
+    readonly warmWallTimes_ms: readonly number[];
+    readonly allPeakRSS_MB: readonly number[];
+    readonly coldWallTime_ms: number;
+  };
+  readonly gitSha: string;
+  readonly timestamp: string;
+  readonly nodeVersion: string;
+  readonly platform: string;
+  readonly arch: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  await fs.mkdir(BASELINE_DIR, { recursive: true });
+
+  const workspaceRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "formspec-stripe-realistic-snapshot-")
+  );
+
+  try {
+    const fixtureSrc = await fs.readFile(path.join(FIXTURE_DIR, FIXTURE_FILE), "utf8");
+    const fixturePath = path.join(workspaceRoot, FIXTURE_FILE);
+    await fs.writeFile(fixturePath, fixtureSrc, "utf8");
+
+    // Symlink e2e node_modules so ts.createProgram can find stripe types.
+    const e2eNodeModules = path.join(E2E_ROOT, "node_modules");
+    const tmpNodeModules = path.join(workspaceRoot, "node_modules");
+    await fs.symlink(e2eNodeModules, tmpNodeModules, "dir");
+
+    process.stderr.write(`\n=== Stripe Realistic OOM Sweep — Snapshot Surface (Phase 0 baseline) ===\n\n`);
+    process.stderr.write(`  fixture file: ${FIXTURE_FILE}\n`);
+    process.stderr.write(`  runs:         ${String(RUNS)} (run 1 = cold)\n`);
+    process.stderr.write(`  OOM cap:      ${String(OOM_HEAP_CAP_MB)} MB\n\n`);
+
+    const allWallTimeMs: number[] = [];
+    const allPeakRssBytes: number[] = [];
+
+    process.stderr.write(`  Snapshot-path (buildFormSpecAnalysisFileSnapshot):\n`);
+    for (let i = 0; i < RUNS; i++) {
+      const label = i === 0 ? "cold" : "warm";
+      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
+      const result = runSnapshotBenchOnce(fixturePath);
+      allWallTimeMs.push(result.wallTimeMs);
+      allPeakRssBytes.push(result.peakRssBytes);
+      process.stderr.write(
+        ` ${result.wallTimeMs.toFixed(1)}ms  RSS=${(result.peakRssBytes / 1024 / 1024).toFixed(1)}MB\n`
+      );
+    }
+
+    const warmWallTimeMs = allWallTimeMs.slice(1);
+    const warmPeakRssBytes = allPeakRssBytes.slice(1);
+
+    const medianWarmWallTimeMs = warmWallTimeMs.length > 0 ? median(warmWallTimeMs) : (allWallTimeMs[0] ?? 0);
+    const medianWarmPeakRssBytes = warmPeakRssBytes.length > 0 ? median(warmPeakRssBytes) : (allPeakRssBytes[0] ?? 0);
+    const coldWallTimeMs = allWallTimeMs[0] ?? 0;
+    const peakRSSMB = medianWarmPeakRssBytes / 1024 / 1024;
+
+    process.stderr.write(`\n  OOM probe (${String(OOM_HEAP_CAP_MB)} MB cap)...\n`);
+    const didOOM = detectOom(fixturePath, OOM_HEAP_CAP_MB);
+    process.stderr.write(`    didOOM: ${String(didOOM)}\n`);
+
+    process.stderr.write(`\n--- Phase 0 Stripe Realistic Snapshot Baseline ---\n`);
+    process.stderr.write(`  surface:                     snapshot\n`);
+    process.stderr.write(`  wallTime_ms cold:             ${coldWallTimeMs.toFixed(2)}\n`);
+    process.stderr.write(`  wallTime_ms warm (median):    ${medianWarmWallTimeMs.toFixed(2)}\n`);
+    process.stderr.write(`  peakRSS_MB warm (median):    ${peakRSSMB.toFixed(1)} MB\n`);
+    process.stderr.write(`  didOOM (${String(OOM_HEAP_CAP_MB)} MB cap):       ${String(didOOM)}\n`);
+    process.stderr.write(`--------------------------------------------------\n`);
+    process.stderr.write(`\n  Phase 4 gate: peakRSS_MB ≤ ${(peakRSSMB * 0.5).toFixed(1)} MB, zero OOM at 1 GB cap\n\n`);
+
+    const commitSha = process.env["GIT_COMMIT_SHA"] ?? "unknown";
+
+    const baseline: StripeRealisticSnapshotBaseline = {
+      phase: "0",
+      surface: "snapshot",
+      description:
+        "Stripe realistic OOM sweep — snapshot surface (buildFormSpecAnalysisFileSnapshot, direct Stripe types, no Ref<T> wrapper)",
+      fixture: "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
+      runs: RUNS,
+      oomHeapCapMB: OOM_HEAP_CAP_MB,
+      metrics: {
+        peakRSS_MB: Math.round(peakRSSMB * 10) / 10,
+        wallTime_ms: Math.round(medianWarmWallTimeMs * 100) / 100,
+        didOOM,
+        warmWallTimes_ms: warmWallTimeMs.map((v) => Math.round(v * 100) / 100),
+        allPeakRSS_MB: allPeakRssBytes.map((v) => Math.round((v / 1024 / 1024) * 10) / 10),
+        coldWallTime_ms: Math.round(coldWallTimeMs * 100) / 100,
+      },
+      gitSha: commitSha,
+      timestamp: new Date().toISOString(),
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    };
+
+    await fs.writeFile(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+    process.stderr.write(`  Baseline written: ${BASELINE_PATH}\n\n`);
+
+    process.stdout.write(`${JSON.stringify(baseline, null, 2)}\n`);
+  } finally {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/e2e/benchmarks/stripe-realistic-tsserver-bench.ts
+++ b/e2e/benchmarks/stripe-realistic-tsserver-bench.ts
@@ -3,8 +3,10 @@
  *
  * Instantiates `FormSpecSemanticService` (from `@formspec/ts-plugin`) against
  * a TypeScript program that includes the fixture file with direct Stripe types.
- * Simulates an editor open-file event by calling the service's diagnostic
- * handler once cold and twice warm (mimicking keystroke re-analysis).
+ * Simulates an editor session by calling `getDiagnostics` on the SAME service
+ * instance three times: once cold (open-file) and twice warm (first and second
+ * keystroke re-analysis). This better models the user-facing editor scenario
+ * than creating a fresh Program + Service per call.
  *
  * Unlike `e2e/fixtures/stripe-ref-customer/` (which uses a Ref<T> wrapper
  * to engage the external-type bypass in PR #308), this fixture forces the
@@ -63,7 +65,7 @@ const FIXTURE_DIR = path.join(E2E_ROOT, "fixtures", "stripe-realistic-oom");
 const BASELINE_DIR = path.join(E2E_ROOT, "bench", "baselines");
 const BASELINE_PATH = path.join(BASELINE_DIR, "stripe-realistic-tsserver-baseline.json");
 const FIXTURE_FILE = "checkout-form.ts";
-// 1 cold + 2 warm to mimic: open file (cold), first keystroke (warm), second keystroke (warm)
+// getDiagnostics invocations per session: call 1 = cold (open-file), calls 2-3 = warm (keystrokes)
 const RUNS = 3;
 const OOM_HEAP_CAP_MB = 1024;
 
@@ -104,20 +106,33 @@ function startRssPoller(intervalMs = 5): RssPoller {
 }
 
 // ---------------------------------------------------------------------------
-// Single benchmark run (tsserver-plugin path)
+// Session benchmark — one Program+Service, multiple getDiagnostics invocations
 // ---------------------------------------------------------------------------
 
-interface TsserverRunResult {
+interface TsserverInvocationResult {
   readonly wallTimeMs: number;
-  readonly peakRssBytes: number;
   readonly syntheticCompileCount: number;
   readonly diagnosticsCount: number;
 }
 
-function runTsserverBenchOnce(
+interface TsserverSessionResult {
+  /** Per-invocation timing: [cold, warm1, warm2, ...] */
+  readonly invocations: readonly TsserverInvocationResult[];
+  /** Peak RSS across the entire session (bytes). */
+  readonly peakRssBytes: number;
+}
+
+/**
+ * Runs a single editor-session simulation: creates one Program + one
+ * FormSpecSemanticService, then calls `getDiagnostics` `runs` times on the
+ * SAME service (run 0 = cold open-file, runs 1+ = warm keystroke re-analysis).
+ * This is more realistic than creating a fresh service per iteration.
+ */
+function runTsserverSession(
   workspaceRoot: string,
-  fixturePath: string
-): TsserverRunResult {
+  fixturePath: string,
+  runs: number
+): TsserverSessionResult {
   const program = ts.createProgram([fixturePath], COMPILER_OPTIONS);
 
   const service = new FormSpecSemanticService({
@@ -126,25 +141,30 @@ function runTsserverBenchOnce(
     getProgram: () => program,
   });
 
+  const rssPoller = startRssPoller();
+
   try {
-    const statsBefore = service.getStats();
-    const rssPoller = startRssPoller();
-    const start = performance.now();
+    const invocations: TsserverInvocationResult[] = [];
 
-    // Simulate editor open-file event: call getDiagnostics once (the full
-    // analysis pass that would run when a file is first opened).
-    const diagnosticsResult = service.getDiagnostics(fixturePath);
+    for (let i = 0; i < runs; i++) {
+      const statsBefore = service.getStats();
+      const start = performance.now();
 
-    const wallTimeMs = performance.now() - start;
+      const diagnosticsResult = service.getDiagnostics(fixturePath);
+
+      const wallTimeMs = performance.now() - start;
+      const statsAfter = service.getStats();
+
+      invocations.push({
+        wallTimeMs,
+        syntheticCompileCount:
+          statsAfter.syntheticCompileCount - statsBefore.syntheticCompileCount,
+        diagnosticsCount: diagnosticsResult.diagnostics.length,
+      });
+    }
+
     const peakRssBytes = rssPoller.stop();
-    const statsAfter = service.getStats();
-
-    return {
-      wallTimeMs,
-      peakRssBytes,
-      syntheticCompileCount: statsAfter.syntheticCompileCount - statsBefore.syntheticCompileCount,
-      diagnosticsCount: diagnosticsResult.diagnostics.length,
-    };
+    return { invocations, peakRssBytes };
   } finally {
     service.dispose();
   }
@@ -301,33 +321,33 @@ async function main(): Promise<void> {
     process.stderr.write(`\n=== Stripe Realistic OOM Sweep — TSServer-Plugin Surface (Phase 0 baseline) ===\n\n`);
     process.stderr.write(`  fixture file: ${FIXTURE_FILE}\n`);
     process.stderr.write(`  surface:      FormSpecSemanticService.getDiagnostics\n`);
-    process.stderr.write(`  runs:         ${String(RUNS)} (run 1 = cold)\n`);
+    process.stderr.write(`  session:      1 service, ${String(RUNS)} getDiagnostics calls (call 1 = cold open-file, calls 2+ = warm keystrokes)\n`);
     process.stderr.write(`  OOM cap:      ${String(OOM_HEAP_CAP_MB)} MB\n\n`);
 
+    process.stderr.write(`  Plugin-path (FormSpecSemanticService.getDiagnostics):\n`);
+    const session = runTsserverSession(workspaceRoot, fixturePath, RUNS);
+
     const allWallTimeMs: number[] = [];
-    const allPeakRssBytes: number[] = [];
     const allSyntheticCompileCounts: number[] = [];
 
-    process.stderr.write(`  Plugin-path (FormSpecSemanticService.getDiagnostics):\n`);
-    for (let i = 0; i < RUNS; i++) {
+    session.invocations.forEach((inv, i) => {
       const label = i === 0 ? "cold" : "warm";
-      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
-      const result = runTsserverBenchOnce(workspaceRoot, fixturePath);
-      allWallTimeMs.push(result.wallTimeMs);
-      allPeakRssBytes.push(result.peakRssBytes);
-      allSyntheticCompileCounts.push(result.syntheticCompileCount);
+      allWallTimeMs.push(inv.wallTimeMs);
+      allSyntheticCompileCounts.push(inv.syntheticCompileCount);
       process.stderr.write(
-        ` ${result.wallTimeMs.toFixed(1)}ms  RSS=${(result.peakRssBytes / 1024 / 1024).toFixed(1)}MB syntheticCompile=${String(result.syntheticCompileCount)} diags=${String(result.diagnosticsCount)}\n`
+        `    call ${String(i + 1)}/${String(RUNS)} [${label}]: ${inv.wallTimeMs.toFixed(1)}ms  syntheticCompile=${String(inv.syntheticCompileCount)} diags=${String(inv.diagnosticsCount)}\n`
       );
-    }
+    });
+
+    process.stderr.write(
+      `  session peakRSS: ${(session.peakRssBytes / 1024 / 1024).toFixed(1)} MB\n`
+    );
 
     const warmWallTimeMs = allWallTimeMs.slice(1);
-    const warmPeakRssBytes = allPeakRssBytes.slice(1);
 
     const medianWarmWallTimeMs = warmWallTimeMs.length > 0 ? median(warmWallTimeMs) : (allWallTimeMs[0] ?? 0);
-    const medianWarmPeakRssBytes = warmPeakRssBytes.length > 0 ? median(warmPeakRssBytes) : (allPeakRssBytes[0] ?? 0);
     const coldWallTimeMs = allWallTimeMs[0] ?? 0;
-    const peakRSSMB = medianWarmPeakRssBytes / 1024 / 1024;
+    const peakRSSMB = session.peakRssBytes / 1024 / 1024;
 
     process.stderr.write(`\n  OOM probe (${String(OOM_HEAP_CAP_MB)} MB cap)...\n`);
     const didOOM = detectOom(fixturePath, OOM_HEAP_CAP_MB);
@@ -337,7 +357,7 @@ async function main(): Promise<void> {
     process.stderr.write(`  surface:                     tsserver-plugin\n`);
     process.stderr.write(`  wallTime_ms cold:             ${coldWallTimeMs.toFixed(2)}\n`);
     process.stderr.write(`  wallTime_ms warm (median):    ${medianWarmWallTimeMs.toFixed(2)}\n`);
-    process.stderr.write(`  peakRSS_MB warm (median):    ${peakRSSMB.toFixed(1)} MB\n`);
+    process.stderr.write(`  peakRSS_MB (session):        ${peakRSSMB.toFixed(1)} MB\n`);
     process.stderr.write(`  didOOM (${String(OOM_HEAP_CAP_MB)} MB cap):       ${String(didOOM)}\n`);
     process.stderr.write(`  syntheticCompile counts:     [${allSyntheticCompileCounts.join(", ")}]\n`);
     process.stderr.write(`---------------------------------------------------------\n`);
@@ -349,7 +369,7 @@ async function main(): Promise<void> {
       phase: "0",
       surface: "tsserver-plugin",
       description:
-        "Stripe realistic OOM sweep — tsserver-plugin surface (FormSpecSemanticService.getDiagnostics, direct Stripe types, no Ref<T> wrapper)",
+        "Stripe realistic OOM sweep — tsserver-plugin surface (FormSpecSemanticService.getDiagnostics, 1 service × 3 getDiagnostics calls, direct Stripe types, no Ref<T> wrapper)",
       fixture: "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
       runs: RUNS,
       oomHeapCapMB: OOM_HEAP_CAP_MB,
@@ -358,7 +378,7 @@ async function main(): Promise<void> {
         wallTime_ms: Math.round(medianWarmWallTimeMs * 100) / 100,
         didOOM,
         warmWallTimes_ms: warmWallTimeMs.map((v) => Math.round(v * 100) / 100),
-        allPeakRSS_MB: allPeakRssBytes.map((v) => Math.round((v / 1024 / 1024) * 10) / 10),
+        allPeakRSS_MB: [Math.round(peakRSSMB * 10) / 10],
         coldWallTime_ms: Math.round(coldWallTimeMs * 100) / 100,
         syntheticCompileCounts: allSyntheticCompileCounts,
       },

--- a/e2e/benchmarks/stripe-realistic-tsserver-bench.ts
+++ b/e2e/benchmarks/stripe-realistic-tsserver-bench.ts
@@ -1,0 +1,381 @@
+/**
+ * Phase 0 baseline: Stripe realistic OOM sweep — tsserver-plugin surface.
+ *
+ * Instantiates `FormSpecSemanticService` (from `@formspec/ts-plugin`) against
+ * a TypeScript program that includes the fixture file with direct Stripe types.
+ * Simulates an editor open-file event by calling the service's diagnostic
+ * handler once cold and twice warm (mimicking keystroke re-analysis).
+ *
+ * Unlike `e2e/fixtures/stripe-ref-customer/` (which uses a Ref<T> wrapper
+ * to engage the external-type bypass in PR #308), this fixture forces the
+ * semantic service to walk real Stripe.Customer / Stripe.Invoice / etc.
+ *
+ * This surface does NOT spawn actual tsserver — the FormSpecSemanticService
+ * is instantiated directly, which exercises the same composable semantic
+ * service code path that tsserver loads. This avoids tsserver noise while
+ * still exercising the real plugin code path.
+ *
+ * ### Metrics captured
+ *
+ *   1. wallTimeMs   — end-to-end elapsed time (cold + warm median over 3 runs)
+ *   2. peakRSS_MB   — peak resident set size (polling, warm median)
+ *   3. didOOM       — whether the process OOMs at a 1 GB heap cap
+ *   4. syntheticCompileCount — ts.createProgram invocations per run
+ *
+ * ### OOM detection
+ *
+ * The OOM probe spawns a subprocess with `--max-old-space-size=1024`.
+ * Detection checks (in priority order):
+ *   1. Known OOM stderr indicators
+ *   2. SIGKILL termination (OS kills before Node.js writes diagnostics)
+ *   3. Null exit status with any signal
+ *
+ * ### Phase 4 gate
+ *
+ * After host-checker migration: peakRSS_MB ≤ 50% of this baseline,
+ * zero OOM at 1 GB cap across all four surfaces.
+ *
+ * ### How to run
+ *
+ *   pnpm --filter @formspec/e2e run bench:stripe-realistic-tsserver
+ *
+ * Surface label: "tsserver-plugin"
+ * Baseline: e2e/bench/baselines/stripe-realistic-tsserver-baseline.json
+ */
+
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import * as ts from "typescript";
+import { FormSpecSemanticService } from "@formspec/ts-plugin";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BENCH_DIR = path.dirname(fileURLToPath(import.meta.url));
+const E2E_ROOT = path.resolve(BENCH_DIR, "..");
+const FIXTURE_DIR = path.join(E2E_ROOT, "fixtures", "stripe-realistic-oom");
+const BASELINE_DIR = path.join(E2E_ROOT, "bench", "baselines");
+const BASELINE_PATH = path.join(BASELINE_DIR, "stripe-realistic-tsserver-baseline.json");
+const FIXTURE_FILE = "checkout-form.ts";
+// 1 cold + 2 warm to mimic: open file (cold), first keystroke (warm), second keystroke (warm)
+const RUNS = 3;
+const OOM_HEAP_CAP_MB = 1024;
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  strict: true,
+  skipLibCheck: true,
+};
+
+// ---------------------------------------------------------------------------
+// Peak-RSS polling
+// ---------------------------------------------------------------------------
+
+interface RssPoller {
+  stop: () => number;
+}
+
+function startRssPoller(intervalMs = 5): RssPoller {
+  let peak = process.memoryUsage().rss;
+
+  const id = setInterval(() => {
+    const current = process.memoryUsage().rss;
+    if (current > peak) peak = current;
+  }, intervalMs);
+
+  if (typeof id.unref === "function") id.unref();
+
+  return {
+    stop: () => {
+      clearInterval(id);
+      const final = process.memoryUsage().rss;
+      if (final > peak) peak = final;
+      return peak;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Single benchmark run (tsserver-plugin path)
+// ---------------------------------------------------------------------------
+
+interface TsserverRunResult {
+  readonly wallTimeMs: number;
+  readonly peakRssBytes: number;
+  readonly syntheticCompileCount: number;
+  readonly diagnosticsCount: number;
+}
+
+function runTsserverBenchOnce(
+  workspaceRoot: string,
+  fixturePath: string
+): TsserverRunResult {
+  const program = ts.createProgram([fixturePath], COMPILER_OPTIONS);
+
+  const service = new FormSpecSemanticService({
+    workspaceRoot,
+    typescriptVersion: ts.version,
+    getProgram: () => program,
+  });
+
+  try {
+    const statsBefore = service.getStats();
+    const rssPoller = startRssPoller();
+    const start = performance.now();
+
+    // Simulate editor open-file event: call getDiagnostics once (the full
+    // analysis pass that would run when a file is first opened).
+    const diagnosticsResult = service.getDiagnostics(fixturePath);
+
+    const wallTimeMs = performance.now() - start;
+    const peakRssBytes = rssPoller.stop();
+    const statsAfter = service.getStats();
+
+    return {
+      wallTimeMs,
+      peakRssBytes,
+      syntheticCompileCount: statsAfter.syntheticCompileCount - statsBefore.syntheticCompileCount,
+      diagnosticsCount: diagnosticsResult.diagnostics.length,
+    };
+  } finally {
+    service.dispose();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OOM detection via subprocess with memory cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a single semantic service pass in a child Node.js process capped at
+ * `maxOldSpaceMb` MB. Returns `true` if the process ran out of memory.
+ */
+function detectOom(fixturePath: string, maxOldSpaceMb: number): boolean {
+  const scriptTarget = String(ts.ScriptTarget.ES2022);
+  const moduleKind = String(ts.ModuleKind.NodeNext);
+  const moduleResolution = String(ts.ModuleResolutionKind.NodeNext);
+  const workspaceRoot = path.dirname(fixturePath);
+
+  const runnerScript = [
+    `import { createProgram } from "typescript";`,
+    `import { FormSpecSemanticService } from "@formspec/ts-plugin";`,
+    `import * as ts from "typescript";`,
+    `const program = createProgram(${JSON.stringify([fixturePath])}, {`,
+    `  target: ${scriptTarget},`,
+    `  module: ${moduleKind},`,
+    `  moduleResolution: ${moduleResolution},`,
+    `  strict: true,`,
+    `  skipLibCheck: true,`,
+    `});`,
+    `const service = new FormSpecSemanticService({`,
+    `  workspaceRoot: ${JSON.stringify(workspaceRoot)},`,
+    `  typescriptVersion: ts.version,`,
+    `  getProgram: () => program,`,
+    `});`,
+    `try {`,
+    `  service.getDiagnostics(${JSON.stringify(fixturePath)});`,
+    `  process.exit(0);`,
+    `} finally {`,
+    `  service.dispose();`,
+    `}`,
+  ].join("\n");
+
+  const tmpDir = os.tmpdir();
+  const runnerPath = path.join(tmpDir, `formspec-oom-probe-tsserver-${String(process.pid)}.mjs`);
+
+  try {
+    fsSync.writeFileSync(runnerPath, runnerScript, "utf8");
+  } catch {
+    return false;
+  }
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [`--max-old-space-size=${String(maxOldSpaceMb)}`, runnerPath],
+      {
+        encoding: "utf8",
+        timeout: 300_000,
+        env: { ...process.env },
+      }
+    );
+
+    if (result.status === 0) return false;
+
+    const output = `${result.stdout}${result.stderr}`;
+    const oomIndicators = [
+      "ENOMEM",
+      "out of memory",
+      "JavaScript heap out of memory",
+      "Allocation failed",
+    ];
+    if (oomIndicators.some((indicator) => output.toLowerCase().includes(indicator.toLowerCase()))) {
+      return true;
+    }
+
+    if (result.status === null && result.signal !== null) {
+      return true;
+    }
+
+    return false;
+  } finally {
+    try {
+      fsSync.unlinkSync(runnerPath);
+    } catch {
+      // Best effort cleanup.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Median helper
+// ---------------------------------------------------------------------------
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("Cannot compute median of empty array");
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (sorted[mid - 1]! + sorted[mid]!) / 2
+    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      sorted[mid]!;
+}
+
+// ---------------------------------------------------------------------------
+// Baseline JSON shape
+// ---------------------------------------------------------------------------
+
+interface StripeRealisticTsserverBaseline {
+  readonly phase: "0";
+  readonly surface: "tsserver-plugin";
+  readonly description: string;
+  readonly fixture: string;
+  readonly runs: number;
+  readonly oomHeapCapMB: number;
+  readonly metrics: {
+    readonly peakRSS_MB: number;
+    readonly wallTime_ms: number;
+    readonly didOOM: boolean;
+    readonly warmWallTimes_ms: readonly number[];
+    readonly allPeakRSS_MB: readonly number[];
+    readonly coldWallTime_ms: number;
+    readonly syntheticCompileCounts: readonly number[];
+  };
+  readonly gitSha: string;
+  readonly timestamp: string;
+  readonly nodeVersion: string;
+  readonly platform: string;
+  readonly arch: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  await fs.mkdir(BASELINE_DIR, { recursive: true });
+
+  const workspaceRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "formspec-stripe-realistic-tsserver-")
+  );
+
+  try {
+    const fixtureSrc = await fs.readFile(path.join(FIXTURE_DIR, FIXTURE_FILE), "utf8");
+    const fixturePath = path.join(workspaceRoot, FIXTURE_FILE);
+    await fs.writeFile(fixturePath, fixtureSrc, "utf8");
+
+    // Symlink e2e node_modules so ts.createProgram can find stripe types.
+    const e2eNodeModules = path.join(E2E_ROOT, "node_modules");
+    const tmpNodeModules = path.join(workspaceRoot, "node_modules");
+    await fs.symlink(e2eNodeModules, tmpNodeModules, "dir");
+
+    process.stderr.write(`\n=== Stripe Realistic OOM Sweep — TSServer-Plugin Surface (Phase 0 baseline) ===\n\n`);
+    process.stderr.write(`  fixture file: ${FIXTURE_FILE}\n`);
+    process.stderr.write(`  surface:      FormSpecSemanticService.getDiagnostics\n`);
+    process.stderr.write(`  runs:         ${String(RUNS)} (run 1 = cold)\n`);
+    process.stderr.write(`  OOM cap:      ${String(OOM_HEAP_CAP_MB)} MB\n\n`);
+
+    const allWallTimeMs: number[] = [];
+    const allPeakRssBytes: number[] = [];
+    const allSyntheticCompileCounts: number[] = [];
+
+    process.stderr.write(`  Plugin-path (FormSpecSemanticService.getDiagnostics):\n`);
+    for (let i = 0; i < RUNS; i++) {
+      const label = i === 0 ? "cold" : "warm";
+      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
+      const result = runTsserverBenchOnce(workspaceRoot, fixturePath);
+      allWallTimeMs.push(result.wallTimeMs);
+      allPeakRssBytes.push(result.peakRssBytes);
+      allSyntheticCompileCounts.push(result.syntheticCompileCount);
+      process.stderr.write(
+        ` ${result.wallTimeMs.toFixed(1)}ms  RSS=${(result.peakRssBytes / 1024 / 1024).toFixed(1)}MB syntheticCompile=${String(result.syntheticCompileCount)} diags=${String(result.diagnosticsCount)}\n`
+      );
+    }
+
+    const warmWallTimeMs = allWallTimeMs.slice(1);
+    const warmPeakRssBytes = allPeakRssBytes.slice(1);
+
+    const medianWarmWallTimeMs = warmWallTimeMs.length > 0 ? median(warmWallTimeMs) : (allWallTimeMs[0] ?? 0);
+    const medianWarmPeakRssBytes = warmPeakRssBytes.length > 0 ? median(warmPeakRssBytes) : (allPeakRssBytes[0] ?? 0);
+    const coldWallTimeMs = allWallTimeMs[0] ?? 0;
+    const peakRSSMB = medianWarmPeakRssBytes / 1024 / 1024;
+
+    process.stderr.write(`\n  OOM probe (${String(OOM_HEAP_CAP_MB)} MB cap)...\n`);
+    const didOOM = detectOom(fixturePath, OOM_HEAP_CAP_MB);
+    process.stderr.write(`    didOOM: ${String(didOOM)}\n`);
+
+    process.stderr.write(`\n--- Phase 0 Stripe Realistic TSServer-Plugin Baseline ---\n`);
+    process.stderr.write(`  surface:                     tsserver-plugin\n`);
+    process.stderr.write(`  wallTime_ms cold:             ${coldWallTimeMs.toFixed(2)}\n`);
+    process.stderr.write(`  wallTime_ms warm (median):    ${medianWarmWallTimeMs.toFixed(2)}\n`);
+    process.stderr.write(`  peakRSS_MB warm (median):    ${peakRSSMB.toFixed(1)} MB\n`);
+    process.stderr.write(`  didOOM (${String(OOM_HEAP_CAP_MB)} MB cap):       ${String(didOOM)}\n`);
+    process.stderr.write(`  syntheticCompile counts:     [${allSyntheticCompileCounts.join(", ")}]\n`);
+    process.stderr.write(`---------------------------------------------------------\n`);
+    process.stderr.write(`\n  Phase 4 gate: peakRSS_MB ≤ ${(peakRSSMB * 0.5).toFixed(1)} MB, zero OOM at 1 GB cap\n\n`);
+
+    const commitSha = process.env["GIT_COMMIT_SHA"] ?? "unknown";
+
+    const baseline: StripeRealisticTsserverBaseline = {
+      phase: "0",
+      surface: "tsserver-plugin",
+      description:
+        "Stripe realistic OOM sweep — tsserver-plugin surface (FormSpecSemanticService.getDiagnostics, direct Stripe types, no Ref<T> wrapper)",
+      fixture: "e2e/fixtures/stripe-realistic-oom/checkout-form.ts",
+      runs: RUNS,
+      oomHeapCapMB: OOM_HEAP_CAP_MB,
+      metrics: {
+        peakRSS_MB: Math.round(peakRSSMB * 10) / 10,
+        wallTime_ms: Math.round(medianWarmWallTimeMs * 100) / 100,
+        didOOM,
+        warmWallTimes_ms: warmWallTimeMs.map((v) => Math.round(v * 100) / 100),
+        allPeakRSS_MB: allPeakRssBytes.map((v) => Math.round((v / 1024 / 1024) * 10) / 10),
+        coldWallTime_ms: Math.round(coldWallTimeMs * 100) / 100,
+        syntheticCompileCounts: allSyntheticCompileCounts,
+      },
+      gitSha: commitSha,
+      timestamp: new Date().toISOString(),
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    };
+
+    await fs.writeFile(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+    process.stderr.write(`  Baseline written: ${BASELINE_PATH}\n\n`);
+
+    process.stdout.write(`${JSON.stringify(baseline, null, 2)}\n`);
+  } finally {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/e2e/fixtures/stripe-realistic-oom/checkout-form.ts
+++ b/e2e/fixtures/stripe-realistic-oom/checkout-form.ts
@@ -1,0 +1,46 @@
+import type Stripe from "stripe";
+
+/**
+ * Realistic checkout form modeled after how a consumer app would integrate
+ * formspec with the Stripe node SDK. Stripe types are embedded directly —
+ * this is the code path that reportedly OOMs in real user projects.
+ *
+ * Unlike the e2e/fixtures/stripe-ref-customer/ fixture (which uses a Ref<T>
+ * wrapper with a __type phantom property to engage PR #308's external-type
+ * bypass), this fixture deliberately does NOT use that wrapper — so the
+ * analyzer has to walk real Stripe.Customer / Stripe.Invoice / etc. and
+ * emit schema content for them.
+ */
+export class CheckoutForm {
+  /** @minLength 1 */
+  orderId!: string;
+
+  /** Customer record from Stripe */
+  customer!: Stripe.Customer;
+
+  /** Chosen payment method */
+  paymentMethod!: Stripe.PaymentMethod;
+
+  /** Attached subscription, if this is a recurring order */
+  subscription?: Stripe.Subscription;
+
+  /** Invoice preview for this order */
+  invoicePreview!: Stripe.Invoice;
+
+  /** Customer tax ID (for B2B sales) */
+  taxId?: Stripe.TaxId;
+
+  /** @minimum 0 @maximum 1000000 */
+  subtotalCents!: number;
+
+  /** @minimum 0 */
+  discountCents!: number;
+
+  /** @pattern "^[A-Z]{3}$" */
+  currency!: string;
+
+  /** @minLength 0 @maxLength 500 */
+  shippingNotes?: string;
+
+  confirmed!: boolean;
+}

--- a/e2e/fixtures/stripe-realistic-oom/checkout-form.ts
+++ b/e2e/fixtures/stripe-realistic-oom/checkout-form.ts
@@ -36,7 +36,7 @@ export class CheckoutForm {
   /** @minimum 0 */
   discountCents!: number;
 
-  /** @pattern "^[A-Z]{3}$" */
+  /** @pattern ^[A-Z]{3}$ */
   currency!: string;
 
   /** @minLength 0 @maxLength 500 */

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,7 +10,11 @@
     "bench:analysis": "pnpm -r --filter @formspec/build... --filter @formspec/ts-plugin... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/analysis-bench.ts",
     "bench:synthetic-checker": "pnpm -r --filter @formspec/analysis... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/synthetic-checker-baseline.bench.ts",
     "bench:stripe-ref-customer": "pnpm -r --filter @formspec/build... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-ref-customer-bench.ts",
-    "bench:stripe-real-sdk": "pnpm -r --filter @formspec/build... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-real-sdk-bench.ts"
+    "bench:stripe-real-sdk": "pnpm -r --filter @formspec/build... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-real-sdk-bench.ts",
+    "bench:stripe-realistic-build": "pnpm -r --filter @formspec/build... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-realistic-build-bench.ts",
+    "bench:stripe-realistic-snapshot": "pnpm -r --filter @formspec/analysis... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-realistic-snapshot-bench.ts",
+    "bench:stripe-realistic-eslint": "pnpm -r --filter @formspec/eslint-plugin... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-realistic-eslint-bench.ts",
+    "bench:stripe-realistic-tsserver": "pnpm -r --filter @formspec/ts-plugin... run build && tsc --noEmit -p ./tsconfig.benchmarks.json && TSX_TSCONFIG_PATH=./tsconfig.benchmarks.json tsx ./benchmarks/stripe-realistic-tsserver-bench.ts"
   },
   "dependencies": {
     "@formspec/analysis": "workspace:*",
@@ -18,11 +22,14 @@
     "@formspec/cli": "workspace:*",
     "@formspec/core": "workspace:*",
     "@formspec/dsl": "workspace:*",
+    "@formspec/eslint-plugin": "workspace:*",
     "@formspec/language-server": "workspace:*",
     "@formspec/ts-plugin": "workspace:*",
     "@formspec/validator": "workspace:*"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "^8.55.0",
+    "eslint": "^9.39.2",
     "stripe": "^22.0.2",
     "tsx": "^4.21.0",
     "typescript": "^5.0.0",

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -6,10 +6,12 @@
     "baseUrl": "..",
     "paths": {
       "@formspec/analysis": ["packages/analysis/dist/analysis.d.ts"],
+      "@formspec/analysis/internal": ["packages/analysis/dist/internal.d.ts"],
       "@formspec/build": ["packages/build/dist/build.d.ts"],
       "@formspec/build/internals": ["packages/build/dist/internals.d.ts"],
       "@formspec/cli": ["packages/cli/dist/index.d.ts"],
       "@formspec/core/internals": ["packages/core/dist/internals.d.ts"],
+      "@formspec/eslint-plugin": ["packages/eslint-plugin/dist/eslint-plugin.d.ts"],
       "@formspec/language-server": ["packages/language-server/dist/index.d.ts"],
       "@formspec/ts-plugin": ["packages/ts-plugin/dist/index.d.ts"],
       "@formspec/validator": ["packages/validator/dist/validator.d.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@formspec/dsl':
         specifier: workspace:*
         version: link:../packages/dsl
+      '@formspec/eslint-plugin':
+        specifier: workspace:*
+        version: link:../packages/eslint-plugin
       '@formspec/language-server':
         specifier: workspace:*
         version: link:../packages/language-server
@@ -90,6 +93,12 @@ importers:
         specifier: workspace:*
         version: link:../packages/validator
     devDependencies:
+      '@typescript-eslint/parser':
+        specifier: ^8.55.0
+        version: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.2(jiti@2.6.1)
       stripe:
         specifier: ^22.0.2
         version: 22.0.2(@types/node@22.19.7)


### PR DESCRIPTION
## Summary

Adds a realistic Stripe-integration fixture and benchmark runners targeting the user-reported OOM issue. Unlike prior fixtures (`stripe-ref-customer`, `stripe-real-sdk`), which used a `Ref<T>` wrapper with a `__type` phantom property to engage the external-type bypass from PR #308, this fixture embeds Stripe types **directly** — the code path that reportedly OOMs in real user projects.

- **Fixture:** `e2e/fixtures/stripe-realistic-oom/checkout-form.ts` — `CheckoutForm` with 11 fields including `Stripe.Customer`, `Stripe.PaymentMethod`, `Stripe.Subscription`, `Stripe.Invoice`, `Stripe.TaxId`
- **Four bench runners:** one per consumer surface, each with OOM detection at 1 GB heap cap
- **Phase 0 baselines** committed for all four surfaces

## Phase 0 Baseline Numbers (arm64 darwin, Node v24.14.0, 1 GB OOM cap)

| Surface | `peakRSS_MB` warm median | `wallTime_ms` cold | `didOOM` (1 GB) |
|---------|--------------------------|-------------------|-----------------|
| **build** (`generateSchemasFromProgram`) | **861.3 MB** | 432.7 ms | `false` |
| **snapshot** (`buildFormSpecAnalysisFileSnapshot`) | **843.8 MB** | 290.4 ms | `false` |
| **eslint** (`type-compatibility/tag-type-check`) | **519.1 MB** | 420.2 ms | `false` |
| **tsserver-plugin** (`FormSpecSemanticService.getDiagnostics`) | **846.6 MB** | 370.1 ms | `false` |

## Findings

**None of the four surfaces OOMed at 1 GB on this machine (M-series arm64, Node v24.14.0).** However:

- Build / snapshot / tsserver-plugin all land within **160 MB** of the 1 GB cap. A machine with less available RSS headroom, or a Stripe SDK version with a larger type graph, would push these over.
- The ESLint surface is significantly cheaper (~519 MB) because the rule only inspects the checked file rather than walking the full schema emission pipeline.
- The tsserver-plugin surface produced **35 diagnostics** on the first cold run, confirming the analyzer is walking real Stripe types (not being bypassed).
- `syntheticCompileCount` on cold run: **5** (tsserver-plugin surface), confirming the synthetic checker is invoked multiple times for this fixture.

**Comparison with prior fixtures:**

| Fixture | Approach | `peakRSS_MB` | `didOOM` |
|---------|---------|--------------|---------|
| `stripe-ref-customer` (PR #333) | `Ref<T>` wrapper — external-type bypass active | 921.8 MB | false (512 MB cap) |
| `stripe-realistic-oom` (this PR) | Direct Stripe types — bypass NOT active | 843–861 MB | false (1 GB cap) |

The realistic fixture at 1 GB is comparable to the `Ref<T>` fixture at 512 MB cap, confirming the bypass was not what saved the previous fixture — the RSS was already under limit. The new fixture establishes a more honest baseline for the Phase 4 gate.

## Phase 4 Gate (after host-checker migration)

All four surfaces must show:
- `peakRSS_MB` ≤ 50% of corresponding Phase 0 value above
- `didOOM: false` at 1 GB cap

## How to Run

```bash
pnpm --filter @formspec/e2e run bench:stripe-realistic-build
pnpm --filter @formspec/e2e run bench:stripe-realistic-snapshot
pnpm --filter @formspec/e2e run bench:stripe-realistic-eslint
pnpm --filter @formspec/e2e run bench:stripe-realistic-tsserver
```