### PR TITLE
refactor(analysis): typed argument parser skeleton (Phase 1 Slice 0)

### DIFF
--- a/.changeset/phase-1-slice-0-skeleton.md
+++ b/.changeset/phase-1-slice-0-skeleton.md
@@ -1,0 +1,18 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Add typed argument parser skeleton (Phase 1 Slice 0)
+
+Introduces `packages/analysis/src/tag-argument-parser.ts` with the public API,
+tag-family registry, and dispatch stub. Per-family parser bodies are filled
+in by Slices A/B/C; canary tests land in Slice D. This is a no-wiring change —
+consumers (`tsdoc-parser.ts`, `file-snapshots.ts`) keep calling the synthetic
+path as before. Implements §4 "Phase 1" + §9.4 0.5j carryover of
+`docs/refactors/synthetic-checker-retirement.md`.

--- a/packages/analysis/src/__tests__/tag-argument-parser.test.ts
+++ b/packages/analysis/src/__tests__/tag-argument-parser.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { BUILTIN_CONSTRAINT_DEFINITIONS } from "@formspec/core/internals";
 import {
   parseTagArgument,
   TAG_ARGUMENT_FAMILIES,
@@ -7,23 +8,11 @@ import {
 
 describe("parseTagArgument", () => {
   describe("registry", () => {
-    it("maps all 13 constraint-tag names to a family", () => {
-      // Assert TAG_ARGUMENT_FAMILIES has exactly these entries.
-      const expected = new Set([
-        "minimum",
-        "maximum",
-        "exclusiveMinimum",
-        "exclusiveMaximum",
-        "multipleOf",
-        "minLength",
-        "maxLength",
-        "minItems",
-        "maxItems",
-        "uniqueItems",
-        "pattern",
-        "enumOptions",
-        "const",
-      ]);
+    it("maps exactly the keys of BUILTIN_CONSTRAINT_DEFINITIONS to a family", () => {
+      // Derive expected set from the single source of truth so that adding or
+      // removing a tag in core automatically fails this test instead of silently
+      // drifting out of sync with a hard-coded list.
+      const expected = new Set(Object.keys(BUILTIN_CONSTRAINT_DEFINITIONS));
       expect(new Set(Object.keys(TAG_ARGUMENT_FAMILIES))).toEqual(expected);
     });
 

--- a/packages/analysis/src/__tests__/tag-argument-parser.test.ts
+++ b/packages/analysis/src/__tests__/tag-argument-parser.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseTagArgument,
+  TAG_ARGUMENT_FAMILIES,
+  type TagArgumentValue,
+} from "../tag-argument-parser.js";
+
+describe("parseTagArgument", () => {
+  describe("registry", () => {
+    it("maps all 13 constraint-tag names to a family", () => {
+      // Assert TAG_ARGUMENT_FAMILIES has exactly these entries.
+      const expected = new Set([
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "minLength",
+        "maxLength",
+        "minItems",
+        "maxItems",
+        "uniqueItems",
+        "pattern",
+        "enumOptions",
+        "const",
+      ]);
+      expect(new Set(Object.keys(TAG_ARGUMENT_FAMILIES))).toEqual(expected);
+    });
+
+    it("returns UNKNOWN_TAG for tag names not in the registry", () => {
+      const result = parseTagArgument("notATag", "42", "build");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostic.code).toBe("UNKNOWN_TAG");
+        expect(result.diagnostic.message).toContain("notATag");
+      }
+    });
+  });
+
+  // Slice A owns these — tests land in Slice A.
+  describe("numeric family", () => {
+    it.todo("Slice A");
+  });
+  describe("length family", () => {
+    it.todo("Slice A");
+  });
+
+  // Slice B owns these — tests land in Slice B.
+  describe("boolean-marker (@uniqueItems)", () => {
+    it.todo("Slice B");
+  });
+  describe("string-opaque (@pattern)", () => {
+    it.todo("Slice B");
+  });
+
+  // Slice C owns these — tests land in Slice C.
+  describe("json-array (@enumOptions)", () => {
+    it.todo("Slice C");
+  });
+  describe("json-value-with-fallback (@const)", () => {
+    it.todo("Slice C");
+  });
+
+  // Slice D owns this — tests land in Slice D.
+  describe("canaries (silent-acceptance regression guards)", () => {
+    it.todo("Slice D");
+  });
+});
+
+// Suppress unused-import lint for TagArgumentValue — it is imported here so
+// that Slices A/B/C can reference it in tests without adding a new import.
+type _TagArgumentValueUnused = TagArgumentValue;

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -1,4 +1,5 @@
 import type { JsonValue } from "@formspec/core/internals";
+import { BUILTIN_CONSTRAINT_DEFINITIONS } from "@formspec/core/internals";
 
 /**
  * Discriminates between "build" (compile-time via tsdoc-parser.ts) and
@@ -14,12 +15,15 @@ export type TagArgumentLowering = "build" | "snapshot";
  *
  * Each variant maps to a distinct constraint-tag semantic:
  * - `number`  — numeric constraints (minimum, maximum, …)
- * - `string`  — string/pattern constraints
+ * - `string`  — validated string result for `@pattern`; never produced for
+ *               `@const` (use `raw-string-fallback` for that)
  * - `boolean` — flag constraints
  * - `marker`  — presence-only constraints (@uniqueItems)
  * - `json-array` — array-valued constraints (@enumOptions)
  * - `json-value` — arbitrary JSON constraints
- * - `raw-string-fallback` — @const with a non-JSON literal value
+ * - `raw-string-fallback` — ONLY produced for `@const` when the argument is
+ *                            not valid JSON; signals that the value should be
+ *                            treated as an opaque string literal
  */
 export type TagArgumentValue =
   | { readonly kind: "number"; readonly value: number }
@@ -28,7 +32,7 @@ export type TagArgumentValue =
   | { readonly kind: "marker" } // for @uniqueItems — empty or "true"
   | { readonly kind: "json-array"; readonly value: readonly JsonValue[] }
   | { readonly kind: "json-value"; readonly value: JsonValue }
-  | { readonly kind: "raw-string-fallback"; readonly value: string }; // @const only
+  | { readonly kind: "raw-string-fallback"; readonly value: string };
 
 /** Diagnostic codes emitted by {@link parseTagArgument}. */
 export const TAG_ARGUMENT_DIAGNOSTIC_CODES = {
@@ -46,6 +50,9 @@ export interface TagArgumentDiagnostic {
    * Messages for INVALID_TAG_ARGUMENT must start with "Expected " so that the
    * "Expected"-based classifier in `packages/analysis/src/file-snapshots.ts`
    * (~line 1480) remains valid when consumer wiring lands in Phase 2/3.
+   *
+   * @remarks Phase 2/3 should shift the classifier to test `code` directly;
+   * the "Expected " prefix is a bridge convention until that wiring lands.
    */
   readonly message: string;
 }
@@ -69,10 +76,22 @@ export type TagFamily =
 
 /**
  * Maps every built-in constraint-tag name (no leading "@") to its parsing
- * family. Unknown tag names return `undefined` at runtime; the parser returns
- * an `UNKNOWN_TAG` diagnostic in that case.
+ * family. Derived from {@link BUILTIN_CONSTRAINT_DEFINITIONS} — the single
+ * source of truth for which constraint tags exist.
+ *
+ * The `satisfies` guard enforces that every key in BUILTIN_CONSTRAINT_DEFINITIONS
+ * is present here and maps to a valid TagFamily. Adding a new tag to core is
+ * therefore either automatic (if the default mapping covers it) or a type
+ * error (prompting the author to add an entry here).
+ *
+ * Family assignment rules:
+ *   "number" core type → "numeric" for value constraints; "length" for size/
+ *     count constraints (minLength, maxLength, minItems, maxItems)
+ *   "boolean" core type → "boolean-marker"
+ *   "string"  core type → "string-opaque"
+ *   "json"    core type → "json-array" for enumOptions; "json-value-with-fallback" for const
  */
-export const TAG_ARGUMENT_FAMILIES: Readonly<Record<string, TagFamily>> = {
+export const TAG_ARGUMENT_FAMILIES = {
   minimum: "numeric",
   maximum: "numeric",
   exclusiveMinimum: "numeric",
@@ -86,7 +105,7 @@ export const TAG_ARGUMENT_FAMILIES: Readonly<Record<string, TagFamily>> = {
   pattern: "string-opaque",
   enumOptions: "json-array",
   const: "json-value-with-fallback",
-};
+} as const satisfies Record<keyof typeof BUILTIN_CONSTRAINT_DEFINITIONS, TagFamily>;
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -111,22 +130,23 @@ function throwNotImplemented(family: TagFamily): never {
  * synthetic-checker retirement plan §1.
  *
  * @param tagName - normalized tag name (no leading "@")
- * @param rawArgumentText - argument text AFTER parseTagSyntax has stripped
- *                          any path-target prefix (i.e. "effectiveText")
- * @param lowering - build vs snapshot. Phase 1 implementations may treat
- *                   this as a no-op; the parameter is accepted for
- *                   forward-compatibility with Phase 2/3 consumer wiring.
+ * @param _rawArgumentText - argument text AFTER parseTagSyntax has stripped
+ *                           any path-target prefix (i.e. "effectiveText")
+ * @param _lowering - build vs snapshot. Phase 1 implementations do not use
+ *                    this; the parameter is accepted for forward-compatibility
+ *                    with Phase 2/3 consumer wiring.
  */
 export function parseTagArgument(
   tagName: string,
-  rawArgumentText: string,
-  lowering: TagArgumentLowering,
+  _rawArgumentText: string,
+  _lowering: TagArgumentLowering,
 ): TagArgumentParseResult {
-  // Suppress unused-parameter lint — `lowering` is intentionally accepted for
-  // Phase 2/3 forward-compatibility even though Phase 1 does not use it.
-  void lowering;
-
-  const family: TagFamily | undefined = TAG_ARGUMENT_FAMILIES[tagName];
+  // TAG_ARGUMENT_FAMILIES has literal string keys; tagName is a runtime string,
+  // so the cast is needed to index into the typed map. The `| undefined` is
+  // explicit because noUncheckedIndexedAccess is not enabled in this package.
+  const family = TAG_ARGUMENT_FAMILIES[tagName as keyof typeof TAG_ARGUMENT_FAMILIES] as
+    | TagFamily
+    | undefined;
 
   if (family === undefined) {
     return {

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -141,12 +141,13 @@ export function parseTagArgument(
   _rawArgumentText: string,
   _lowering: TagArgumentLowering,
 ): TagArgumentParseResult {
-  // TAG_ARGUMENT_FAMILIES has literal string keys; tagName is a runtime string,
-  // so the cast is needed to index into the typed map. The `| undefined` is
-  // explicit because noUncheckedIndexedAccess is not enabled in this package.
-  const family = TAG_ARGUMENT_FAMILIES[tagName as keyof typeof TAG_ARGUMENT_FAMILIES] as
-    | TagFamily
-    | undefined;
+  // Guard against prototype-pollution: names like "toString", "constructor", or
+  // "__proto__" exist on every plain object's prototype chain and would bypass
+  // the UNKNOWN_TAG path if indexed directly. Object.hasOwn() confines the
+  // lookup to own properties only.
+  const family: TagFamily | undefined = Object.hasOwn(TAG_ARGUMENT_FAMILIES, tagName)
+    ? TAG_ARGUMENT_FAMILIES[tagName as keyof typeof TAG_ARGUMENT_FAMILIES]
+    : undefined;
 
   if (family === undefined) {
     return {

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -1,0 +1,163 @@
+import type { JsonValue } from "@formspec/core/internals";
+
+/**
+ * Discriminates between "build" (compile-time via tsdoc-parser.ts) and
+ * "snapshot" (runtime via file-snapshots.ts) lowering contexts.
+ *
+ * Phase 1 implementations treat this as a no-op; it is accepted here for
+ * forward-compatibility with Phase 2/3 consumer wiring.
+ */
+export type TagArgumentLowering = "build" | "snapshot";
+
+/**
+ * The strongly-typed result of a successful tag-argument parse.
+ *
+ * Each variant maps to a distinct constraint-tag semantic:
+ * - `number`  — numeric constraints (minimum, maximum, …)
+ * - `string`  — string/pattern constraints
+ * - `boolean` — flag constraints
+ * - `marker`  — presence-only constraints (@uniqueItems)
+ * - `json-array` — array-valued constraints (@enumOptions)
+ * - `json-value` — arbitrary JSON constraints
+ * - `raw-string-fallback` — @const with a non-JSON literal value
+ */
+export type TagArgumentValue =
+  | { readonly kind: "number"; readonly value: number }
+  | { readonly kind: "string"; readonly value: string }
+  | { readonly kind: "boolean"; readonly value: boolean }
+  | { readonly kind: "marker" } // for @uniqueItems — empty or "true"
+  | { readonly kind: "json-array"; readonly value: readonly JsonValue[] }
+  | { readonly kind: "json-value"; readonly value: JsonValue }
+  | { readonly kind: "raw-string-fallback"; readonly value: string }; // @const only
+
+/** Diagnostic codes emitted by {@link parseTagArgument}. */
+export const TAG_ARGUMENT_DIAGNOSTIC_CODES = {
+  INVALID_TAG_ARGUMENT: "INVALID_TAG_ARGUMENT",
+  MISSING_TAG_ARGUMENT: "MISSING_TAG_ARGUMENT",
+  UNKNOWN_TAG: "UNKNOWN_TAG",
+} as const;
+
+export type TagArgumentDiagnosticCode =
+  (typeof TAG_ARGUMENT_DIAGNOSTIC_CODES)[keyof typeof TAG_ARGUMENT_DIAGNOSTIC_CODES];
+
+export interface TagArgumentDiagnostic {
+  readonly code: TagArgumentDiagnosticCode;
+  /**
+   * Messages for INVALID_TAG_ARGUMENT must start with "Expected " so that the
+   * "Expected"-based classifier in `packages/analysis/src/file-snapshots.ts`
+   * (~line 1480) remains valid when consumer wiring lands in Phase 2/3.
+   */
+  readonly message: string;
+}
+
+/** The result type returned by {@link parseTagArgument}. */
+export type TagArgumentParseResult =
+  | { readonly ok: true; readonly value: TagArgumentValue }
+  | { readonly ok: false; readonly diagnostic: TagArgumentDiagnostic };
+
+/**
+ * Constraint-tag parsing families. Each family shares a common argument
+ * structure and is implemented by a dedicated parser in Slices A/B/C.
+ */
+export type TagFamily =
+  | "numeric"
+  | "length"
+  | "boolean-marker"
+  | "string-opaque"
+  | "json-array"
+  | "json-value-with-fallback";
+
+/**
+ * Maps every built-in constraint-tag name (no leading "@") to its parsing
+ * family. Unknown tag names return `undefined` at runtime; the parser returns
+ * an `UNKNOWN_TAG` diagnostic in that case.
+ */
+export const TAG_ARGUMENT_FAMILIES: Readonly<Record<string, TagFamily>> = {
+  minimum: "numeric",
+  maximum: "numeric",
+  exclusiveMinimum: "numeric",
+  exclusiveMaximum: "numeric",
+  multipleOf: "numeric",
+  minLength: "length",
+  maxLength: "length",
+  minItems: "length",
+  maxItems: "length",
+  uniqueItems: "boolean-marker",
+  pattern: "string-opaque",
+  enumOptions: "json-array",
+  const: "json-value-with-fallback",
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Throws a clearly-labelled "not-implemented" error for a tag family.
+ * Slices A, B, and C replace this throw with real implementations.
+ *
+ * @param family - the family whose parser has not yet been implemented
+ */
+function throwNotImplemented(family: TagFamily): never {
+  throw new Error(`not-implemented: tag family "${family}" parser (Slice A/B/C)`);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a single constraint-tag argument literal. Role C of the
+ * synthetic-checker retirement plan §1.
+ *
+ * @param tagName - normalized tag name (no leading "@")
+ * @param rawArgumentText - argument text AFTER parseTagSyntax has stripped
+ *                          any path-target prefix (i.e. "effectiveText")
+ * @param lowering - build vs snapshot. Phase 1 implementations may treat
+ *                   this as a no-op; the parameter is accepted for
+ *                   forward-compatibility with Phase 2/3 consumer wiring.
+ */
+export function parseTagArgument(
+  tagName: string,
+  rawArgumentText: string,
+  lowering: TagArgumentLowering,
+): TagArgumentParseResult {
+  // Suppress unused-parameter lint — `lowering` is intentionally accepted for
+  // Phase 2/3 forward-compatibility even though Phase 1 does not use it.
+  void lowering;
+
+  const family: TagFamily | undefined = TAG_ARGUMENT_FAMILIES[tagName];
+
+  if (family === undefined) {
+    return {
+      ok: false,
+      diagnostic: {
+        code: TAG_ARGUMENT_DIAGNOSTIC_CODES.UNKNOWN_TAG,
+        message: `Unknown constraint tag "${tagName}".`,
+      },
+    };
+  }
+
+  // Exhaustive switch — TypeScript's `never` check ensures all families are
+  // handled. Slices A, B, C replace the throwNotImplemented calls.
+  switch (family) {
+    case "numeric":
+      return throwNotImplemented(family);
+    case "length":
+      return throwNotImplemented(family);
+    case "boolean-marker":
+      return throwNotImplemented(family);
+    case "string-opaque":
+      return throwNotImplemented(family);
+    case "json-array":
+      return throwNotImplemented(family);
+    case "json-value-with-fallback":
+      return throwNotImplemented(family);
+    default: {
+      // Exhaustiveness guard: if a new TagFamily variant is added without
+      // updating this switch, the compiler will flag the assignment below.
+      const _exhaustiveCheck: never = family;
+      throw new Error(`Unexpected tag family: ${String(_exhaustiveCheck)}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `packages/analysis/src/tag-argument-parser.ts` as a sibling to the existing `tag-value-parser.ts` — no wiring to consumers yet (build and snapshot paths unchanged)
- Establishes the full public API: `parseTagArgument`, `TAG_ARGUMENT_FAMILIES`, `TagArgumentValue`, `TagArgumentParseResult`, `TagArgumentDiagnostic`, `TAG_ARGUMENT_DIAGNOSTIC_CODES`, `TagFamily`, `TagArgumentLowering`
- Dispatch stub: returns `UNKNOWN_TAG` for unrecognized tag names; throws `not-implemented` for all 6 known families via a `throwNotImplemented(family)` helper that Slices A/B/C will replace with real implementations
- Exhaustive `switch` on `TagFamily` with a `never` default guard ensures TypeScript catches any future family additions that miss a case

## API surface introduced

```ts
export type TagArgumentLowering = "build" | "snapshot";
export type TagArgumentValue = { kind: "number"; value: number } | { kind: "string"; value: string } | { kind: "boolean"; value: boolean } | { kind: "marker" } | { kind: "json-array"; value: readonly JsonValue[] } | { kind: "json-value"; value: JsonValue } | { kind: "raw-string-fallback"; value: string };
export const TAG_ARGUMENT_DIAGNOSTIC_CODES = { INVALID_TAG_ARGUMENT, MISSING_TAG_ARGUMENT, UNKNOWN_TAG };
export type TagArgumentDiagnosticCode = ...;
export interface TagArgumentDiagnostic { code: TagArgumentDiagnosticCode; message: string; }
export type TagArgumentParseResult = { ok: true; value: TagArgumentValue } | { ok: false; diagnostic: TagArgumentDiagnostic };
export type TagFamily = "numeric" | "length" | "boolean-marker" | "string-opaque" | "json-array" | "json-value-with-fallback";
export const TAG_ARGUMENT_FAMILIES: Readonly<Record<string, TagFamily>>;  // 13 entries
export function parseTagArgument(tagName, rawArgumentText, lowering): TagArgumentParseResult;
```

## Test coverage (this PR)

Two registry tests run and pass:
1. `maps all 13 constraint-tag names to a family` — asserts exact `Set` equality against the known constraint names
2. `returns UNKNOWN_TAG for tag names not in the registry` — verifies the fallback diagnostic code and message content

Family describe blocks (`numeric`, `length`, `boolean-marker`, `string-opaque`, `json-array`, `json-value-with-fallback`) and the canaries block are present as empty scaffolds with `it.todo` placeholders.

## Constraints / non-goals

- `parseTagArgument` is **not** exported from `packages/analysis/src/index.ts` or `packages/analysis/src/internal.ts`. Phase 2/3 decides the export surface when consumer wiring lands.
- `packages/analysis/src/tag-value-parser.ts`, `tsdoc-parser.ts`, and `file-snapshots.ts` are untouched.

## Reference

- `docs/refactors/synthetic-checker-retirement.md` §4 "Phase 1" — skeleton step
- `docs/refactors/synthetic-checker-retirement.md` §9.4 0.5j carryover

## What follows

Slices A, B, C, D follow sequentially:
- **Slice A** — numeric + length family parser bodies
- **Slice B** — boolean-marker + string-opaque family parser bodies
- **Slice C** — json-array + json-value-with-fallback family parser bodies
- **Slice D** — canary regression guards

This PR **intentionally** leaves all family implementations stubbed. A known-tag argument call will throw `not-implemented` until Slice A/B/C lands.