### PR TITLE
refactor(analysis): marker + pattern family parsers (Phase 1 Slice B)

### DIFF
--- a/.changeset/phase-1-slice-b-marker-pattern.md
+++ b/.changeset/phase-1-slice-b-marker-pattern.md
@@ -1,0 +1,16 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Implement boolean-marker + string-opaque family argument parsers (Phase 1 Slice B)
+
+Fills in the `throw throwNotImplemented` sites in tag-argument-parser.ts
+for `@uniqueItems` (boolean-marker) and `@pattern` (string-opaque).
+Preserves current opaque-string behavior for `@pattern` (no regex
+compilation) per §6 risk 2 of the retirement plan. No consumer wiring.

--- a/packages/analysis/src/__tests__/tag-argument-parser.test.ts
+++ b/packages/analysis/src/__tests__/tag-argument-parser.test.ts
@@ -34,12 +34,151 @@ describe("parseTagArgument", () => {
     it.todo("Slice A");
   });
 
-  // Slice B owns these — tests land in Slice B.
+  // Slice B owns these.
   describe("boolean-marker (@uniqueItems)", () => {
-    it.todo("Slice B");
+    // ---------------------------------------------------------------------------
+    // Local helpers
+    // ---------------------------------------------------------------------------
+
+    /** Assert that the result is an ok marker. */
+    function expectMarker(rawText: string): void {
+      const result = parseTagArgument("uniqueItems", rawText, "build");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual({ kind: "marker" });
+      }
+    }
+
+    /** Assert that the result is INVALID_TAG_ARGUMENT containing the offending value. */
+    function expectInvalidMarker(rawText: string): void {
+      const result = parseTagArgument("uniqueItems", rawText, "build");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+        expect(result.diagnostic.message).toMatch(/^Expected/);
+        expect(result.diagnostic.message).toContain(rawText.trim());
+      }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Valid inputs → marker
+    // ---------------------------------------------------------------------------
+
+    it("empty string → marker", () => {
+      expectMarker("");
+    });
+
+    it("whitespace-only → marker", () => {
+      expectMarker("   ");
+    });
+
+    it('"true" → marker', () => {
+      expectMarker("true");
+    });
+
+    it('"true" with surrounding whitespace → marker (trimmed)', () => {
+      expectMarker("  true  ");
+    });
+
+    // ---------------------------------------------------------------------------
+    // Invalid inputs → INVALID_TAG_ARGUMENT
+    // ---------------------------------------------------------------------------
+
+    it('"false" → INVALID (not a valid presence-marker value)', () => {
+      expectInvalidMarker("false");
+    });
+
+    it('"yes" → INVALID', () => {
+      expectInvalidMarker("yes");
+    });
+
+    it('"1" → INVALID', () => {
+      expectInvalidMarker("1");
+    });
+
+    it('"TRUE" → INVALID (case-sensitive — pin current behavior)', () => {
+      expectInvalidMarker("TRUE");
+    });
+
+    it('"maybe" → INVALID', () => {
+      expectInvalidMarker("maybe");
+    });
+
+    // ---------------------------------------------------------------------------
+    // Lowering flag is a no-op in Phase 1 — both contexts produce identical output
+    // ---------------------------------------------------------------------------
+
+    it("lowering flag does not affect output (representative case: empty string)", () => {
+      const buildResult = parseTagArgument("uniqueItems", "", "build");
+      const snapshotResult = parseTagArgument("uniqueItems", "", "snapshot");
+      expect(buildResult).toEqual(snapshotResult);
+    });
   });
+
   describe("string-opaque (@pattern)", () => {
-    it.todo("Slice B");
+    // ---------------------------------------------------------------------------
+    // Local helpers
+    // ---------------------------------------------------------------------------
+
+    /** Assert that the result is an ok string value equal to `expected`. */
+    function expectPatternString(rawText: string, expected: string): void {
+      const result = parseTagArgument("pattern", rawText, "build");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual({ kind: "string", value: expected });
+      }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Valid inputs → string
+    // ---------------------------------------------------------------------------
+
+    it("bare pattern string", () => {
+      expectPatternString("^[A-Z]{3}$", "^[A-Z]{3}$");
+    });
+
+    it("quoted pattern string — quotes are preserved (opaque pass-through)", () => {
+      expectPatternString('"quoted"', '"quoted"');
+    });
+
+    it("unclosed bracket — no regex compile, returned opaque", () => {
+      expectPatternString("[unclosed", "[unclosed");
+    });
+
+    it("pattern with surrounding whitespace → trimmed", () => {
+      expectPatternString("  .*  ", ".*");
+    });
+
+    // ---------------------------------------------------------------------------
+    // Invalid inputs → MISSING_TAG_ARGUMENT
+    // ---------------------------------------------------------------------------
+
+    it("empty string → MISSING_TAG_ARGUMENT", () => {
+      const result = parseTagArgument("pattern", "", "build");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostic.code).toBe("MISSING_TAG_ARGUMENT");
+        expect(result.diagnostic.message).toMatch(/^Expected/);
+      }
+    });
+
+    it("whitespace-only → MISSING_TAG_ARGUMENT (trims to empty)", () => {
+      const result = parseTagArgument("pattern", "   ", "build");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostic.code).toBe("MISSING_TAG_ARGUMENT");
+      }
+    });
+
+    // ---------------------------------------------------------------------------
+    // Lowering flag is a no-op in Phase 1
+    // ---------------------------------------------------------------------------
+
+    it("lowering flag does not affect output (representative case: bare pattern)", () => {
+      const buildResult = parseTagArgument("pattern", "^[A-Z]{3}$", "build");
+      const snapshotResult = parseTagArgument("pattern", "^[A-Z]{3}$", "snapshot");
+      expect(buildResult).toEqual(snapshotResult);
+    });
   });
 
   // Slice C owns these — tests land in Slice C.

--- a/packages/analysis/src/__tests__/tag-argument-parser.test.ts
+++ b/packages/analysis/src/__tests__/tag-argument-parser.test.ts
@@ -24,6 +24,32 @@ describe("parseTagArgument", () => {
         expect(result.diagnostic.message).toContain("notATag");
       }
     });
+
+    it("all diagnostics from implemented families start with 'Expected '", () => {
+      // Enforces the "Expected " prefix convention documented in TagArgumentDiagnostic.
+      // The classifier in file-snapshots.ts (~line 1480) relies on this prefix to
+      // remain valid until Phase 2/3 wiring shifts it to test `code` directly.
+      //
+      // ADD ONE CASE HERE per newly-implemented family when each Slice lands.
+      // Each entry should use an invalid argument that produces a diagnostic.
+      const cases: { tag: string; raw: string; description: string }[] = [
+        // boolean-marker family (@uniqueItems) — INVALID_TAG_ARGUMENT
+        { tag: "uniqueItems", raw: "false", description: "@uniqueItems with 'false'" },
+        // string family (@pattern) — MISSING_TAG_ARGUMENT (empty is the only invalid case)
+        { tag: "pattern", raw: "", description: "@pattern with empty string" },
+      ];
+
+      for (const { tag, raw, description } of cases) {
+        const result = parseTagArgument(tag, raw, "build");
+        expect(result.ok, `expected failure for ${description}`).toBe(false);
+        if (!result.ok) {
+          expect(
+            result.diagnostic.message,
+            `message for ${description} must start with "Expected "`,
+          ).toMatch(/^Expected /);
+        }
+      }
+    });
   });
 
   // Slice A owns these — tests land in Slice A.
@@ -100,6 +126,10 @@ describe("parseTagArgument", () => {
       expectInvalidMarker("TRUE");
     });
 
+    it('"True" → INVALID (case-sensitive — pin current behavior)', () => {
+      expectInvalidMarker("True");
+    });
+
     it('"maybe" → INVALID', () => {
       expectInvalidMarker("maybe");
     });
@@ -115,7 +145,7 @@ describe("parseTagArgument", () => {
     });
   });
 
-  describe("string-opaque (@pattern)", () => {
+  describe("string family (@pattern)", () => {
     // ---------------------------------------------------------------------------
     // Local helpers
     // ---------------------------------------------------------------------------

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -121,6 +121,55 @@ function throwNotImplemented(family: TagFamily): never {
   throw new Error(`not-implemented: tag family "${family}" parser (Slice A/B/C)`);
 }
 
+/**
+ * Parses the argument for `@uniqueItems` (boolean-marker family).
+ *
+ * Preserves current `tag-value-parser.ts` semantics exactly:
+ * - Empty or whitespace-only → ok marker
+ * - Literal `"true"` (after trim) → ok marker
+ * - Anything else (including `"false"`) → INVALID_TAG_ARGUMENT
+ *
+ * Note: `"false"` is invalid because `@uniqueItems` is a presence-only
+ * constraint — there is no "uniqueItems: false" JSON Schema keyword that
+ * FormSpec emits. The value is always serialized as `true`.
+ */
+function parseUniqueItemsArgument(rawArgumentText: string): TagArgumentParseResult {
+  const trimmed = rawArgumentText.trim();
+  if (trimmed === "" || trimmed === "true") {
+    return { ok: true, value: { kind: "marker" } };
+  }
+  return {
+    ok: false,
+    diagnostic: {
+      code: TAG_ARGUMENT_DIAGNOSTIC_CODES.INVALID_TAG_ARGUMENT,
+      message: `Expected @uniqueItems to be either empty or "true", got "${trimmed}".`,
+    },
+  };
+}
+
+/**
+ * Parses the argument for `@pattern` (string-opaque family).
+ *
+ * Preserves current opaque-pass-through behavior per §3 of the retirement
+ * plan: the raw text is trimmed and returned as-is. `new RegExp(text)` is
+ * deliberately NOT called — regex validation is deferred to Phase 2/3 per
+ * §6 risk 2. Quoted vs. unquoted strings produce different values (current
+ * behavior; normalization is a Phase 2/3 concern).
+ */
+function parsePatternArgument(rawArgumentText: string): TagArgumentParseResult {
+  const trimmed = rawArgumentText.trim();
+  if (trimmed === "") {
+    return {
+      ok: false,
+      diagnostic: {
+        code: TAG_ARGUMENT_DIAGNOSTIC_CODES.MISSING_TAG_ARGUMENT,
+        message: "Expected a pattern string for @pattern.",
+      },
+    };
+  }
+  return { ok: true, value: { kind: "string", value: trimmed } };
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -167,9 +216,9 @@ export function parseTagArgument(
     case "length":
       return throwNotImplemented(family);
     case "boolean-marker":
-      return throwNotImplemented(family);
+      return parseUniqueItemsArgument(_rawArgumentText);
     case "string-opaque":
-      return throwNotImplemented(family);
+      return parsePatternArgument(_rawArgumentText);
     case "json-array":
       return throwNotImplemented(family);
     case "json-value-with-fallback":

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -70,7 +70,7 @@ export type TagFamily =
   | "numeric"
   | "length"
   | "boolean-marker"
-  | "string-opaque"
+  | "string"
   | "json-array"
   | "json-value-with-fallback";
 
@@ -88,7 +88,7 @@ export type TagFamily =
  *   "number" core type → "numeric" for value constraints; "length" for size/
  *     count constraints (minLength, maxLength, minItems, maxItems)
  *   "boolean" core type → "boolean-marker"
- *   "string"  core type → "string-opaque"
+ *   "string"  core type → "string"
  *   "json"    core type → "json-array" for enumOptions; "json-value-with-fallback" for const
  */
 export const TAG_ARGUMENT_FAMILIES = {
@@ -102,7 +102,7 @@ export const TAG_ARGUMENT_FAMILIES = {
   minItems: "length",
   maxItems: "length",
   uniqueItems: "boolean-marker",
-  pattern: "string-opaque",
+  pattern: "string",
   enumOptions: "json-array",
   const: "json-value-with-fallback",
 } as const satisfies Record<keyof typeof BUILTIN_CONSTRAINT_DEFINITIONS, TagFamily>;
@@ -179,15 +179,15 @@ function parsePatternArgument(rawArgumentText: string): TagArgumentParseResult {
  * synthetic-checker retirement plan §1.
  *
  * @param tagName - normalized tag name (no leading "@")
- * @param _rawArgumentText - argument text AFTER parseTagSyntax has stripped
- *                           any path-target prefix (i.e. "effectiveText")
+ * @param rawArgumentText - argument text AFTER parseTagSyntax has stripped
+ *                          any path-target prefix (i.e. "effectiveText")
  * @param _lowering - build vs snapshot. Phase 1 implementations do not use
  *                    this; the parameter is accepted for forward-compatibility
  *                    with Phase 2/3 consumer wiring.
  */
 export function parseTagArgument(
   tagName: string,
-  _rawArgumentText: string,
+  rawArgumentText: string,
   _lowering: TagArgumentLowering,
 ): TagArgumentParseResult {
   // Guard against prototype-pollution: names like "toString", "constructor", or
@@ -216,9 +216,9 @@ export function parseTagArgument(
     case "length":
       return throwNotImplemented(family);
     case "boolean-marker":
-      return parseUniqueItemsArgument(_rawArgumentText);
-    case "string-opaque":
-      return parsePatternArgument(_rawArgumentText);
+      return parseUniqueItemsArgument(rawArgumentText);
+    case "string":
+      return parsePatternArgument(rawArgumentText);
     case "json-array":
       return throwNotImplemented(family);
     case "json-value-with-fallback":


### PR DESCRIPTION
## Summary

Phase 1 Slice B of the synthetic-checker retirement. Fills in the `throwNotImplemented` sites in `tag-argument-parser.ts` for two families:

- **`@uniqueItems` (boolean-marker)**: empty or `"true"` → marker; anything else → INVALID
- **`@pattern` (string-opaque)**: opaque pass-through (no regex compile); empty → MISSING

## Test plan

- [x] `pnpm --filter @formspec/analysis run build` — green
- [x] `pnpm --filter @formspec/analysis run test` — 24 tests in tag-argument-parser.test.ts pass (was 2 after Slice 0)
- [x] `pnpm run lint` — clean

## Refactor-plan reference

- docs/refactors/synthetic-checker-retirement.md §1.6, §3, §6 risk 2 (no regex compile)