### PR TITLE
refactor(analysis): numeric + length family parsers (Phase 1 Slice A)

### DIFF
--- a/.changeset/phase-1-slice-a-numeric-length.md
+++ b/.changeset/phase-1-slice-a-numeric-length.md
@@ -1,0 +1,19 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Implement numeric + length family argument parsers (Phase 1 Slice A)
+
+Fills in the two `throw throwNotImplemented` sites in tag-argument-parser.ts
+for the numeric (`@minimum`, `@maximum`, `@exclusiveMinimum`,
+`@exclusiveMaximum`, `@multipleOf`) and length (`@minLength`, `@maxLength`,
+`@minItems`, `@maxItems`) constraint-tag families. Pins current behavior
+for `Infinity`/`NaN`/non-integer values per §3 of the retirement plan. No
+consumer wiring — `tsdoc-parser.ts` and `file-snapshots.ts` keep calling
+the synthetic path.

--- a/packages/analysis/src/__tests__/tag-argument-parser.test.ts
+++ b/packages/analysis/src/__tests__/tag-argument-parser.test.ts
@@ -147,6 +147,30 @@ describe("parseTagArgument", () => {
         expectNumericValue("minimum", "NaN", NaN);
       });
 
+      it("accepts -0 (pins current behavior — Object.is distinguishes -0 from +0)", () => {
+        const result = parseTagArgument("minimum", "-0", "build");
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value.kind).toBe("number");
+          if (result.value.kind === "number") {
+            // Object.is distinguishes -0 from +0; Number("-0") === -0.
+            expect(Object.is(result.value.value, -0)).toBe(true);
+          }
+        }
+      });
+
+      it("accepts .5 (leading-decimal shorthand for 0.5)", () => {
+        expectNumericValue("minimum", ".5", 0.5);
+      });
+
+      it("accepts 5. (trailing-decimal shorthand for 5)", () => {
+        expectNumericValue("minimum", "5.", 5);
+      });
+
+      it("accepts valid small scientific notation (1e-10)", () => {
+        expectNumericValue("minimum", "1e-10", 1e-10);
+      });
+
       it("returns MISSING_TAG_ARGUMENT for empty string", () => {
         expectMissingArgument("minimum", "");
       });
@@ -161,6 +185,39 @@ describe("parseTagArgument", () => {
 
       it("returns INVALID_TAG_ARGUMENT for numeric text with invalid suffix", () => {
         expectInvalidArgument("minimum", "10x");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for hex literal (0x10 must not silently become 16)", () => {
+        // Regression: Number("0x10") === 16, but @minimum 0x10 is not TSDoc-idiomatic.
+        expectInvalidArgument("minimum", "0x10");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for binary literal (0b10 must not silently become 2)", () => {
+        expectInvalidArgument("minimum", "0b10");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for octal literal (0o10 must not silently become 8)", () => {
+        expectInvalidArgument("minimum", "0o10");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for lowercase 'infinity' (case-sensitive; only 'Infinity' is accepted)", () => {
+        // Pins case-sensitivity: only the exact identifier "Infinity" is accepted.
+        expectInvalidArgument("minimum", "infinity");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for lowercase 'nan' (case-sensitive; only 'NaN' is accepted)", () => {
+        expectInvalidArgument("minimum", "nan");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for scientific overflow (1e400 overflows to Infinity)", () => {
+        // Only the explicit "Infinity" identifier is accepted; decimal overflow is rejected.
+        const result = parseTagArgument("minimum", "1e400", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+          expect(result.diagnostic.message).toMatch(/^Expected /);
+          expect(result.diagnostic.message).toContain("overflows to Infinity");
+        }
       });
 
       it("includes tag name in INVALID_TAG_ARGUMENT message", () => {

--- a/packages/analysis/src/__tests__/tag-argument-parser.test.ts
+++ b/packages/analysis/src/__tests__/tag-argument-parser.test.ts
@@ -1,10 +1,66 @@
 import { describe, expect, it } from "vitest";
 import { BUILTIN_CONSTRAINT_DEFINITIONS } from "@formspec/core/internals";
 import {
+  type TagArgumentLowering,
   parseTagArgument,
   TAG_ARGUMENT_FAMILIES,
   type TagArgumentValue,
 } from "../tag-argument-parser.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers (local — keep in this file, not promoted to a shared helper)
+// ---------------------------------------------------------------------------
+
+/**
+ * Asserts that parseTagArgument returns `{ ok: true, kind: "number", value }`.
+ * Uses `Number.isNaN` comparison for NaN values since `NaN !== NaN`.
+ */
+function expectNumericValue(tag: string, text: string, expectedValue: number): void {
+  const result = parseTagArgument(tag, text, "build");
+  expect(result.ok, `Expected ok:true for @${tag} "${text}"`).toBe(true);
+  if (result.ok) {
+    expect(result.value.kind).toBe("number");
+    if (result.value.kind === "number") {
+      if (Number.isNaN(expectedValue)) {
+        expect(Number.isNaN(result.value.value), "Expected NaN value").toBe(true);
+      } else {
+        expect(result.value.value).toBe(expectedValue);
+      }
+    }
+  }
+}
+
+/**
+ * Asserts that parseTagArgument returns `{ ok: false, code: "MISSING_TAG_ARGUMENT" }`.
+ */
+function expectMissingArgument(tag: string, text: string): void {
+  const result = parseTagArgument(tag, text, "build");
+  expect(result.ok, `Expected ok:false for @${tag} "${text}"`).toBe(false);
+  if (!result.ok) {
+    expect(result.diagnostic.code).toBe("MISSING_TAG_ARGUMENT");
+    expect(result.diagnostic.message).toMatch(/^Expected /);
+    expect(result.diagnostic.message).toContain(`@${tag}`);
+  }
+}
+
+/**
+ * Asserts that parseTagArgument returns `{ ok: false, code: "INVALID_TAG_ARGUMENT" }`
+ * with a message that starts with "Expected " (required bridge convention for Phase 2/3
+ * consumer classifier per §1.7 of the retirement plan).
+ */
+function expectInvalidArgument(tag: string, text: string): void {
+  const result = parseTagArgument(tag, text, "build");
+  expect(result.ok, `Expected ok:false for @${tag} "${text}"`).toBe(false);
+  if (!result.ok) {
+    expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+    expect(result.diagnostic.message).toMatch(/^Expected /);
+    expect(result.diagnostic.message).toContain("numeric literal");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe("parseTagArgument", () => {
   describe("registry", () => {
@@ -52,12 +108,264 @@ describe("parseTagArgument", () => {
     });
   });
 
-  // Slice A owns these — tests land in Slice A.
+  // ---------------------------------------------------------------------------
+  // Slice A: numeric family
+  // ---------------------------------------------------------------------------
   describe("numeric family", () => {
-    it.todo("Slice A");
+    // Full battery on @minimum; abbreviated per-tag tests for the others.
+
+    describe("@minimum — full battery", () => {
+      it("parses a positive integer", () => {
+        expectNumericValue("minimum", "10", 10);
+      });
+
+      it("parses a positive float (integer erasure: no rejection)", () => {
+        // Per §1.6 of the retirement plan: integer erasure means Role C must NOT
+        // reject non-integer arguments. Rejecting is a Role D concern.
+        expectNumericValue("minimum", "10.5", 10.5);
+      });
+
+      it("parses a negative integer", () => {
+        expectNumericValue("minimum", "-5", -5);
+      });
+
+      it("parses zero", () => {
+        expectNumericValue("minimum", "0", 0);
+      });
+
+      it("accepts Infinity (pins §3 divergence behavior — snapshot path passes through)", () => {
+        expectNumericValue("minimum", "Infinity", Infinity);
+      });
+
+      it("accepts -Infinity", () => {
+        expectNumericValue("minimum", "-Infinity", -Infinity);
+      });
+
+      it("accepts NaN (pins §3 divergence behavior — snapshot path passes through)", () => {
+        // NaN !== NaN, so we cannot use expectNumericValue's toEqual branch here.
+        // The helper uses Number.isNaN internally for this case.
+        expectNumericValue("minimum", "NaN", NaN);
+      });
+
+      it("returns MISSING_TAG_ARGUMENT for empty string", () => {
+        expectMissingArgument("minimum", "");
+      });
+
+      it("returns MISSING_TAG_ARGUMENT for whitespace-only string", () => {
+        expectMissingArgument("minimum", "   ");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for alphabetic text", () => {
+        expectInvalidArgument("minimum", "hello");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for numeric text with invalid suffix", () => {
+        expectInvalidArgument("minimum", "10x");
+      });
+
+      it("includes tag name in INVALID_TAG_ARGUMENT message", () => {
+        const result = parseTagArgument("minimum", "hello", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.message).toContain("@minimum");
+        }
+      });
+
+      it("includes the bad text in INVALID_TAG_ARGUMENT message", () => {
+        const result = parseTagArgument("minimum", "hello", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.message).toContain('"hello"');
+        }
+      });
+    });
+
+    describe("@maximum — one positive + one negative (shared helper, tag name in message)", () => {
+      it("parses a valid number", () => {
+        expectNumericValue("maximum", "100", 100);
+      });
+
+      it("returns INVALID_TAG_ARGUMENT with correct tag name in message", () => {
+        const result = parseTagArgument("maximum", "bad", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+          expect(result.diagnostic.message).toContain("@maximum");
+        }
+      });
+    });
+
+    describe("@exclusiveMinimum", () => {
+      it("parses a valid number", () => {
+        expectNumericValue("exclusiveMinimum", "0.5", 0.5);
+      });
+
+      it("returns INVALID_TAG_ARGUMENT with correct tag name in message", () => {
+        const result = parseTagArgument("exclusiveMinimum", "bad", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+          expect(result.diagnostic.message).toContain("@exclusiveMinimum");
+        }
+      });
+    });
+
+    describe("@exclusiveMaximum", () => {
+      it("parses a valid number", () => {
+        expectNumericValue("exclusiveMaximum", "1000", 1000);
+      });
+
+      it("returns INVALID_TAG_ARGUMENT with correct tag name in message", () => {
+        const result = parseTagArgument("exclusiveMaximum", "bad", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+          expect(result.diagnostic.message).toContain("@exclusiveMaximum");
+        }
+      });
+    });
+
+    describe("@multipleOf", () => {
+      it("parses a valid number", () => {
+        expectNumericValue("multipleOf", "5", 5);
+      });
+
+      it("returns INVALID_TAG_ARGUMENT with correct tag name in message", () => {
+        const result = parseTagArgument("multipleOf", "bad", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+          expect(result.diagnostic.message).toContain("@multipleOf");
+        }
+      });
+    });
+
+    describe("lowering flag is a no-op in Phase 1", () => {
+      it("produces identical output for 'build' and 'snapshot' lowering", () => {
+        const buildResult = parseTagArgument("minimum", "42", "build");
+        const snapshotResult = parseTagArgument("minimum", "42", "snapshot");
+        expect(buildResult).toEqual(snapshotResult);
+      });
+
+      it("produces identical error for 'build' and 'snapshot' lowering on invalid input", () => {
+        const buildResult = parseTagArgument("minimum", "bad", "build");
+        const snapshotResult = parseTagArgument("minimum", "bad", "snapshot");
+        expect(buildResult).toEqual(snapshotResult);
+      });
+    });
   });
+
+  // ---------------------------------------------------------------------------
+  // Slice A: length family
+  // ---------------------------------------------------------------------------
   describe("length family", () => {
-    it.todo("Slice A");
+    // Full battery on @minLength; abbreviated per-tag tests for the others.
+
+    describe("@minLength — full battery", () => {
+      it("parses a positive integer", () => {
+        expectNumericValue("minLength", "1", 1);
+      });
+
+      it("parses zero", () => {
+        expectNumericValue("minLength", "0", 0);
+      });
+
+      it("parses a float — integer erasure, NOT rejected (Role D concern, not Role C)", () => {
+        // Key invariant from §1.6: integer erasure means @minLength 1.5 must
+        // return ok:true with value 1.5. The consumer may later cast to integer,
+        // but the parser must not reject it.
+        expectNumericValue("minLength", "1.5", 1.5);
+      });
+
+      it("accepts Infinity", () => {
+        expectNumericValue("minLength", "Infinity", Infinity);
+      });
+
+      it("accepts -Infinity", () => {
+        expectNumericValue("minLength", "-Infinity", -Infinity);
+      });
+
+      it("accepts NaN", () => {
+        expectNumericValue("minLength", "NaN", NaN);
+      });
+
+      it("returns MISSING_TAG_ARGUMENT for empty string", () => {
+        expectMissingArgument("minLength", "");
+      });
+
+      it("returns MISSING_TAG_ARGUMENT for whitespace-only string", () => {
+        expectMissingArgument("minLength", "   ");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for alphabetic text", () => {
+        expectInvalidArgument("minLength", "hello");
+      });
+
+      it("returns INVALID_TAG_ARGUMENT for numeric text with invalid suffix", () => {
+        expectInvalidArgument("minLength", "10x");
+      });
+
+      it("includes tag name in INVALID_TAG_ARGUMENT message", () => {
+        const result = parseTagArgument("minLength", "bad", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.message).toContain("@minLength");
+        }
+      });
+    });
+
+    describe("@maxLength", () => {
+      it("parses a valid number", () => {
+        expectNumericValue("maxLength", "255", 255);
+      });
+
+      it("returns INVALID_TAG_ARGUMENT with correct tag name in message", () => {
+        const result = parseTagArgument("maxLength", "bad", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+          expect(result.diagnostic.message).toContain("@maxLength");
+        }
+      });
+    });
+
+    describe("@minItems", () => {
+      it("parses a valid number", () => {
+        expectNumericValue("minItems", "2", 2);
+      });
+
+      it("returns INVALID_TAG_ARGUMENT with correct tag name in message", () => {
+        const result = parseTagArgument("minItems", "bad", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+          expect(result.diagnostic.message).toContain("@minItems");
+        }
+      });
+    });
+
+    describe("@maxItems", () => {
+      it("parses a valid number", () => {
+        expectNumericValue("maxItems", "10", 10);
+      });
+
+      it("returns INVALID_TAG_ARGUMENT with correct tag name in message", () => {
+        const result = parseTagArgument("maxItems", "bad", "build");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+          expect(result.diagnostic.message).toContain("@maxItems");
+        }
+      });
+    });
+
+    describe("lowering flag is a no-op in Phase 1", () => {
+      it("produces identical output for 'build' and 'snapshot' lowering", () => {
+        const buildResult = parseTagArgument("minLength", "5", "build");
+        const snapshotResult = parseTagArgument("minLength", "5", "snapshot");
+        expect(buildResult).toEqual(snapshotResult);
+      });
+    });
   });
 
   // Slice B owns these.
@@ -228,3 +536,5 @@ describe("parseTagArgument", () => {
 // Suppress unused-import lint for TagArgumentValue — it is imported here so
 // that Slices A/B/C can reference it in tests without adding a new import.
 type _TagArgumentValueUnused = TagArgumentValue;
+// Suppress unused-import lint for TagArgumentLowering.
+type _TagArgumentLoweringUnused = TagArgumentLowering;

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -148,7 +148,7 @@ function parseUniqueItemsArgument(rawArgumentText: string): TagArgumentParseResu
 }
 
 /**
- * Parses the argument for `@pattern` (string-opaque family).
+ * Parses the argument for `@pattern` (string family).
  *
  * Preserves current opaque-pass-through behavior per §3 of the retirement
  * plan: the raw text is trimmed and returned as-is. `new RegExp(text)` is
@@ -168,6 +168,67 @@ function parsePatternArgument(rawArgumentText: string): TagArgumentParseResult {
     };
   }
   return { ok: true, value: { kind: "string", value: trimmed } };
+}
+
+/**
+ * Parses a numeric argument for both the "numeric" and "length" families.
+ *
+ * Phase 1 semantics (per §3 of the retirement plan):
+ * - Empty/whitespace-only text → MISSING_TAG_ARGUMENT
+ * - `Infinity`, `-Infinity`, `NaN` identifiers → accepted as-is (pins current
+ *   snapshot-consumer behavior; build-consumer stringifies — divergence is
+ *   handled by `lowering` in Phase 2/3)
+ * - `Number(text) === NaN` (and text was not the literal "NaN") → INVALID_TAG_ARGUMENT
+ * - Otherwise → `{ kind: "number", value }` with the parsed number
+ *
+ * Integer erasure is preserved: `@minLength 1.5` returns `ok: true` with
+ * `value: 1.5`. Rejecting non-integer values is a Role D concern, not Role C.
+ *
+ * @param tagName - normalized tag name (no "@") — used only in error messages
+ * @param rawArgumentText - argument text, already stripped of path-target prefix
+ */
+function parseNumericArgument(
+  tagName: string,
+  rawArgumentText: string,
+): TagArgumentParseResult {
+  const text = rawArgumentText.trim();
+
+  if (text.length === 0) {
+    return {
+      ok: false,
+      diagnostic: {
+        code: TAG_ARGUMENT_DIAGNOSTIC_CODES.MISSING_TAG_ARGUMENT,
+        message: `Expected a numeric literal for @${tagName}.`,
+      },
+    };
+  }
+
+  // Pin current consumer behavior: Infinity, -Infinity, and NaN are accepted
+  // as valid numeric arguments. The synthetic snapshot path passes these
+  // identifiers through as-is. See §3 "Tie-break Infinity/NaN" and §9.3 #16.
+  if (text === "Infinity") {
+    return { ok: true, value: { kind: "number", value: Infinity } };
+  }
+  if (text === "-Infinity") {
+    return { ok: true, value: { kind: "number", value: -Infinity } };
+  }
+  if (text === "NaN") {
+    return { ok: true, value: { kind: "number", value: NaN } };
+  }
+
+  const value = Number(text);
+
+  if (Number.isNaN(value)) {
+    return {
+      ok: false,
+      diagnostic: {
+        code: TAG_ARGUMENT_DIAGNOSTIC_CODES.INVALID_TAG_ARGUMENT,
+        message: `Expected a numeric literal for @${tagName}, got "${text}".`,
+      },
+    };
+  }
+
+  return { ok: true, value: { kind: "number", value } };
 }
 
 // ---------------------------------------------------------------------------
@@ -212,9 +273,13 @@ export function parseTagArgument(
   // handled. Slices A, B, C replace the throwNotImplemented calls.
   switch (family) {
     case "numeric":
-      return throwNotImplemented(family);
+      // Numeric constraint tags: @minimum, @maximum, @exclusiveMinimum,
+      // @exclusiveMaximum, @multipleOf
+      return parseNumericArgument(tagName, rawArgumentText);
     case "length":
-      return throwNotImplemented(family);
+      // Length/count constraint tags: @minLength, @maxLength, @minItems, @maxItems
+      // Same parse rule as numeric; Phase 2/3 may diverge them if needed.
+      return parseNumericArgument(tagName, rawArgumentText);
     case "boolean-marker":
       return parseUniqueItemsArgument(rawArgumentText);
     case "string":

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -171,6 +171,16 @@ function parsePatternArgument(rawArgumentText: string): TagArgumentParseResult {
 }
 
 /**
+ * Matches decimal numeric literals only: optional sign, decimal digits, optional
+ * fractional part, optional scientific exponent. Does NOT match hex (`0x`),
+ * binary (`0b`), octal (`0o`), or any other non-decimal form.
+ *
+ * Used as a pre-check in {@link parseNumericArgument} to prevent `Number()`
+ * from silently accepting non-TSDoc-idiomatic forms like `0x10` → `16`.
+ */
+const DECIMAL_PATTERN = /^-?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/;
+
+/**
  * Parses a numeric argument for both the "numeric" and "length" families.
  *
  * Phase 1 semantics (per §3 of the retirement plan):
@@ -178,18 +188,30 @@ function parsePatternArgument(rawArgumentText: string): TagArgumentParseResult {
  * - `Infinity`, `-Infinity`, `NaN` identifiers → accepted as-is (pins current
  *   snapshot-consumer behavior; build-consumer stringifies — divergence is
  *   handled by `lowering` in Phase 2/3)
+ * - Non-decimal numeric forms (hex `0x`, binary `0b`, octal `0o`) → INVALID
+ * - Scientific overflow (e.g. `1e400` → Infinity) → INVALID (only the explicit
+ *   `Infinity` identifier, not overflow, is accepted)
  * - `Number(text) === NaN` (and text was not the literal "NaN") → INVALID_TAG_ARGUMENT
  * - Otherwise → `{ kind: "number", value }` with the parsed number
  *
  * Integer erasure is preserved: `@minLength 1.5` returns `ok: true` with
  * `value: 1.5`. Rejecting non-integer values is a Role D concern, not Role C.
  *
- * @param tagName - normalized tag name (no "@") — used only in error messages
+ * The `family` and `_lowering` parameters are unused in Phase 1 but are
+ * accepted here for forward-compatibility with Phase 2/3 divergence wiring.
+ *
+ * @param tagName - normalized tag name (no "@"), typed as a known registry key
  * @param rawArgumentText - argument text, already stripped of path-target prefix
+ * @param _family - "numeric" or "length"; reserved for Phase 2/3 message divergence
+ *   (rename to `family` when Phase 2/3 diverges error messages between families)
+ * @param _lowering - build vs snapshot; reserved for Phase 2/3 consumer wiring
  */
+// TODO Phase 2/5: consolidate numeric parsing with tag-value-parser.ts
 function parseNumericArgument(
-  tagName: string,
+  tagName: keyof typeof TAG_ARGUMENT_FAMILIES,
   rawArgumentText: string,
+  _family: "numeric" | "length",
+  _lowering: TagArgumentLowering
 ): TagArgumentParseResult {
   const text = rawArgumentText.trim();
 
@@ -216,14 +238,30 @@ function parseNumericArgument(
     return { ok: true, value: { kind: "number", value: NaN } };
   }
 
-  const value = Number(text);
-
-  if (Number.isNaN(value)) {
+  // Reject non-decimal numeric literals (hex, binary, octal) and any other
+  // non-TSDoc-idiomatic form that `Number()` would silently accept.
+  // The explicit `Infinity`/`-Infinity`/`NaN` identifiers are handled above.
+  if (!DECIMAL_PATTERN.test(text)) {
     return {
       ok: false,
       diagnostic: {
         code: TAG_ARGUMENT_DIAGNOSTIC_CODES.INVALID_TAG_ARGUMENT,
         message: `Expected a numeric literal for @${tagName}, got "${text}".`,
+      },
+    };
+  }
+
+  const value = Number(text);
+
+  // A decimal literal that overflows to Infinity (e.g. `1e400`) is not a valid
+  // TSDoc constraint argument. Only the explicit `Infinity` identifier (handled
+  // above) is accepted.
+  if (!isFinite(value)) {
+    return {
+      ok: false,
+      diagnostic: {
+        code: TAG_ARGUMENT_DIAGNOSTIC_CODES.INVALID_TAG_ARGUMENT,
+        message: `Expected a finite numeric literal for @${tagName}, got ${text} (overflows to Infinity).`,
       },
     };
   }
@@ -249,7 +287,7 @@ function parseNumericArgument(
 export function parseTagArgument(
   tagName: string,
   rawArgumentText: string,
-  _lowering: TagArgumentLowering,
+  _lowering: TagArgumentLowering
 ): TagArgumentParseResult {
   // Guard against prototype-pollution: names like "toString", "constructor", or
   // "__proto__" exist on every plain object's prototype chain and would bypass
@@ -273,13 +311,22 @@ export function parseTagArgument(
   // handled. Slices A, B, C replace the throwNotImplemented calls.
   switch (family) {
     case "numeric":
-      // Numeric constraint tags: @minimum, @maximum, @exclusiveMinimum,
-      // @exclusiveMaximum, @multipleOf
-      return parseNumericArgument(tagName, rawArgumentText);
+      // Cast is safe: Object.hasOwn guard above confirmed tagName ∈ TAG_ARGUMENT_FAMILIES.
+      return parseNumericArgument(
+        tagName as keyof typeof TAG_ARGUMENT_FAMILIES,
+        rawArgumentText,
+        "numeric",
+        _lowering
+      );
     case "length":
-      // Length/count constraint tags: @minLength, @maxLength, @minItems, @maxItems
       // Same parse rule as numeric; Phase 2/3 may diverge them if needed.
-      return parseNumericArgument(tagName, rawArgumentText);
+      // Cast is safe: same Object.hasOwn guard as the "numeric" arm.
+      return parseNumericArgument(
+        tagName as keyof typeof TAG_ARGUMENT_FAMILIES,
+        rawArgumentText,
+        "length",
+        _lowering
+      );
     case "boolean-marker":
       return parseUniqueItemsArgument(rawArgumentText);
     case "string":


### PR DESCRIPTION
## Summary

Phase 1 Slice A of the synthetic-checker retirement. Fills in the `throwNotImplemented` sites in `tag-argument-parser.ts` for two families that share identical parse rules today:

- **Numeric**: `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, `@multipleOf`
- **Length**: `@minLength`, `@maxLength`, `@minItems`, `@maxItems`

Rules pinned:
- Accepts `Infinity`/`-Infinity`/`NaN` as numeric identifiers (per §3 of the refactor plan — pinning current behavior; divergence normalization is Phase 2/3 work)
- No integer-ness check (integer erasure is Role D, not Role C) — `@minLength 1.5` produces `{ kind: "number", value: 1.5 }`
- Invalid arguments produce `INVALID_TAG_ARGUMENT` diagnostics whose messages start with "Expected " so the current `file-snapshots.ts` classifier stays valid when consumer wiring lands in Phase 2/3

## Test plan

- [x] `pnpm --filter @formspec/analysis run build` — green
- [x] `pnpm --filter @formspec/analysis run test` — all green
- [x] `pnpm run lint` — clean

## Refactor-plan reference

- docs/refactors/synthetic-checker-retirement.md §1.6, §3