### PR TITLE
feat(build): add smart-size enum serialization

### DIFF
--- a/.changeset/real-singers-battle.md
+++ b/.changeset/real-singers-battle.md
@@ -1,0 +1,10 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/config": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"formspec": patch
+---
+
+Add `enumSerialization: "smart-size"` for compact enum output that preserves distinct labels only when needed.

--- a/e2e/tests/cli-subprocess.test.ts
+++ b/e2e/tests/cli-subprocess.test.ts
@@ -191,6 +191,38 @@ export const ProductConfigForm = formspec(
       expect(schema.$defs?.["PlanStatus"]?.["enum"]).toBeUndefined();
     });
 
+    it("emits smart-size oneOf enum schemas when labels would otherwise be lost", () => {
+      const fixturePath = resolveFixture("tsdoc-class", "parity-plan-status.ts");
+      const outDir = path.join(tempDir, "smart-size-enums");
+      const result = runCli([
+        "generate",
+        fixturePath,
+        "Subscription",
+        "--enum-serialization",
+        "smart-size",
+        "-o",
+        outDir,
+      ]);
+
+      expect(result.exitCode).toBe(0);
+
+      const schemaFile = findSchemaFile(outDir, "schema.json");
+      expect(schemaFile).toBeDefined();
+      if (!schemaFile) throw new Error("schema.json not found");
+
+      const schema = readJson(schemaFile) as {
+        $defs?: Record<string, Record<string, unknown>>;
+      };
+      expect(schema.$defs?.["PlanStatus"]).toMatchObject({
+        oneOf: [
+          { const: "active", title: "Active" },
+          { const: "paused", title: "Paused" },
+          { const: "cancelled", title: "Cancelled" },
+        ],
+      });
+      expect(schema.$defs?.["PlanStatus"]?.["enum"]).toBeUndefined();
+    });
+
     it("rejects invalid enum serialization values", () => {
       const fixturePath = resolveFixture("tsdoc-class", "parity-plan-status.ts");
       const result = runCli([
@@ -205,7 +237,7 @@ export const ProductConfigForm = formspec(
 
       expect(result.exitCode).not.toBe(0);
       const output = result.stdout + result.stderr;
-      expect(output).toContain('--enum-serialization must be "enum" or "oneOf"');
+      expect(output).toContain('--enum-serialization must be "enum", "oneOf", or "smart-size"');
     });
   });
 

--- a/packages/build/api-report/build.alpha.api.md
+++ b/packages/build/api-report/build.alpha.api.md
@@ -183,7 +183,7 @@ export { FormSpec }
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition_2[];
     readonly metadata?: MetadataPolicyInput_2;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;
@@ -210,7 +210,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 
 // @public
 export interface GenerateJsonSchemaOptions {
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
@@ -540,7 +540,7 @@ export interface StaticSchemaGenerationOptions {
     readonly configPath?: string | undefined;
     readonly discriminator?: DiscriminatorResolutionOptions | undefined;
     // @deprecated
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     // @deprecated
     readonly extensionRegistry?: ExtensionRegistry | undefined;
     // @deprecated

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -184,7 +184,7 @@ export { FormSpec }
 export interface FormSpecConfig {
     // Warning: (ae-forgotten-export) The symbol "ConstraintConfig" needs to be exported by the entry point index.d.ts
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     // Warning: (ae-forgotten-export) The symbol "ExtensionDefinition_2" needs to be exported by the entry point index.d.ts
     readonly extensions?: readonly ExtensionDefinition_2[];
     // Warning: (ae-forgotten-export) The symbol "MetadataPolicyInput_2" needs to be exported by the entry point index.d.ts
@@ -214,7 +214,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 
 // @public
 export interface GenerateJsonSchemaOptions {
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
@@ -544,7 +544,7 @@ export interface StaticSchemaGenerationOptions {
     readonly configPath?: string | undefined;
     readonly discriminator?: DiscriminatorResolutionOptions | undefined;
     // @deprecated
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     // @deprecated
     readonly extensionRegistry?: ExtensionRegistry | undefined;
     // @deprecated

--- a/packages/build/api-report/build.beta.api.md
+++ b/packages/build/api-report/build.beta.api.md
@@ -183,7 +183,7 @@ export { FormSpec }
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition_2[];
     readonly metadata?: MetadataPolicyInput_2;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;
@@ -210,7 +210,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 
 // @public
 export interface GenerateJsonSchemaOptions {
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
@@ -540,7 +540,7 @@ export interface StaticSchemaGenerationOptions {
     readonly configPath?: string | undefined;
     readonly discriminator?: DiscriminatorResolutionOptions | undefined;
     // @deprecated
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     // @deprecated
     readonly extensionRegistry?: ExtensionRegistry | undefined;
     // @deprecated

--- a/packages/build/api-report/build.public.api.md
+++ b/packages/build/api-report/build.public.api.md
@@ -183,7 +183,7 @@ export { FormSpec }
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition_2[];
     readonly metadata?: MetadataPolicyInput_2;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;
@@ -210,7 +210,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 
 // @public
 export interface GenerateJsonSchemaOptions {
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;
@@ -540,7 +540,7 @@ export interface StaticSchemaGenerationOptions {
     readonly configPath?: string | undefined;
     readonly discriminator?: DiscriminatorResolutionOptions | undefined;
     // @deprecated
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     // @deprecated
     readonly extensionRegistry?: ExtensionRegistry | undefined;
     // @deprecated

--- a/packages/build/src/__tests__/cli.test.ts
+++ b/packages/build/src/__tests__/cli.test.ts
@@ -113,7 +113,7 @@ describe("CLI", () => {
       expect(result.stdout).toContain("--enum-serialization requires a value");
     });
 
-    it('should fail when --enum-serialization is not "enum" or "oneOf"', () => {
+    it('should fail when --enum-serialization is not "enum", "oneOf", or "smart-size"', () => {
       const formFile = createFormFile(
         "form.js",
         `
@@ -122,7 +122,9 @@ describe("CLI", () => {
       );
       const result = runCli([formFile, "--enum-serialization", "invalid"]);
       expect(result.exitCode).not.toBe(0);
-      expect(result.stdout).toContain('--enum-serialization must be "enum" or "oneOf"');
+      expect(result.stdout).toContain(
+        '--enum-serialization must be "enum", "oneOf", or "smart-size"'
+      );
     });
   });
 
@@ -284,6 +286,44 @@ describe("CLI", () => {
 
       const schema = JSON.parse(
         fs.readFileSync(path.join(outDir, "form-enum-schema.json"), "utf-8")
+      ) as Record<string, { oneOf?: unknown }>;
+      const properties = schema["properties"] as Record<string, unknown>;
+
+      expect(properties["status"]).toEqual({
+        oneOf: [
+          { const: "draft", title: "Draft" },
+          { const: "sent", title: "Sent to Customer" },
+        ],
+      });
+    });
+
+    it("should support smart-size enum serialization", () => {
+      const formFile = createFormFile(
+        "form-enum-smart-size.js",
+        `
+        export default {
+          elements: [
+            {
+              _type: "field",
+              _field: "enum",
+              name: "status",
+              options: [
+                { id: "draft", label: "Draft" },
+                { id: "sent", label: "Sent to Customer" }
+              ]
+            }
+          ]
+        };
+      `
+      );
+
+      const outDir = path.join(tempDir, "out-smart-size");
+      const result = runCli([formFile, "-o", outDir, "--enum-serialization", "smart-size"]);
+
+      expect(result.exitCode).toBe(0);
+
+      const schema = JSON.parse(
+        fs.readFileSync(path.join(outDir, "form-enum-smart-size-schema.json"), "utf-8")
       ) as Record<string, { oneOf?: unknown }>;
       const properties = schema["properties"] as Record<string, unknown>;
 

--- a/packages/build/src/__tests__/generate-schemas-config.test.ts
+++ b/packages/build/src/__tests__/generate-schemas-config.test.ts
@@ -125,6 +125,47 @@ describe("generateSchemas with FormSpecConfig", () => {
     }
   });
 
+  it("resolves smart-size enumSerialization from config", () => {
+    const filePath = writeTempSource(`
+      export type PlanStatus = "draft" | "sent";
+
+      export interface InvoiceModel {
+        status: PlanStatus;
+      }
+    `);
+
+    try {
+      const config: FormSpecConfig = {
+        enumSerialization: "smart-size",
+        metadata: {
+          enumMember: {
+            displayName: {
+              mode: "infer-if-missing",
+              infer: ({ logicalName }) => (logicalName === "draft" ? "Draft" : logicalName),
+            },
+          },
+        },
+      };
+
+      const result = generateSchemas({
+        filePath,
+        typeName: "InvoiceModel",
+        config,
+        errorReporting: "throw",
+      });
+
+      expect(result.jsonSchema.$defs?.["PlanStatus"]).toMatchObject({
+        oneOf: [
+          { const: "draft", title: "Draft" },
+          { const: "sent" },
+        ],
+      });
+      expect(result.jsonSchema.$defs?.["PlanStatus"]).not.toHaveProperty("enum");
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
   it("resolves metadata from config", () => {
     const filePath = writeTempSource(`
       export interface UserForm {

--- a/packages/build/src/__tests__/generator.test.ts
+++ b/packages/build/src/__tests__/generator.test.ts
@@ -60,6 +60,29 @@ describe("generateJsonSchema", () => {
     });
   });
 
+  it("should support smart-size enum serialization for distinct option labels", () => {
+    const form = formspec(
+      field.enum(
+        "priority",
+        [
+          { id: "low", label: "Low Priority" },
+          { id: "high", label: "High Priority" },
+        ] as const,
+        { label: "Priority" }
+      )
+    );
+
+    const schema = generateJsonSchema(form, { enumSerialization: "smart-size" });
+
+    expect(schema.properties?.["priority"]).toEqual({
+      title: "Priority",
+      oneOf: [
+        { const: "low", title: "Low Priority" },
+        { const: "high", title: "High Priority" },
+      ],
+    });
+  });
+
   it("should handle required fields", () => {
     const form = formspec(field.text("name", { required: true }), field.text("optional"));
 

--- a/packages/build/src/__tests__/ir-json-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-json-schema-generator.test.ts
@@ -596,6 +596,17 @@ describe("generateJsonSchemaFromIR", () => {
       });
     });
 
+    it("throws when enumSerialization is invalid at runtime", () => {
+      const ir = makeIR([]);
+      const invalidOptions = {
+        enumSerialization: "invalid",
+      } as unknown as Parameters<typeof generateJsonSchemaFromIR>[1];
+
+      expect(() => generateJsonSchemaFromIR(ir, invalidOptions)).toThrow(
+        'Invalid enumSerialization "invalid". Expected "enum", "oneOf", or "smart-size".'
+      );
+    });
+
     it("uses the configured vendorPrefix for the display-name extension", () => {
       const ir = makeIR([
         makeField("status", {

--- a/packages/build/src/__tests__/ir-json-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-json-schema-generator.test.ts
@@ -557,6 +557,45 @@ describe("generateJsonSchemaFromIR", () => {
       },
     );
 
+    it("uses compact enum serialization in smart-size mode when titles would be redundant", () => {
+      const ir = makeIR([
+        makeField("status", {
+          kind: "enum",
+          members: [
+            { value: "draft", displayName: "draft" },
+            { value: "sent" },
+          ],
+        }),
+      ]);
+      const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "smart-size" });
+      const prop = (schema.properties as Record<string, unknown>)["status"];
+
+      expect(prop).toEqual({
+        enum: ["draft", "sent"],
+      });
+    });
+
+    it("uses oneOf serialization in smart-size mode when any title is distinct", () => {
+      const ir = makeIR([
+        makeField("status", {
+          kind: "enum",
+          members: [
+            { value: "draft", displayName: "Draft" },
+            { value: "sent" },
+          ],
+        }),
+      ]);
+      const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "smart-size" });
+      const prop = (schema.properties as Record<string, unknown>)["status"];
+
+      expect(prop).toEqual({
+        oneOf: [
+          { const: "draft", title: "Draft" },
+          { const: "sent" },
+        ],
+      });
+    });
+
     it("uses the configured vendorPrefix for the display-name extension", () => {
       const ir = makeIR([
         makeField("status", {

--- a/packages/build/src/__tests__/write-schemas.test.ts
+++ b/packages/build/src/__tests__/write-schemas.test.ts
@@ -129,6 +129,35 @@ describe("writeSchemas", () => {
       expect(statusProperty?.enum).toEqual(["draft", "published", "archived"]);
     });
 
+    it("should support smart-size enum serialization", () => {
+      const form = formspec(
+        field.enum(
+          "status",
+          [
+            { id: "draft", label: "Draft" },
+            { id: "published", label: "Published" },
+          ] as const
+        )
+      );
+
+      const result = writeSchemas(form, {
+        outDir: tempDir,
+        name: "smart-size",
+        enumSerialization: "smart-size",
+      });
+
+      const jsonSchema = JSON.parse(
+        fs.readFileSync(result.jsonSchemaPath, "utf-8")
+      ) as JSONSchema7;
+
+      expect(jsonSchema.properties?.["status"]).toEqual({
+        oneOf: [
+          { const: "draft", title: "Draft" },
+          { const: "published", title: "Published" },
+        ],
+      });
+    });
+
     it("should handle forms with nested objects", () => {
       const form = formspec(field.object("address", field.text("street"), field.text("city")));
 

--- a/packages/build/src/cli.ts
+++ b/packages/build/src/cli.ts
@@ -24,7 +24,7 @@ interface CliOptions {
   inputFile: string;
   outDir: string;
   name: string;
-  enumSerialization: "enum" | "oneOf";
+  enumSerialization: "enum" | "oneOf" | "smart-size";
 }
 
 function printHelp(): void {
@@ -37,7 +37,7 @@ Usage:
 Options:
   -o, --out-dir <dir>   Output directory (default: ./generated)
   -n, --name <name>     Base name for output files (default: derived from input)
-  --enum-serialization <enum|oneOf>
+  --enum-serialization <enum|oneOf|smart-size>
                          Enum JSON Schema representation (default: enum)
   -h, --help            Show this help message
 
@@ -56,7 +56,7 @@ function parseArgs(args: string[]): CliOptions | null {
   const positional: string[] = [];
   let outDir = "./generated";
   let name = "";
-  let enumSerialization: "enum" | "oneOf" = "enum";
+  let enumSerialization: "enum" | "oneOf" | "smart-size" = "enum";
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -95,8 +95,14 @@ function parseArgs(args: string[]): CliOptions | null {
         console.error("Error: --enum-serialization requires a value");
         return null;
       }
-      if (nextArg !== "enum" && nextArg !== "oneOf") {
-        console.error('Error: --enum-serialization must be "enum" or "oneOf"');
+      if (
+        nextArg !== "enum" &&
+        nextArg !== "oneOf" &&
+        nextArg !== "smart-size"
+      ) {
+        console.error(
+          'Error: --enum-serialization must be "enum", "oneOf", or "smart-size"'
+        );
         return null;
       }
       enumSerialization = nextArg;

--- a/packages/build/src/generators/class-schema.ts
+++ b/packages/build/src/generators/class-schema.ts
@@ -233,7 +233,7 @@ export interface StaticSchemaGenerationOptions {
    * @defaultValue "enum"
    * @deprecated Provide a `FormSpecConfig` via the `config` option instead.
    */
-  readonly enumSerialization?: "enum" | "oneOf";
+  readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
   /**
    * Metadata resolution policy for static schema generation.
    * @deprecated Provide a `FormSpecConfig` via the `config` option instead.
@@ -730,7 +730,7 @@ function isMutableRegistry(reg: ExtensionRegistry): reg is MutableExtensionRegis
 export function resolveStaticOptions(options: StaticSchemaGenerationOptions): {
   extensionRegistry: ExtensionRegistry | undefined;
   vendorPrefix: string | undefined;
-  enumSerialization: "enum" | "oneOf" | undefined;
+  enumSerialization: "enum" | "oneOf" | "smart-size" | undefined;
   metadata: MetadataPolicyInput | undefined;
 } {
   // eslint-disable-next-line @typescript-eslint/no-deprecated -- migration bridge reads deprecated fields
@@ -758,7 +758,7 @@ export function resolveStaticOptions(options: StaticSchemaGenerationOptions): {
 function resolveOptions(options: StaticSchemaGenerationOptions): {
   extensionRegistry: MutableExtensionRegistry | undefined;
   vendorPrefix: string | undefined;
-  enumSerialization: "enum" | "oneOf" | undefined;
+  enumSerialization: "enum" | "oneOf" | "smart-size" | undefined;
   metadata: MetadataPolicyInput | undefined;
 } {
   const configRegistry =
@@ -832,7 +832,7 @@ function generateSchemasFromResolvedOptions(
   resolved: {
     extensionRegistry: MutableExtensionRegistry | undefined;
     vendorPrefix: string | undefined;
-    enumSerialization: "enum" | "oneOf" | undefined;
+    enumSerialization: "enum" | "oneOf" | "smart-size" | undefined;
     metadata: MetadataPolicyInput | undefined;
   },
   discriminator: DiscriminatorResolutionOptions | undefined

--- a/packages/build/src/json-schema/generator.ts
+++ b/packages/build/src/json-schema/generator.ts
@@ -28,7 +28,7 @@ export interface GenerateJsonSchemaOptions {
    * JSON Schema representation to use for static enums.
    * @defaultValue "enum"
    */
-  readonly enumSerialization?: "enum" | "oneOf";
+  readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
   /** Metadata resolution policy for chain DSL generation. */
   readonly metadata?: MetadataPolicyInput | undefined;
   /**

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -132,7 +132,7 @@ interface GeneratorContext {
   /** Vendor prefix passed through to extension toJsonSchema handlers. */
   readonly vendorPrefix: string;
   /** Selected JSON Schema representation for enum-like values. */
-  readonly enumSerialization: "enum" | "oneOf";
+  readonly enumSerialization: "enum" | "oneOf" | "smart-size";
 }
 
 /**
@@ -157,27 +157,26 @@ export interface GenerateJsonSchemaFromIROptions {
    * JSON Schema representation to use for static enums.
    * @defaultValue "enum"
    */
-  readonly enumSerialization?: "enum" | "oneOf" | undefined;
+  readonly enumSerialization?: "enum" | "oneOf" | "smart-size" | undefined;
 }
 
 function makeContext(options?: GenerateJsonSchemaFromIROptions): GeneratorContext {
   const vendorPrefix = options?.vendorPrefix ?? "x-formspec";
-  const rawEnumSerialization = options?.enumSerialization as string | undefined;
+  const enumSerialization = options?.enumSerialization ?? "enum";
   if (!vendorPrefix.startsWith("x-")) {
     throw new Error(
       `Invalid vendorPrefix "${vendorPrefix}". Extension JSON Schema keywords must start with "x-".`
     );
   }
   if (
-    rawEnumSerialization !== undefined &&
-    rawEnumSerialization !== "enum" &&
-    rawEnumSerialization !== "oneOf"
+    enumSerialization !== "enum" &&
+    enumSerialization !== "oneOf" &&
+    enumSerialization !== "smart-size"
   ) {
     throw new Error(
-      `Invalid enumSerialization "${rawEnumSerialization}". Expected "enum" or "oneOf".`
+      `Invalid enumSerialization "${enumSerialization}". Expected "enum", "oneOf", or "smart-size".`
     );
   }
-  const enumSerialization: GeneratorContext["enumSerialization"] = rawEnumSerialization ?? "enum";
 
   return {
     defs: {},
@@ -578,10 +577,15 @@ function generatePrimitiveType(type: PrimitiveTypeNode): JsonSchema2020 {
  * any member label is available. The `oneOf` mode emits per-member `const`
  * entries, and includes `title` only when the member has an explicit
  * `@displayName` that differs from the value — omitting redundant titles
- * such as `{ "const": "USD", "title": "USD" }` (#310).
+ * such as `{ "const": "USD", "title": "USD" }` (#310). `smart-size`
+ * chooses `oneOf` only when any effective title differs from the serialized
+ * enum value.
  */
 function generateEnumType(type: EnumTypeNode, ctx: GeneratorContext): JsonSchema2020 {
-  if (ctx.enumSerialization === "oneOf") {
+  if (
+    ctx.enumSerialization === "oneOf" ||
+    (ctx.enumSerialization === "smart-size" && shouldSerializeEnumAsOneOf(type))
+  ) {
     return {
       oneOf: type.members.map((m) => {
         const stringValue = String(m.value);
@@ -593,12 +597,27 @@ function generateEnumType(type: EnumTypeNode, ctx: GeneratorContext): JsonSchema
   }
 
   const schema: JsonSchema2020 = { enum: type.members.map((m) => m.value) };
+  if (ctx.enumSerialization === "smart-size") {
+    return schema;
+  }
+
   const displayNames = buildEnumDisplayNameExtension(type);
   if (displayNames !== undefined) {
     // Emit either no extension at all or a complete map for every member.
     schema[`${ctx.vendorPrefix}-display-names` as `x-${string}`] = displayNames;
   }
   return schema;
+}
+
+/**
+ * `smart-size` can stay compact when every visible title would only restate
+ * the enum value. Any distinct title requires `oneOf` so that label survives.
+ */
+function shouldSerializeEnumAsOneOf(type: EnumTypeNode): boolean {
+  return type.members.some((member) => {
+    const title = member.displayName ?? String(member.value);
+    return title !== String(member.value);
+  });
 }
 
 function buildEnumDisplayNameExtension(type: EnumTypeNode): Record<string, string> | undefined {

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -160,21 +160,32 @@ export interface GenerateJsonSchemaFromIROptions {
   readonly enumSerialization?: "enum" | "oneOf" | "smart-size" | undefined;
 }
 
+/**
+ * Normalizes enum serialization input so JavaScript callers still get a
+ * runtime validation error for unsupported values.
+ */
+function parseEnumSerialization(value: unknown): GeneratorContext["enumSerialization"] {
+  switch (value) {
+    case undefined:
+    case "enum":
+      return "enum";
+    case "oneOf":
+      return "oneOf";
+    case "smart-size":
+      return "smart-size";
+    default:
+      throw new Error(
+        `Invalid enumSerialization "${String(value)}". Expected "enum", "oneOf", or "smart-size".`
+      );
+  }
+}
+
 function makeContext(options?: GenerateJsonSchemaFromIROptions): GeneratorContext {
   const vendorPrefix = options?.vendorPrefix ?? "x-formspec";
-  const enumSerialization = options?.enumSerialization ?? "enum";
+  const enumSerialization = parseEnumSerialization(options?.enumSerialization);
   if (!vendorPrefix.startsWith("x-")) {
     throw new Error(
       `Invalid vendorPrefix "${vendorPrefix}". Extension JSON Schema keywords must start with "x-".`
-    );
-  }
-  if (
-    enumSerialization !== "enum" &&
-    enumSerialization !== "oneOf" &&
-    enumSerialization !== "smart-size"
-  ) {
-    throw new Error(
-      `Invalid enumSerialization "${enumSerialization}". Expected "enum", "oneOf", or "smart-size".`
     );
   }
 

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -141,6 +141,43 @@ describe("generators", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("threads smart-size enum serialization into static method schemas", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-method-smart-size-"));
+    const filePath = path.join(dir, "enum-methods.ts");
+    fs.writeFileSync(
+      filePath,
+      `
+      export class EnumMethods {
+        updateStatus(status: "draft" | "sent"): "draft" | "sent" {
+          return status;
+        }
+      }
+    `
+    );
+
+    try {
+      const ctx = createProgramContext(filePath);
+      const classDecl = findClassByName(ctx.sourceFile, "EnumMethods");
+      if (!classDecl) throw new Error("EnumMethods class not found");
+      const analysis = analyzeClassToIR(classDecl, ctx.checker, filePath);
+      const updateStatus = analysis.instanceMethods[0];
+      if (!updateStatus) throw new Error("updateStatus method not found");
+
+      const methodSchemas = generateMethodSchemas(updateStatus, ctx.checker, new Map(), {
+        enumSerialization: "smart-size",
+      });
+
+      expect(methodSchemas.params?.jsonSchema).toEqual({
+        enum: ["draft", "sent"],
+      });
+      expect(methodSchemas.returnType).toEqual({
+        enum: ["draft", "sent"],
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("isFormSpec", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -65,7 +65,7 @@ interface CliOptions {
   compiledPath: string | undefined;
   /** Explicit path to a formspec config file. */
   configPath: string | undefined;
-  enumSerialization: "enum" | "oneOf" | undefined;
+  enumSerialization: "enum" | "oneOf" | "smart-size" | undefined;
   /** Emit FormIR JSON alongside generated schemas. */
   emitIr: boolean;
   /** Run constraint validation only; do not write schema files. */
@@ -103,7 +103,7 @@ function parseArgs(args: string[]): CliOptions {
   let outDir = "./generated";
   let compiledPath: string | undefined;
   let configPath: string | undefined;
-  let enumSerialization: "enum" | "oneOf" | undefined;
+  let enumSerialization: "enum" | "oneOf" | "smart-size" | undefined;
   let emitIr = false;
   let validateOnly = false;
   let dryRun = false;
@@ -125,11 +125,15 @@ function parseArgs(args: string[]): CliOptions {
     } else if (arg === "--enum-serialization") {
       const nextArg = rest[++i];
       if (!nextArg) {
-        console.error('Error: --enum-serialization requires "enum" or "oneOf"');
+        console.error('Error: --enum-serialization requires "enum", "oneOf", or "smart-size"');
         process.exit(1);
       }
-      if (nextArg !== "enum" && nextArg !== "oneOf") {
-        console.error('Error: --enum-serialization must be "enum" or "oneOf"');
+      if (
+        nextArg !== "enum" &&
+        nextArg !== "oneOf" &&
+        nextArg !== "smart-size"
+      ) {
+        console.error('Error: --enum-serialization must be "enum", "oneOf", or "smart-size"');
         process.exit(1);
       }
       enumSerialization = nextArg;
@@ -204,7 +208,7 @@ OPTIONS:
   -o, --output <dir>    Output directory (default: ./generated)
   -c, --compiled <path> Path to compiled JS file (auto-detected if omitted)
   --config <path>       Path to formspec.config.ts (auto-discovered if omitted)
-  --enum-serialization <enum|oneOf>
+  --enum-serialization <enum|oneOf|smart-size>
                        Enum JSON Schema representation (default: enum, or from config)
   --emit-ir             Emit FormIR JSON alongside generated schemas
   --validate-only       Validate constraints only; do not write schema files
@@ -379,7 +383,7 @@ async function main(): Promise<void> {
   }
 
   // CLI flag overrides config; config overrides built-in default of "enum"
-  const enumSerialization: "enum" | "oneOf" =
+  const enumSerialization: "enum" | "oneOf" | "smart-size" =
     options.enumSerialization ?? formSpecConfig?.enumSerialization ?? "enum";
 
   console.log(`Generating schemas from: ${options.filePath}`);

--- a/packages/cli/src/runtime/formspec-loader.ts
+++ b/packages/cli/src/runtime/formspec-loader.ts
@@ -22,7 +22,7 @@ interface FormSpecLike {
 
 interface LoadFormSpecsOptions {
   /** JSON Schema representation to use for static enums. */
-  readonly enumSerialization?: "enum" | "oneOf" | undefined;
+  readonly enumSerialization?: "enum" | "oneOf" | "smart-size" | undefined;
 }
 
 /**

--- a/packages/config/api-report/config.alpha.api.md
+++ b/packages/config/api-report/config.alpha.api.md
@@ -160,7 +160,7 @@ export interface FormSpec<Elements extends readonly FormElement[]> {
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition[];
     readonly metadata?: MetadataPolicyInput;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;
@@ -170,7 +170,7 @@ export interface FormSpecConfig {
 // @public
 export interface FormSpecPackageOverride {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly metadata?: MetadataPolicyInput;
 }
 
@@ -314,7 +314,7 @@ export interface ResolvedConstraintConfig {
 // @public
 export interface ResolvedFormSpecConfig {
     readonly constraints: ResolvedConstraintConfig;
-    readonly enumSerialization: "enum" | "oneOf";
+    readonly enumSerialization: "enum" | "oneOf" | "smart-size";
     readonly extensions: readonly ExtensionDefinition[];
     readonly metadata: MetadataPolicyInput | undefined;
     readonly vendorPrefix: string;

--- a/packages/config/api-report/config.api.md
+++ b/packages/config/api-report/config.api.md
@@ -160,7 +160,7 @@ export interface FormSpec<Elements extends readonly FormElement[]> {
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     // Warning: (ae-forgotten-export) The symbol "ExtensionDefinition" needs to be exported by the entry point index.d.ts
     readonly extensions?: readonly ExtensionDefinition[];
     // Warning: (ae-forgotten-export) The symbol "MetadataPolicyInput" needs to be exported by the entry point index.d.ts
@@ -172,7 +172,7 @@ export interface FormSpecConfig {
 // @public
 export interface FormSpecPackageOverride {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly metadata?: MetadataPolicyInput;
 }
 
@@ -316,7 +316,7 @@ export interface ResolvedConstraintConfig {
 // @public
 export interface ResolvedFormSpecConfig {
     readonly constraints: ResolvedConstraintConfig;
-    readonly enumSerialization: "enum" | "oneOf";
+    readonly enumSerialization: "enum" | "oneOf" | "smart-size";
     readonly extensions: readonly ExtensionDefinition[];
     readonly metadata: MetadataPolicyInput | undefined;
     readonly vendorPrefix: string;

--- a/packages/config/api-report/config.beta.api.md
+++ b/packages/config/api-report/config.beta.api.md
@@ -160,7 +160,7 @@ export interface FormSpec<Elements extends readonly FormElement[]> {
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition[];
     readonly metadata?: MetadataPolicyInput;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;
@@ -170,7 +170,7 @@ export interface FormSpecConfig {
 // @public
 export interface FormSpecPackageOverride {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly metadata?: MetadataPolicyInput;
 }
 
@@ -314,7 +314,7 @@ export interface ResolvedConstraintConfig {
 // @public
 export interface ResolvedFormSpecConfig {
     readonly constraints: ResolvedConstraintConfig;
-    readonly enumSerialization: "enum" | "oneOf";
+    readonly enumSerialization: "enum" | "oneOf" | "smart-size";
     readonly extensions: readonly ExtensionDefinition[];
     readonly metadata: MetadataPolicyInput | undefined;
     readonly vendorPrefix: string;

--- a/packages/config/api-report/config.public.api.md
+++ b/packages/config/api-report/config.public.api.md
@@ -134,7 +134,7 @@ export interface FormSpec<Elements extends readonly FormElement[]> {
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition[];
     readonly metadata?: MetadataPolicyInput;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;
@@ -144,7 +144,7 @@ export interface FormSpecConfig {
 // @public
 export interface FormSpecPackageOverride {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly metadata?: MetadataPolicyInput;
 }
 
@@ -259,7 +259,7 @@ export interface ResolvedConstraintConfig {
 // @public
 export interface ResolvedFormSpecConfig {
     readonly constraints: ResolvedConstraintConfig;
-    readonly enumSerialization: "enum" | "oneOf";
+    readonly enumSerialization: "enum" | "oneOf" | "smart-size";
     readonly extensions: readonly ExtensionDefinition[];
     readonly metadata: MetadataPolicyInput | undefined;
     readonly vendorPrefix: string;

--- a/packages/config/src/__tests__/loader.test.ts
+++ b/packages/config/src/__tests__/loader.test.ts
@@ -74,6 +74,32 @@ export default defineFormSpecConfig({
       expect(result.config.constraints?.fieldTypes?.text).toBe("error");
     });
 
+    it("accepts smart-size enum serialization", async () => {
+      const dir = await createTempDir();
+      const filePath = join(dir, "formspec.config.ts");
+      await writeFile(filePath, `export default { enumSerialization: "smart-size" };`, "utf-8");
+
+      const result = await loadFormSpecConfig({ configPath: filePath });
+
+      expect(result.found).toBe(true);
+      if (!result.found) throw new Error("Expected found");
+      expect(result.config.enumSerialization).toBe("smart-size");
+    });
+
+    it("rejects invalid package override enum serialization", async () => {
+      const dir = await createTempDir();
+      const filePath = join(dir, "formspec.config.ts");
+      await writeFile(
+        filePath,
+        `export default { packages: { "packages/*": { enumSerialization: "invalid" } } };`,
+        "utf-8"
+      );
+
+      await expect(loadFormSpecConfig({ configPath: filePath })).rejects.toThrow(
+        /packages\["packages\/\*"\]\.enumSerialization/
+      );
+    });
+
     it("throws when configPath file does not exist", async () => {
       const dir = await createTempDir();
       const nonExistent = join(dir, "does-not-exist.ts");

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -170,14 +170,26 @@ function validateLoadedConfig(config: FormSpecConfig, filePath: string): void {
       `Invalid config at ${filePath}: "vendorPrefix" must be a string starting with "x-", got ${JSON.stringify(config.vendorPrefix)}`
     );
   }
-  const enumSerialization: unknown = config.enumSerialization;
-  if (
-    enumSerialization !== undefined &&
-    enumSerialization !== "enum" &&
-    enumSerialization !== "oneOf"
-  ) {
+  validateEnumSerializationValue(config.enumSerialization, "enumSerialization", filePath);
+  if (config.packages !== undefined) {
+    for (const [pattern, override] of Object.entries(config.packages)) {
+      validateEnumSerializationValue(
+        override.enumSerialization,
+        `packages[${JSON.stringify(pattern)}].enumSerialization`,
+        filePath
+      );
+    }
+  }
+}
+
+function validateEnumSerializationValue(
+  value: unknown,
+  label: string,
+  filePath: string
+): void {
+  if (value !== undefined && value !== "enum" && value !== "oneOf" && value !== "smart-size") {
     throw new Error(
-      `Invalid config at ${filePath}: "enumSerialization" must be "enum" or "oneOf", got ${JSON.stringify(config.enumSerialization)}`
+      `Invalid config at ${filePath}: "${label}" must be "enum", "oneOf", or "smart-size", got ${JSON.stringify(value)}`
     );
   }
 }

--- a/packages/config/src/resolve.ts
+++ b/packages/config/src/resolve.ts
@@ -22,7 +22,7 @@ export interface ResolvedFormSpecConfig {
   /** Resolved vendor prefix. */
   readonly vendorPrefix: string;
   /** Resolved enum serialization mode. */
-  readonly enumSerialization: "enum" | "oneOf";
+  readonly enumSerialization: "enum" | "oneOf" | "smart-size";
 }
 
 /**

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -241,11 +241,12 @@ export interface FormSpecConfig {
 
   /**
    * JSON Schema representation for static enums.
-   * - "enum": flat { "enum": ["a", "b"] }
-   * - "oneOf": { "oneOf": [{ "const": "a" }, ...] }
+   * - "enum": compact `enum` output, plus a display-name extension when labels exist
+   * - "oneOf": per-member `const` output, with `title` only for distinct labels
+   * - "smart-size": uses `enum` unless a distinct display label would be lost
    * @defaultValue "enum"
    */
-  readonly enumSerialization?: "enum" | "oneOf";
+  readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
 
   /**
    * Per-package configuration overrides for monorepos.
@@ -265,7 +266,7 @@ export interface FormSpecPackageOverride {
   /** Override constraint surface for this package. */
   readonly constraints?: ConstraintConfig;
   /** Override enum serialization for this package. */
-  readonly enumSerialization?: "enum" | "oneOf";
+  readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
   /** Override metadata policy for this package. */
   readonly metadata?: import("@formspec/core").MetadataPolicyInput;
 }

--- a/packages/eslint-plugin/api-report/eslint-plugin.alpha.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.alpha.api.md
@@ -59,7 +59,7 @@ export { ExplicitMetadataSource }
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition[];
     readonly metadata?: MetadataPolicyInput;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;

--- a/packages/eslint-plugin/api-report/eslint-plugin.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.api.md
@@ -60,7 +60,7 @@ export { ExplicitMetadataSource }
 export interface FormSpecConfig {
     // Warning: (ae-forgotten-export) The symbol "ConstraintConfig" needs to be exported by the entry point index.d.ts
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     // Warning: (ae-forgotten-export) The symbol "ExtensionDefinition" needs to be exported by the entry point index.d.ts
     readonly extensions?: readonly ExtensionDefinition[];
     // Warning: (ae-forgotten-export) The symbol "MetadataPolicyInput" needs to be exported by the entry point index.d.ts

--- a/packages/eslint-plugin/api-report/eslint-plugin.beta.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.beta.api.md
@@ -59,7 +59,7 @@ export { ExplicitMetadataSource }
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition[];
     readonly metadata?: MetadataPolicyInput;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;

--- a/packages/eslint-plugin/api-report/eslint-plugin.public.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.public.api.md
@@ -59,7 +59,7 @@ export { ExplicitMetadataSource }
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition[];
     readonly metadata?: MetadataPolicyInput;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;

--- a/packages/formspec/api-report/formspec.alpha.api.md
+++ b/packages/formspec/api-report/formspec.alpha.api.md
@@ -290,7 +290,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 
 // @public
 export interface GenerateJsonSchemaOptions {
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;

--- a/packages/formspec/api-report/formspec.api.md
+++ b/packages/formspec/api-report/formspec.api.md
@@ -290,7 +290,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 
 // @public
 export interface GenerateJsonSchemaOptions {
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;

--- a/packages/formspec/api-report/formspec.beta.api.md
+++ b/packages/formspec/api-report/formspec.beta.api.md
@@ -290,7 +290,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 
 // @public
 export interface GenerateJsonSchemaOptions {
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;

--- a/packages/formspec/api-report/formspec.public.api.md
+++ b/packages/formspec/api-report/formspec.public.api.md
@@ -290,7 +290,7 @@ export function generateJsonSchema<E extends readonly FormElement[]>(form: FormS
 
 // @public
 export interface GenerateJsonSchemaOptions {
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly logger?: LoggerLike | undefined;
     readonly metadata?: MetadataPolicyInput | undefined;
     readonly vendorPrefix?: string | undefined;

--- a/packages/language-server/api-report/language-server.alpha.api.md
+++ b/packages/language-server/api-report/language-server.alpha.api.md
@@ -67,7 +67,7 @@ export interface FormSpecAnalysisDiagnosticLocation {
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition_2[];
     readonly metadata?: MetadataPolicyInput;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;

--- a/packages/language-server/api-report/language-server.api.md
+++ b/packages/language-server/api-report/language-server.api.md
@@ -68,7 +68,7 @@ export interface FormSpecAnalysisDiagnosticLocation {
 export interface FormSpecConfig {
     // Warning: (ae-forgotten-export) The symbol "ConstraintConfig" needs to be exported by the entry point index.d.ts
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     // Warning: (ae-forgotten-export) The symbol "ExtensionDefinition_2" needs to be exported by the entry point index.d.ts
     readonly extensions?: readonly ExtensionDefinition_2[];
     // Warning: (ae-forgotten-export) The symbol "MetadataPolicyInput" needs to be exported by the entry point index.d.ts

--- a/packages/language-server/api-report/language-server.beta.api.md
+++ b/packages/language-server/api-report/language-server.beta.api.md
@@ -67,7 +67,7 @@ export interface FormSpecAnalysisDiagnosticLocation {
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition_2[];
     readonly metadata?: MetadataPolicyInput;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;

--- a/packages/language-server/api-report/language-server.public.api.md
+++ b/packages/language-server/api-report/language-server.public.api.md
@@ -67,7 +67,7 @@ export interface FormSpecAnalysisDiagnosticLocation {
 // @public
 export interface FormSpecConfig {
     readonly constraints?: ConstraintConfig;
-    readonly enumSerialization?: "enum" | "oneOf";
+    readonly enumSerialization?: "enum" | "oneOf" | "smart-size";
     readonly extensions?: readonly ExtensionDefinition_2[];
     readonly metadata?: MetadataPolicyInput;
     readonly packages?: Readonly<Record<string, FormSpecPackageOverride>>;


### PR DESCRIPTION
## Summary
- add `enumSerialization: \"smart-size\"` across build, config, and CLI surfaces
- serialize enums as compact `enum` output unless a distinct label would be lost, then fall back to `oneOf`
- cover the new mode in IR, build, config, CLI, and CLI subprocess tests and refresh affected API reports

## Test plan
- `pnpm --filter @formspec/core run build`
- `pnpm --filter @formspec/dsl run build`
- `pnpm --filter @formspec/config run build`
- `pnpm --filter @formspec/analysis run build`
- `pnpm --filter @formspec/runtime run build`
- `pnpm --filter @formspec/build run build`
- `pnpm --filter @formspec/cli run build`
- `pnpm --filter formspec run build`
- `pnpm --filter @formspec/eslint-plugin run build`
- `pnpm --filter @formspec/language-server run build`
- `pnpm --filter @formspec/config run typecheck`
- `pnpm --filter @formspec/build run typecheck`
- `pnpm --filter @formspec/cli run typecheck`
- `pnpm --filter @formspec/config exec vitest run src/__tests__/loader.test.ts`
- `pnpm --filter @formspec/build exec vitest run src/__tests__/ir-json-schema-generator.test.ts src/__tests__/generator.test.ts src/__tests__/generate-schemas-config.test.ts src/__tests__/cli.test.ts src/__tests__/write-schemas.test.ts`
- `pnpm --filter @formspec/cli exec vitest run src/__tests__/integration.test.ts`
- `pnpm --filter @formspec/e2e exec vitest run tests/cli-subprocess.test.ts`