### PR TITLE
fix(analysis): tighten Array.isArray narrowing in parseEnumOptionsArgument

### DIFF
--- a/.changeset/fix-enumoptions-array-narrowing.md
+++ b/.changeset/fix-enumoptions-array-narrowing.md
@@ -1,0 +1,15 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Tighten Array.isArray narrowing in parseEnumOptionsArgument (#345)
+
+Re-bind to `unknown[]` after `Array.isArray` so the `isJsonValue`
+predicate narrows soundly to `JsonValue[]` rather than relying on the
+`any` escape hatch. No behavior change.

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -342,7 +342,12 @@ function parseEnumOptionsArgument(rawArgumentText: string): TagArgumentParseResu
     };
   }
 
-  if (!parsed.every(isJsonValue)) {
+  // Re-bind to unknown[] so the isJsonValue predicate narrows soundly to
+  // JsonValue[] instead of relying on the any-typed Array.isArray narrowing
+  // (Array.isArray(x: unknown) narrows to any[], not unknown[]).
+  const arr: unknown[] = parsed;
+
+  if (!arr.every(isJsonValue)) {
     return {
       ok: false,
       diagnostic: {
@@ -354,7 +359,7 @@ function parseEnumOptionsArgument(rawArgumentText: string): TagArgumentParseResu
 
   return {
     ok: true,
-    value: { kind: "json-array", value: parsed },
+    value: { kind: "json-array", value: arr },
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #345.

- `Array.isArray(x: unknown)` narrows to `any[]`, not `unknown[]`, due to TypeScript's built-in overload. This means `.every(isJsonValue)` on the resulting array operated on `any[]`, bypassing the type predicate's narrowing guarantee.
- The fix re-binds the result to `const arr: unknown[]` immediately after the `Array.isArray` guard. `arr.every(isJsonValue)` then correctly narrows `arr` to `JsonValue[]` via the type predicate before the final `return`.
- No behavior change — this is a pure type-soundness improvement surfaced by Copilot review on #344.

## Test plan

- [ ] `pnpm --filter @formspec/analysis run build` — passes
- [ ] `pnpm --filter @formspec/analysis run test` — all 517 tests pass
- [ ] `pnpm exec eslint packages/analysis/src/` — no errors