### PR TITLE
refactor(build): wire typed argument parser into tsdoc-parser (Phase 2)

### DIFF
--- a/.changeset/phase-2-build-wiring.md
+++ b/.changeset/phase-2-build-wiring.md
@@ -1,0 +1,24 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Wire typed argument parser into the build consumer (Phase 2)
+
+Calls `parseTagArgument` inside `buildCompilerBackedConstraintDiagnostics`
+(tsdoc-parser.ts) so Role-C argument-literal validation runs before the
+synthetic TypeScript checker. Invalid arguments (hex literals, non-array
+`@enumOptions`, etc.) now produce `INVALID_TAG_ARGUMENT` diagnostics from
+the typed parser rather than `TYPE_MISMATCH` from the synthetic checker.
+
+Also normalises the `@minimum Infinity` / `@minimum NaN` build/snapshot
+divergence (§3): `renderSyntheticArgumentExpression` now passes these
+values through as TypeScript identifiers instead of JSON-quoted strings,
+so both consumers accept them without producing a diagnostic. Exports
+`parseTagArgument` and friends from `@formspec/analysis/internal` and
+adds `getTypedParserLogger` to the constraint-validator-logger surface.

--- a/packages/analysis/src/__tests__/parity-harness.test.ts
+++ b/packages/analysis/src/__tests__/parity-harness.test.ts
@@ -89,20 +89,14 @@ const KNOWN_DIVERGENCES: readonly KnownDivergenceEntry[] = [
     reason:
       "§3: Build path passes quoted string literal for invalid JSON; snapshot omits argument. See docs/refactors/synthetic-checker-retirement.md §3.",
   },
-  // §3: @minimum Infinity — build stringifies; snapshot passes through as identifier
-  {
-    fixtureLabel: "@minimum Infinity on number",
-    divergenceKind: "any",
-    reason:
-      "§3: Build path stringifies Infinity to '\"Infinity\"'; snapshot passes it through as an identifier. See docs/refactors/synthetic-checker-retirement.md §3.",
-  },
-  // §3: @minimum NaN — build stringifies; snapshot passes through as identifier
-  {
-    fixtureLabel: "@minimum NaN on number",
-    divergenceKind: "any",
-    reason:
-      "§3: Build path stringifies NaN to '\"NaN\"'; snapshot passes it through as an identifier. See docs/refactors/synthetic-checker-retirement.md §3.",
-  },
+  // §3: @minimum Infinity — NORMALIZED in Phase 2.
+  // Build path now passes Infinity as an identifier (same as snapshot). Both
+  // renderSyntheticArgumentExpression (in tsdoc-parser.ts) and renderBuildArgumentExpression
+  // (this harness proxy) were updated to handle Infinity as an identifier.
+  // This KNOWN_DIVERGENCES entry is intentionally removed; no divergence expected.
+  //
+  // §3: @minimum NaN — NORMALIZED in Phase 2. Same mechanism as Infinity.
+  // This KNOWN_DIVERGENCES entry is intentionally removed; no divergence expected.
   // Integer-brand snapshot-path gap (PR #315): build has isIntegerBrandedType bypass;
   // snapshot does not replicate it, so numeric constraints on Integer types may diverge.
   {
@@ -435,15 +429,18 @@ function generateFixtureSource(fixture: ParityFixture): string {
  * `packages/build/src/analyzer/tsdoc-parser.ts` — the build-path argument
  * lowering function.
  *
- * Key semantics (§3):
- *   - number/integer/signedInteger: finite numbers pass through; non-finite
- *     values (Infinity, NaN) are JSON-stringified to a string literal.
+ * Key semantics (§3, updated for Phase 2):
+ *   - number/integer/signedInteger: finite numbers pass through; Infinity,
+ *     -Infinity, and NaN pass through as identifiers (Phase 2 fix — no longer
+ *     JSON-stringified). Other non-parseable text is JSON-stringified.
  *   - string: always JSON-quoted.
  *   - json: parses and re-renders valid JSON; falls back to JSON.stringify on
  *     parse error (this is the divergence from the snapshot path for `@const`
  *     with invalid JSON).
  *   - boolean: accepts "true"/"false"; otherwise JSON-stringifies.
  *   - null / condition: pass-through special cases.
+ *
+ * @see packages/build/src/analyzer/tsdoc-parser.ts renderSyntheticArgumentExpression
  */
 function renderBuildArgumentExpression(
   valueKind: string | null | undefined,
@@ -458,6 +455,11 @@ function renderBuildArgumentExpression(
     case "number":
     case "integer":
     case "signedInteger":
+      // Phase 2: Infinity, -Infinity, NaN pass through as identifiers.
+      // Snapshot path has always done this; build path now matches.
+      if (trimmed === "Infinity" || trimmed === "-Infinity" || trimmed === "NaN") {
+        return trimmed;
+      }
       return Number.isFinite(Number(trimmed)) ? trimmed : JSON.stringify(trimmed);
     case "string":
       return JSON.stringify(argumentText);

--- a/packages/analysis/src/__tests__/parity-harness.test.ts
+++ b/packages/analysis/src/__tests__/parity-harness.test.ts
@@ -91,7 +91,7 @@ const KNOWN_DIVERGENCES: readonly KnownDivergenceEntry[] = [
   },
   // §3: @minimum Infinity — NORMALIZED in Phase 2.
   // Build path now passes Infinity as an identifier (same as snapshot). Both
-  // renderSyntheticArgumentExpression (in tsdoc-parser.ts) and renderBuildArgumentExpression
+  // renderSyntheticArgumentExpression (in tsdoc-parser.ts) and renderBuildArgumentExpressionProxy
   // (this harness proxy) were updated to handle Infinity as an identifier.
   // This KNOWN_DIVERGENCES entry is intentionally removed; no divergence expected.
   //
@@ -422,12 +422,32 @@ function generateFixtureSource(fixture: ParityFixture): string {
 // here (not imported) because the build package is not a dependency of
 // @formspec/analysis. Keeping it in-test ensures it stays in sync with the
 // spec description in §3 of the retirement plan.
+//
+// ============================================================================
+// SYNC CONTRACT — keep this proxy in sync with the canonical implementation:
+//   packages/build/src/analyzer/tsdoc-parser.ts  renderSyntheticArgumentExpression  (lines ~406-419)
+//
+// Branches that MUST stay in sync:
+//   1. "number" / "integer" / "signedInteger" — Infinity/NaN pass through as
+//      identifiers (Phase 2 fix). Other non-parseable text is JSON.stringify'd.
+//   2. "string" — always JSON.stringify(argumentText) (note: full text, not trimmed).
+//   3. "json"   — JSON.parse + wrap in parens on success; JSON.stringify fallback on error.
+//   4. "boolean" — pass "true"/"false" through; JSON.stringify everything else.
+//   5. "condition" — "undefined as unknown as FormSpecCondition" literal.
+//   6. null/undefined — return null (no argument).
+//   7. Infinity/NaN handling — "Infinity", "-Infinity", "NaN" must pass through
+//      as identifiers for the number/integer/signedInteger branch (not stringified).
+// ============================================================================
 // ---------------------------------------------------------------------------
 
 /**
- * Replicates `renderSyntheticArgumentExpression` from
+ * Proxy replicating `renderSyntheticArgumentExpression` from
  * `packages/build/src/analyzer/tsdoc-parser.ts` — the build-path argument
  * lowering function.
+ *
+ * Named `renderBuildArgumentExpressionProxy` to make clear this is a local
+ * copy that must be kept in sync with the canonical implementation. See the
+ * SYNC CONTRACT block above for the exact branches to maintain.
  *
  * Key semantics (§3, updated for Phase 2):
  *   - number/integer/signedInteger: finite numbers pass through; Infinity,
@@ -442,7 +462,7 @@ function generateFixtureSource(fixture: ParityFixture): string {
  *
  * @see packages/build/src/analyzer/tsdoc-parser.ts renderSyntheticArgumentExpression
  */
-function renderBuildArgumentExpression(
+function renderBuildArgumentExpressionProxy(
   valueKind: string | null | undefined,
   argumentText: string,
 ): string | null {
@@ -516,7 +536,7 @@ interface BuildConsumerResult {
  *
  * Finds the `field` property on `TestClass`, resolves its subject type, and
  * calls {@link checkSyntheticTagApplication} with arguments prepared via
- * {@link renderBuildArgumentExpression} (the build-path lowering function).
+ * {@link renderBuildArgumentExpressionProxy} (the build-path lowering function).
  *
  * Returns a structured result suitable for conversion to a
  * {@link ParityLogEntry}.
@@ -558,7 +578,7 @@ function runBuildConsumer(fixture: ParityFixture): BuildConsumerResult {
   const valueKind = definition?.valueKind ?? null;
 
   // Prepare argument expression using build-path lowering
-  const argumentExpression = renderBuildArgumentExpression(valueKind, fixture.tagArgument);
+  const argumentExpression = renderBuildArgumentExpressionProxy(valueKind, fixture.tagArgument);
 
   // subjectType text for the synthetic call
   const subjectTypeText =

--- a/packages/analysis/src/constraint-validator-logger.ts
+++ b/packages/analysis/src/constraint-validator-logger.ts
@@ -191,7 +191,7 @@ export const CONSTRAINT_VALIDATOR_BUILD_NS = `${CONSTRAINT_VALIDATOR_NS}:build`;
 /** Sub-namespace for the snapshot consumer (file-snapshots.ts). */
 export const CONSTRAINT_VALIDATOR_SNAPSHOT_NS = `${CONSTRAINT_VALIDATOR_NS}:snapshot`;
 
-/** Sub-namespace for the future typed-argument parser (Phase 1). */
+/** Sub-namespace for the typed-argument parser (active from Phase 2). */
 export const CONSTRAINT_VALIDATOR_TYPED_PARSER_NS = `${CONSTRAINT_VALIDATOR_NS}:typed-parser`;
 
 /** Sub-namespace for synthetic-program invocations. */

--- a/packages/analysis/src/constraint-validator-logger.ts
+++ b/packages/analysis/src/constraint-validator-logger.ts
@@ -303,6 +303,11 @@ export function getSyntheticLogger(): LoggerLike {
   return getOrCreateLogger(CONSTRAINT_VALIDATOR_SYNTHETIC_NS);
 }
 
+/** Returns the module-level logger for the typed-argument-parser namespace. */
+export function getTypedParserLogger(): LoggerLike {
+  return getOrCreateLogger(CONSTRAINT_VALIDATOR_TYPED_PARSER_NS);
+}
+
 /** Returns the module-level logger for the broadening-bypass namespace. */
 export function getBroadeningLogger(): LoggerLike {
   return getOrCreateLogger(CONSTRAINT_VALIDATOR_BROADENING_NS);

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -169,6 +169,15 @@ export {
   type UnifiedParseOptions,
 } from "./unified-comment-parser.js";
 export {
+  parseTagArgument,
+  TAG_ARGUMENT_DIAGNOSTIC_CODES,
+  type TagArgumentValue,
+  type TagArgumentParseResult,
+  type TagArgumentDiagnostic,
+  type TagArgumentDiagnosticCode,
+  type TagArgumentLowering,
+} from "./tag-argument-parser.js";
+export {
   CONSTRAINT_VALIDATOR_NS,
   CONSTRAINT_VALIDATOR_BUILD_NS,
   CONSTRAINT_VALIDATOR_SNAPSHOT_NS,
@@ -178,6 +187,7 @@ export {
   getBuildLogger,
   getSnapshotLogger,
   getSyntheticLogger,
+  getTypedParserLogger,
   getBroadeningLogger,
   nowMicros,
   elapsedMicros,

--- a/packages/build/src/__tests__/helpers/build-fixture-dir.ts
+++ b/packages/build/src/__tests__/helpers/build-fixture-dir.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared helper for build-consumer test files that need a real tsconfig.json
+ * on disk alongside generated TypeScript fixture files.
+ *
+ * Both `typed-parser-canaries.test.ts` and `parity-divergences.test.ts` use
+ * this to set up a temp directory in `beforeAll` and clean up in `afterAll`.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export interface BuildFixtureDir {
+  /** Absolute path to the temp directory. */
+  readonly dirPath: string;
+  /**
+   * Writes a file at `relPath` (relative to `dirPath`) with the given content.
+   * Parent directories are created automatically.
+   */
+  writeFile(relPath: string, content: string): void;
+  /** Removes the temp directory and all its contents. */
+  cleanup(): void;
+}
+
+/**
+ * Creates a temporary directory populated with a `tsconfig.json` suitable for
+ * build-consumer probe fixtures.
+ *
+ * Call this in `beforeAll` and call `cleanup()` in `afterAll`.
+ *
+ * ```ts
+ * let fixture: BuildFixtureDir;
+ * beforeAll(() => { fixture = createBuildFixtureDir("my-test-prefix"); });
+ * afterAll(() => { fixture.cleanup(); });
+ * ```
+ */
+export function createBuildFixtureDir(prefix = "formspec-build-fixture-"): BuildFixtureDir {
+  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+
+  fs.writeFileSync(
+    path.join(dirPath, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "nodenext",
+          strict: true,
+          skipLibCheck: true,
+        },
+      },
+      null,
+      2
+    )
+  );
+
+  return {
+    dirPath,
+    writeFile(relPath: string, content: string): void {
+      const fullPath = path.join(dirPath, relPath);
+      fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+      fs.writeFileSync(fullPath, content);
+    },
+    cleanup(): void {
+      if (fs.existsSync(dirPath)) {
+        fs.rmSync(dirPath, { recursive: true });
+      }
+    },
+  };
+}

--- a/packages/build/src/__tests__/parity-divergences.test.ts
+++ b/packages/build/src/__tests__/parity-divergences.test.ts
@@ -241,44 +241,42 @@ describe("known divergence: @const not-json", () => {
 // =============================================================================
 // Divergence case 2: @minimum Infinity
 //
-// Build path (renderSyntheticArgumentExpression, valueKind="number"):
+// PHASE 2 UPDATE — divergence NORMALIZED:
+//
+// Before Phase 2 (build path, renderSyntheticArgumentExpression, valueKind="number"):
 //   Number.isFinite(Infinity) = false → JSON.stringify("Infinity") = '"Infinity"' (a string).
 //   checkSyntheticTagApplication sees tag_minimum(ctx, "Infinity").
-//   tag_minimum expects number; string is not assignable to number → TypeScript error.
-//   buildCompilerBackedConstraintDiagnostics wraps the TypeScript error into:
-//     code: TYPE_MISMATCH, message: 'Tag "@minimum" received an invalid argument for number.'
+//   tag_minimum expects number; string is not assignable to number → TYPE_MISMATCH.
 //
-// Snapshot path (getArgumentExpression):
+// After Phase 2 (build path):
+//   parseTagArgument("minimum", "Infinity", "build") → ok: true, { kind: "number", value: Infinity }
+//   renderSyntheticArgumentExpression now passes "Infinity" through as an identifier
+//   (not a quoted string), aligning with the snapshot path.
+//   checkSyntheticTagApplication sees tag_minimum(ctx, Infinity).
+//   Infinity is typed as number → no diagnostic.
+//
+// Snapshot path (getArgumentExpression, unchanged):
 //   number-label branch → returns "Infinity" unchanged (passed as identifier).
 //   Synthetic call: tag_minimum(ctx, Infinity). Infinity is typed as number → no diagnostic.
 //
-// KNOWN DIVERGENCE (refactor plan §3):
-//   build:    Infinity stringified to '"Infinity"'; TYPE_MISMATCH from synthetic checker
-//   snapshot: Infinity passed as identifier; no diagnostic
-// Phase 2/3 normalization must pick one: treat Infinity as valid number, or reject it.
+// NORMALIZED (refactor plan §3, Phase 2): both consumers now accept Infinity.
+// The §3 catalogue entry is resolved. The §4 Phase 2 work (typed-parser wiring +
+// renderSyntheticArgumentExpression fix) aligned the build path with snapshot.
 // =============================================================================
 
-describe("known divergence: @minimum Infinity", () => {
-  it("BUILD consumer: emits TYPE_MISMATCH (Infinity stringified to '\"Infinity\"', a string)", () => {
-    // KNOWN DIVERGENCE (refactor plan §3): build produces TYPE_MISMATCH here.
-    // renderSyntheticArgumentExpression (build path, valueKind="number"):
-    //   Number.isFinite(Infinity) = false → JSON.stringify("Infinity") = '"Infinity"' (string).
-    // tag_minimum expects number; string is not assignable to number → TypeScript error.
-    // buildCompilerBackedConstraintDiagnostics wraps this into:
-    //   code: TYPE_MISMATCH, message: 'Tag "@minimum" received an invalid argument for number.'
+describe("normalized: @minimum Infinity (both consumers accept, Phase 2)", () => {
+  it("BUILD consumer: no diagnostic (Infinity passed as identifier after Phase 2 fix)", () => {
+    // NORMALIZED (refactor plan §3): build now produces NO diagnostic here.
+    // Phase 2 changes:
+    //   1. parseTagArgument("minimum", "Infinity", "build") → ok: true (typed parser accepts)
+    //   2. renderSyntheticArgumentExpression now passes "Infinity" as-is (not quoted)
+    //   3. checkSyntheticTagApplication sees tag_minimum(ctx, Infinity) → number → no error
     const result = runBuildConsumer("minimum", "Infinity");
-
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-    const diagnostic = result.diagnostics[0];
-    expect(diagnostic?.code).toBe("TYPE_MISMATCH");
-    // The FormSpec-level message is the stable contract, not the raw TypeScript message.
-    // The message contains "invalid argument" and "number" (from capabilityLabel("number")).
-    expect(diagnostic?.message).toContain("invalid argument");
-    expect(diagnostic?.message).toContain("number");
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("SNAPSHOT consumer: no diagnostic (Infinity passed as identifier, typed as number)", () => {
-    // KNOWN DIVERGENCE (refactor plan §3): snapshot produces NO diagnostic here.
+    // UNCHANGED (refactor plan §3): snapshot produces NO diagnostic here.
     // getArgumentExpression: number-label branch → returns "Infinity" unchanged.
     // In the synthetic program, Infinity is a well-known global of type `number`,
     // so tag_minimum(ctx, Infinity) type-checks correctly.
@@ -289,7 +287,6 @@ describe("known divergence: @minimum Infinity", () => {
       }
     `;
     const snapshot = runSnapshotConsumer(source);
-
     expect(snapshot.diagnostics).toEqual([]);
   });
 });
@@ -297,43 +294,41 @@ describe("known divergence: @minimum Infinity", () => {
 // =============================================================================
 // Divergence case 3: @minimum NaN
 //
-// Build path (renderSyntheticArgumentExpression, valueKind="number"):
+// PHASE 2 UPDATE — divergence NORMALIZED:
+//
+// Before Phase 2 (build path, renderSyntheticArgumentExpression, valueKind="number"):
 //   Number.isFinite(NaN) = false → JSON.stringify("NaN") = '"NaN"' (a string).
 //   checkSyntheticTagApplication sees tag_minimum(ctx, "NaN").
-//   tag_minimum expects number; string is not assignable to number → TypeScript error.
-//   buildCompilerBackedConstraintDiagnostics wraps the TypeScript error into:
-//     code: TYPE_MISMATCH, message: 'Tag "@minimum" received an invalid argument for number.'
+//   tag_minimum expects number; string is not assignable to number → TYPE_MISMATCH.
 //
-// Snapshot path (getArgumentExpression):
+// After Phase 2 (build path):
+//   parseTagArgument("minimum", "NaN", "build") → ok: true, { kind: "number", value: NaN }
+//   renderSyntheticArgumentExpression now passes "NaN" through as an identifier
+//   (not a quoted string), aligning with the snapshot path.
+//   checkSyntheticTagApplication sees tag_minimum(ctx, NaN).
+//   NaN is typed as number → no diagnostic.
+//
+// Snapshot path (getArgumentExpression, unchanged):
 //   number-label branch → returns "NaN" unchanged (passed as identifier).
 //   Synthetic call: tag_minimum(ctx, NaN). NaN is typed as number → no diagnostic.
 //
-// KNOWN DIVERGENCE (refactor plan §3):
-//   build:    NaN stringified to '"NaN"'; TYPE_MISMATCH from synthetic checker
-//   snapshot: NaN passed as identifier; no diagnostic
-// Phase 2/3 normalization must pick one: treat NaN as valid number arg, or reject it.
+// NORMALIZED (refactor plan §3, Phase 2): both consumers now accept NaN.
+// The §3 catalogue entry is resolved. Same mechanism as the Infinity case above.
 // =============================================================================
 
-describe("known divergence: @minimum NaN", () => {
-  it("BUILD consumer: emits TYPE_MISMATCH (NaN stringified to '\"NaN\"', a string)", () => {
-    // KNOWN DIVERGENCE (refactor plan §3): build produces TYPE_MISMATCH here.
-    // renderSyntheticArgumentExpression (build path, valueKind="number"):
-    //   Number.isFinite(NaN) = false → JSON.stringify("NaN") = '"NaN"' (string).
-    // tag_minimum expects number; string is not assignable to number → TypeScript error.
-    // buildCompilerBackedConstraintDiagnostics wraps this into:
-    //   code: TYPE_MISMATCH, message: 'Tag "@minimum" received an invalid argument for number.'
-    // Same pattern as the Infinity case above.
+describe("normalized: @minimum NaN (both consumers accept, Phase 2)", () => {
+  it("BUILD consumer: no diagnostic (NaN passed as identifier after Phase 2 fix)", () => {
+    // NORMALIZED (refactor plan §3): build now produces NO diagnostic here.
+    // Phase 2 changes:
+    //   1. parseTagArgument("minimum", "NaN", "build") → ok: true (typed parser accepts)
+    //   2. renderSyntheticArgumentExpression now passes "NaN" as-is (not quoted)
+    //   3. checkSyntheticTagApplication sees tag_minimum(ctx, NaN) → number → no error
     const result = runBuildConsumer("minimum", "NaN");
-
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-    const diagnostic = result.diagnostics[0];
-    expect(diagnostic?.code).toBe("TYPE_MISMATCH");
-    expect(diagnostic?.message).toContain("invalid argument");
-    expect(diagnostic?.message).toContain("number");
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("SNAPSHOT consumer: no diagnostic (NaN passed as identifier, typed as number)", () => {
-    // KNOWN DIVERGENCE (refactor plan §3): snapshot produces NO diagnostic here.
+    // UNCHANGED (refactor plan §3): snapshot produces NO diagnostic here.
     // getArgumentExpression: number-label branch → returns "NaN" unchanged.
     // In the synthetic program, NaN is a well-known global of type `number`,
     // so tag_minimum(ctx, NaN) type-checks correctly.
@@ -344,7 +339,6 @@ describe("known divergence: @minimum NaN", () => {
       }
     `;
     const snapshot = runSnapshotConsumer(source);
-
     expect(snapshot.diagnostics).toEqual([]);
   });
 });

--- a/packages/build/src/__tests__/parity-divergences.test.ts
+++ b/packages/build/src/__tests__/parity-divergences.test.ts
@@ -25,44 +25,31 @@
  */
 
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import * as ts from "typescript";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { generateSchemas } from "../generators/class-schema.js";
 import { buildFormSpecAnalysisFileSnapshot } from "@formspec/analysis/internal";
+import {
+  type BuildFixtureDir,
+  createBuildFixtureDir,
+} from "./helpers/build-fixture-dir.js";
 
 // =============================================================================
 // Temp directory — shared across all build-path probe fixtures
 // =============================================================================
 
+let fixture: BuildFixtureDir;
+/** Convenience alias — test bodies reference `tmpDir` as a string path. */
 let tmpDir: string;
 
 beforeAll(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-parity-divergence-"));
-
-  fs.writeFileSync(
-    path.join(tmpDir, "tsconfig.json"),
-    JSON.stringify(
-      {
-        compilerOptions: {
-          target: "ES2022",
-          module: "NodeNext",
-          moduleResolution: "nodenext",
-          strict: true,
-          skipLibCheck: true,
-        },
-      },
-      null,
-      2
-    )
-  );
+  fixture = createBuildFixtureDir("formspec-parity-divergence-");
+  tmpDir = fixture.dirPath;
 });
 
 afterAll(() => {
-  if (fs.existsSync(tmpDir)) {
-    fs.rmSync(tmpDir, { recursive: true });
-  }
+  fixture.cleanup();
 });
 
 // =============================================================================

--- a/packages/build/src/__tests__/typed-parser-canaries.test.ts
+++ b/packages/build/src/__tests__/typed-parser-canaries.test.ts
@@ -31,10 +31,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { generateSchemas } from "../generators/class-schema.js";
-import {
-  type BuildFixtureDir,
-  createBuildFixtureDir,
-} from "./helpers/build-fixture-dir.js";
+import { type BuildFixtureDir, createBuildFixtureDir } from "./helpers/build-fixture-dir.js";
 
 // =============================================================================
 // Temp directory — shared across all build-consumer probe fixtures
@@ -90,11 +87,15 @@ function buildDiagnosticsFor(
 describe("@minimum typed-parser Role-C canaries (build consumer)", () => {
   it("emits INVALID_TAG_ARGUMENT for non-decimal argument (hex literal 0x10)", () => {
     // parseTagArgument("minimum", "0x10", "build") → INVALID_TAG_ARGUMENT
-    // (DECIMAL_PATTERN rejects hex forms). Before Phase 2, the synthetic checker
-    // would have produced TYPE_MISMATCH for this input.
+    // (DECIMAL_PATTERN rejects hex forms). Before Phase 2, this input was not
+    // rejected here; the synthetic lowering likely accepted 0x10 silently by
+    // passing it through as a numeric literal. Phase 2 now rejects at Role C.
     const diagnostics = buildDiagnosticsFor("minimum", "0x10", "number", "hex-arg");
     const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
-    expect(diagnostic, "Expected INVALID_TAG_ARGUMENT for hex literal from typed parser").toBeDefined();
+    expect(
+      diagnostic,
+      "Expected INVALID_TAG_ARGUMENT for hex literal from typed parser"
+    ).toBeDefined();
   });
 });
 
@@ -217,11 +218,18 @@ describe("@const typed-parser Role-C canaries (build consumer)", () => {
     // parseTagArgument("const", "not-json", "build") → ok: true, { kind: "raw-string-fallback" }
     // The typed parser deliberately accepts invalid-JSON @const with a raw-string fallback.
     // The downstream IR compatibility check decides if the raw string is compatible.
-    // For a number field, the IR validator produces TYPE_MISMATCH.
-    // Assert the code is NOT INVALID_TAG_ARGUMENT (typed parser passes through).
+    // For a number field, the IR rejects the raw string value as a TYPE_MISMATCH.
+    //
+    // Two assertions are required:
+    //   1. INVALID_TAG_ARGUMENT is absent — typed parser (Role C) passed through.
+    //   2. TYPE_MISMATCH is present — proves the pipeline ran end-to-end and the
+    //      IR-level check fired. Without this a broken/skipped typed-parser invocation
+    //      would also satisfy assertion 1.
     const diagnostics = buildDiagnosticsFor("const", "not-json", "number", "not-json");
     const hasInvalidArg = diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT");
+    const hasTypeMismatch = diagnostics.some((d) => d.code === "TYPE_MISMATCH");
     expect(hasInvalidArg).toBe(false);
+    expect(hasTypeMismatch).toBe(true);
   });
 });
 

--- a/packages/build/src/__tests__/typed-parser-canaries.test.ts
+++ b/packages/build/src/__tests__/typed-parser-canaries.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Build-consumer typed-argument-parser canary tests (Phase 2).
+ *
+ * These tests verify that the typed argument parser (parseTagArgument,
+ * introduced in Phase 1) is now correctly wired into the BUILD consumer
+ * (buildCompilerBackedConstraintDiagnostics in tsdoc-parser.ts).
+ *
+ * Each test exercises a case where the typed parser's Role-C argument-literal
+ * validation should fire BEFORE the synthetic TypeScript checker is invoked.
+ * The expected diagnostic is emitted by the typed parser (INVALID_TAG_ARGUMENT),
+ * NOT by the synthetic checker (which would produce TYPE_MISMATCH for the
+ * same inputs).
+ *
+ * # Scope of this test file
+ *
+ * Only tests with NON-EMPTY arguments are included here. Tags with missing
+ * arguments (e.g. `@minimum` with no value) are silently skipped by the
+ * pre-existing empty-text guard in tsdoc-parser.ts (lines 1272/1300) BEFORE
+ * they reach processConstraintTag or the typed parser. Those cases are a
+ * pre-Phase-2 pipeline concern and are documented separately.
+ *
+ * Companion file: packages/analysis/src/__tests__/constraint-canaries.test.ts
+ * covers the SNAPSHOT consumer — those `.fails` cases remain `.fails` until
+ * Phase 3 (snapshot wiring).
+ *
+ * @see docs/refactors/synthetic-checker-retirement.md §4 Phase 2
+ * @see docs/refactors/synthetic-checker-retirement.md §9.3 #14
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { generateSchemas } from "../generators/class-schema.js";
+
+// =============================================================================
+// Temp directory — shared across all build-consumer probe fixtures
+// =============================================================================
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-typed-parser-canary-"));
+
+  fs.writeFileSync(
+    path.join(tmpDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "nodenext",
+          strict: true,
+          skipLibCheck: true,
+        },
+      },
+      null,
+      2
+    )
+  );
+});
+
+afterAll(() => {
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
+// =============================================================================
+// Helper: invoke the build consumer and return its diagnostics
+// =============================================================================
+
+function buildDiagnosticsFor(
+  tagName: string,
+  tagArg: string,
+  fieldType: string,
+  label: string
+): readonly { code: string; message: string }[] {
+  const source = [
+    "export interface TestForm {",
+    `  /** @${tagName} ${tagArg} */`,
+    `  value: ${fieldType};`,
+    "}",
+  ].join("\n");
+
+  const safeName = `${tagName}-${label}`.replace(/[^a-z0-9]/gi, "_");
+  const fixturePath = path.join(tmpDir, `canary-${safeName}.ts`);
+  fs.writeFileSync(fixturePath, source);
+
+  const result = generateSchemas({
+    filePath: fixturePath,
+    typeName: "TestForm",
+    errorReporting: "diagnostics",
+  });
+
+  return result.diagnostics;
+}
+
+// =============================================================================
+// @minimum — typed parser Role C rejection for invalid argument format
+// =============================================================================
+
+describe("@minimum typed-parser Role-C canaries (build consumer)", () => {
+  it("emits INVALID_TAG_ARGUMENT for non-decimal argument (hex literal 0x10)", () => {
+    // parseTagArgument("minimum", "0x10", "build") → INVALID_TAG_ARGUMENT
+    // (DECIMAL_PATTERN rejects hex forms). Before Phase 2, the synthetic checker
+    // would have produced TYPE_MISMATCH for this input.
+    const diagnostics = buildDiagnosticsFor("minimum", "0x10", "number", "hex-arg");
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected INVALID_TAG_ARGUMENT for hex literal from typed parser").toBeDefined();
+  });
+});
+
+// =============================================================================
+// @enumOptions — typed parser Role C rejections for non-array arguments
+//
+// @enumOptions requires "enum-member-addressable" capability (string literal
+// union type). Using `"a" | "b"` as the field type passes the capability check
+// so the typed parser is reached.
+//
+// Before Phase 2: the build path was silent for scalar/object arguments
+// (the synthetic checker accepted them via jsonValue ≤ unknown).
+// After Phase 2: the typed parser rejects non-array JSON at Role C with
+// INVALID_TAG_ARGUMENT before the synthetic checker is invoked.
+// =============================================================================
+
+describe("@enumOptions typed-parser Role-C canaries (build consumer)", () => {
+  it("emits INVALID_TAG_ARGUMENT for a scalar number argument (not an array)", () => {
+    // parseTagArgument("enumOptions", "5", "build") → INVALID_TAG_ARGUMENT
+    // "Expected @enumOptions to be a JSON array, got number."
+    const diagnostics = buildDiagnosticsFor("enumOptions", "5", '"a" | "b"', "scalar");
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected INVALID_TAG_ARGUMENT for scalar enumOptions").toBeDefined();
+    expect(diagnostic?.message).toContain("JSON array");
+  });
+
+  it("emits INVALID_TAG_ARGUMENT for a plain object argument (not an array)", () => {
+    // parseTagArgument("enumOptions", "{}", "build") → INVALID_TAG_ARGUMENT
+    // "Expected @enumOptions to be a JSON array, got object."
+    // Note: TSDoc parses {} as an inline tag delimiter; the TS compiler fallback
+    // provides the raw text for TAGS_REQUIRING_RAW_TEXT tags like @enumOptions.
+    const diagnostics = buildDiagnosticsFor("enumOptions", "{}", '"a" | "b"', "object");
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected INVALID_TAG_ARGUMENT for object enumOptions").toBeDefined();
+    expect(diagnostic?.message).toContain("JSON array");
+  });
+
+  it("emits INVALID_TAG_ARGUMENT for malformed JSON (truncated array)", () => {
+    // parseTagArgument("enumOptions", "[1,", "build") → INVALID_TAG_ARGUMENT
+    // "Expected @enumOptions to be a JSON array, got invalid JSON."
+    const diagnostics = buildDiagnosticsFor("enumOptions", "[1,", '"a" | "b"', "malformed");
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected INVALID_TAG_ARGUMENT for malformed JSON").toBeDefined();
+    expect(diagnostic?.message).toContain("invalid JSON");
+  });
+});
+
+// =============================================================================
+// @uniqueItems — typed parser Role C rejection for non-marker boolean argument
+// =============================================================================
+
+describe("@uniqueItems typed-parser Role-C canaries (build consumer)", () => {
+  it("emits INVALID_TAG_ARGUMENT for @uniqueItems false (typed parser rejects explicit false)", () => {
+    // parseTagArgument("uniqueItems", "false", "build") → INVALID_TAG_ARGUMENT
+    // "false" is not a valid boolean marker (only empty or "true" are accepted).
+    // Before Phase 2, the build path emitted TYPE_MISMATCH from the synthetic checker.
+    const diagnostics = buildDiagnosticsFor("uniqueItems", "false", "string[]", "false-arg");
+    const diagnostic = diagnostics.find(
+      (d) => d.code === "INVALID_TAG_ARGUMENT" || d.code === "TYPE_MISMATCH"
+    );
+    expect(diagnostic, "Expected a diagnostic for @uniqueItems false").toBeDefined();
+  });
+});
+
+// =============================================================================
+// @const — raw-string-fallback pass-through (typed parser does NOT reject)
+// =============================================================================
+
+describe("@const typed-parser Role-C canaries (build consumer)", () => {
+  it("accepts @const not-json via raw-string-fallback (not rejected by typed parser)", () => {
+    // parseTagArgument("const", "not-json", "build") → ok: true, { kind: "raw-string-fallback" }
+    // The typed parser deliberately accepts invalid-JSON @const with a raw-string fallback.
+    // The downstream IR compatibility check decides if the raw string is compatible.
+    // For a number field, the IR validator produces TYPE_MISMATCH.
+    // Assert the code is NOT INVALID_TAG_ARGUMENT (typed parser passes through).
+    const diagnostics = buildDiagnosticsFor("const", "not-json", "number", "not-json");
+    const hasInvalidArg = diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(hasInvalidArg).toBe(false);
+  });
+});
+
+// =============================================================================
+// Infinity/NaN normalization (§3, Phase 2)
+// =============================================================================
+
+describe("@minimum Infinity/NaN normalization (Phase 2 — §3 divergence resolved)", () => {
+  it("accepts @minimum Infinity on a number field (no TYPE_MISMATCH in build path)", () => {
+    // Before Phase 2: build emitted TYPE_MISMATCH (Infinity stringified to '"Infinity"').
+    // After Phase 2: typed parser accepts Infinity; renderSyntheticArgumentExpression
+    // passes it through as an identifier → synthetic sees tag_minimum(ctx, Infinity) → ok.
+    const diagnostics = buildDiagnosticsFor("minimum", "Infinity", "number", "infinity");
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("accepts @minimum NaN on a number field (no TYPE_MISMATCH in build path)", () => {
+    // Same mechanism as Infinity above.
+    const diagnostics = buildDiagnosticsFor("minimum", "NaN", "number", "nan");
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/packages/build/src/__tests__/typed-parser-canaries.test.ts
+++ b/packages/build/src/__tests__/typed-parser-canaries.test.ts
@@ -28,42 +28,29 @@
  */
 
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { generateSchemas } from "../generators/class-schema.js";
+import {
+  type BuildFixtureDir,
+  createBuildFixtureDir,
+} from "./helpers/build-fixture-dir.js";
 
 // =============================================================================
 // Temp directory — shared across all build-consumer probe fixtures
 // =============================================================================
 
+let fixture: BuildFixtureDir;
+/** Convenience alias — test bodies reference `tmpDir` as a string path. */
 let tmpDir: string;
 
 beforeAll(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-typed-parser-canary-"));
-
-  fs.writeFileSync(
-    path.join(tmpDir, "tsconfig.json"),
-    JSON.stringify(
-      {
-        compilerOptions: {
-          target: "ES2022",
-          module: "NodeNext",
-          moduleResolution: "nodenext",
-          strict: true,
-          skipLibCheck: true,
-        },
-      },
-      null,
-      2
-    )
-  );
+  fixture = createBuildFixtureDir("formspec-typed-parser-canary-");
+  tmpDir = fixture.dirPath;
 });
 
 afterAll(() => {
-  if (fs.existsSync(tmpDir)) {
-    fs.rmSync(tmpDir, { recursive: true });
-  }
+  fixture.cleanup();
 });
 
 // =============================================================================
@@ -108,6 +95,49 @@ describe("@minimum typed-parser Role-C canaries (build consumer)", () => {
     const diagnostics = buildDiagnosticsFor("minimum", "0x10", "number", "hex-arg");
     const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
     expect(diagnostic, "Expected INVALID_TAG_ARGUMENT for hex literal from typed parser").toBeDefined();
+  });
+});
+
+// =============================================================================
+// Broadening bypass — typed parser must NOT fire for broadened (D1/D2) fields
+//
+// Fix: the hasBroadening check was moved BEFORE the parseTagArgument call
+// (Phase 2 review fix #1). Before the fix, a broadened field with a typed-
+// parser-rejectable argument would spuriously emit INVALID_TAG_ARGUMENT instead
+// of being bypassed. This section guards against that regression.
+// =============================================================================
+
+describe("broadening bypass — typed parser must not fire for D1 broadened fields (build consumer)", () => {
+  it("accepts @minimum 0x10 on an integer-branded type (D1 broadening — no INVALID_TAG_ARGUMENT)", () => {
+    // Integer-branded types receive D1 broadening for numeric-comparable tags.
+    // Before the fix, the typed parser ran before the hasBroadening check and
+    // emitted INVALID_TAG_ARGUMENT for the hex literal. With the fix the field
+    // is bypassed entirely and no diagnostic is emitted.
+    // The brand key MUST be `__integerBrand` — that is what isIntegerBrandedType
+    // (packages/build/src/analyzer/builtin-brands.ts) looks for. Using any other
+    // brand name would not trigger D1 broadening.
+    const source = [
+      "declare const __integerBrand: unique symbol;",
+      "type Integer = number & { readonly [__integerBrand]: true };",
+      "export interface TestForm {",
+      "  /** @minimum 0x10 */",
+      "  value: Integer;",
+      "}",
+    ].join("\n");
+
+    const safeName = "broadening-d1-minimum-hex";
+    const fixturePath = path.join(tmpDir, `canary-${safeName}.ts`);
+    fs.writeFileSync(fixturePath, source);
+
+    const result = generateSchemas({
+      filePath: fixturePath,
+      typeName: "TestForm",
+      errorReporting: "diagnostics",
+    });
+
+    // D1 broadened — the typed parser should not have fired.
+    // The integer-branded bypass absorbs this entirely; no INVALID_TAG_ARGUMENT.
+    expect(result.diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT")).toBe(false);
   });
 });
 
@@ -164,11 +194,17 @@ describe("@uniqueItems typed-parser Role-C canaries (build consumer)", () => {
     // parseTagArgument("uniqueItems", "false", "build") → INVALID_TAG_ARGUMENT
     // "false" is not a valid boolean marker (only empty or "true" are accepted).
     // Before Phase 2, the build path emitted TYPE_MISMATCH from the synthetic checker.
+    // This assertion is intentionally strict: INVALID_TAG_ARGUMENT confirms the typed
+    // parser fires (Role C), NOT the synthetic checker (which would emit TYPE_MISMATCH).
     const diagnostics = buildDiagnosticsFor("uniqueItems", "false", "string[]", "false-arg");
-    const diagnostic = diagnostics.find(
-      (d) => d.code === "INVALID_TAG_ARGUMENT" || d.code === "TYPE_MISMATCH"
-    );
-    expect(diagnostic, "Expected a diagnostic for @uniqueItems false").toBeDefined();
+    expect(
+      diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT"),
+      "Expected INVALID_TAG_ARGUMENT from typed parser (Role C)"
+    ).toBe(true);
+    expect(
+      diagnostics.some((d) => d.code === "TYPE_MISMATCH"),
+      "Expected no TYPE_MISMATCH (synthetic checker must not fire)"
+    ).toBe(false);
   });
 });
 

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -83,7 +83,6 @@ import {
   getSyntheticLogger,
   getTypedParserLogger,
   parseTagArgument,
-  TAG_ARGUMENT_DIAGNOSTIC_CODES,
   describeTypeKind,
   elapsedMicros,
   nowMicros,
@@ -378,6 +377,7 @@ function processConstraintTag(
     sourceFile,
     tagName,
     parsedTag,
+    text,
     provenance,
     supportingDeclarations,
     options
@@ -708,6 +708,7 @@ function buildCompilerBackedConstraintDiagnostics(
   sourceFile: ts.SourceFile,
   tagName: string,
   parsedTag: ParsedCommentTag | null,
+  rawText: string,
   provenance: Provenance,
   supportingDeclarations: readonly string[],
   options?: ParseTSDocOptions
@@ -907,12 +908,26 @@ function buildCompilerBackedConstraintDiagnostics(
   // `@enumOptions` arg?). Roles A/B/D1/D2 remain the synthetic checker's
   // responsibility until Phase 4.
   //
-  // Behaviour:
+  // IMPORTANT: the typed-parser call is guarded by `if (!hasBroadening)` so that
+  // broadened fields (D1/D2) bypass Role C entirely. Without this guard a broadened
+  // field whose argument the typed parser would reject (e.g. a non-JSON @enumOptions
+  // arg on a Decimal path-target) would spuriously emit INVALID_TAG_ARGUMENT instead
+  // of being silently bypassed as Role D1/D2 requires.
+  //
+  // Behaviour (non-broadened path):
   //   - ok: false → emit C-reject with the typed parser's code + message; skip synthetic.
   //   - ok: true (including raw-string-fallback for @const) → proceed to synthetic.
   //     The raw-string-fallback is a successful parse; the downstream IR compatibility
   //     check (semantic-targets.ts:~1255-1298) owns the final decision for @const.
-  const effectiveArgumentText = parsedTag?.argumentText ?? "";
+  // TODO: text and parsedTag.argumentText can diverge for TAGS_REQUIRING_RAW_TEXT —
+  // revisit if orphan path becomes reachable. Using rawText as fallback ensures
+  // orphaned-tag arguments are forwarded rather than silently replaced with "".
+  const effectiveArgumentText = parsedTag?.argumentText ?? rawText;
+
+  if (hasBroadening) {
+    return emit("bypass", []);
+  }
+
   const typedParseResult = parseTagArgument(tagName, effectiveArgumentText, "build");
 
   if (!typedParseResult.ok) {
@@ -927,14 +942,30 @@ function buildCompilerBackedConstraintDiagnostics(
         diagnosticCode: typedParseResult.diagnostic.code,
       });
     }
+    // Map the typed-parser diagnostic code to a ConstraintSemanticDiagnostic code.
+    // UNKNOWN_TAG is structurally unreachable here: parseTagArgument is only called
+    // after the tag was resolved via getTagDefinition above. If it fires, it's a bug.
+    let mappedCode: "MISSING_TAG_ARGUMENT" | "INVALID_TAG_ARGUMENT";
+    switch (typedParseResult.diagnostic.code) {
+      case "MISSING_TAG_ARGUMENT":
+        mappedCode = "MISSING_TAG_ARGUMENT";
+        break;
+      case "INVALID_TAG_ARGUMENT":
+        mappedCode = "INVALID_TAG_ARGUMENT";
+        break;
+      case "UNKNOWN_TAG":
+        // Structurally unreachable: parseTagArgument is only called for tags
+        // already resolved via getTagDefinition above. If this fires it's a bug.
+        throw new Error(
+          `Unexpected UNKNOWN_TAG from parseTagArgument("${tagName}") — tag was resolved via getTagDefinition.`
+        );
+      default: {
+        const _exhaustive: never = typedParseResult.diagnostic.code;
+        throw new Error(`Unknown diagnostic code: ${String(_exhaustive)}`);
+      }
+    }
     return emit("C-reject", [
-      makeDiagnostic(
-        typedParseResult.diagnostic.code === TAG_ARGUMENT_DIAGNOSTIC_CODES.MISSING_TAG_ARGUMENT
-          ? "MISSING_TAG_ARGUMENT"
-          : "INVALID_TAG_ARGUMENT",
-        typedParseResult.diagnostic.message,
-        provenance
-      ),
+      makeDiagnostic(mappedCode, typedParseResult.diagnostic.message, provenance),
     ]);
   }
 
@@ -955,13 +986,14 @@ function buildCompilerBackedConstraintDiagnostics(
     definition.valueKind,
     effectiveArgumentText
   );
-  if (definition.requiresArgument && argumentExpression === null) {
-    return emit("A-pass", []);
-  }
-
-  if (hasBroadening) {
-    return emit("bypass", []);
-  }
+  // NOTE (Phase 2): the `requiresArgument && argumentExpression === null` guard
+  // that previously lived here was removed because it is dead code after Phase 2.
+  // For every `requiresArgument: true` tag, the typed parser returns ok: false
+  // (MISSING_TAG_ARGUMENT) when the argument text is empty, so the C-reject
+  // branch above fires before this point can be reached. The guard was labelled
+  // "A-pass" which was misleading — it represented "typed-parser-passed-but-
+  // rendering-returned-null", not a true Role-A miss. Dead branch confirmed by
+  // exhaustive analysis of parseTagArgument return values for all tag families.
 
   const subjectTypeText = checker.typeToString(subjectType, node, SYNTHETIC_TYPE_FORMAT_FLAGS);
   const hostType = options?.hostType ?? subjectType;

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -81,6 +81,9 @@ import {
   getBuildLogger,
   getBroadeningLogger,
   getSyntheticLogger,
+  getTypedParserLogger,
+  parseTagArgument,
+  TAG_ARGUMENT_DIAGNOSTIC_CODES,
   describeTypeKind,
   elapsedMicros,
   nowMicros,
@@ -407,6 +410,13 @@ function renderSyntheticArgumentExpression(
     case "number":
     case "integer":
     case "signedInteger":
+      // Pass Infinity, -Infinity, and NaN through as TS identifiers (not quoted
+      // strings). The typed parser (Phase 2) accepts these values; the snapshot
+      // path has always passed them through as identifiers. Aligning the build
+      // path with the snapshot path normalises the §3 Infinity/NaN divergence.
+      if (trimmed === "Infinity" || trimmed === "-Infinity" || trimmed === "NaN") {
+        return trimmed;
+      }
       return Number.isFinite(Number(trimmed)) ? trimmed : JSON.stringify(trimmed);
     case "string":
       return JSON.stringify(argumentText);
@@ -729,8 +739,10 @@ function buildCompilerBackedConstraintDiagnostics(
   const log = getBuildLogger();
   const broadeningLog = getBroadeningLogger();
   const syntheticLog = getSyntheticLogger();
+  const typedParserLog = getTypedParserLogger();
   const logsEnabled = log !== noopLogger || broadeningLog !== noopLogger;
   const syntheticTraceEnabled = syntheticLog !== noopLogger;
+  const typedParserTraceEnabled = typedParserLog !== noopLogger;
   const logStart = logsEnabled ? nowMicros() : 0;
   const subjectTypeKind = logsEnabled ? describeTypeKind(subjectType, checker) : "";
 
@@ -889,9 +901,59 @@ function buildCompilerBackedConstraintDiagnostics(
     }
   }
 
+  // §4 Phase 2 — Role C: validate argument literal via the typed parser BEFORE
+  // the synthetic-checker call. The typed parser is the new gatekeeper for
+  // argument-shape validity (is `10.5` a valid `@minLength` arg? is `[]` a valid
+  // `@enumOptions` arg?). Roles A/B/D1/D2 remain the synthetic checker's
+  // responsibility until Phase 4.
+  //
+  // Behaviour:
+  //   - ok: false → emit C-reject with the typed parser's code + message; skip synthetic.
+  //   - ok: true (including raw-string-fallback for @const) → proceed to synthetic.
+  //     The raw-string-fallback is a successful parse; the downstream IR compatibility
+  //     check (semantic-targets.ts:~1255-1298) owns the final decision for @const.
+  const effectiveArgumentText = parsedTag?.argumentText ?? "";
+  const typedParseResult = parseTagArgument(tagName, effectiveArgumentText, "build");
+
+  if (!typedParseResult.ok) {
+    // §8.3 — emit typed-parser trace log when enabled.
+    if (typedParserTraceEnabled) {
+      typedParserLog.trace("typed-parser C-reject", {
+        consumer: "build",
+        tag: tagName,
+        placement: nonNullPlacement,
+        subjectTypeKind: subjectTypeKind !== "" ? subjectTypeKind : "-",
+        roleOutcome: "C-reject",
+        diagnosticCode: typedParseResult.diagnostic.code,
+      });
+    }
+    return emit("C-reject", [
+      makeDiagnostic(
+        typedParseResult.diagnostic.code === TAG_ARGUMENT_DIAGNOSTIC_CODES.MISSING_TAG_ARGUMENT
+          ? "MISSING_TAG_ARGUMENT"
+          : "INVALID_TAG_ARGUMENT",
+        typedParseResult.diagnostic.message,
+        provenance
+      ),
+    ]);
+  }
+
+  // Typed parser accepted the argument. Log at trace level before falling through
+  // to the synthetic checker (which handles Roles A/B/D1/D2 until Phase 4).
+  if (typedParserTraceEnabled) {
+    typedParserLog.trace("typed-parser C-pass", {
+      consumer: "build",
+      tag: tagName,
+      placement: nonNullPlacement,
+      subjectTypeKind: subjectTypeKind !== "" ? subjectTypeKind : "-",
+      roleOutcome: "C-pass",
+      valueKind: typedParseResult.value.kind,
+    });
+  }
+
   const argumentExpression = renderSyntheticArgumentExpression(
     definition.valueKind,
-    parsedTag?.argumentText ?? ""
+    effectiveArgumentText
   );
   if (definition.requiresArgument && argumentExpression === null) {
     return emit("A-pass", []);

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -186,10 +186,7 @@ function isNonReferenceIdentifier(node: ts.Identifier): boolean {
   return false;
 }
 
-function astReferencesImportedName(
-  root: ts.Node,
-  importedNames: ReadonlySet<string>
-): boolean {
+function astReferencesImportedName(root: ts.Node, importedNames: ReadonlySet<string>): boolean {
   if (importedNames.size === 0) {
     return false;
   }
@@ -488,10 +485,7 @@ function isCallableType(type: ts.Type): boolean {
   return type.getCallSignatures().length > 0 || type.getConstructSignatures().length > 0;
 }
 
-function isUserEmittableHintProperty(
-  property: ts.Symbol,
-  declaration: ts.Declaration
-): boolean {
+function isUserEmittableHintProperty(property: ts.Symbol, declaration: ts.Declaration): boolean {
   if (property.name.startsWith("__")) {
     return false;
   }
@@ -500,11 +494,7 @@ function isUserEmittableHintProperty(
     if (ts.isComputedPropertyName(name) || ts.isPrivateIdentifier(name)) {
       return false;
     }
-    if (
-      !ts.isIdentifier(name) &&
-      !ts.isStringLiteral(name) &&
-      !ts.isNumericLiteral(name)
-    ) {
+    if (!ts.isIdentifier(name) && !ts.isStringLiteral(name) && !ts.isNumericLiteral(name)) {
       return false;
     }
   }
@@ -919,10 +909,16 @@ function buildCompilerBackedConstraintDiagnostics(
   //   - ok: true (including raw-string-fallback for @const) → proceed to synthetic.
   //     The raw-string-fallback is a successful parse; the downstream IR compatibility
   //     check (semantic-targets.ts:~1255-1298) owns the final decision for @const.
-  // TODO: text and parsedTag.argumentText can diverge for TAGS_REQUIRING_RAW_TEXT —
-  // revisit if orphan path becomes reachable. Using rawText as fallback ensures
-  // orphaned-tag arguments are forwarded rather than silently replaced with "".
-  const effectiveArgumentText = parsedTag?.argumentText ?? rawText;
+  // §4 Phase 2 — Option A: always derive argumentText from rawText (the
+  // canonical post-choosePreferredPayloadText string) so the typed parser sees
+  // the same text as parseConstraintTagValue (Role D). For TAGS_REQUIRING_RAW_TEXT,
+  // choosePreferredPayloadText may have selected the compiler-API fallback, making
+  // rawText differ from parsedTag.argumentText (which was derived from
+  // tag.resolvedPayloadText). Re-parsing from rawText also applies the same
+  // path-target prefix stripping that the original parse would have applied.
+  // TODO: once choosePreferredPayloadText is threaded upstream, this can go away.
+  const effectiveArgumentText =
+    parsedTag !== null ? parseTagSyntax(tagName, rawText).argumentText : rawText;
 
   if (hasBroadening) {
     return emit("bypass", []);


### PR DESCRIPTION
## Summary

Wires `parseTagArgument` (introduced in Phase 1) into the **build consumer** (`buildCompilerBackedConstraintDiagnostics` in `tsdoc-parser.ts`) as Role-C argument-literal validation gatekeeper.

### What changed

- **`tsdoc-parser.ts`**: `parseTagArgument` is now called BEFORE `renderSyntheticArgumentExpression` inside `buildCompilerBackedConstraintDiagnostics`. Arguments rejected by the typed parser emit `INVALID_TAG_ARGUMENT` diagnostics and skip the synthetic checker entirely.

- **Infinity/NaN normalisation (§3 divergence)**: `renderSyntheticArgumentExpression` now passes `Infinity`, `-Infinity`, and `NaN` through as TypeScript identifiers instead of JSON-quoted strings. This closes the build/snapshot divergence where `@minimum Infinity` previously produced `TYPE_MISMATCH` on the build path.

- **`@formspec/analysis/internal` exports**: `parseTagArgument`, `TAG_ARGUMENT_DIAGNOSTIC_CODES`, and related types are now exported; `getTypedParserLogger` is added to `constraint-validator-logger`.

- **`parity-harness.test.ts`**: `renderBuildArgumentExpression` updated to match the Infinity/NaN identifier fix; `@minimum Infinity` and `@minimum NaN` removed from `KNOWN_DIVERGENCES`.

- **`parity-divergences.test.ts`**: Infinity/NaN tests updated from "BUILD emits TYPE_MISMATCH" to "both consumers accept, no diagnostic".

- **`typed-parser-canaries.test.ts`** (new): Build-consumer canary tests confirming typed-parser Role-C rejections for hex literals (`@minimum 0x10`), non-array `@enumOptions` arguments, explicit `@uniqueItems false`, and the `@const not-json` raw-string-fallback pass-through.

### What was NOT changed (per spec)

- Snapshot consumer (`file-snapshots.ts`) is not wired — Phase 3.
- Synthetic checker code is not deleted — Phases 3–4.
- Roles A, B, D1, D2 are unchanged.

## Test plan

- [x] `pnpm --filter @formspec/build exec vitest run` — 826 tests passing (37 files)
- [x] `pnpm --filter @formspec/analysis exec vitest run` — 529 tests passing (22 files, 1 skipped)
- [x] `pnpm run build` — clean build from scratch
- [x] `pnpm run lint` — no lint errors
- [x] `pnpm run test` — all packages + e2e passing