### PR TITLE
fix(eslint-plugin): recognize extension-registered annotation tags (#350)

### DIFF
--- a/.changeset/fix-350-eslint-annotation-tags.md
+++ b/.changeset/fix-350-eslint-annotation-tags.md
@@ -1,0 +1,5 @@
+---
+"@formspec/eslint-plugin": patch
+---
+
+Fix `tag-recognition/no-unknown-tags` and `tag-recognition/tsdoc-comment-syntax` rejecting extension-registered annotation tags (e.g. `@primaryField`). Both rules now iterate `extension.annotations` in addition to `constraintTags` and `metadataSlots`.

--- a/packages/eslint-plugin/src/__tests__/rules/tag-recognition.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/tag-recognition.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Tests for tag-recognition rules: no-unknown-tags, require-tag-arguments,
+ * no-disabled-tags, no-markdown-formatting.
+ *
+ * Regression tests for issue #350: extension-registered annotation tags,
+ * constraint tags, and metadata slots supplied via `context.settings` were not
+ * recognized by `no-unknown-tags` and were incorrectly flagged as unknown.
+ *
+ * @see https://github.com/mike-north/formspec/issues/350
+ */
 import { RuleTester } from "@typescript-eslint/rule-tester";
 import * as vitest from "vitest";
 import { noUnknownTags } from "../../rules/tag-recognition/no-unknown-tags.js";
@@ -70,6 +80,71 @@ ruleTester.run("no-unknown-tags", noUnknownTags, {
         }
       `,
     },
+    // Regression test for issue #350: annotation tag registered via
+    // `defineAnnotation()` must not be flagged as unknown by `no-unknown-tags`.
+    // Previously the rule only consulted built-in tags and ignored extension
+    // settings entirely, so `@primaryField` would be reported as unknown.
+    {
+      code: `
+        class Form {
+          /** @primaryField */
+          id!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                annotations: [{ annotationName: "primaryField" }],
+              },
+            ],
+          },
+        },
+      },
+    },
+    // Regression test for issue #350: extension constraint tag recognized via
+    // settings must not be flagged.
+    {
+      code: `
+        class Form {
+          /** @afterDate 2025-01-01 */
+          startsAt!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                constraintTags: [{ tagName: "afterDate" }],
+              },
+            ],
+          },
+        },
+      },
+    },
+    // Regression test for issue #350: extension metadata slot recognized via
+    // settings must not be flagged.
+    {
+      code: `
+        class Form {
+          /** @fieldLabel First name */
+          firstName!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                metadataSlots: [{ tagName: "fieldLabel" }],
+              },
+            ],
+          },
+        },
+      },
+    },
   ],
   invalid: [
     {
@@ -79,6 +154,27 @@ ruleTester.run("no-unknown-tags", noUnknownTags, {
           name!: string;
         }
       `,
+      errors: [{ messageId: "unknownTag" }],
+    },
+    // Extension tag in settings does not exempt unrelated unknown tags.
+    {
+      code: `
+        class Form {
+          /** @wat 1 */
+          name!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                annotations: [{ annotationName: "primaryField" }],
+              },
+            ],
+          },
+        },
+      },
       errors: [{ messageId: "unknownTag" }],
     },
   ],

--- a/packages/eslint-plugin/src/__tests__/rules/tag-recognition.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/tag-recognition.test.ts
@@ -145,6 +145,151 @@ ruleTester.run("no-unknown-tags", noUnknownTags, {
         },
       },
     },
+    // An annotation whose annotationName shadows a built-in tag name (e.g.
+    // "minimum") must not break built-in handling. `getTagMetadata` for the
+    // built-in is consulted first (before the extension set), so the built-in
+    // tag is still recognized correctly and neither tag produces an "unknown"
+    // error. Registering an annotation named "minimum" is unusual but must not
+    // regress built-in behaviour.
+    {
+      code: `
+        class Form {
+          /** @minimum 0 */
+          count!: number;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                annotations: [{ annotationName: "minimum" }],
+              },
+            ],
+          },
+        },
+      },
+    },
+    // constraintTags with a leading-@ tagName is normalized and recognized.
+    {
+      code: `
+        class Form {
+          /** @someConstraint 5 */
+          count!: number;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                constraintTags: [{ tagName: "@someConstraint" }],
+              },
+            ],
+          },
+        },
+      },
+    },
+    // metadataSlots with a leading-@ tagName is normalized and recognized.
+    {
+      code: `
+        class Form {
+          /** @someSlot value */
+          name!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                metadataSlots: [{ tagName: "@someSlot" }],
+              },
+            ],
+          },
+        },
+      },
+    },
+    // Empty extensions array is a no-op — no crash and built-in tags still pass.
+    {
+      code: `
+        class Form {
+          /** @minimum 0 */
+          count!: number;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [],
+          },
+        },
+      },
+    },
+    // Two extensions (one declaring an annotation, another a constraintTag)
+    // used in the same file — both tags must be recognized.
+    {
+      code: `
+        class Form {
+          /** @primaryField */
+          id!: string;
+          /** @afterDate 2025-01-01 */
+          startsAt!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              { annotations: [{ annotationName: "primaryField" }] },
+              { constraintTags: [{ tagName: "afterDate" }] },
+            ],
+          },
+        },
+      },
+    },
+    // annotationName without a leading @ is normalized and recognized —
+    // verifies the normalization path for bare (no-@ prefix) annotation names.
+    {
+      code: `
+        class Form {
+          /** @bareAnno */
+          id!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                annotations: [{ annotationName: "bareAnno" }],
+              },
+            ],
+          },
+        },
+      },
+    },
+    // settings.formspec is absent — only built-in tags are enforced; no crash.
+    {
+      code: `
+        class Form {
+          /** @minimum 0 */
+          count!: number;
+        }
+      `,
+    },
+    // settings.formspec is null — only built-in tags are enforced; no crash.
+    {
+      code: `
+        class Form {
+          /** @minimum 0 */
+          count!: number;
+        }
+      `,
+      settings: {
+        formspec: null,
+      },
+    },
   ],
   invalid: [
     {
@@ -170,6 +315,72 @@ ruleTester.run("no-unknown-tags", noUnknownTags, {
             extensions: [
               {
                 annotations: [{ annotationName: "primaryField" }],
+              },
+            ],
+          },
+        },
+      },
+      errors: [{ messageId: "unknownTag" }],
+    },
+    // constraintTags populated but comment uses a different unknown tag —
+    // the exemption set must not leak to unregistered names.
+    {
+      code: `
+        class Form {
+          /** @unknownTag 1 */
+          count!: number;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                constraintTags: [{ tagName: "someConstraint" }],
+              },
+            ],
+          },
+        },
+      },
+      errors: [{ messageId: "unknownTag" }],
+    },
+    // metadataSlots populated but an unrelated unknown tag is still flagged.
+    {
+      code: `
+        class Form {
+          /** @unknownTag value */
+          name!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                metadataSlots: [{ tagName: "someSlot" }],
+              },
+            ],
+          },
+        },
+      },
+      errors: [{ messageId: "unknownTag" }],
+    },
+    // Empty `extension.annotations: []` must not silently allow-list any tags.
+    // An unknown tag must still be reported even when the extension is registered
+    // with an empty annotations array.
+    {
+      code: `
+        class Form {
+          /** @unknownExtensionTag */
+          name!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                annotations: [],
               },
             ],
           },

--- a/packages/eslint-plugin/src/__tests__/rules/tag-recognition/tsdoc-comment-syntax.test.ts
+++ b/packages/eslint-plugin/src/__tests__/rules/tag-recognition/tsdoc-comment-syntax.test.ts
@@ -6,7 +6,12 @@
  * This rule suppresses those false positives while still validating TSDoc syntax
  * outside raw-text tag payloads.
  *
+ * Regression tests for issue #350: extension-registered annotation tags (via
+ * `defineAnnotation()`) were not recognized by the TSDoc parser and were
+ * incorrectly flagged as unknown tags.
+ *
  * @see https://github.com/mike-north/formspec/issues/291
+ * @see https://github.com/mike-north/formspec/issues/350
  * @see https://tsdoc.org/
  */
 import { RuleTester } from "@typescript-eslint/rule-tester";
@@ -128,6 +133,52 @@ ruleTester.run("tsdoc-comment-syntax", tsdocCommentSyntax, {
             extensions: [
               {
                 constraintTags: [{ tagName: "afterDate" }],
+              },
+            ],
+          },
+        },
+      },
+    },
+    // Regression test for issue #350: extension-registered annotation tags (via
+    // `defineAnnotation()`) must not be flagged as unknown by the TSDoc parser.
+    // Previously, `readExtensionTagNames()` only iterated `constraintTags` and
+    // `metadataSlots`, causing annotation tags like `@primaryField` to be reported
+    // as unknown TSDoc tags.
+    {
+      code: `
+        class Form {
+          /** @primaryField */
+          id!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                annotations: [{ annotationName: "primaryField" }],
+              },
+            ],
+          },
+        },
+      },
+    },
+    // Extension-defined metadata slot alongside an annotation tag — both must be
+    // recognized without either triggering a TSDoc unknown-tag diagnostic.
+    {
+      code: `
+        class Form {
+          /** @secondaryField @fieldLabel Primary key */
+          id!: string;
+        }
+      `,
+      settings: {
+        formspec: {
+          extensionRegistry: {
+            extensions: [
+              {
+                annotations: [{ annotationName: "secondaryField" }],
+                metadataSlots: [{ tagName: "fieldLabel" }],
               },
             ],
           },

--- a/packages/eslint-plugin/src/rules/tag-recognition/no-unknown-tags.ts
+++ b/packages/eslint-plugin/src/rules/tag-recognition/no-unknown-tags.ts
@@ -29,7 +29,7 @@ export const noUnknownTags = createRule<[], "unknownTag">({
     // Build a set of extension-defined tag names (constraint tags, metadata
     // slots, and annotation tags) from `context.settings` so they are not
     // incorrectly flagged as unknown.
-    const extensionTagNameSet = new Set(readExtensionTagNames(context.settings));
+    const extensionTagNameSet = readExtensionTagNames(context.settings);
 
     return createDeclarationVisitor((node) => {
       for (const tag of scanFormSpecTags(node, context.sourceCode)) {

--- a/packages/eslint-plugin/src/rules/tag-recognition/no-unknown-tags.ts
+++ b/packages/eslint-plugin/src/rules/tag-recognition/no-unknown-tags.ts
@@ -1,7 +1,7 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { createDeclarationVisitor } from "../../utils/rule-helpers.js";
 import { scanFormSpecTags } from "../../utils/tag-scanner.js";
-import { getTagMetadata } from "../../utils/tag-metadata.js";
+import { getTagMetadata, readExtensionTagNames } from "../../utils/tag-metadata.js";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) => `https://formspec.dev/eslint-plugin/rules/${name}`
@@ -26,9 +26,15 @@ export const noUnknownTags = createRule<[], "unknownTag">({
   },
   defaultOptions: [],
   create(context) {
+    // Build a set of extension-defined tag names (constraint tags, metadata
+    // slots, and annotation tags) from `context.settings` so they are not
+    // incorrectly flagged as unknown.
+    const extensionTagNameSet = new Set(readExtensionTagNames(context.settings));
+
     return createDeclarationVisitor((node) => {
       for (const tag of scanFormSpecTags(node, context.sourceCode)) {
         if (getTagMetadata(tag.rawName) !== null) continue;
+        if (extensionTagNameSet.has(tag.normalizedName)) continue;
         context.report({
           loc: tag.comment.loc,
           messageId: "unknownTag",

--- a/packages/eslint-plugin/src/rules/tag-recognition/tsdoc-comment-syntax.ts
+++ b/packages/eslint-plugin/src/rules/tag-recognition/tsdoc-comment-syntax.ts
@@ -1,50 +1,12 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { createDeclarationVisitor } from "../../utils/rule-helpers.js";
 import { scanFormSpecTags, getLeadingJSDocComments } from "../../utils/tag-scanner.js";
-import { normalizeFormSpecTagName } from "../../utils/tag-metadata.js";
+import { readExtensionTagNames } from "../../utils/tag-metadata.js";
 import { TAGS_REQUIRING_RAW_TEXT, getOrCreateTSDocParser } from "@formspec/analysis/internal";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) => `https://formspec.dev/eslint-plugin/rules/${name}`
 );
-
-/**
- * Minimal structural view of the `ExtensionRegistry` stored in
- * `context.settings.formspec.extensionRegistry`. Typed locally to avoid
- * pulling `@formspec/build` into this rule.
- */
-interface SettingsExtensionRegistry {
-  readonly extensions: readonly SettingsExtensionDefinition[];
-}
-
-interface SettingsExtensionDefinition {
-  readonly constraintTags?: readonly SettingsTagName[];
-  readonly metadataSlots?: readonly SettingsTagName[];
-}
-
-interface SettingsTagName {
-  readonly tagName: string;
-}
-
-function readExtensionTagNames(settings: Readonly<Record<string, unknown>>): readonly string[] {
-  const formspec = settings["formspec"];
-  if (typeof formspec !== "object" || formspec === null) return [];
-  const registry = (formspec as Record<string, unknown>)["extensionRegistry"];
-  if (typeof registry !== "object" || registry === null) return [];
-  const extensions = (registry as Partial<SettingsExtensionRegistry>).extensions;
-  if (!Array.isArray(extensions)) return [];
-  const typedExtensions: readonly SettingsExtensionDefinition[] = extensions;
-  const names = new Set<string>();
-  for (const extension of typedExtensions) {
-    for (const tag of extension.constraintTags ?? []) {
-      names.add(normalizeFormSpecTagName(tag.tagName));
-    }
-    for (const slot of extension.metadataSlots ?? []) {
-      names.add(normalizeFormSpecTagName(slot.tagName));
-    }
-  }
-  return [...names].sort();
-}
 
 /**
  * ESLint rule that validates TSDoc comment syntax using FormSpec's TSDoc
@@ -71,9 +33,9 @@ export const tsdocCommentSyntax = createRule<[], "tsdocSyntax">({
   },
   defaultOptions: [],
   create(context) {
-    // Thread extension-defined constraint and metadata tag names through to
-    // the TSDoc parser so custom project tags registered via `withConfig()`
-    // aren't reported as unknown.
+    // Thread extension-defined constraint, metadata, and annotation tag names
+    // through to the TSDoc parser so custom project tags registered via
+    // `withConfig()` aren't reported as unknown.
     const extensionTagNames = readExtensionTagNames(context.settings);
     const parser = getOrCreateTSDocParser(extensionTagNames);
 

--- a/packages/eslint-plugin/src/rules/tag-recognition/tsdoc-comment-syntax.ts
+++ b/packages/eslint-plugin/src/rules/tag-recognition/tsdoc-comment-syntax.ts
@@ -36,8 +36,7 @@ export const tsdocCommentSyntax = createRule<[], "tsdocSyntax">({
     // Thread extension-defined constraint, metadata, and annotation tag names
     // through to the TSDoc parser so custom project tags registered via
     // `withConfig()` aren't reported as unknown.
-    const extensionTagNames = readExtensionTagNames(context.settings);
-    const parser = getOrCreateTSDocParser(extensionTagNames);
+    const parser = getOrCreateTSDocParser([...readExtensionTagNames(context.settings)]);
 
     return createDeclarationVisitor((node) => {
       // Collect raw-text payload ranges for tags that allow TSDoc-significant

--- a/packages/eslint-plugin/src/utils/tag-metadata.ts
+++ b/packages/eslint-plugin/src/utils/tag-metadata.ts
@@ -24,9 +24,21 @@ interface SettingsExtensionRegistry {
 }
 
 interface SettingsExtensionDefinition {
-  readonly constraintTags?: readonly { readonly tagName: string }[];
-  readonly metadataSlots?: readonly { readonly tagName: string }[];
-  readonly annotations?: readonly { readonly annotationName: string }[];
+  readonly constraintTags?: readonly { readonly tagName: unknown }[];
+  readonly metadataSlots?: readonly { readonly tagName: unknown }[];
+  readonly annotations?: readonly { readonly annotationName: unknown }[];
+}
+
+/**
+ * Strips a leading `@` from a tag name (if present) then normalizes it.
+ *
+ * Extension registries may store tag names with or without a leading `@`.
+ * The scanner always produces normalized names _without_ the `@`, so we must
+ * strip it before building the lookup set.
+ */
+function normalizeExtensionTagName(rawName: string): string {
+  const stripped = rawName.startsWith("@") ? rawName.slice(1) : rawName;
+  return normalizeFormSpecTagName(stripped);
 }
 
 /**
@@ -35,27 +47,33 @@ interface SettingsExtensionDefinition {
  * Covers constraint tags, metadata slots, and annotation tags — all three
  * can be authored as TSDoc block tags in FormSpec class declarations.
  *
- * Returns a sorted, deduplicated array of normalized tag names (no `@` prefix).
+ * Returns a deduplicated set of normalized tag names (no `@` prefix).
+ * Non-object extensions and entries whose name is not a string are silently
+ * skipped so malformed `context.settings` input does not cause runtime errors.
  */
-export function readExtensionTagNames(settings: Readonly<Record<string, unknown>>): readonly string[] {
+export function readExtensionTagNames(
+  settings: Readonly<Record<string, unknown>>
+): ReadonlySet<string> {
   const formspec = settings["formspec"];
-  if (typeof formspec !== "object" || formspec === null) return [];
+  if (typeof formspec !== "object" || formspec === null) return new Set();
   const registry = (formspec as Record<string, unknown>)["extensionRegistry"];
-  if (typeof registry !== "object" || registry === null) return [];
+  if (typeof registry !== "object" || registry === null) return new Set();
   const extensions = (registry as Partial<SettingsExtensionRegistry>).extensions;
-  if (!Array.isArray(extensions)) return [];
-  const typedExtensions: readonly SettingsExtensionDefinition[] = extensions;
+  if (!Array.isArray(extensions)) return new Set();
   const names = new Set<string>();
-  for (const extension of typedExtensions) {
-    for (const tag of extension.constraintTags ?? []) {
-      names.add(normalizeFormSpecTagName(tag.tagName));
+  for (const extension of extensions) {
+    if (typeof extension !== "object" || extension === null) continue;
+    const typedExtension = extension as SettingsExtensionDefinition;
+    for (const tag of typedExtension.constraintTags ?? []) {
+      if (typeof tag.tagName === "string") names.add(normalizeExtensionTagName(tag.tagName));
     }
-    for (const slot of extension.metadataSlots ?? []) {
-      names.add(normalizeFormSpecTagName(slot.tagName));
+    for (const slot of typedExtension.metadataSlots ?? []) {
+      if (typeof slot.tagName === "string") names.add(normalizeExtensionTagName(slot.tagName));
     }
-    for (const annotation of extension.annotations ?? []) {
-      names.add(normalizeFormSpecTagName(annotation.annotationName));
+    for (const annotation of typedExtension.annotations ?? []) {
+      if (typeof annotation.annotationName === "string")
+        names.add(normalizeExtensionTagName(annotation.annotationName));
     }
   }
-  return [...names].sort();
+  return names;
 }

--- a/packages/eslint-plugin/src/utils/tag-metadata.ts
+++ b/packages/eslint-plugin/src/utils/tag-metadata.ts
@@ -11,3 +11,51 @@ export { normalizeFormSpecTagName };
 export function getTagMetadata(rawName: string): TagDefinition | null {
   return getTagDefinition(rawName);
 }
+
+// ---------------------------------------------------------------------------
+// Extension-settings tag-name extraction
+// ---------------------------------------------------------------------------
+// Minimal structural views of the `ExtensionRegistry` stored in
+// `context.settings.formspec.extensionRegistry`. Typed locally to avoid
+// pulling `@formspec/build` into ESLint rules.
+
+interface SettingsExtensionRegistry {
+  readonly extensions: readonly SettingsExtensionDefinition[];
+}
+
+interface SettingsExtensionDefinition {
+  readonly constraintTags?: readonly { readonly tagName: string }[];
+  readonly metadataSlots?: readonly { readonly tagName: string }[];
+  readonly annotations?: readonly { readonly annotationName: string }[];
+}
+
+/**
+ * Reads all tag names registered by extensions in `context.settings`.
+ *
+ * Covers constraint tags, metadata slots, and annotation tags — all three
+ * can be authored as TSDoc block tags in FormSpec class declarations.
+ *
+ * Returns a sorted, deduplicated array of normalized tag names (no `@` prefix).
+ */
+export function readExtensionTagNames(settings: Readonly<Record<string, unknown>>): readonly string[] {
+  const formspec = settings["formspec"];
+  if (typeof formspec !== "object" || formspec === null) return [];
+  const registry = (formspec as Record<string, unknown>)["extensionRegistry"];
+  if (typeof registry !== "object" || registry === null) return [];
+  const extensions = (registry as Partial<SettingsExtensionRegistry>).extensions;
+  if (!Array.isArray(extensions)) return [];
+  const typedExtensions: readonly SettingsExtensionDefinition[] = extensions;
+  const names = new Set<string>();
+  for (const extension of typedExtensions) {
+    for (const tag of extension.constraintTags ?? []) {
+      names.add(normalizeFormSpecTagName(tag.tagName));
+    }
+    for (const slot of extension.metadataSlots ?? []) {
+      names.add(normalizeFormSpecTagName(slot.tagName));
+    }
+    for (const annotation of extension.annotations ?? []) {
+      names.add(normalizeFormSpecTagName(annotation.annotationName));
+    }
+  }
+  return [...names].sort();
+}


### PR DESCRIPTION
## Summary

- Fixes #350. `tag-recognition/no-unknown-tags` and `tag-recognition/tsdoc-comment-syntax` previously ignored tags registered as `annotations` on an extension (only `constraintTags` and `metadataSlots` were considered). As a result, tags declared via `defineAnnotation()` (e.g. `@primaryField`, `@secondaryField`) were reported as unknown.
- Extracts a shared `readExtensionTagNames()` helper in `packages/eslint-plugin/src/utils/tag-metadata.ts` that flattens `constraintTags + metadataSlots + annotations` from the settings-bound extension registry. `no-unknown-tags` now consults it via `context.settings`, matching how `tsdoc-comment-syntax` already does.
- Hardens the helper against malformed settings: non-object extension entries are skipped, and `tagName` / `annotationName` are string-guarded before use. Annotation names registered with a leading `@` are normalized.

Closes #350.

## Test plan

- [x] Failing regression tests added first (demonstrated the bug pre-fix), now passing:
  - Annotation-only declaration — `@primaryField` accepted by both rules.
  - Constraint-tag and metadata-slot branches exercised with `@`-prefixed and bare names.
  - Multi-extension merge (one annotation + one constraintTag across two extensions).
  - Negative cases: unrelated unknown tag still flagged when extensions exist; empty `extensions: []`; missing/`null` `settings.formspec`.
- [x] `pnpm --filter @formspec/eslint-plugin run test` — 319 passing.
- [x] `pnpm --filter @formspec/eslint-plugin run typecheck`, `lint` — clean.
- [x] `pnpm run format:check` — clean on modified files.

## Follow-ups (filed separately)

- Relocate `readExtensionTagNames` to `@formspec/analysis` so `@formspec/ts-plugin` and `@formspec/language-server` can reuse the same extension-tag flattening.
- Deduplicate the `context.settings.formspec.extensionRegistry` access currently duplicated between `utils/tag-metadata.ts` and `rules/type-compatibility/tag-type-check.ts`.