### PR TITLE
refactor(analysis): wire typed argument parser into snapshot consumer (Phase 3)

### DIFF
--- a/.changeset/phase-3-snapshot-wiring.md
+++ b/.changeset/phase-3-snapshot-wiring.md
@@ -1,0 +1,18 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Wire typed argument parser into snapshot consumer (Phase 3)
+
+Routes the snapshot consumer's Role C (argument-literal validation)
+through parseTagArgument. The synthetic TypeScript checker still handles
+Roles A/B/D1/D2 until Phase 4. Fixes the snapshot-side subset of
+silent-acceptance bugs tracked in #326 and completes normalization of
+build/snapshot divergences #329/#330 that Phase 2 began. Implements §4
+Phase 3 of docs/refactors/synthetic-checker-retirement.md.

--- a/packages/analysis/src/__tests__/constraint-canaries.test.ts
+++ b/packages/analysis/src/__tests__/constraint-canaries.test.ts
@@ -1,35 +1,37 @@
 // Silent-acceptance canary tests (Phase 0.5j, refactor plan S.9.3 #14).
 //
-// These are negative-only tests whose sole purpose is to catch a Phase 2
-// regression in which the typed parser silently accepts invalid tag arguments
-// instead of emitting a diagnostic. Each test exercises one invalid usage of a
-// constraint tag and asserts that a diagnostic IS produced with the expected
-// code.
+// These are negative-only tests whose sole purpose is to catch a regression in
+// which the typed parser silently accepts invalid tag arguments instead of
+// emitting a diagnostic. Each test exercises one invalid usage of a constraint
+// tag and asserts that a diagnostic IS produced with the expected code.
 //
-// Probe methodology (2026-04-19):
-// Before writing this file every case was run through
-// buildFormSpecAnalysisFileSnapshot to determine which diagnostics fire
-// today. Cases where no diagnostic fires are pre-existing silent-acceptance
-// gaps and are marked .fails so they track what Phase 2 must fix; once the
-// underlying bug is fixed the test flips to unexpected-pass, failing the suite.
-// Cases that do fire diagnostics today are pinned as live assertions so any
-// future regression is caught immediately.
+// Phase 3 update (2026-04-20):
+// The snapshot consumer now routes builtin constraint tags through
+// parseTagArgument before the synthetic batch (Role C validation wired in
+// packages/analysis/src/file-snapshots.ts, §4 Phase 3). This shifts several
+// diagnostic codes:
 //
-// IMPORTANT: FormSpec comments must be in multi-line form above a field
-// declaration to be recognised by the analysis pipeline. Inline single-line
-// comments on the same line as the field are not picked up (separate tracking
-// issue); all sources below use the multi-line format.
+//   - Missing required arguments: INVALID_TAG_ARGUMENT → MISSING_TAG_ARGUMENT
+//     (typed parser distinguishes missing vs. wrong-type at Role C)
+//   - Wrong-type arguments on numeric tags: TYPE_MISMATCH → INVALID_TAG_ARGUMENT
+//     (typed parser catches "hello" / true before the synthetic checker does)
+//   - @uniqueItems false/yes/maybe: TYPE_MISMATCH → INVALID_TAG_ARGUMENT
+//     (typed parser rejects non-empty non-"true" arguments for the marker family)
 //
-// Summary of pre-existing silent acceptances (all marked .fails):
-// - @minimum 0 on string / boolean fields (TYPE_MISMATCH not emitted)
-// - @enumOptions with a scalar (5) or object ({}) argument
-// - @enumOptions on a plain number field
-// - @pattern with a numeric literal argument (42)
-// - @pattern on number / boolean / array fields
-// - @uniqueItems on string / number fields
-// - @const with mismatched type (string vs number, object type, nested JSON)
+// Remaining silent acceptances (Role B — placement/capability, Phase 4 target):
+// - @minimum 0 on string / boolean fields (capability check, not argument check)
+// - @enumOptions on a plain number field (enum capability check)
+// - @pattern with a numeric literal argument (typed parser accepts all non-empty text)
+// - @pattern on number / boolean / array fields (capability check)
+// - @uniqueItems on string / number fields (capability check)
+// - @const with mismatched type (IR-level TYPE_MISMATCH from semantic-targets.ts)
+//
+// Phase 3 flips (previously .fails, now passing regular assertions):
+// - @enumOptions 5 (scalar not array) — typed parser catches at Role C
+// - @enumOptions {} (object not array) — typed parser catches at Role C
 //
 // @see docs/refactors/synthetic-checker-retirement.md S.9.3 #14
+// @see docs/refactors/synthetic-checker-retirement.md §4 (Phase 3 scope)
 import { describe, expect, it } from "vitest";
 import { buildFormSpecAnalysisFileSnapshot } from "../internal.js";
 import { createProgram } from "./helpers.js";
@@ -49,9 +51,10 @@ function diagnosticsFor(source: string, label: string) {
 
 describe("@minimum silent-acceptance canaries", () => {
   // @minimum "hello" -- a quoted string is not a valid numeric argument.
-  // The synthetic checker emits TYPE_MISMATCH because the string expression
-  // cannot satisfy the numeric parameter.
-  it('emits TYPE_MISMATCH for @minimum "hello" (string-literal argument on a number field)', () => {
+  // Phase 3: typed parser (Role C) catches the string argument and emits
+  // INVALID_TAG_ARGUMENT before the synthetic checker runs.
+  // (Previously: the synthetic checker emitted TYPE_MISMATCH.)
+  it('emits INVALID_TAG_ARGUMENT for @minimum "hello" (string-literal argument on a number field)', () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
@@ -62,8 +65,8 @@ describe("@minimum silent-acceptance canaries", () => {
       "minimum-string-arg"
     );
 
-    const diagnostic = diagnostics.find((d) => d.code === "TYPE_MISMATCH");
-    expect(diagnostic, "Expected a TYPE_MISMATCH diagnostic").toBeDefined();
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
     // range is always present; verify it points somewhere in the source
     expect(diagnostic?.range).toBeDefined();
     expect(typeof diagnostic?.range.start).toBe("number");
@@ -71,8 +74,9 @@ describe("@minimum silent-acceptance canaries", () => {
   });
 
   // @minimum true -- boolean is not a valid numeric argument.
-  // The synthetic checker emits TYPE_MISMATCH.
-  it("emits TYPE_MISMATCH for @minimum true (boolean argument on a number field)", () => {
+  // Phase 3: typed parser (Role C) catches the boolean and emits INVALID_TAG_ARGUMENT.
+  // (Previously: the synthetic checker emitted TYPE_MISMATCH.)
+  it("emits INVALID_TAG_ARGUMENT for @minimum true (boolean argument on a number field)", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
@@ -83,14 +87,15 @@ describe("@minimum silent-acceptance canaries", () => {
       "minimum-true-arg"
     );
 
-    const diagnostic = diagnostics.find((d) => d.code === "TYPE_MISMATCH");
-    expect(diagnostic, "Expected a TYPE_MISMATCH diagnostic").toBeDefined();
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
     expect(diagnostic?.range).toBeDefined();
   });
 
   // @minimum with no argument omits the required numeric value.
-  // The synthetic checker emits INVALID_TAG_ARGUMENT.
-  it("emits INVALID_TAG_ARGUMENT for @minimum with no argument", () => {
+  // Phase 3: typed parser (Role C) emits MISSING_TAG_ARGUMENT for the empty argument.
+  // (Previously: the synthetic checker emitted INVALID_TAG_ARGUMENT.)
+  it("emits MISSING_TAG_ARGUMENT for @minimum with no argument", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
@@ -101,8 +106,8 @@ describe("@minimum silent-acceptance canaries", () => {
       "minimum-empty-arg"
     );
 
-    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
-    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
+    const diagnostic = diagnostics.find((d) => d.code === "MISSING_TAG_ARGUMENT");
+    expect(diagnostic, "Expected a MISSING_TAG_ARGUMENT diagnostic").toBeDefined();
     expect(diagnostic?.range).toBeDefined();
   });
 
@@ -149,8 +154,9 @@ describe("@minimum silent-acceptance canaries", () => {
 
 describe("@enumOptions silent-acceptance canaries", () => {
   // @enumOptions with no argument omits the required JSON array.
-  // The synthetic checker emits INVALID_TAG_ARGUMENT.
-  it("emits INVALID_TAG_ARGUMENT for @enumOptions with no argument", () => {
+  // Phase 3: typed parser (Role C) emits MISSING_TAG_ARGUMENT for the empty argument.
+  // (Previously: the synthetic checker emitted INVALID_TAG_ARGUMENT.)
+  it("emits MISSING_TAG_ARGUMENT for @enumOptions with no argument", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
@@ -161,8 +167,8 @@ describe("@enumOptions silent-acceptance canaries", () => {
       "enumOptions-empty"
     );
 
-    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
-    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
+    const diagnostic = diagnostics.find((d) => d.code === "MISSING_TAG_ARGUMENT");
+    expect(diagnostic, "Expected a MISSING_TAG_ARGUMENT diagnostic").toBeDefined();
     expect(diagnostic?.range).toBeDefined();
   });
 
@@ -185,40 +191,40 @@ describe("@enumOptions silent-acceptance canaries", () => {
   });
 
   // @enumOptions 5 -- scalar number, not a JSON array.
-  // SILENT ACCEPTANCE today -- pre-existing gap; Phase 2 must address.
-  it.fails(
-    "emits INVALID_TAG_ARGUMENT for @enumOptions 5 (scalar, not array) [known silent acceptance, refactor plan S.9.3 #14]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @enumOptions 5 */
-          value!: string;
-        }
-        `,
-        "enumOptions-scalar"
-      );
-      expect(diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT")).toBe(true);
-    }
-  );
+  // Phase 3 FLIP: typed parser (Role C) now rejects this with INVALID_TAG_ARGUMENT.
+  // (Previously: silent acceptance — no diagnostic emitted.)
+  it("emits INVALID_TAG_ARGUMENT for @enumOptions 5 (scalar, not array)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @enumOptions 5 */
+        value!: string;
+      }
+      `,
+      "enumOptions-scalar"
+    );
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
+    expect(diagnostic?.range).toBeDefined();
+  });
 
   // @enumOptions {} -- plain object, not a JSON array.
-  // SILENT ACCEPTANCE today -- pre-existing gap; Phase 2 must address.
-  it.fails(
-    "emits INVALID_TAG_ARGUMENT for @enumOptions {} (object, not array) [known silent acceptance, refactor plan S.9.3 #14]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @enumOptions {} */
-          value!: string;
-        }
-        `,
-        "enumOptions-object"
-      );
-      expect(diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT")).toBe(true);
-    }
-  );
+  // Phase 3 FLIP: typed parser (Role C) now rejects this with INVALID_TAG_ARGUMENT.
+  // (Previously: silent acceptance — no diagnostic emitted.)
+  it("emits INVALID_TAG_ARGUMENT for @enumOptions {} (object, not array)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @enumOptions {} */
+        value!: string;
+      }
+      `,
+      "enumOptions-object"
+    );
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
+    expect(diagnostic?.range).toBeDefined();
+  });
 
   // @enumOptions on a number field -- no enum-member-addressable capability.
   // SILENT ACCEPTANCE today -- pre-existing gap; Phase 2 must address.
@@ -245,8 +251,9 @@ describe("@enumOptions silent-acceptance canaries", () => {
 
 describe("@pattern silent-acceptance canaries", () => {
   // @pattern with no argument omits the required regex string.
-  // The synthetic checker emits INVALID_TAG_ARGUMENT.
-  it("emits INVALID_TAG_ARGUMENT for @pattern with no argument", () => {
+  // Phase 3: typed parser (Role C) emits MISSING_TAG_ARGUMENT for the empty argument.
+  // (Previously: the synthetic checker emitted INVALID_TAG_ARGUMENT.)
+  it("emits MISSING_TAG_ARGUMENT for @pattern with no argument", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
@@ -257,8 +264,8 @@ describe("@pattern silent-acceptance canaries", () => {
       "pattern-empty"
     );
 
-    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
-    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
+    const diagnostic = diagnostics.find((d) => d.code === "MISSING_TAG_ARGUMENT");
+    expect(diagnostic, "Expected a MISSING_TAG_ARGUMENT diagnostic").toBeDefined();
     expect(diagnostic?.range).toBeDefined();
   });
 
@@ -342,9 +349,11 @@ describe("@pattern silent-acceptance canaries", () => {
 // ---------------------------------------------------------------------------
 
 describe("@uniqueItems silent-acceptance canaries", () => {
-  // @uniqueItems false -- the tag accepts no argument; false is an invalid
-  // payload that is treated as an identifier target, producing TYPE_MISMATCH.
-  it("emits TYPE_MISMATCH for @uniqueItems false (argument treated as invalid target)", () => {
+  // @uniqueItems false -- the boolean-marker family rejects anything that is
+  // not empty or "true". Phase 3: typed parser (Role C) emits INVALID_TAG_ARGUMENT.
+  // (Previously: the synthetic checker treated "false" as an identifier target
+  // and emitted TYPE_MISMATCH.)
+  it("emits INVALID_TAG_ARGUMENT for @uniqueItems false (invalid argument for marker family)", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
@@ -355,14 +364,15 @@ describe("@uniqueItems silent-acceptance canaries", () => {
       "uniqueItems-false"
     );
 
-    const diagnostic = diagnostics.find((d) => d.code === "TYPE_MISMATCH");
-    expect(diagnostic, "Expected a TYPE_MISMATCH diagnostic").toBeDefined();
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
     expect(diagnostic?.range).toBeDefined();
   });
 
-  // @uniqueItems yes -- yes is an invalid payload treated as an identifier
-  // target, producing TYPE_MISMATCH.
-  it("emits TYPE_MISMATCH for @uniqueItems yes (unknown identifier argument)", () => {
+  // @uniqueItems yes -- the boolean-marker family rejects anything that is not
+  // empty or "true". Phase 3: typed parser (Role C) emits INVALID_TAG_ARGUMENT.
+  // (Previously: the synthetic checker emitted TYPE_MISMATCH.)
+  it("emits INVALID_TAG_ARGUMENT for @uniqueItems yes (invalid argument for marker family)", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
@@ -373,14 +383,15 @@ describe("@uniqueItems silent-acceptance canaries", () => {
       "uniqueItems-yes"
     );
 
-    const diagnostic = diagnostics.find((d) => d.code === "TYPE_MISMATCH");
-    expect(diagnostic, "Expected a TYPE_MISMATCH diagnostic").toBeDefined();
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
     expect(diagnostic?.range).toBeDefined();
   });
 
-  // @uniqueItems maybe -- maybe is an invalid payload treated as an
-  // identifier target, producing TYPE_MISMATCH.
-  it("emits TYPE_MISMATCH for @uniqueItems maybe (unknown identifier argument)", () => {
+  // @uniqueItems maybe -- the boolean-marker family rejects anything that is not
+  // empty or "true". Phase 3: typed parser (Role C) emits INVALID_TAG_ARGUMENT.
+  // (Previously: the synthetic checker emitted TYPE_MISMATCH.)
+  it("emits INVALID_TAG_ARGUMENT for @uniqueItems maybe (invalid argument for marker family)", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
@@ -391,8 +402,8 @@ describe("@uniqueItems silent-acceptance canaries", () => {
       "uniqueItems-maybe"
     );
 
-    const diagnostic = diagnostics.find((d) => d.code === "TYPE_MISMATCH");
-    expect(diagnostic, "Expected a TYPE_MISMATCH diagnostic").toBeDefined();
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
     expect(diagnostic?.range).toBeDefined();
   });
 
@@ -439,8 +450,9 @@ describe("@uniqueItems silent-acceptance canaries", () => {
 
 describe("@const silent-acceptance canaries", () => {
   // @const with no argument omits the required JSON literal.
-  // The synthetic checker emits INVALID_TAG_ARGUMENT.
-  it("emits INVALID_TAG_ARGUMENT for @const with no argument", () => {
+  // Phase 3: typed parser (Role C) emits MISSING_TAG_ARGUMENT for the empty argument.
+  // (Previously: the synthetic checker emitted INVALID_TAG_ARGUMENT.)
+  it("emits MISSING_TAG_ARGUMENT for @const with no argument", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
@@ -451,8 +463,8 @@ describe("@const silent-acceptance canaries", () => {
       "const-empty"
     );
 
-    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
-    expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
+    const diagnostic = diagnostics.find((d) => d.code === "MISSING_TAG_ARGUMENT");
+    expect(diagnostic, "Expected a MISSING_TAG_ARGUMENT diagnostic").toBeDefined();
     expect(diagnostic?.range).toBeDefined();
   });
 

--- a/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
+++ b/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
@@ -46,7 +46,7 @@ function snapshotDiagnosticsFor(
   tagArg: string,
   fieldType: string,
   label: string
-): readonly { code: string; message: string }[] {
+): readonly { code: string; message: string; severity: string; category: string }[] {
   const source = [
     "class TestForm {",
     `  /** @${tagName} ${tagArg} */`,
@@ -72,12 +72,18 @@ describe("@minimum typed-parser Role-C canaries (snapshot consumer)", () => {
     // (typed parser rejects non-numeric argument for @minimum).
     // Before Phase 3 this triggered TYPE_MISMATCH from the synthetic checker.
     // After Phase 3 the typed parser intercepts it at Role C.
+    //
+    // Severity/category canary: INVALID_TAG_ARGUMENT must be severity "error" and
+    // category "value-parsing". This guards against diagnosticSeverity /
+    // diagnosticCategory fall-through regressions (same fix covers MISSING_TAG_ARGUMENT).
     const diagnostics = snapshotDiagnosticsFor("minimum", '"hello"', "number", "string-arg");
-    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    const invalidArgDiags = diagnostics.filter((d) => d.code === "INVALID_TAG_ARGUMENT");
     expect(
-      diagnostic,
-      "Expected INVALID_TAG_ARGUMENT for string-literal argument from typed parser"
-    ).toBeDefined();
+      invalidArgDiags,
+      "Expected exactly one INVALID_TAG_ARGUMENT for string-literal argument from typed parser"
+    ).toHaveLength(1);
+    expect(invalidArgDiags[0]?.severity).toBe("error");
+    expect(invalidArgDiags[0]?.category).toBe("value-parsing");
     // TYPE_MISMATCH must NOT appear — the synthetic checker must not fire.
     expect(
       diagnostics.some((d) => d.code === "TYPE_MISMATCH"),
@@ -128,9 +134,9 @@ describe("@uniqueItems typed-parser Role-C canaries (snapshot consumer)", () => 
     //   - Absence of TYPE_MISMATCH confirms the synthetic checker does NOT fire.
     const diagnostics = snapshotDiagnosticsFor("uniqueItems", "false", "string[]", "false-arg");
     expect(
-      diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT"),
-      "Expected INVALID_TAG_ARGUMENT from typed parser (Role C)"
-    ).toBe(true);
+      diagnostics.filter((d) => d.code === "INVALID_TAG_ARGUMENT"),
+      "Expected exactly one INVALID_TAG_ARGUMENT from typed parser (Role C)"
+    ).toHaveLength(1);
     expect(
       diagnostics.some((d) => d.code === "TYPE_MISMATCH"),
       "Expected no TYPE_MISMATCH — synthetic checker must not run after Role-C rejection"
@@ -149,12 +155,26 @@ describe("@enumOptions typed-parser Role-C canaries (snapshot consumer)", () => 
     // Before Phase 3 this was a `.fails` case (constraint-canaries.test.ts).
     // Phase 3 wires the typed parser into the snapshot path, converting it.
     const diagnostics = snapshotDiagnosticsFor("enumOptions", "5", "string", "scalar");
-    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    const invalidArgDiags = diagnostics.filter((d) => d.code === "INVALID_TAG_ARGUMENT");
     expect(
-      diagnostic,
-      "Expected INVALID_TAG_ARGUMENT for scalar @enumOptions argument"
-    ).toBeDefined();
-    expect(diagnostic?.message).toContain("JSON array");
+      invalidArgDiags,
+      "Expected exactly one INVALID_TAG_ARGUMENT for scalar @enumOptions argument"
+    ).toHaveLength(1);
+    expect(invalidArgDiags[0]?.message).toContain("JSON array");
+  });
+
+  it("emits INVALID_TAG_ARGUMENT for an object argument (@enumOptions {})", () => {
+    // parseTagArgument("enumOptions", "{}", "snapshot") → INVALID_TAG_ARGUMENT
+    // "Expected @enumOptions to be a JSON array, got object."
+    // Mirrors the build-consumer canary for @enumOptions {} (typed-parser-canaries.test.ts).
+    // Phase 3 wires the typed parser into the snapshot path for this case.
+    const diagnostics = snapshotDiagnosticsFor("enumOptions", "{}", "string", "object");
+    const invalidArgDiags = diagnostics.filter((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(
+      invalidArgDiags,
+      "Expected exactly one INVALID_TAG_ARGUMENT for object @enumOptions argument"
+    ).toHaveLength(1);
+    expect(invalidArgDiags[0]?.message).toContain("JSON array");
   });
 });
 

--- a/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
+++ b/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Snapshot-consumer typed-argument-parser canary tests (Phase 3).
+ *
+ * These tests verify that the typed argument parser (parseTagArgument) is now
+ * correctly wired into the SNAPSHOT consumer (buildFormSpecAnalysisFileSnapshot
+ * via buildTagDiagnostics in file-snapshots.ts, §4 Phase 3).
+ *
+ * Each test exercises a case where the typed parser's Role-C argument-literal
+ * validation should fire BEFORE the synthetic TypeScript checker is invoked.
+ * The expected diagnostic is emitted by the typed parser (INVALID_TAG_ARGUMENT),
+ * NOT by the synthetic checker (which would produce TYPE_MISMATCH for the same
+ * inputs).
+ *
+ * Mirrors the companion build-consumer tests at:
+ *   packages/build/src/__tests__/typed-parser-canaries.test.ts
+ *
+ * The snapshot consumer uses an in-memory TypeScript program (no disk I/O),
+ * so these tests are self-contained without a temp-directory setup.
+ *
+ * # Scope of this test file
+ *
+ * Only tests with NON-EMPTY arguments are included here. Tags with missing
+ * arguments (e.g. `@minimum` with no value) are silently skipped by the
+ * pre-existing empty-text guard BEFORE they reach buildTagDiagnostics or the
+ * typed parser. Those cases are a pre-Phase-3 pipeline concern.
+ *
+ * @see docs/refactors/synthetic-checker-retirement.md §4 Phase 3
+ * @see docs/refactors/synthetic-checker-retirement.md §9.3 #14
+ * @see packages/build/src/__tests__/typed-parser-canaries.test.ts (build-consumer mirror)
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildFormSpecAnalysisFileSnapshot } from "../internal.js";
+import {
+  defineCustomType,
+  defineExtension,
+} from "@formspec/core";
+import { createProgram } from "./helpers.js";
+
+// =============================================================================
+// Helper: invoke the snapshot consumer and return its diagnostics
+// =============================================================================
+
+function snapshotDiagnosticsFor(
+  tagName: string,
+  tagArg: string,
+  fieldType: string,
+  label: string
+): readonly { code: string; message: string }[] {
+  const source = [
+    "class TestForm {",
+    `  /** @${tagName} ${tagArg} */`,
+    `  value!: ${fieldType};`,
+    "}",
+  ].join("\n");
+
+  const { checker, sourceFile } = createProgram(
+    source,
+    `/virtual/snapshot-canary-${label}.ts`
+  );
+  const snapshot = buildFormSpecAnalysisFileSnapshot(sourceFile, { checker });
+  return snapshot.diagnostics;
+}
+
+// =============================================================================
+// @minimum — typed parser Role C rejection for invalid argument format
+// =============================================================================
+
+describe("@minimum typed-parser Role-C canaries (snapshot consumer)", () => {
+  it('emits INVALID_TAG_ARGUMENT for a quoted-string argument (@minimum "hello" on number)', () => {
+    // parseTagArgument("minimum", '"hello"', "snapshot") → INVALID_TAG_ARGUMENT
+    // (typed parser rejects non-numeric argument for @minimum).
+    // Before Phase 3 this triggered TYPE_MISMATCH from the synthetic checker.
+    // After Phase 3 the typed parser intercepts it at Role C.
+    const diagnostics = snapshotDiagnosticsFor("minimum", '"hello"', "number", "string-arg");
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(
+      diagnostic,
+      "Expected INVALID_TAG_ARGUMENT for string-literal argument from typed parser"
+    ).toBeDefined();
+    // TYPE_MISMATCH must NOT appear — the synthetic checker must not fire.
+    expect(
+      diagnostics.some((d) => d.code === "TYPE_MISMATCH"),
+      "Expected no TYPE_MISMATCH — synthetic checker must not run after Role-C rejection"
+    ).toBe(false);
+  });
+
+  it("emits INVALID_TAG_ARGUMENT for non-decimal argument (hex literal 0x10)", () => {
+    // parseTagArgument("minimum", "0x10", "snapshot") → INVALID_TAG_ARGUMENT
+    // (DECIMAL_PATTERN rejects hex forms). Before Phase 3 the snapshot path
+    // accepted 0x10 silently or produced TYPE_MISMATCH. Phase 3 rejects at Role C.
+    const diagnostics = snapshotDiagnosticsFor("minimum", "0x10", "number", "hex-arg");
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(
+      diagnostic,
+      "Expected INVALID_TAG_ARGUMENT for hex literal from typed parser"
+    ).toBeDefined();
+  });
+
+  it("accepts @minimum Infinity on a number field — no diagnostic (convergence pin)", () => {
+    // parseTagArgument("minimum", "Infinity", "snapshot") → ok: true, number value
+    // The snapshot path passes Infinity as an identifier; the synthetic checker
+    // sees tag_minimum(ctx, Infinity) → number → no error.
+    // This pin guards the Phase 2 Infinity normalization for the snapshot path.
+    const diagnostics = snapshotDiagnosticsFor("minimum", "Infinity", "number", "infinity");
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("accepts @minimum NaN on a number field — no diagnostic (convergence pin)", () => {
+    // parseTagArgument("minimum", "NaN", "snapshot") → ok: true, number value
+    // Same mechanism as Infinity above — NaN passes as an identifier.
+    const diagnostics = snapshotDiagnosticsFor("minimum", "NaN", "number", "nan");
+    expect(diagnostics).toEqual([]);
+  });
+});
+
+// =============================================================================
+// @uniqueItems — typed parser Role C rejection for explicit false argument
+// =============================================================================
+
+describe("@uniqueItems typed-parser Role-C canaries (snapshot consumer)", () => {
+  it("emits INVALID_TAG_ARGUMENT for @uniqueItems false — no TYPE_MISMATCH (tight assertion)", () => {
+    // parseTagArgument("uniqueItems", "false", "snapshot") → INVALID_TAG_ARGUMENT
+    // "false" is not a valid boolean marker (only empty or "true" are accepted).
+    // Before Phase 3, the snapshot path emitted TYPE_MISMATCH from the synthetic
+    // checker. This assertion is intentionally strict:
+    //   - INVALID_TAG_ARGUMENT confirms the typed parser fires (Role C).
+    //   - Absence of TYPE_MISMATCH confirms the synthetic checker does NOT fire.
+    const diagnostics = snapshotDiagnosticsFor("uniqueItems", "false", "string[]", "false-arg");
+    expect(
+      diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT"),
+      "Expected INVALID_TAG_ARGUMENT from typed parser (Role C)"
+    ).toBe(true);
+    expect(
+      diagnostics.some((d) => d.code === "TYPE_MISMATCH"),
+      "Expected no TYPE_MISMATCH — synthetic checker must not run after Role-C rejection"
+    ).toBe(false);
+  });
+});
+
+// =============================================================================
+// @enumOptions — typed parser Role C rejections for non-array arguments
+// =============================================================================
+
+describe("@enumOptions typed-parser Role-C canaries (snapshot consumer)", () => {
+  it("emits INVALID_TAG_ARGUMENT for a scalar number argument (@enumOptions 5)", () => {
+    // parseTagArgument("enumOptions", "5", "snapshot") → INVALID_TAG_ARGUMENT
+    // "Expected @enumOptions to be a JSON array, got number."
+    // Before Phase 3 this was a `.fails` case (constraint-canaries.test.ts).
+    // Phase 3 wires the typed parser into the snapshot path, converting it.
+    const diagnostics = snapshotDiagnosticsFor("enumOptions", "5", "string", "scalar");
+    const diagnostic = diagnostics.find((d) => d.code === "INVALID_TAG_ARGUMENT");
+    expect(
+      diagnostic,
+      "Expected INVALID_TAG_ARGUMENT for scalar @enumOptions argument"
+    ).toBeDefined();
+    expect(diagnostic?.message).toContain("JSON array");
+  });
+});
+
+// =============================================================================
+// @const — raw-string-fallback pass-through (typed parser does NOT reject)
+// =============================================================================
+
+describe("@const typed-parser Role-C canaries (snapshot consumer)", () => {
+  it("accepts @const not-json via raw-string-fallback (typed parser passes through; synthetic checker catches it)", () => {
+    // parseTagArgument("const", "not-json", "snapshot") → ok: true, { kind: "raw-string-fallback" }
+    // The typed parser deliberately accepts invalid-JSON @const with a raw-string fallback.
+    //
+    // After the typed-parser pass-through, the snapshot path's getArgumentExpression
+    // returns null for invalid JSON (it cannot produce a TypeScript AST node for
+    // non-parseable text), so the synthetic call is missing the required value
+    // argument. The synthetic checker then fires:
+    //   "Expected 2-3 arguments, but got 1." → INVALID_TAG_ARGUMENT
+    //
+    // This is the known divergence from parity-harness.test.ts §3:
+    //   - Snapshot: INVALID_TAG_ARGUMENT from synthetic checker (arity error).
+    //   - Build:    TYPE_MISMATCH from IR validator (string-vs-number).
+    //
+    // Phase 3 assertion (mirrors the build canary structure):
+    //   The diagnostic must be INVALID_TAG_ARGUMENT with an arity message
+    //   ("Expected N arguments") — not a typed-parser format rejection.
+    //   The typed parser's own rejection messages say e.g. "Expected @const to be ..."
+    //   so the arity message confirms that Role C passed through and the rejection
+    //   came from the synthetic checker.
+    const source = [
+      "class Form {",
+      "  /** @const not-json */",
+      "  value!: number;",
+      "}",
+    ].join("\n");
+
+    const { checker, sourceFile } = createProgram(
+      source,
+      "/virtual/snapshot-canary-const-not-json.ts"
+    );
+    const snapshot = buildFormSpecAnalysisFileSnapshot(sourceFile, { checker });
+    const diagnostics = snapshot.diagnostics;
+
+    // The downstream synthetic checker emits INVALID_TAG_ARGUMENT with an arity
+    // error message ("Expected 2-3 arguments, but got 1.").
+    // Role C does NOT reject @const not-json — the typed parser returns ok: true.
+    const syntheticArityDiag = diagnostics.find(
+      (d) =>
+        d.code === "INVALID_TAG_ARGUMENT" &&
+        typeof d.message === "string" &&
+        d.message.startsWith("Expected") &&
+        d.message.includes("arguments")
+    );
+    expect(
+      syntheticArityDiag,
+      "Expected INVALID_TAG_ARGUMENT from the synthetic arity check (not from Role C)"
+    ).toBeDefined();
+
+    // Confirm: no TYPE_MISMATCH (the snapshot path does not have an IR validator;
+    // the synthetic arity check fires instead, unlike the build path).
+    expect(
+      diagnostics.some((d) => d.code === "TYPE_MISMATCH"),
+      "Expected no TYPE_MISMATCH — snapshot path uses synthetic arity check, not IR validator"
+    ).toBe(false);
+  });
+});
+
+// =============================================================================
+// Extension-broadening bypass — typed parser must NOT fire for broadened fields
+//
+// Phase 3 lesson 1: the broadening check MUST run BEFORE the typed-parser call.
+// A broadened field whose argument would otherwise be rejected by the typed
+// parser must be bypassed entirely (D1/D2 routing). Without this guard the
+// field would spuriously emit INVALID_TAG_ARGUMENT instead of being routed to
+// the extension-broadening handler.
+//
+// This canary guards against regression of that Phase 3 fix.
+// =============================================================================
+
+describe("extension-broadening bypass — typed parser must not fire for broadened fields (snapshot consumer)", () => {
+  it("accepts @minimum 0x10 on a custom type with registered @minimum broadening — no INVALID_TAG_ARGUMENT", () => {
+    // Set up a Decimal custom type that registers @minimum broadening.
+    // When the snapshot consumer sees `value: Decimal` with `@minimum 0x10`,
+    // it should detect the broadening BEFORE calling parseTagArgument.
+    // The broadened field bypasses Role C entirely — no INVALID_TAG_ARGUMENT.
+    //
+    // The brand name "Decimal" is registered via tsTypeNames so the snapshot
+    // path's name-based detection (checker.typeToString on the field type)
+    // can find it in the extensionDefinitions registry.
+    const extension = defineExtension({
+      extensionId: "x-test/broadening-bypass",
+      types: [
+        defineCustomType({
+          typeName: "Decimal",
+          tsTypeNames: ["Decimal"],
+          builtinConstraintBroadenings: [
+            {
+              tagName: "minimum",
+              constraintName: "DecimalMinimum",
+              parseValue: (raw) => Number(raw),
+            },
+          ],
+          toJsonSchema: (_payload, _prefix) => ({ type: "string" }),
+        }),
+      ],
+    });
+
+    const source = [
+      "type Decimal = string & { readonly __decimalBrand: true };",
+      "class TestForm {",
+      "  /** @minimum 0x10 */",
+      "  value!: Decimal;",
+      "}",
+    ].join("\n");
+
+    const { checker, sourceFile } = createProgram(
+      source,
+      "/virtual/snapshot-canary-broadening-bypass.ts"
+    );
+
+    const snapshot = buildFormSpecAnalysisFileSnapshot(sourceFile, {
+      checker,
+      extensionDefinitions: [extension],
+    });
+
+    // The broadening bypass must suppress the typed parser entirely for this field.
+    // The typed parser would have rejected "0x10" with INVALID_TAG_ARGUMENT, but
+    // the broadening guard short-circuits Role C before parseTagArgument is called.
+    expect(snapshot.diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT")).toBe(false);
+  });
+});

--- a/packages/analysis/src/constraint-validator-logger.ts
+++ b/packages/analysis/src/constraint-validator-logger.ts
@@ -54,6 +54,8 @@ export type ConstraintValidatorConsumer = "build" | "snapshot";
  *   D1 — direct-field custom-constraint dispatch (no synthetic involvement)
  *   D2 — path-target built-in broadening dispatch
  *   bypass — broadening registry short-circuit (tag accepted without role-C check)
+ *   D-pass — synthetic batch accepted a tag that previously passed Role-C (no diagnostics
+ *             produced by the synthetic checker for this application)
  *
  * @public
  */
@@ -64,6 +66,7 @@ export type ConstraintValidatorRoleOutcome =
   | "B-reject"
   | "C-pass"
   | "C-reject"
+  | "D-pass"
   | "D1"
   | "D2"
   | "bypass";

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -69,7 +69,7 @@ import {
   elapsedMicros,
   type ConstraintValidatorRoleOutcome,
 } from "./constraint-validator-logger.js";
-import { parseTagArgument } from "./tag-argument-parser.js";
+import { mapTypedParserDiagnosticCode, parseTagArgument } from "./tag-argument-parser.js";
 
 /**
  * Options used when building a serializable, editor-oriented snapshot for a
@@ -223,6 +223,11 @@ function createConstraintTagRegistry(
  * test) and is tracked separately. Phase 3 only wires the extension-registry
  * broadening check.
  */
+// TODO(Phase 4/5): consolidate with hasBuiltinConstraintBroadening in
+// tsdoc-parser.ts. Same semantic question ("does this tag have a registered
+// broadening for this type?"); different data model (TypeScript type-name
+// strings here, IR FieldType + ExtensionRegistry there). Unify once symbol-
+// based detection replaces name-based detection.
 function hasExtensionBroadening(
   tagName: string,
   subjectType: ts.Type,
@@ -1011,6 +1016,7 @@ function isIdentifierLikeTagOperand(argumentText: string): boolean {
 
 function diagnosticSeverity(code: string): FormSpecAnalysisDiagnostic["severity"] {
   switch (code) {
+    case "MISSING_TAG_ARGUMENT":
     case "INVALID_TAG_ARGUMENT":
     case "INVALID_TAG_PLACEMENT":
     case "SYNTHETIC_SETUP_FAILURE":
@@ -1034,6 +1040,7 @@ function diagnosticSeverity(code: string): FormSpecAnalysisDiagnostic["severity"
 
 function diagnosticCategory(code: string): FormSpecAnalysisDiagnostic["category"] {
   switch (code) {
+    case "MISSING_TAG_ARGUMENT":
     case "INVALID_TAG_ARGUMENT":
       return "value-parsing";
     case "INVALID_TAG_PLACEMENT":
@@ -1444,8 +1451,16 @@ function buildTagDiagnostics(
         checker,
         extensionDefinitions
       );
+      // TODO(Phase 4): add isIntegerBrandedType bypass here before removing the
+      // synthetic checker. Snapshot consumer does NOT currently have this bypass
+      // (tracked in #325); build consumer's tsdoc-parser.ts does. Phase 4 must
+      // unify before the synthetic checker can be deleted in Phase 5.
 
       if (!hasBroadening) {
+        // TODO(Phase 4): Snapshot consumer passes tag.argumentText directly; build consumer
+        // re-derives via parseTagSyntax(tagName, rawText).argumentText to handle the
+        // TAGS_REQUIRING_RAW_TEXT compiler-API fallback path. Reconcile in Phase 4
+        // once both consumers use a shared argument-text extraction helper.
         const typedParseResult = parseTagArgument(
           tag.normalizedTagName,
           tag.argumentText,
@@ -1468,27 +1483,12 @@ function buildTagDiagnostics(
           // Map the typed-parser diagnostic code to a snapshot diagnostic code.
           // UNKNOWN_TAG is structurally unreachable here: parseTagArgument is only
           // called after isBuiltinConstraintName guard above. If it fires, it's a bug.
-          // Lesson 3 from Phase 2: use exhaustive switch, NOT a binary ternary —
-          // a ternary silently collapses UNKNOWN_TAG to INVALID_TAG_ARGUMENT.
-          let mappedCode: "MISSING_TAG_ARGUMENT" | "INVALID_TAG_ARGUMENT";
-          switch (typedParseResult.diagnostic.code) {
-            case "MISSING_TAG_ARGUMENT":
-              mappedCode = "MISSING_TAG_ARGUMENT";
-              break;
-            case "INVALID_TAG_ARGUMENT":
-              mappedCode = "INVALID_TAG_ARGUMENT";
-              break;
-            case "UNKNOWN_TAG":
-              // Structurally unreachable: parseTagArgument is only called for tags
-              // that passed the isBuiltinConstraintName guard above.
-              throw new Error(
-                `Unexpected UNKNOWN_TAG from parseTagArgument("${tag.normalizedTagName}") — tag passed isBuiltinConstraintName guard.`
-              );
-            default: {
-              const _exhaustive: never = typedParseResult.diagnostic.code;
-              throw new Error(`Unhandled diagnostic code: ${String(_exhaustive)}`);
-            }
-          }
+          // mapTypedParserDiagnosticCode provides an exhaustive switch shared with the
+          // build consumer — avoids the Lesson 3 silent-ternary-collapse pitfall.
+          const mappedCode = mapTypedParserDiagnosticCode(
+            typedParseResult.diagnostic.code,
+            tag.normalizedTagName,
+          );
 
           diagnostics.push(
             createAnalysisDiagnostic(mappedCode, typedParseResult.diagnostic.message, tag.fullSpan, {
@@ -1629,10 +1629,14 @@ function buildTagDiagnostics(
     }
 
     // §8.3b — determine role outcome for this tag application and log.
+    // "D-pass": the synthetic batch produced no diagnostics for this application.
+    // This is distinct from "C-pass" (typed-parser accepted the argument literal
+    // at Role C before the synthetic batch ran). "D-pass" means the synthetic
+    // checker found nothing wrong after Role C already passed.
     if (snapshotLogsEnabled) {
       const roleOutcome: ConstraintValidatorRoleOutcome =
         result.diagnostics.length === 0
-          ? "C-pass"
+          ? "D-pass"
           : result.diagnostics.some((d) => d.message.includes("No overload"))
             ? "A-reject"
             : "C-reject";

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -55,17 +55,21 @@ import {
   hasTypeSemanticCapability,
   resolveDeclarationPlacement,
   resolvePathTargetType,
+  stripNullishUnion,
 } from "./ts-binding.js";
 import { noopLogger } from "@formspec/core";
+import { isBuiltinConstraintName } from "@formspec/core/internals";
 import {
   getSnapshotLogger,
   getSyntheticLogger,
+  getTypedParserLogger,
   describeTypeKind,
   logTagApplication,
   nowMicros,
   elapsedMicros,
   type ConstraintValidatorRoleOutcome,
 } from "./constraint-validator-logger.js";
+import { parseTagArgument } from "./tag-argument-parser.js";
 
 /**
  * Options used when building a serializable, editor-oriented snapshot for a
@@ -197,6 +201,59 @@ function createConstraintTagRegistry(
       return undefined;
     },
   };
+}
+
+/**
+ * §4 Phase 3 — snapshot-path broadening check.
+ *
+ * Returns `true` when the given builtin constraint tag has a registered
+ * broadening for the field's TypeScript type. When broadening is active the
+ * tag application bypasses Role C (typed-argument validation) and proceeds
+ * directly to the synthetic batch, which routes it to D1/D2 handling.
+ *
+ * This mirrors the build path's `hasBuiltinConstraintBroadening` function in
+ * `tsdoc-parser.ts`, adapted for the snapshot consumer's data model:
+ *   - The build path holds a full `ExtensionRegistry` with `fieldType` IR data.
+ *   - The snapshot path holds `ExtensionDefinition[]` with TypeScript type names.
+ *   The type is matched by name against `registration.tsTypeNames ?? [typeName]`,
+ *   which is the same string-based detection used elsewhere in file-snapshots.ts.
+ *
+ * Notably, `isIntegerBrandedType` bypass is NOT replicated here. That bypass is
+ * a known build/snapshot divergence (PR #315 / file-snapshots.integer-bypass
+ * test) and is tracked separately. Phase 3 only wires the extension-registry
+ * broadening check.
+ */
+function hasExtensionBroadening(
+  tagName: string,
+  subjectType: ts.Type,
+  checker: ts.TypeChecker,
+  extensionDefinitions: readonly ExtensionDefinition[] | undefined
+): boolean {
+  if (extensionDefinitions === undefined || extensionDefinitions.length === 0) {
+    return false;
+  }
+
+  // Strip nullish union members (| null | undefined) before name-matching,
+  // consistent with how the build path strips before isIntegerBrandedType.
+  const effectiveType = stripNullishUnion(subjectType);
+  const typeName = checker.typeToString(effectiveType);
+
+  for (const extension of extensionDefinitions) {
+    for (const type of extension.types ?? []) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- file-snapshots is the name-based detection bridge; it must read tsTypeNames until that mechanism is fully replaced by symbol-based detection
+      const registeredNames = type.tsTypeNames ?? [type.typeName];
+      if (!registeredNames.includes(typeName)) {
+        continue;
+      }
+      for (const broadening of type.builtinConstraintBroadenings ?? []) {
+        if (broadening.tagName === tagName) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
 }
 
 function renderTargetLabel(targetPath: string | null): string {
@@ -1249,7 +1306,8 @@ function buildTagDiagnostics(
   subjectType: ts.Type | undefined,
   commentTags: ReturnType<typeof parseCommentBlock>["tags"],
   semanticOptions: CommentSemanticContextOptions,
-  performance: FormSpecPerformanceRecorder | undefined
+  performance: FormSpecPerformanceRecorder | undefined,
+  extensionDefinitions: readonly ExtensionDefinition[] | undefined
 ): FormSpecAnalysisDiagnostic[] {
   if (placement === null || subjectType === undefined) {
     return [];
@@ -1284,7 +1342,9 @@ function buildTagDiagnostics(
   // §8.3b — module-level loggers for the snapshot consumer.
   const snapshotLog = getSnapshotLogger();
   const syntheticLog = getSyntheticLogger();
+  const typedParserLog = getTypedParserLogger();
   const snapshotLogsEnabled = snapshotLog !== noopLogger;
+  const typedParserTraceEnabled = typedParserLog !== noopLogger;
 
   const syntheticApplications: {
     readonly tag: (typeof commentTags)[number];
@@ -1358,6 +1418,116 @@ function buildTagDiagnostics(
     // §8.3b — record per-tag start time; subjectTypeKindForLog is hoisted
     // above the loop. Both are only consumed when logging is enabled.
     const tagStartMicros = snapshotLogsEnabled ? nowMicros() : 0;
+
+    // §4 Phase 3 — Role C: validate argument literal via the typed parser BEFORE
+    // the synthetic-checker call, mirroring the Phase 2 wiring in tsdoc-parser.ts.
+    //
+    // IMPORTANT (Lesson 1 from Phase 2): the broadening check MUST run BEFORE the
+    // typed-parser call. Broadened fields (D1/D2) bypass Role C entirely. Without
+    // this guard a broadened field whose argument the typed parser would reject
+    // (e.g. a custom type with a registered @minimum broadening) would spuriously
+    // emit INVALID_TAG_ARGUMENT instead of being routed to D1/D2.
+    //
+    // Guard: only call parseTagArgument for builtin constraint tags. Extension tags
+    // are not in the typed parser's registry (they would return UNKNOWN_TAG), and
+    // they bypass this path via the `!isBuiltinConstraintName` guard below.
+    //
+    // Behaviour (non-broadened builtin constraint path):
+    //   - ok: false → emit INVALID_TAG_ARGUMENT or MISSING_TAG_ARGUMENT; skip
+    //                 adding this application to syntheticApplications.
+    //   - ok: true (including raw-string-fallback for @const) → proceed to
+    //                 lowerTagApplicationToSyntheticCall as before.
+    if (isBuiltinConstraintName(tag.normalizedTagName)) {
+      const hasBroadening = hasExtensionBroadening(
+        tag.normalizedTagName,
+        subjectType,
+        checker,
+        extensionDefinitions
+      );
+
+      if (!hasBroadening) {
+        const typedParseResult = parseTagArgument(
+          tag.normalizedTagName,
+          tag.argumentText,
+          "snapshot"
+        );
+
+        if (!typedParseResult.ok) {
+          // §8.3 — emit typed-parser trace log when enabled.
+          if (typedParserTraceEnabled) {
+            typedParserLog.trace("typed-parser C-reject", {
+              consumer: "snapshot",
+              tag: tag.normalizedTagName,
+              placement,
+              subjectTypeKind: subjectTypeKindForLog !== "" ? subjectTypeKindForLog : "-",
+              roleOutcome: "C-reject",
+              diagnosticCode: typedParseResult.diagnostic.code,
+            });
+          }
+
+          // Map the typed-parser diagnostic code to a snapshot diagnostic code.
+          // UNKNOWN_TAG is structurally unreachable here: parseTagArgument is only
+          // called after isBuiltinConstraintName guard above. If it fires, it's a bug.
+          // Lesson 3 from Phase 2: use exhaustive switch, NOT a binary ternary —
+          // a ternary silently collapses UNKNOWN_TAG to INVALID_TAG_ARGUMENT.
+          let mappedCode: "MISSING_TAG_ARGUMENT" | "INVALID_TAG_ARGUMENT";
+          switch (typedParseResult.diagnostic.code) {
+            case "MISSING_TAG_ARGUMENT":
+              mappedCode = "MISSING_TAG_ARGUMENT";
+              break;
+            case "INVALID_TAG_ARGUMENT":
+              mappedCode = "INVALID_TAG_ARGUMENT";
+              break;
+            case "UNKNOWN_TAG":
+              // Structurally unreachable: parseTagArgument is only called for tags
+              // that passed the isBuiltinConstraintName guard above.
+              throw new Error(
+                `Unexpected UNKNOWN_TAG from parseTagArgument("${tag.normalizedTagName}") — tag passed isBuiltinConstraintName guard.`
+              );
+            default: {
+              const _exhaustive: never = typedParseResult.diagnostic.code;
+              throw new Error(`Unhandled diagnostic code: ${String(_exhaustive)}`);
+            }
+          }
+
+          diagnostics.push(
+            createAnalysisDiagnostic(mappedCode, typedParseResult.diagnostic.message, tag.fullSpan, {
+              tagName: tag.normalizedTagName,
+              placement,
+              ...(target === null
+                ? {}
+                : { targetKind: target.kind, targetText: target.text }),
+            })
+          );
+          // Skip adding to syntheticApplications — typed parser already rejected at Role C.
+          continue;
+        }
+
+        // Typed parser accepted the argument. Log at trace level before falling
+        // through to the synthetic batch (which handles Roles A/B/D1/D2 until Phase 4).
+        if (typedParserTraceEnabled) {
+          typedParserLog.trace("typed-parser C-pass", {
+            consumer: "snapshot",
+            tag: tag.normalizedTagName,
+            placement,
+            subjectTypeKind: subjectTypeKindForLog !== "" ? subjectTypeKindForLog : "-",
+            roleOutcome: "C-pass",
+            valueKind: typedParseResult.value.kind,
+          });
+        }
+      } else {
+        // Broadened — bypass typed parser. Log at trace level if enabled.
+        if (typedParserTraceEnabled) {
+          typedParserLog.trace("typed-parser bypass", {
+            consumer: "snapshot",
+            tag: tag.normalizedTagName,
+            placement,
+            subjectTypeKind: subjectTypeKindForLog !== "" ? subjectTypeKindForLog : "-",
+            roleOutcome: "bypass",
+          });
+        }
+      }
+    }
 
     try {
       const syntheticOptions = {
@@ -1654,7 +1824,8 @@ export function buildFormSpecAnalysisFileSnapshot(
                   placement,
                   ...(extensions === undefined ? {} : { extensions }),
                 },
-                options.performance
+                options.performance,
+                options.extensionDefinitions
               )
           )
         );

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -170,7 +170,9 @@ export {
 } from "./unified-comment-parser.js";
 export {
   parseTagArgument,
+  mapTypedParserDiagnosticCode,
   TAG_ARGUMENT_DIAGNOSTIC_CODES,
+  type MappedTypedParserCode,
   type TagArgumentValue,
   type TagArgumentParseResult,
   type TagArgumentDiagnostic,

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -492,3 +492,52 @@ export function parseTagArgument(
     }
   }
 }
+
+// =============================================================================
+// Shared code-mapping helper used by both consumers
+// =============================================================================
+
+/**
+ * The subset of diagnostic codes that both consumers (build and snapshot) may
+ * emit as a result of a typed-parser rejection at Role C.
+ *
+ * `UNKNOWN_TAG` is never included: it is structurally unreachable in any
+ * consumer that guards the {@link parseTagArgument} call with an
+ * `isBuiltinConstraintName` or `getTagDefinition` check.
+ */
+export type MappedTypedParserCode = "MISSING_TAG_ARGUMENT" | "INVALID_TAG_ARGUMENT";
+
+/**
+ * Maps a {@link TagArgumentDiagnosticCode} from {@link parseTagArgument} to the
+ * canonical consumer-level code emitted when the typed parser rejects an
+ * argument at Role C.
+ *
+ * Both the build consumer (`tsdoc-parser.ts`) and the snapshot consumer
+ * (`file-snapshots.ts`) previously contained identical exhaustive switches for
+ * this mapping. This helper centralises the logic.
+ *
+ * @throws if `code` is `UNKNOWN_TAG` (structurally unreachable after the
+ *   `isBuiltinConstraintName` / `getTagDefinition` guard) or an unrecognised
+ *   value (exhaustiveness guard for future additions).
+ */
+export function mapTypedParserDiagnosticCode(
+  code: TagArgumentDiagnosticCode,
+  tagName: string,
+): MappedTypedParserCode {
+  switch (code) {
+    case "MISSING_TAG_ARGUMENT":
+      return "MISSING_TAG_ARGUMENT";
+    case "INVALID_TAG_ARGUMENT":
+      return "INVALID_TAG_ARGUMENT";
+    case "UNKNOWN_TAG":
+      // Structurally unreachable: callers must guard with isBuiltinConstraintName /
+      // getTagDefinition before invoking parseTagArgument. If this fires, it's a bug.
+      throw new Error(
+        `Unexpected UNKNOWN_TAG from parseTagArgument("${tagName}") — tag was resolved via getTagDefinition.`,
+      );
+    default: {
+      const _exhaustive: never = code;
+      throw new Error(`Unhandled diagnostic code: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -82,6 +82,7 @@ import {
   getBroadeningLogger,
   getSyntheticLogger,
   getTypedParserLogger,
+  mapTypedParserDiagnosticCode,
   parseTagArgument,
   describeTypeKind,
   elapsedMicros,
@@ -941,25 +942,9 @@ function buildCompilerBackedConstraintDiagnostics(
     // Map the typed-parser diagnostic code to a ConstraintSemanticDiagnostic code.
     // UNKNOWN_TAG is structurally unreachable here: parseTagArgument is only called
     // after the tag was resolved via getTagDefinition above. If it fires, it's a bug.
-    let mappedCode: "MISSING_TAG_ARGUMENT" | "INVALID_TAG_ARGUMENT";
-    switch (typedParseResult.diagnostic.code) {
-      case "MISSING_TAG_ARGUMENT":
-        mappedCode = "MISSING_TAG_ARGUMENT";
-        break;
-      case "INVALID_TAG_ARGUMENT":
-        mappedCode = "INVALID_TAG_ARGUMENT";
-        break;
-      case "UNKNOWN_TAG":
-        // Structurally unreachable: parseTagArgument is only called for tags
-        // already resolved via getTagDefinition above. If this fires it's a bug.
-        throw new Error(
-          `Unexpected UNKNOWN_TAG from parseTagArgument("${tagName}") — tag was resolved via getTagDefinition.`
-        );
-      default: {
-        const _exhaustive: never = typedParseResult.diagnostic.code;
-        throw new Error(`Unknown diagnostic code: ${String(_exhaustive)}`);
-      }
-    }
+    // mapTypedParserDiagnosticCode provides an exhaustive switch shared with the
+    // snapshot consumer — avoids the Lesson 3 silent-ternary-collapse pitfall.
+    const mappedCode = mapTypedParserDiagnosticCode(typedParseResult.diagnostic.code, tagName);
     return emit("C-reject", [
       makeDiagnostic(mappedCode, typedParseResult.diagnostic.message, provenance),
     ]);
@@ -1041,7 +1026,10 @@ function buildCompilerBackedConstraintDiagnostics(
   });
 
   if (result.diagnostics.length === 0) {
-    return emit("C-pass", []);
+    // "D-pass": the synthetic batch produced no diagnostics for this application.
+    // This is distinct from "C-pass" (typed-parser accepted the argument at Role C
+    // before the batch ran). "D-pass" means the synthetic checker found nothing wrong.
+    return emit("D-pass", []);
   }
 
   const setupDiagnostic = result.diagnostics.find((diagnostic) => diagnostic.kind !== "typescript");


### PR DESCRIPTION
## Summary

Phase 3 of the synthetic-checker retirement. Routes the snapshot consumer's Role C (argument-literal validation) through `parseTagArgument` from `@formspec/analysis/internal`, mirroring Phase 2's build-consumer wiring (#348). The synthetic TypeScript checker still handles Roles A/B/D1/D2 until Phase 4.

**Status:** draft — core wiring + canary conversions are complete and green. A few trailing items (see below) are being wrapped up separately.

## Scope (this PR)

### Wiring — `packages/analysis/src/file-snapshots.ts`
- New `hasExtensionBroadening` helper that checks whether a builtin constraint tag has a registered broadening for the field's TypeScript type. Matches by name against `tsTypeNames` (consistent with the existing file-snapshots name-based detection bridge). The `isIntegerBrandedType` bypass is **intentionally not replicated** — that is a separately-tracked known divergence (#315).
- `buildTagDiagnostics` now takes an `extensionDefinitions` parameter, threaded through from `buildFormSpecAnalysisFileSnapshot`.
- `parseTagArgument` is called before the synthetic batch, guarded by `isBuiltinConstraintName` AND `!hasBroadening` (Phase 2 Lesson 1 — broadening check must run **before** the typed parser so D1/D2 fields bypass Role C correctly).
- Typed-parser diagnostic codes are mapped via an **exhaustive switch** with a throwing `UNKNOWN_TAG` branch and `never`-typed default arm (Phase 2 Lesson 3 — no binary ternary).
- Structured trace logs with `consumer: "snapshot"` emitted through `getTypedParserLogger()` (§8.3).

### Canary updates — `packages/analysis/src/__tests__/constraint-canaries.test.ts`

**Regression-test assertions shifted (8 tests):**

| Test | Before | After |
|---|---|---|
| `@minimum "hello"` on `number` | `TYPE_MISMATCH` | `INVALID_TAG_ARGUMENT` |
| `@minimum true` on `number` | `TYPE_MISMATCH` | `INVALID_TAG_ARGUMENT` |
| `@minimum` (no arg) | `INVALID_TAG_ARGUMENT` | `MISSING_TAG_ARGUMENT` |
| `@enumOptions` (no arg) | `INVALID_TAG_ARGUMENT` | `MISSING_TAG_ARGUMENT` |
| `@pattern` (no arg) | `INVALID_TAG_ARGUMENT` | `MISSING_TAG_ARGUMENT` |
| `@uniqueItems false` | `TYPE_MISMATCH` | `INVALID_TAG_ARGUMENT` |
| `@uniqueItems yes` | `TYPE_MISMATCH` | `INVALID_TAG_ARGUMENT` |
| `@uniqueItems maybe` | `TYPE_MISMATCH` | `INVALID_TAG_ARGUMENT` |
| `@const` (no arg) | `INVALID_TAG_ARGUMENT` | `MISSING_TAG_ARGUMENT` |

**`.fails` cases that flipped to regular `it()`:**
- `@enumOptions 5` (scalar, not array) — typed parser now catches at Role C
- `@enumOptions {}` (object, not array) — typed parser now catches at Role C

**`.fails` cases that remain (Phase 4 targets — placement/capability checks, not argument checks):**
- `@minimum 0` on string / boolean fields
- `@enumOptions` on a plain number field
- `@pattern 42`, `@pattern` on number / boolean / array fields
- `@uniqueItems` on string / number fields
- All four `@const` type-mismatch cases (IR-level `TYPE_MISMATCH` from `semantic-targets.ts`)

## Out of scope (this PR)

To keep the landing surface small, the following trailing items were deliberately not included and are being wrapped up separately:

1. **New test file** `packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts` mirroring PR #348's `typed-parser-canaries.test.ts` for the snapshot path.
2. **Parity-harness audit** — the `KNOWN_DIVERGENCES` list in `parity-harness.test.ts` may have entries that are now normalized; needs inspection.
3. **`parity-divergences.test.ts` refresh** — the three pinned divergences may need their snapshot-side assertions re-pinned.
4. **Changeset file** `.changeset/phase-3-snapshot-wiring.md` covering all 7 packages (`@formspec/analysis`, `@formspec/build`, `@formspec/cli`, `@formspec/eslint-plugin`, `@formspec/language-server`, `@formspec/ts-plugin`, `formspec`).
5. **Full-suite verification** (`pnpm run test` / `lint` / `format:check`) and performance comparison against the Phase 2 baseline microbenchmark.

These are mostly mechanical wrap-ups of a complete core implementation. Marked draft so the wrap-up can land before review.

## Verification so far

- `pnpm --filter @formspec/analysis run build` — green.
- `pnpm --filter @formspec/analysis run test` — **all 529 tests pass**, including:
  - 25 `constraint-canaries.test.ts` cases (all previously-failing regressions now pass).
  - 25 `parity-harness.test.ts` fixtures (KNOWN_DIVERGENCES gate still green — no unexplained divergences introduced).
  - 7 `file-snapshots.integer-bypass.test.ts` cases (known integer-brand divergence preserved).

## Test plan

- [ ] `pnpm run test` (full monorepo suite)
- [ ] `pnpm run lint`
- [ ] `pnpm run format:check`
- [ ] Parity-harness review — shrink `KNOWN_DIVERGENCES` entries now normalized
- [ ] `parity-divergences.test.ts` — refresh pinned snapshot assertions
- [ ] Add `typed-parser-snapshot-canaries.test.ts`
- [ ] Add `.changeset/phase-3-snapshot-wiring.md` (7 packages, patch)
- [ ] `e2e/benchmarks/synthetic-checker-baseline.bench.ts` — warm-median no worse than Phase 2

## References

- Phase 2: #348
- Plan: `docs/refactors/synthetic-checker-retirement.md` §4 Phase 3, §8.3 structured logging
- Tracked silent acceptances: #326
- Build/snapshot normalization: #329, #330
- Integer-brand snapshot divergence (out of scope): #315