### PR TITLE
fix(build): use $ref sibling keywords instead of allOf (#364)

### DIFF
--- a/.changeset/fix-364-ref-with-sibling-keywords.md
+++ b/.changeset/fix-364-ref-with-sibling-keywords.md
@@ -1,13 +1,7 @@
 ---
-"@formspec/analysis": patch
 "@formspec/build": patch
 "@formspec/cli": patch
-"@formspec/config": patch
-"@formspec/dsl": patch
 "@formspec/eslint-plugin": patch
-"@formspec/language-server": patch
-"@formspec/runtime": patch
-"@formspec/ts-plugin": patch
 "formspec": patch
 ---
 

--- a/.changeset/fix-364-ref-with-sibling-keywords.md
+++ b/.changeset/fix-364-ref-with-sibling-keywords.md
@@ -1,0 +1,14 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/config": patch
+"@formspec/dsl": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/runtime": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Fix unnecessary `allOf` composition when field-level constraints or annotations are applied to `$ref`-based types. JSON Schema 2020-12 (§10.2.1) allows sibling keywords next to `$ref`, so the generator now emits `{ "$ref": "#/$defs/X", "properties": {...} }` directly instead of wrapping in `allOf`. This preserves `$defs` deduplication and produces output that downstream renderers can consume without needing to unwrap `allOf` as a workaround.

--- a/docs/003-json-schema-vocabulary.md
+++ b/docs/003-json-schema-vocabulary.md
@@ -429,26 +429,22 @@ All `$defs` entries are placed at the root schema level. Nested schemas do not h
 
 When an author applies subfield constraints (via `@minimum :value 0` on a `MonetaryAmount` field — see document 002 §4), the generator must decide whether to:
 
-**Option A: Inline refinement at the use site** — emit the `$ref` wrapped in an `allOf` that adds the constraints:
+**Option A: Sibling keywords alongside `$ref`** — emit the `$ref` with the refinement keywords as siblings of the reference:
 
 ```json
 {
-  "allOf": [
-    { "$ref": "#/$defs/MonetaryAmount" },
-    {
-      "properties": {
-        "value": { "minimum": 0 }
-      }
-    }
-  ]
+  "$ref": "#/$defs/MonetaryAmount",
+  "properties": {
+    "value": { "minimum": 0 }
+  }
 }
 ```
 
-**Option B: Derived `$defs` entry** — create a new named `$defs` entry (e.g., `MonetaryAmount_constrained_discount`) that `allOf`s the base type with the refinements.
+**Option B: Derived `$defs` entry** — create a new named `$defs` entry (e.g., `MonetaryAmount_constrained_discount`) that composes the base type with the refinements.
 
-**Decision: Option A (inline `allOf` at the use site) is the default.** Option B is reserved for future work when multiple fields share the same constraint profile and deduplication is beneficial. Option A is simpler, more readable, and correctly represents that the constraints are field-specific, not type-specific.
+**Decision: Option A (sibling keywords alongside `$ref`) is the default.** Option B is reserved for future work when multiple fields share the same constraint profile and deduplication is beneficial. Option A is simpler, more readable, and correctly represents that the constraints are field-specific, not type-specific.
 
-The `allOf` + `$ref` pattern is standard 2020-12 and is the idiomatic way to express "this type, but with additional constraints." Standards-compliant validators handle it correctly.
+Sibling keywords alongside `$ref` are standard JSON Schema 2020-12. Draft 2019-09 changed `$ref` so it no longer ignores adjacent keywords — the `$ref` and its siblings are evaluated together. Standards-compliant 2020-12 validators honor both halves. This is also the shape that downstream renderers expect: wrapping in `allOf` adds a layer of composition that many renderers do not unwrap, resulting in the constraints being silently dropped from the rendered view.
 
 ### 5.5 Circular Reference Handling
 
@@ -536,9 +532,9 @@ As described in §5, named types use `$ref` to the `$defs` entry:
 { "$ref": "#/$defs/Address" }
 ```
 
-### 7.2 `allOf` for Progressive Refinement
+### 7.2 Sibling Keywords for Progressive Refinement
 
-When a TypeScript type extends another (or when subfield constraints are applied), the generator uses `allOf` to compose the base type with refinements:
+When subfield constraints are applied to a `$ref`-based field, the generator emits the refinement keywords as siblings of the `$ref` — not wrapped in an `allOf`:
 
 ```typescript
 interface BaseAmount {
@@ -546,23 +542,22 @@ interface BaseAmount {
   currency: string;
 }
 
-interface PositiveAmount extends BaseAmount {
-  // Constraints applied at the use site via @minimum :value 0
+interface Invoice {
+  /** @minimum :value 0 */
+  total: BaseAmount;
 }
 ```
 
 ```json
 {
-  "allOf": [
-    { "$ref": "#/$defs/BaseAmount" },
-    {
-      "properties": {
-        "value": { "minimum": 0 }
-      }
-    }
-  ]
+  "$ref": "#/$defs/BaseAmount",
+  "properties": {
+    "value": { "minimum": 0 }
+  }
 }
 ```
+
+Sibling keywords are the canonical shape for `$ref` refinements in 2020-12 (see §5.4). `allOf` is reserved for composition cases that cannot be expressed as siblings — for example, when the base schema itself is already an `allOf` that must be extended.
 
 ### 7.3 `oneOf` for Discriminated Unions
 
@@ -795,18 +790,14 @@ interface InvoiceFormData {
       "default": "draft"
     },
     "total": {
-      "allOf": [
-        { "$ref": "#/$defs/MonetaryAmount" },
-        {
-          "properties": {
-            "value": {
-              "minimum": 0.01,
-              "maximum": 9999999.99,
-              "multipleOf": 0.01
-            }
-          }
+      "$ref": "#/$defs/MonetaryAmount",
+      "properties": {
+        "value": {
+          "minimum": 0.01,
+          "maximum": 9999999.99,
+          "multipleOf": 0.01
         }
-      ],
+      },
       "title": "Total Amount"
     },
     "billingAddress": {
@@ -848,7 +839,7 @@ interface InvoiceFormData {
 }
 ```
 
-**Note on `$ref` + sibling keywords:** JSON Schema 2020-12 allows sibling keywords alongside `$ref` (unlike draft-07, where siblings were ignored). The `"title"` alongside `"$ref"` in `billingAddress` and the `allOf` + `"title"` in `total` are valid 2020-12. This is a deliberate 2020-12 feature used by FormSpec for clean output.
+**Note on `$ref` + sibling keywords:** JSON Schema 2020-12 allows sibling keywords alongside `$ref` (unlike draft-07, where siblings were ignored). `billingAddress` pairs a bare `$ref` with a sibling `title`; `total` adds path-targeted subfield overrides as siblings (`properties`) plus a `title`. Both shapes are valid 2020-12 and are emitted directly by FormSpec — no `allOf` wrapping is introduced for these cases (see §5.4).
 
 ---
 

--- a/docs/005-numeric-types.md
+++ b/docs/005-numeric-types.md
@@ -188,13 +188,14 @@ Generated `$defs`:
   "$defs": {
     "Integer": { "type": "integer" },
     "USDCents": {
-      "allOf": [{ "$ref": "#/$defs/Integer" }, { "minimum": 0 }]
+      "$ref": "#/$defs/Integer",
+      "minimum": 0
     }
   }
 }
 ```
 
-The `allOf` + `$ref` pattern (003 §7.2) handles constraint narrowing at each level of the alias chain. `USDCents` inherits the integer type from `Integer` and adds `@minimum 0`. A field of type `USDCents` inherits both (PP3, S1, C1).
+The `$ref` + sibling keyword pattern (003 §7.2) handles constraint narrowing at each level of the alias chain. `USDCents` inherits the integer type from `Integer` and adds `@minimum 0` as a sibling keyword. A field of type `USDCents` inherits both (PP3, S1, C1).
 
 ### 3.4 Type Alias Patterns
 
@@ -673,22 +674,16 @@ Generated JSON Schema:
       "required": ["value", "currency"]
     },
     "USDAmount": {
-      "allOf": [
-        { "$ref": "#/$defs/MonetaryAmount" },
-        { "properties": { "currency": { "const": "USD" } } }
-      ]
+      "$ref": "#/$defs/MonetaryAmount",
+      "properties": { "currency": { "const": "USD" } }
     }
   },
   "properties": {
     "charge": {
-      "allOf": [
-        { "$ref": "#/$defs/USDAmount" },
-        {
-          "properties": {
-            "value": { "minimum": 0.01, "maximum": 9999999.99, "multipleOf": 0.01 }
-          }
-        }
-      ],
+      "$ref": "#/$defs/USDAmount",
+      "properties": {
+        "value": { "minimum": 0.01, "maximum": 9999999.99, "multipleOf": 0.01 }
+      },
       "title": "Total Amount"
     }
   },
@@ -696,7 +691,7 @@ Generated JSON Schema:
 }
 ```
 
-Subfield constraint targeting (S5) directs `:value` constraints to the `value: number` property; constraint applicability is evaluated against the subfield's type, not the parent. The `allOf` + `$ref` chain accumulates constraints from each alias level — `USDAmount` fixes the currency, and the use-site annotation adds the numeric bounds on the value.
+Subfield constraint targeting (S5) directs `:value` constraints to the `value: number` property; constraint applicability is evaluated against the subfield's type, not the parent. Sibling keywords alongside `$ref` accumulate constraints from each alias level — `USDAmount` fixes the currency, and the use-site annotation adds the numeric bounds on the value. The `$ref` and its siblings are evaluated together under JSON Schema 2020-12.
 
 ---
 
@@ -785,4 +780,4 @@ This composition is performed in the Validate phase of the pipeline (A5), after 
 | OD-1 | §3.1    | Should type alias resolution be eager (at analysis time) or lazy (at generation time)?                                                                               | Eager — resolved at Canonicalize phase to enable Validate phase contradiction detection                                                                           |
 | OD-2 | §3.3    | Should the generator emit `{ "type": "integer" }` or `{ "type": "number", "multipleOf": 1 }` for aliases with `MultipleOfConstraint(1)`?                             | **DECIDED:** `{ "type": "integer" }`. Integer is a first-class FormSpec numeric kind; `number + @multipleOf 1` is a TSDoc authoring path that canonicalizes to it |
 | OD-3 | §4.3    | Should `broadenConstraintTag` be a compile-time registration or a runtime registration?                                                                              | Compile-time, via extension npm package loaded at build time (E5)                                                                                                 |
-| OD-4 | §6      | When a type alias inherits subfield constraints, should the generator always emit `allOf` + `$ref`, or inline when the alias adds only a single subfield constraint? | Always `allOf` + `$ref` for consistency and high-fidelity output (PP7)                                                                                            |
+| OD-4 | §6      | When a type alias inherits subfield constraints, how should the generator emit the composed shape?                                                                   | Sibling keywords alongside `$ref` (see 003 §5.4) — no `allOf` wrapping. Renderer-compatible and consistent across the alias chain (PP7)                          |

--- a/docs/e2e-test-matrix.md
+++ b/docs/e2e-test-matrix.md
@@ -23,7 +23,7 @@
 - `@multipleOf 1` → integer promotion (inherited-constraints)
 - 2-level alias chain propagation (inherited-constraints)
 - Field-level narrowing of alias constraints (inherited-constraints)
-- Path-target on `$ref` type — `allOf` composition (path-target-constraints)
+- Path-target on `$ref` type — sibling keywords alongside `$ref` (path-target-constraints; see 003 §5.4)
 - Path-target on array item type — transparency (path-target-constraints)
 - Chain DSL: groups, conditionals, labeled enums, dynamic enums, objects, arrays (chain-dsl fixtures)
 
@@ -1008,10 +1008,12 @@ export class NetworkForm {
   "$defs": {
     "Integer": { "type": "integer" },
     "NonNegativeInteger": {
-      "allOf": [{ "$ref": "#/$defs/Integer" }, { "minimum": 0 }]
+      "$ref": "#/$defs/Integer",
+      "minimum": 0
     },
     "PortNumber": {
-      "allOf": [{ "$ref": "#/$defs/NonNegativeInteger" }, { "maximum": 65535 }]
+      "$ref": "#/$defs/NonNegativeInteger",
+      "maximum": 65535
     }
   }
 }
@@ -1154,48 +1156,36 @@ export class PathTargetExpandedForm {
   "type": "object",
   "properties": {
     "size": {
-      "allOf": [
-        { "$ref": "#/$defs/Dimensions" },
-        {
-          "properties": {
-            "width": { "minimum": 0, "maximum": 10000 },
-            "height": { "minimum": 0, "maximum": 10000 },
-            "unit": { "pattern": "^(cm|in|px)$" }
-          }
-        }
-      ]
+      "$ref": "#/$defs/Dimensions",
+      "properties": {
+        "width": { "minimum": 0, "maximum": 10000 },
+        "height": { "minimum": 0, "maximum": 10000 },
+        "unit": { "pattern": "^(cm|in|px)$" }
+      }
     },
     "total": {
-      "allOf": [
-        { "$ref": "#/$defs/MonetaryAmount" },
-        {
-          "properties": {
-            "value": {
-              "minimum": 0.01,
-              "maximum": 9999999.99,
-              "multipleOf": 0.01
-            },
-            "currency": {
-              "minLength": 3,
-              "maxLength": 3,
-              "pattern": "^[A-Z]{3}$"
-            }
-          }
+      "$ref": "#/$defs/MonetaryAmount",
+      "properties": {
+        "value": {
+          "minimum": 0.01,
+          "maximum": 9999999.99,
+          "multipleOf": 0.01
+        },
+        "currency": {
+          "minLength": 3,
+          "maxLength": 3,
+          "pattern": "^[A-Z]{3}$"
         }
-      ]
+      }
     },
     "lineItems": {
       "type": "array",
       "items": {
-        "allOf": [
-          { "$ref": "#/$defs/MonetaryAmount" },
-          {
-            "properties": {
-              "value": { "minimum": 0 },
-              "currency": { "minLength": 3, "maxLength": 3 }
-            }
-          }
-        ]
+        "$ref": "#/$defs/MonetaryAmount",
+        "properties": {
+          "value": { "minimum": 0 },
+          "currency": { "minLength": 3, "maxLength": 3 }
+        }
       }
     },
     "shipments": {
@@ -1203,29 +1193,21 @@ export class PathTargetExpandedForm {
       "minItems": 1,
       "maxItems": 100,
       "items": {
-        "allOf": [
-          { "$ref": "#/$defs/Shipment" },
-          {
-            "properties": {
-              "lineItems": {
-                "minItems": 1,
-                "maxItems": 25,
-                "uniqueItems": true
-              }
-            }
+        "$ref": "#/$defs/Shipment",
+        "properties": {
+          "lineItems": {
+            "minItems": 1,
+            "maxItems": 25,
+            "uniqueItems": true
           }
-        ]
+        }
       }
     },
     "optionalAmount": {
-      "allOf": [
-        { "$ref": "#/$defs/MonetaryAmount" },
-        {
-          "properties": {
-            "value": { "minimum": 0 }
-          }
-        }
-      ]
+      "$ref": "#/$defs/MonetaryAmount",
+      "properties": {
+        "value": { "minimum": 0 }
+      }
     }
   },
   "required": ["size", "total", "lineItems"],
@@ -1269,9 +1251,9 @@ export class PathTargetExpandedForm {
 - [ ] Array transparency: `lineItems` has path-targeted constraints applied to `items` (spec 002 §4.3)
 - [ ] Untargeted `@minItems` / `@maxItems` on `shipments` constrain the outer array itself (spec 002 §4.3)
 - [ ] Path-targeted `@minItems :lineItems` / `@maxItems :lineItems` / `@uniqueItems :lineItems` constrain the nested array field on each shipment item (spec 002 §4.3)
-- [ ] Optional field with path target: `optionalAmount` emits `allOf` and is NOT in `required` (spec S8)
+- [ ] Optional field with path target: `optionalAmount` emits `$ref` + sibling keywords and is NOT in `required` (spec S8)
 - [ ] All named types appear in `$defs` (spec 003 §5.2, PP7)
-- [ ] `allOf` contains `$ref` + constraint object (spec 003 §5.4)
+- [ ] Path-targeted overrides emit as sibling keywords alongside `$ref`, not wrapped in `allOf` (spec 003 §5.4)
 
 ---
 
@@ -1779,7 +1761,7 @@ export class LineItem {
       "title": "Unit Price"
     },
     "quantity": {
-      "allOf": [{ "$ref": "#/$defs/USDCents" }],
+      "$ref": "#/$defs/USDCents",
       "minimum": 1,
       "maximum": 9999,
       "title": "Quantity"
@@ -1792,7 +1774,8 @@ export class LineItem {
       "maximum": 99999999999999
     },
     "USDCents": {
-      "allOf": [{ "$ref": "#/$defs/Integer" }, { "minimum": 0 }]
+      "$ref": "#/$defs/Integer",
+      "minimum": 0
     }
   }
 }

--- a/e2e/tests/tsdoc-path-target.test.ts
+++ b/e2e/tests/tsdoc-path-target.test.ts
@@ -47,31 +47,28 @@ describe("TSDoc Path-Target Constraints", () => {
   });
 
   describe("path-targeted constraints on reference type", () => {
-    it("total field uses allOf with $ref and value constraints", () => {
+    it("total field uses $ref + sibling properties with value constraints (issue #364)", () => {
+      // JSON Schema 2020-12 §10.2.1: sibling keywords next to $ref are valid.
+      // The path-targeted constraints appear as a sibling `properties` keyword,
+      // not wrapped in allOf. See: https://github.com/mike-north/formspec/issues/364
       const properties = schema["properties"] as Record<string, unknown>;
       const total = properties["total"] as Record<string, unknown>;
-      expect(total).toHaveProperty("allOf");
-      const allOf = total["allOf"] as Record<string, unknown>[];
-      expect(allOf).toContainEqual({ $ref: "#/$defs/MonetaryAmount" });
-      const override = allOf.find((m) => m["properties"] !== undefined);
-      expect(override).toBeDefined();
-      if (!override) throw new Error("override not found");
-      const overrideProps = override["properties"] as Record<string, unknown>;
+      expect(total).toHaveProperty("$ref", "#/$defs/MonetaryAmount");
+      expect(total).not.toHaveProperty("allOf");
+      const overrideProps = total["properties"] as Record<string, unknown>;
       expect(overrideProps["value"]).toMatchObject({ minimum: 0, maximum: 9999999.99 });
     });
   });
 
   describe("path-targeted string constraints", () => {
-    it("discount field targets currency subproperty via allOf", () => {
+    it("discount field targets currency subproperty via sibling properties (issue #364)", () => {
+      // JSON Schema 2020-12 §10.2.1: sibling keywords next to $ref are valid.
+      // See: https://github.com/mike-north/formspec/issues/364
       const properties = schema["properties"] as Record<string, unknown>;
       const discount = properties["discount"] as Record<string, unknown>;
-      expect(discount).toHaveProperty("allOf");
-      const allOf = discount["allOf"] as Record<string, unknown>[];
-      expect(allOf).toContainEqual({ $ref: "#/$defs/MonetaryAmount" });
-      const override = allOf.find((m) => m["properties"] !== undefined);
-      expect(override).toBeDefined();
-      if (!override) throw new Error("override not found");
-      const overrideProps = override["properties"] as Record<string, unknown>;
+      expect(discount).toHaveProperty("$ref", "#/$defs/MonetaryAmount");
+      expect(discount).not.toHaveProperty("allOf");
+      const overrideProps = discount["properties"] as Record<string, unknown>;
       const currency = overrideProps["currency"] as Record<string, unknown>;
       expect(currency).toMatchObject({
         minLength: 3,
@@ -82,18 +79,16 @@ describe("TSDoc Path-Target Constraints", () => {
   });
 
   describe("array transparency", () => {
-    it("lineItems applies path-targeted constraints to items via allOf", () => {
+    it("lineItems applies path-targeted constraints to items via sibling properties (issue #364)", () => {
+      // JSON Schema 2020-12 §10.2.1: sibling keywords next to $ref are valid.
+      // The items schema uses sibling keywords, not allOf. (#364)
       const properties = schema["properties"] as Record<string, unknown>;
       const lineItems = properties["lineItems"] as Record<string, unknown>;
       expect(lineItems).toHaveProperty("type", "array");
       const items = lineItems["items"] as Record<string, unknown>;
-      expect(items).toHaveProperty("allOf");
-      const allOf = items["allOf"] as Record<string, unknown>[];
-      expect(allOf).toContainEqual({ $ref: "#/$defs/MonetaryAmount" });
-      const override = allOf.find((m) => m["properties"] !== undefined);
-      expect(override).toBeDefined();
-      if (!override) throw new Error("override not found");
-      const overrideProps = override["properties"] as Record<string, unknown>;
+      expect(items).toHaveProperty("$ref", "#/$defs/MonetaryAmount");
+      expect(items).not.toHaveProperty("allOf");
+      const overrideProps = items["properties"] as Record<string, unknown>;
       expect(overrideProps["value"]).toMatchObject({ minimum: 0 });
     });
   });

--- a/packages/build/src/__tests__/generate-schemas-config.test.ts
+++ b/packages/build/src/__tests__/generate-schemas-config.test.ts
@@ -293,25 +293,29 @@ describe("generateSchemas with FormSpecConfig", () => {
       }
     }
 
-    // A path-target override is emitted as an `allOf` entry with
-    // `properties.<segment>.<jsonSchemaKeyword>: <value>`. Asserting via a
-    // direct `allOf` shape — then scanning its entries — keeps the Jest
-    // matcher types clean (no unsafe-any from `expect.arrayContaining`) while
-    // using the real `JsonSchema2020` typing for property access.
+    // Path-target overrides are emitted as sibling keywords alongside `$ref`
+    // (JSON Schema 2020-12 §10.2.1). The `properties` override appears directly
+    // on the field schema, not wrapped in `allOf`. Asserting via the sibling
+    // `properties` key keeps the Jest matcher types clean while using the real
+    // `JsonSchema2020` typing for property access.
+    // See: https://github.com/mike-north/formspec/issues/364
     function findPathOverride(
       result: ClassSchemas,
       fieldName: string,
-      predicate: (entry: JsonSchema2020) => boolean
+      predicate: (schema: JsonSchema2020) => boolean
     ): JsonSchema2020 | undefined {
       const field = result.jsonSchema.properties?.[fieldName];
-      const allOf = field?.allOf;
       expect(
-        allOf,
-        `expected allOf on property '${fieldName}' but found ${
-          allOf === undefined ? "none" : "empty"
-        }`
+        field,
+        `expected a schema for property '${fieldName}'`
       ).toBeDefined();
-      return allOf?.find(predicate);
+      // The field schema itself is the "override container" — sibling keywords
+      // sit directly on it alongside $ref. Wrap in an array to keep the predicate
+      // interface compatible with callers that previously scanned allOf entries.
+      if (field !== undefined && predicate(field)) {
+        return field;
+      }
+      return undefined;
     }
 
     function expectPathOverride(
@@ -321,28 +325,25 @@ describe("generateSchemas with FormSpecConfig", () => {
       keyword: string,
       value: unknown
     ) {
-      const override = findPathOverride(
-        result,
-        fieldName,
-        (entry) => {
-          const segmentSchema = entry.properties?.[segment];
-          if (segmentSchema === undefined) return false;
-          return (segmentSchema as Record<string, unknown>)[keyword] === value;
-        }
-      );
+      const field = result.jsonSchema.properties?.[fieldName];
+      expect(field, `expected schema for field '${fieldName}'`).toBeDefined();
+      const segmentSchema = field?.properties?.[segment];
       expect(
-        override,
-        `no allOf entry with properties.${segment}.${keyword} === ${String(
-          value
-        )} on field '${fieldName}'`
+        segmentSchema,
+        `expected field '${fieldName}' to have sibling properties.${segment} (path override)`
       ).toBeDefined();
+      expect(
+        (segmentSchema as Record<string, unknown>)[keyword],
+        `expected properties.${segment}.${keyword} === ${String(value)} on field '${fieldName}'`
+      ).toBe(value);
     }
 
     // Path-target overrides emit the standard JSON Schema keyword directly
     // on the sub-path — not the vendor-prefixed custom-constraint keyword
-    // that's used for the type's own direct-target broadening. See the
-    // `allOf: [{ $ref }, { properties: { amount: { minimum: 0 } } }]`
-    // shape asserted by `expectPathOverride`.
+    // that's used for the type's own direct-target broadening. The emitted
+    // shape is `{ "$ref": "#/$defs/X", "properties": { amount: { minimum: 0 } } }`
+    // per JSON Schema 2020-12 §10.2.1 (sibling keywords next to $ref are valid).
+    // See: https://github.com/mike-north/formspec/issues/364
     const numericTagCases: readonly {
       tag: string;
       argument: string;

--- a/packages/build/src/__tests__/generate-schemas-config.test.ts
+++ b/packages/build/src/__tests__/generate-schemas-config.test.ts
@@ -155,10 +155,7 @@ describe("generateSchemas with FormSpecConfig", () => {
       });
 
       expect(result.jsonSchema.$defs?.["PlanStatus"]).toMatchObject({
-        oneOf: [
-          { const: "draft", title: "Draft" },
-          { const: "sent" },
-        ],
+        oneOf: [{ const: "draft", title: "Draft" }, { const: "sent" }],
       });
       expect(result.jsonSchema.$defs?.["PlanStatus"]).not.toHaveProperty("enum");
     } finally {
@@ -305,10 +302,7 @@ describe("generateSchemas with FormSpecConfig", () => {
       predicate: (schema: JsonSchema2020) => boolean
     ): JsonSchema2020 | undefined {
       const field = result.jsonSchema.properties?.[fieldName];
-      expect(
-        field,
-        `expected a schema for property '${fieldName}'`
-      ).toBeDefined();
+      expect(field, `expected a schema for property '${fieldName}'`).toBeDefined();
       // The field schema itself is the "override container" — sibling keywords
       // sit directly on it alongside $ref. Wrap in an array to keep the predicate
       // interface compatible with callers that previously scanned allOf entries.
@@ -511,9 +505,7 @@ describe("generateSchemas with FormSpecConfig", () => {
             label: string;
           }
         `;
-        expect(() => runSchema(source, { vendorPrefix: "x-formspec" })).toThrow(
-          /TYPE_MISMATCH/
-        );
+        expect(() => runSchema(source, { vendorPrefix: "x-formspec" })).toThrow(/TYPE_MISMATCH/);
       });
     });
 

--- a/packages/build/src/__tests__/generate-schemas.test.ts
+++ b/packages/build/src/__tests__/generate-schemas.test.ts
@@ -358,6 +358,98 @@ describe("generateSchemas", () => {
       fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
     }
   });
+
+  // ---------------------------------------------------------------------------
+  // Narrowing type alias with a path-targeted constraint (issue #364).
+  //
+  // Scenario from user feedback on PR #365:
+  //
+  //   interface MonetaryAmount { amount: number; currency: string; }
+  //   /** @minimum :amount 0 */
+  //   type PositiveMonetaryAmount = MonetaryAmount;
+  //
+  //   class Form { price!: PositiveMonetaryAmount; }
+  //
+  // The emitter MUST produce `$ref` + sibling keywords at the field use site —
+  // never an `allOf` wrapper — because downstream renderers (Stripe dashboard
+  // config UI) do not unwrap `allOf` and the constraints would be silently
+  // dropped from the rendered view.
+  //
+  // Spec 003 §5.4 — sibling keywords alongside `$ref` are canonical.
+  // ---------------------------------------------------------------------------
+  it("emits $ref + sibling keywords for a narrowing alias whose constraint uses path targeting (issue #364)", () => {
+    const filePath = writeTempSource(`
+      export interface MonetaryAmount {
+        amount: number;
+        currency: string;
+      }
+
+      /** @minimum :amount 0 */
+      export type PositiveMonetaryAmount = MonetaryAmount;
+
+      export class Form {
+        price!: PositiveMonetaryAmount;
+      }
+    `);
+
+    try {
+      const result = generateSchemasOrThrow({
+        filePath,
+        typeName: "Form",
+      });
+
+      const priceProp = (result.jsonSchema.properties as Record<string, unknown>)["price"] as
+        | Record<string, unknown>
+        | undefined;
+
+      // $ref + siblings shape — spec 003 §5.4.
+      expect(priceProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+      expect(priceProp?.["properties"]).toEqual({ amount: { minimum: 0 } });
+
+      // The regression guard: no allOf wrapping anywhere in the price subschema.
+      expect(priceProp?.["allOf"]).toBeUndefined();
+
+      // $defs entry for the base type must still be present (dedup preserved).
+      expect(result.jsonSchema.$defs).toHaveProperty("MonetaryAmount");
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
+
+  it("composes alias-level and use-site path targets as siblings on a single $ref (issue #364)", () => {
+    // Alias carries `@minimum :amount 0`; the field annotation adds
+    // `@maximum :amount 9999`. Both bounds must land as siblings on the same
+    // `amount` subschema — no allOf layering, no duplication across members.
+    const filePath = writeTempSource(`
+      export interface MonetaryAmount {
+        amount: number;
+        currency: string;
+      }
+
+      /** @minimum :amount 0 */
+      export type PositiveMonetaryAmount = MonetaryAmount;
+
+      export class Form {
+        /** @maximum :amount 9999 */
+        cap!: PositiveMonetaryAmount;
+      }
+    `);
+
+    try {
+      const result = generateSchemasOrThrow({ filePath, typeName: "Form" });
+      const capProp = (result.jsonSchema.properties as Record<string, unknown>)["cap"] as
+        | Record<string, unknown>
+        | undefined;
+
+      expect(capProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+      expect(capProp?.["properties"]).toEqual({
+        amount: { minimum: 0, maximum: 9999 },
+      });
+      expect(capProp?.["allOf"]).toBeUndefined();
+    } finally {
+      fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+    }
+  });
 });
 
 describe("generateJsonSchema", () => {

--- a/packages/build/src/__tests__/generate-schemas.test.ts
+++ b/packages/build/src/__tests__/generate-schemas.test.ts
@@ -88,24 +88,23 @@ describe("generateSchemas", () => {
       typeName: "BlogConfig",
     });
 
+    // JSON Schema 2020-12 §10.2.1: sibling keywords next to $ref are valid.
+    // Path-targeted constraints on a $ref-based items schema must emit sibling
+    // keywords rather than allOf composition. (Fixes #364.)
     expect(result.jsonSchema.properties).toMatchObject({
       articles: {
         type: "array",
         minItems: 1,
         maxItems: 50,
         items: {
-          allOf: [
-            { $ref: "#/$defs/Article" },
-            {
-              properties: {
-                tags: {
-                  minItems: 1,
-                  maxItems: 20,
-                  uniqueItems: true,
-                },
-              },
+          $ref: "#/$defs/Article",
+          properties: {
+            tags: {
+              minItems: 1,
+              maxItems: 20,
+              uniqueItems: true,
             },
-          ],
+          },
         },
       },
     });
@@ -117,13 +116,14 @@ describe("generateSchemas", () => {
       typeName: "SerializedNameForm",
     });
 
+    // JSON Schema 2020-12 §10.2.1: sibling keywords next to $ref are valid.
+    // The path-targeted constraint on `total` must appear as a sibling
+    // `properties` keyword alongside `$ref`, not wrapped in allOf. (#364.)
     expect(result.jsonSchema.properties).toMatchObject({
       first_name: { type: "string" },
       total: {
-        allOf: [
-          { $ref: "#/$defs/RenamedAmount" },
-          { properties: { amount_value: { minimum: 0 } } },
-        ],
+        $ref: "#/$defs/RenamedAmount",
+        properties: { amount_value: { minimum: 0 } },
       },
       address: { $ref: "#/$defs/PostalAddress" },
     });

--- a/packages/build/src/__tests__/ir-json-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-json-schema-generator.test.ts
@@ -501,11 +501,7 @@ describe("generateJsonSchemaFromIR", () => {
       const prop = (schema.properties as Record<string, unknown>)["currency"];
 
       expect(prop).toEqual({
-        oneOf: [
-          { const: "USD" },
-          { const: "EUR", title: "Euro" },
-          { const: "GBP" },
-        ],
+        oneOf: [{ const: "USD" }, { const: "EUR", title: "Euro" }, { const: "GBP" }],
       });
     });
 
@@ -537,34 +533,28 @@ describe("generateJsonSchemaFromIR", () => {
         displayName: "usd",
         expectedTitle: true,
       },
-    ])(
-      "oneOf title omission edge case: $label",
-      ({ value, displayName, expectedTitle }) => {
-        const ir = makeIR([
-          makeField("f", {
-            kind: "enum",
-            members: [{ value, displayName }],
-          }),
-        ]);
-        const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "oneOf" });
-        const prop = (schema.properties as Record<string, unknown>)["f"];
+    ])("oneOf title omission edge case: $label", ({ value, displayName, expectedTitle }) => {
+      const ir = makeIR([
+        makeField("f", {
+          kind: "enum",
+          members: [{ value, displayName }],
+        }),
+      ]);
+      const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "oneOf" });
+      const prop = (schema.properties as Record<string, unknown>)["f"];
 
-        if (expectedTitle) {
-          expect(prop).toEqual({ oneOf: [{ const: value, title: displayName }] });
-        } else {
-          expect(prop).toEqual({ oneOf: [{ const: value }] });
-        }
-      },
-    );
+      if (expectedTitle) {
+        expect(prop).toEqual({ oneOf: [{ const: value, title: displayName }] });
+      } else {
+        expect(prop).toEqual({ oneOf: [{ const: value }] });
+      }
+    });
 
     it("uses compact enum serialization in smart-size mode when titles would be redundant", () => {
       const ir = makeIR([
         makeField("status", {
           kind: "enum",
-          members: [
-            { value: "draft", displayName: "draft" },
-            { value: "sent" },
-          ],
+          members: [{ value: "draft", displayName: "draft" }, { value: "sent" }],
         }),
       ]);
       const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "smart-size" });
@@ -579,20 +569,14 @@ describe("generateJsonSchemaFromIR", () => {
       const ir = makeIR([
         makeField("status", {
           kind: "enum",
-          members: [
-            { value: "draft", displayName: "Draft" },
-            { value: "sent" },
-          ],
+          members: [{ value: "draft", displayName: "Draft" }, { value: "sent" }],
         }),
       ]);
       const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "smart-size" });
       const prop = (schema.properties as Record<string, unknown>)["status"];
 
       expect(prop).toEqual({
-        oneOf: [
-          { const: "draft", title: "Draft" },
-          { const: "sent" },
-        ],
+        oneOf: [{ const: "draft", title: "Draft" }, { const: "sent" }],
       });
     });
 

--- a/packages/build/src/__tests__/ir-json-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-json-schema-generator.test.ts
@@ -2087,7 +2087,10 @@ describe("generateJsonSchemaFromIR", () => {
       },
     };
 
-    it("emits allOf with $ref and property overrides for path-targeted constraints on reference types", () => {
+    it("emits $ref + sibling properties keyword for path-targeted constraints on reference types (issue #364)", () => {
+      // JSON Schema 2020-12 §10.2.1 allows sibling keywords next to $ref.
+      // The output must use sibling keywords, NOT allOf composition.
+      // See: https://github.com/mike-north/formspec/issues/364
       const ir: FormIR = {
         kind: "form-ir",
         irVersion: IR_VERSION,
@@ -2118,7 +2121,8 @@ describe("generateJsonSchemaFromIR", () => {
       };
       const schema = generateJsonSchemaFromIR(ir);
       expect((schema.properties as Record<string, unknown>)["total"]).toEqual({
-        allOf: [{ $ref: "#/$defs/MonetaryAmount" }, { properties: { value: { minimum: 0 } } }],
+        $ref: "#/$defs/MonetaryAmount",
+        properties: { value: { minimum: 0 } },
       });
     });
 
@@ -2226,8 +2230,11 @@ describe("generateJsonSchemaFromIR", () => {
         type: "array",
         minItems: 1,
       });
+      // JSON Schema 2020-12 §10.2.1: sibling keywords next to $ref are valid.
+      // The items schema must use sibling keywords, not allOf. (#364)
       expect(lineItems["items"]).toEqual({
-        allOf: [{ $ref: "#/$defs/MonetaryAmount" }, { properties: { value: { minimum: 0 } } }],
+        $ref: "#/$defs/MonetaryAmount",
+        properties: { value: { minimum: 0 } },
       });
     });
 
@@ -2292,11 +2299,11 @@ describe("generateJsonSchemaFromIR", () => {
         unknown
       >;
 
+      // JSON Schema 2020-12 §10.2.1: sibling keywords next to $ref are valid.
+      // The remapped property name must appear in sibling properties, not allOf. (#364)
       expect(lineItems["items"]).toEqual({
-        allOf: [
-          { $ref: "#/$defs/RenamedAmount" },
-          { properties: { amount_value: { minimum: 0 } } },
-        ],
+        $ref: "#/$defs/RenamedAmount",
+        properties: { amount_value: { minimum: 0 } },
       });
     });
 
@@ -2803,15 +2810,14 @@ describe("generateJsonSchemaFromIR", () => {
         typeRegistry: MONETARY_AMOUNT_REGISTRY,
         provenance: PROVENANCE,
       };
+      // JSON Schema 2020-12 §10.2.1: sibling keywords next to $ref are valid.
+      // All overrides (title, properties) must appear as siblings alongside $ref,
+      // not wrapped in allOf. (Fixes #364.)
       const schema = generateJsonSchemaFromIR(ir);
       expect((schema.properties as Record<string, unknown>)["total"]).toEqual({
-        allOf: [
-          { $ref: "#/$defs/MonetaryAmount" },
-          {
-            title: "Total Amount",
-            properties: { value: { minimum: 0, maximum: 999999 } },
-          },
-        ],
+        $ref: "#/$defs/MonetaryAmount",
+        title: "Total Amount",
+        properties: { value: { minimum: 0, maximum: 999999 } },
       });
     });
   });

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -307,9 +307,7 @@ describe("$ref with sibling keywords — issue #364", () => {
       const schema = generateJsonSchemaFromIR(ir);
       const lineItemsItems = schema.properties?.["lineItems"]?.items;
 
-      expect((lineItemsItems as Record<string, unknown>)["$ref"]).toBe(
-        "#/$defs/MonetaryAmount"
-      );
+      expect((lineItemsItems as Record<string, unknown>)["$ref"]).toBe("#/$defs/MonetaryAmount");
       expect((lineItemsItems as Record<string, unknown>)["properties"]).toEqual({
         value: { minimum: 0 },
       });
@@ -360,6 +358,124 @@ describe("$ref with sibling keywords — issue #364", () => {
       expect(totalProp?.properties).toEqual({
         value: { minimum: 0 },
         currency: { maxLength: 3 },
+      });
+      expect(totalProp?.allOf).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Annotation-only: metadata on a $ref field with no path-targeted constraint
+  // ---------------------------------------------------------------------------
+  describe("annotations on a $ref-based field without path-targeted constraints", () => {
+    it("emits $ref + sibling title without allOf", () => {
+      // Ensures the no-constraint annotation path also avoids allOf. Path-target
+      // constraints are what trigger `applyPathTargetedConstraints`, but
+      // annotations flow through `applyAnnotations` on the same schema — the
+      // resulting shape should still be flat siblings, never `allOf`.
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "total",
+            type: { kind: "reference", name: "MonetaryAmount", typeArguments: [] },
+            required: true,
+            constraints: [],
+            annotations: [
+              {
+                kind: "annotation",
+                annotationKind: "displayName",
+                value: "Total Amount",
+                provenance: PROVENANCE,
+              },
+            ],
+            provenance: PROVENANCE,
+          },
+        ],
+        MONETARY_AMOUNT_REGISTRY
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const totalProp = schema.properties?.["total"];
+
+      expect(totalProp?.$ref).toBe("#/$defs/MonetaryAmount");
+      expect(totalProp?.title).toBe("Total Amount");
+      expect(totalProp?.allOf).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Deeply-nested path targets: constraint segments more than one level deep
+  // ---------------------------------------------------------------------------
+  describe("deeply-nested path-targeted constraints on a $ref field", () => {
+    it("emits nested sibling properties for multi-segment path targets", () => {
+      // Exercises the `buildPropertyOverrides` logic for path segments longer
+      // than 1. Registers a type where `value` is itself an object with an
+      // `amount` property, then applies a constraint at `value.amount`.
+      const registry: FormIR["typeRegistry"] = {
+        NestedMonetary: {
+          name: "NestedMonetary",
+          type: {
+            kind: "object",
+            properties: [
+              {
+                name: "value",
+                type: {
+                  kind: "object",
+                  properties: [
+                    {
+                      name: "amount",
+                      type: { kind: "primitive", primitiveKind: "number" },
+                      optional: false,
+                      constraints: [],
+                      annotations: [],
+                      provenance: PROVENANCE,
+                    },
+                  ],
+                  additionalProperties: true,
+                },
+                optional: false,
+                constraints: [],
+                annotations: [],
+                provenance: PROVENANCE,
+              },
+            ],
+            additionalProperties: true,
+          },
+          provenance: PROVENANCE,
+        },
+      };
+
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "total",
+            type: { kind: "reference", name: "NestedMonetary", typeArguments: [] },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minimum",
+                value: 0,
+                path: { segments: ["value", "amount"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        registry
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const totalProp = schema.properties?.["total"];
+
+      expect(totalProp?.$ref).toBe("#/$defs/NestedMonetary");
+      // The constraint lives two levels deep — once inside sibling
+      // `properties.value`, and again inside that schema's `properties.amount`.
+      expect(totalProp?.properties).toEqual({
+        value: { properties: { amount: { minimum: 0 } } },
       });
       expect(totalProp?.allOf).toBeUndefined();
     });

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Regression tests for issue #364: `allOf` composition when field-level
+ * constraints or annotations are applied to `$ref`-based types.
+ *
+ * Root cause: `applyPathTargetedConstraints` wrapped `{ $ref }` in an
+ * `allOf` to add property overrides, even though JSON Schema 2020-12 allows
+ * sibling keywords next to `$ref` (unlike draft-07). This produced:
+ *
+ *   { "allOf": [{ "$ref": "#/$defs/X" }, { "properties": {...}, "title": "..." }] }
+ *
+ * The fix uses sibling keywords instead:
+ *
+ *   { "$ref": "#/$defs/X", "properties": {...}, "title": "..." }
+ *
+ * This preserves `$defs` deduplication while emitting valid 2020-12 output
+ * that downstream renderers can consume without needing to handle `allOf`
+ * as a workaround for a spec-level limitation that no longer exists.
+ *
+ * @see https://github.com/mike-north/formspec/issues/364
+ * @see https://json-schema.org/draft/2020-12/json-schema-core — §10.2.1 allows sibling keywords next to $ref
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  FormIR,
+  FieldNode,
+  ConstraintNode,
+  AnnotationNode,
+  Provenance,
+} from "@formspec/core/internals";
+import { IR_VERSION } from "@formspec/core/internals";
+import { generateJsonSchemaFromIR } from "../json-schema/ir-generator.js";
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+const PROVENANCE: Provenance = {
+  surface: "chain-dsl",
+  file: "/test.ts",
+  line: 1,
+  column: 0,
+};
+
+const TSDOC_PROVENANCE: Provenance = {
+  surface: "tsdoc",
+  file: "/test.ts",
+  line: 1,
+  column: 0,
+  tagName: "@exclusiveMinimum",
+};
+
+function makeIR(fields: FieldNode[], typeRegistry: FormIR["typeRegistry"] = {}): FormIR {
+  return {
+    kind: "form-ir",
+    irVersion: IR_VERSION,
+    elements: fields,
+    typeRegistry,
+    provenance: PROVENANCE,
+  };
+}
+
+/**
+ * Registry with a `MonetaryAmount` type that has `value: number` and
+ * `currency: string` — matches the scenario described in issue #364.
+ */
+const MONETARY_AMOUNT_REGISTRY: FormIR["typeRegistry"] = {
+  MonetaryAmount: {
+    name: "MonetaryAmount",
+    type: {
+      kind: "object" as const,
+      properties: [
+        {
+          name: "value",
+          type: { kind: "primitive" as const, primitiveKind: "number" as const },
+          optional: false,
+          constraints: [] as ConstraintNode[],
+          annotations: [] as AnnotationNode[],
+          provenance: PROVENANCE,
+        },
+        {
+          name: "currency",
+          type: { kind: "primitive" as const, primitiveKind: "string" as const },
+          optional: false,
+          constraints: [] as ConstraintNode[],
+          annotations: [] as AnnotationNode[],
+          provenance: PROVENANCE,
+        },
+      ],
+      additionalProperties: true,
+    },
+    provenance: PROVENANCE,
+  },
+};
+
+// =============================================================================
+// REGRESSION TESTS — issue #364
+// =============================================================================
+
+describe("$ref with sibling keywords — issue #364", () => {
+  // ---------------------------------------------------------------------------
+  // Primary regression: path-targeted constraints on a $ref-based field
+  // ---------------------------------------------------------------------------
+  describe("path-targeted constraints on a $ref-based field", () => {
+    it("emits $ref + sibling properties keyword instead of allOf", () => {
+      // Scenario: interface with a field typed as a $defs-worthy type AND
+      // a path-targeted constraint like `@exclusiveMinimum :value 0`.
+      //
+      // Before fix: { "allOf": [{ "$ref": "#/$defs/MonetaryAmount" }, { "properties": { "value": { "exclusiveMinimum": 0 } } }] }
+      // After fix:  { "$ref": "#/$defs/MonetaryAmount", "properties": { "value": { "exclusiveMinimum": 0 } } }
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "total",
+            type: { kind: "reference", name: "MonetaryAmount", typeArguments: [] },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "exclusiveMinimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        MONETARY_AMOUNT_REGISTRY
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const totalProp = schema.properties?.["total"];
+
+      // The $ref must appear as a sibling keyword, not inside allOf.
+      expect(totalProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+
+      // The property override must appear alongside $ref, not wrapped in allOf.
+      expect(totalProp?.["properties"]).toEqual({ value: { exclusiveMinimum: 0 } });
+
+      // The allOf wrapper must NOT be present — this is the key regression guard.
+      // spec: JSON Schema 2020-12 §10.2.1 allows sibling keywords next to $ref.
+      expect(totalProp?.["allOf"]).toBeUndefined();
+    });
+
+    it("emits $ref + sibling properties for @minimum constraint on nested field", () => {
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "total",
+            type: { kind: "reference", name: "MonetaryAmount", typeArguments: [] },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        MONETARY_AMOUNT_REGISTRY
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const totalProp = schema.properties?.["total"];
+
+      expect(totalProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+      expect(totalProp?.["properties"]).toEqual({ value: { minimum: 0 } });
+      expect(totalProp?.["allOf"]).toBeUndefined();
+    });
+
+    it("emits $ref + sibling title keyword when metadata is also present", () => {
+      // Scenario: field has both a path-targeted constraint AND a display name
+      // (title), which ends up on the outer schema alongside $ref.
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "total",
+            type: { kind: "reference", name: "MonetaryAmount", typeArguments: [] },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "exclusiveMinimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [
+              {
+                kind: "annotation",
+                annotationKind: "displayName",
+                value: "Total Amount",
+                provenance: PROVENANCE,
+              },
+            ],
+            provenance: PROVENANCE,
+          },
+        ],
+        MONETARY_AMOUNT_REGISTRY
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const totalProp = schema.properties?.["total"];
+
+      // Both $ref and title must appear as siblings on the same object.
+      expect(totalProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+      expect(totalProp?.["title"]).toBe("Total Amount");
+      expect(totalProp?.["properties"]).toEqual({ value: { exclusiveMinimum: 0 } });
+      expect(totalProp?.["allOf"]).toBeUndefined();
+    });
+
+    it("preserves $defs deduplication — MonetaryAmount still appears in $defs", () => {
+      // Deduplication must not be lost when path-targeted constraints are applied.
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "subtotal",
+            type: { kind: "reference", name: "MonetaryAmount", typeArguments: [] },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+          {
+            kind: "field",
+            name: "total",
+            type: { kind: "reference", name: "MonetaryAmount", typeArguments: [] },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        MONETARY_AMOUNT_REGISTRY
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+
+      // $defs must still contain MonetaryAmount.
+      expect(schema.$defs).toHaveProperty("MonetaryAmount");
+
+      // Both fields reference it — deduplication preserved.
+      expect(schema.properties?.["subtotal"]?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+      expect(schema.properties?.["total"]?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Array items: path-targeted constraints on a $ref-typed array element
+  // ---------------------------------------------------------------------------
+  describe("path-targeted constraints on array items that are $ref-based", () => {
+    it("emits $ref + sibling properties on the items schema instead of allOf", () => {
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "lineItems",
+            type: {
+              kind: "array",
+              items: { kind: "reference", name: "MonetaryAmount", typeArguments: [] },
+            },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        MONETARY_AMOUNT_REGISTRY
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const lineItemsItems = schema.properties?.["lineItems"]?.["items"];
+
+      expect((lineItemsItems as Record<string, unknown>)?.["$ref"]).toBe(
+        "#/$defs/MonetaryAmount"
+      );
+      expect((lineItemsItems as Record<string, unknown>)?.["properties"]).toEqual({
+        value: { minimum: 0 },
+      });
+      // No allOf wrapping on the items schema either.
+      expect((lineItemsItems as Record<string, unknown>)?.["allOf"]).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multiple path-targeted constraints on the same $ref field
+  // ---------------------------------------------------------------------------
+  describe("multiple path-targeted constraints on the same $ref field", () => {
+    it("merges multiple property overrides into a single sibling properties map", () => {
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "total",
+            type: { kind: "reference", name: "MonetaryAmount", typeArguments: [] },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+              {
+                kind: "constraint",
+                constraintKind: "maxLength",
+                value: 3,
+                path: { segments: ["currency"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        MONETARY_AMOUNT_REGISTRY
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const totalProp = schema.properties?.["total"];
+
+      expect(totalProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+      expect(totalProp?.["properties"]).toEqual({
+        value: { minimum: 0 },
+        currency: { maxLength: 3 },
+      });
+      expect(totalProp?.["allOf"]).toBeUndefined();
+    });
+  });
+});

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -480,4 +480,168 @@ describe("$ref with sibling keywords — issue #364", () => {
       expect(totalProp?.allOf).toBeUndefined();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Top-level nullable $ref: `field: SomeRef | null` with a path-targeted
+  // constraint. Exercises the `nullableValueBranch` recursion at
+  // ir-generator.ts:467-480 where the $ref branch inside the nullable oneOf
+  // must still emit as $ref + siblings (not allOf). Nested-nullable is
+  // already covered in ir-json-schema-generator.test.ts; this fills the
+  // top-level gap identified in the PR review.
+  // ---------------------------------------------------------------------------
+  describe("top-level nullable $ref with path-targeted constraint", () => {
+    const NULLABLE_REGISTRY: FormIR["typeRegistry"] = {
+      PostalAddress: {
+        name: "PostalAddress",
+        type: {
+          kind: "object",
+          properties: [
+            {
+              name: "postalCode",
+              type: { kind: "primitive", primitiveKind: "string" },
+              optional: false,
+              constraints: [],
+              annotations: [],
+              provenance: PROVENANCE,
+            },
+          ],
+          additionalProperties: true,
+        },
+        provenance: PROVENANCE,
+      },
+    };
+
+    it("emits $ref + sibling properties on the non-null oneOf branch", () => {
+      // Scenario: a top-level field typed `PostalAddress | null` carries a
+      // path-targeted constraint on a subfield of the non-null branch.
+      // The schema must be a nullable oneOf where the $ref branch has the
+      // override as a sibling keyword — not wrapped in allOf.
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "billing",
+            type: {
+              kind: "union",
+              members: [
+                { kind: "reference", name: "PostalAddress", typeArguments: [] },
+                { kind: "primitive", primitiveKind: "null" },
+              ],
+            },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "pattern",
+                pattern: "^\\d{5}$",
+                path: { segments: ["postalCode"] },
+                provenance: {
+                  surface: "tsdoc",
+                  file: "/test.ts",
+                  line: 1,
+                  column: 0,
+                  tagName: "@pattern",
+                },
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        NULLABLE_REGISTRY
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const billingProp = schema.properties?.["billing"];
+
+      // Nullable oneOf: the $ref branch carries sibling `properties`; the null
+      // branch is `{ type: "null" }`. The $ref branch must NOT be wrapped in
+      // allOf — that's the regression guard.
+      expect(billingProp).toMatchObject({
+        oneOf: [
+          {
+            $ref: "#/$defs/PostalAddress",
+            properties: { postalCode: { pattern: "^\\d{5}$" } },
+          },
+          { type: "null" },
+        ],
+      });
+
+      const refBranch = billingProp?.oneOf?.[0] as Record<string, unknown> | undefined;
+      expect(refBranch?.["allOf"]).toBeUndefined();
+    });
+
+    it("preserves $defs deduplication for top-level nullable $ref overrides", () => {
+      // Two independent top-level nullable $ref fields must still share the
+      // same $defs entry — siblings attach to each $ref branch, not to the
+      // deduplicated definition itself.
+      const ir = makeIR(
+        [
+          {
+            kind: "field",
+            name: "billing",
+            type: {
+              kind: "union",
+              members: [
+                { kind: "reference", name: "PostalAddress", typeArguments: [] },
+                { kind: "primitive", primitiveKind: "null" },
+              ],
+            },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "pattern",
+                pattern: "^\\d{5}$",
+                path: { segments: ["postalCode"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+          {
+            kind: "field",
+            name: "shipping",
+            type: {
+              kind: "union",
+              members: [
+                { kind: "reference", name: "PostalAddress", typeArguments: [] },
+                { kind: "primitive", primitiveKind: "null" },
+              ],
+            },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minLength",
+                value: 5,
+                path: { segments: ["postalCode"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        NULLABLE_REGISTRY
+      );
+
+      const schema = generateJsonSchemaFromIR(ir);
+
+      expect(schema.$defs).toHaveProperty("PostalAddress");
+      const billingBranch = (schema.properties?.["billing"]?.oneOf?.[0] ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const shippingBranch = (schema.properties?.["shipping"]?.oneOf?.[0] ?? {}) as Record<
+        string,
+        unknown
+      >;
+      expect(billingBranch["$ref"]).toBe("#/$defs/PostalAddress");
+      expect(shippingBranch["$ref"]).toBe("#/$defs/PostalAddress");
+      expect(billingBranch["allOf"]).toBeUndefined();
+      expect(shippingBranch["allOf"]).toBeUndefined();
+    });
+  });
 });

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -135,14 +135,14 @@ describe("$ref with sibling keywords — issue #364", () => {
       const totalProp = schema.properties?.["total"];
 
       // The $ref must appear as a sibling keyword, not inside allOf.
-      expect(totalProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+      expect(totalProp?.$ref).toBe("#/$defs/MonetaryAmount");
 
       // The property override must appear alongside $ref, not wrapped in allOf.
-      expect(totalProp?.["properties"]).toEqual({ value: { exclusiveMinimum: 0 } });
+      expect(totalProp?.properties).toEqual({ value: { exclusiveMinimum: 0 } });
 
       // The allOf wrapper must NOT be present — this is the key regression guard.
       // spec: JSON Schema 2020-12 §10.2.1 allows sibling keywords next to $ref.
-      expect(totalProp?.["allOf"]).toBeUndefined();
+      expect(totalProp?.allOf).toBeUndefined();
     });
 
     it("emits $ref + sibling properties for @minimum constraint on nested field", () => {
@@ -172,9 +172,9 @@ describe("$ref with sibling keywords — issue #364", () => {
       const schema = generateJsonSchemaFromIR(ir);
       const totalProp = schema.properties?.["total"];
 
-      expect(totalProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
-      expect(totalProp?.["properties"]).toEqual({ value: { minimum: 0 } });
-      expect(totalProp?.["allOf"]).toBeUndefined();
+      expect(totalProp?.$ref).toBe("#/$defs/MonetaryAmount");
+      expect(totalProp?.properties).toEqual({ value: { minimum: 0 } });
+      expect(totalProp?.allOf).toBeUndefined();
     });
 
     it("emits $ref + sibling title keyword when metadata is also present", () => {
@@ -214,10 +214,10 @@ describe("$ref with sibling keywords — issue #364", () => {
       const totalProp = schema.properties?.["total"];
 
       // Both $ref and title must appear as siblings on the same object.
-      expect(totalProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
-      expect(totalProp?.["title"]).toBe("Total Amount");
-      expect(totalProp?.["properties"]).toEqual({ value: { exclusiveMinimum: 0 } });
-      expect(totalProp?.["allOf"]).toBeUndefined();
+      expect(totalProp?.$ref).toBe("#/$defs/MonetaryAmount");
+      expect(totalProp?.title).toBe("Total Amount");
+      expect(totalProp?.properties).toEqual({ value: { exclusiveMinimum: 0 } });
+      expect(totalProp?.allOf).toBeUndefined();
     });
 
     it("preserves $defs deduplication — MonetaryAmount still appears in $defs", () => {
@@ -268,8 +268,8 @@ describe("$ref with sibling keywords — issue #364", () => {
       expect(schema.$defs).toHaveProperty("MonetaryAmount");
 
       // Both fields reference it — deduplication preserved.
-      expect(schema.properties?.["subtotal"]?.["$ref"]).toBe("#/$defs/MonetaryAmount");
-      expect(schema.properties?.["total"]?.["$ref"]).toBe("#/$defs/MonetaryAmount");
+      expect(schema.properties?.["subtotal"]?.$ref).toBe("#/$defs/MonetaryAmount");
+      expect(schema.properties?.["total"]?.$ref).toBe("#/$defs/MonetaryAmount");
     });
   });
 
@@ -305,16 +305,16 @@ describe("$ref with sibling keywords — issue #364", () => {
       );
 
       const schema = generateJsonSchemaFromIR(ir);
-      const lineItemsItems = schema.properties?.["lineItems"]?.["items"];
+      const lineItemsItems = schema.properties?.["lineItems"]?.items;
 
-      expect((lineItemsItems as Record<string, unknown>)?.["$ref"]).toBe(
+      expect((lineItemsItems as Record<string, unknown>)["$ref"]).toBe(
         "#/$defs/MonetaryAmount"
       );
-      expect((lineItemsItems as Record<string, unknown>)?.["properties"]).toEqual({
+      expect((lineItemsItems as Record<string, unknown>)["properties"]).toEqual({
         value: { minimum: 0 },
       });
       // No allOf wrapping on the items schema either.
-      expect((lineItemsItems as Record<string, unknown>)?.["allOf"]).toBeUndefined();
+      expect((lineItemsItems as Record<string, unknown>)["allOf"]).toBeUndefined();
     });
   });
 
@@ -356,12 +356,12 @@ describe("$ref with sibling keywords — issue #364", () => {
       const schema = generateJsonSchemaFromIR(ir);
       const totalProp = schema.properties?.["total"];
 
-      expect(totalProp?.["$ref"]).toBe("#/$defs/MonetaryAmount");
-      expect(totalProp?.["properties"]).toEqual({
+      expect(totalProp?.$ref).toBe("#/$defs/MonetaryAmount");
+      expect(totalProp?.properties).toEqual({
         value: { minimum: 0 },
         currency: { maxLength: 3 },
       });
-      expect(totalProp?.["allOf"]).toBeUndefined();
+      expect(totalProp?.allOf).toBeUndefined();
     });
   });
 });

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -484,6 +484,11 @@ function applyPathTargetedConstraints(
   // $ref, unlike draft-07 where $ref caused all siblings to be ignored. Using
   // sibling keywords avoids unnecessary allOf composition and preserves $defs
   // deduplication. (Fixes #364.)
+  //
+  // Invariant: upstream reference resolution produces `$ref` schemas that do
+  // not carry their own `properties` key, so this spread-then-overwrite is
+  // safe today. If that ever changes, the override must still win — merge
+  // explicitly via `properties: { ...schema.properties, ...propertyOverrides }`.
   if (schema.$ref) {
     return {
       ...schema,

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -426,11 +426,20 @@ function isStringItemConstraint(constraint: ConstraintNode): boolean {
 }
 
 /**
- * Applies path-targeted constraints to a schema via allOf composition.
+ * Applies path-targeted constraints to a schema using sibling keywords
+ * (JSON Schema 2020-12) or allOf composition for inline schemas.
  *
- * For $ref schemas: wraps in allOf with property overrides.
+ * For $ref schemas: merges property overrides as sibling keywords alongside
+ * `$ref`. JSON Schema 2020-12 (§10.2.1) allows all keywords to appear next
+ * to `$ref`; the draft-07 restriction that made allOf necessary no longer
+ * applies. Using sibling keywords preserves `$defs` deduplication and
+ * produces leaner output that downstream renderers can consume directly.
+ *
  * For inline object schemas: applies directly to nested properties.
  * For array schemas: applies path constraints to the items sub-schema.
+ *
+ * @see https://github.com/mike-north/formspec/issues/364
+ * @see https://json-schema.org/draft/2020-12/json-schema-core — §10.2.1 sibling keywords
  */
 function applyPathTargetedConstraints(
   schema: JsonSchema2020,
@@ -470,15 +479,16 @@ function applyPathTargetedConstraints(
     return schema;
   }
 
-  // $ref schema: wrap in allOf to preserve $ref semantics while adding overrides.
+  // $ref schema: add property overrides as sibling keywords alongside $ref.
+  // JSON Schema 2020-12 §10.2.1 explicitly permits sibling keywords next to
+  // $ref, unlike draft-07 where $ref caused all siblings to be ignored. Using
+  // sibling keywords avoids unnecessary allOf composition and preserves $defs
+  // deduplication. (Fixes #364.)
   if (schema.$ref) {
-    const { $ref, ...rest } = schema;
-    const refPart: JsonSchema2020 = { $ref };
-    const overridePart: JsonSchema2020 = {
+    return {
+      ...schema,
       properties: propertyOverrides,
-      ...rest,
     };
-    return { allOf: [refPart, overridePart] };
   }
 
   // Inline object schema: merge property overrides directly where possible.


### PR DESCRIPTION
## Summary

- Fixes [#364](https://github.com/mike-north/formspec/issues/364): when a field referencing a `$defs` type also carries path-targeted constraints or annotations, FormSpec emitted an `allOf` wrapper that breaks downstream renderers (Stripe dashboard config UI).
- The fix switches `applyPathTargetedConstraints` to emit sibling keywords alongside `$ref`, which JSON Schema 2020-12 §10.2.1 explicitly permits (draft-07's "siblings next to `$ref` are ignored" rule was removed).
- `$defs` deduplication (introduced in alpha.55 via #309) is preserved — the referenced type still appears in `$defs` and is reused across call sites.

## Before / After

TypeScript source:
```typescript
interface MinAmountConfig {
  /**
   * @displayName Minimum amount
   * @exclusiveMinimum :value 0
   */
  minimumAmount: MonetaryAmount;
}
```

```diff
 {
   "minimumAmount": {
-    "allOf": [
-      { "$ref": "#/$defs/MonetaryAmount" },
-      {
-        "properties": { "value": { "exclusiveMinimum": 0 } },
-        "title": "Minimum amount"
-      }
-    ]
+    "$ref": "#/$defs/MonetaryAmount",
+    "properties": { "value": { "exclusiveMinimum": 0 } },
+    "title": "Minimum amount"
   }
 }
```

## Spec alignment

`docs/003-json-schema-vocabulary.md` §5.4 and §7.2 now declare sibling keywords alongside `$ref` as the canonical refinement shape. Cross-referenced examples in `docs/005-numeric-types.md` and `docs/e2e-test-matrix.md` (and the "putting it all together" example in 003 Appendix A) are updated to match.

## Scope note

Two remaining `allOf` emission sites in `applyPathTargetedConstraints` cover *inline-object* cases (missing-property overrides at [ir-generator.ts:517](https://github.com/mike-north/formspec/blob/fix/364-allof-composition-with-ref/packages/build/src/json-schema/ir-generator.ts#L517) and already-composed `allOf` schemas at line 523). Those are legitimately out of scope for #364 (which reports `$ref + allOf`), but share the same renderer-compatibility concern — tracked in [#382](https://github.com/mike-north/formspec/issues/382).

## Test plan

- [x] Primary regression suite [`packages/build/src/__tests__/ref-with-sibling-keywords.test.ts`](packages/build/src/__tests__/ref-with-sibling-keywords.test.ts) — 10 cases covering the primary bug, metadata combination, `$defs` deduplication, array items, multi-property overrides, annotation-only fields, deeply-nested path targets, and **top-level nullable `$ref`** (added in response to PR review — covers the `field: SomeRef | null` recursion at `ir-generator.ts:467-480`).
- [x] Narrowing-alias integration coverage in [`packages/build/src/__tests__/generate-schemas.test.ts`](packages/build/src/__tests__/generate-schemas.test.ts) — `type PositiveMonetaryAmount = MonetaryAmount` with `/** @minimum :amount 0 */` emits `$ref` + sibling `properties` at the field use site, and composes with a use-site `@maximum :amount N` override as further siblings on the same subschema.
- [x] Existing tests asserting the old `allOf` shape updated to the new sibling-keyword shape (4 files) — no assertion strength lost.
- [x] Every assertion pairs a positive check (sibling keyword present) with a negative check (`allOf` absent).
- [x] `pnpm run clean && pnpm install && pnpm run build && pnpm run lint && pnpm run test && pnpm run test:e2e` — all green against current `origin/main`.
- [x] `pnpm run api-extractor` — no public API change.