### PR TITLE
fix(build): inherit @format from base type to derived class/interface (#367)

### DIFF
--- a/.changeset/fix-format-inheritance-derived-types.md
+++ b/.changeset/fix-format-inheritance-derived-types.md
@@ -1,0 +1,15 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/config": patch
+"@formspec/core": patch
+"@formspec/dsl": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/runtime": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Fix type-level `@format` inheritance on derived interfaces and classes (issue #367). When an interface or class extends a base that declares a type-level `@format`, the derived type's `$defs` entry now carries the inherited `format` keyword. Explicit `@format` on the derived type continues to win over the inherited value.

--- a/packages/build/src/__tests__/format-inheritance-derived-types.test.ts
+++ b/packages/build/src/__tests__/format-inheritance-derived-types.test.ts
@@ -54,7 +54,11 @@ const INTERFACE_INHERITANCE_SOURCE = [
 ].join("\n");
 
 /**
- * Derived type overrides the base's `@format` — the override must win.
+ * Derived type overrides the base's `@format` — the override must win. A
+ * third sibling type extends the base WITHOUT a local `@format`, and must
+ * still inherit the base value in the same run. The sibling guards against
+ * regressions where overrides and inheritance are collapsed into a single
+ * "any local annotation wins" short-circuit.
  */
 const OVERRIDE_SOURCE = [
   "/** @format monetary-amount */",
@@ -68,9 +72,154 @@ const OVERRIDE_SOURCE = [
   "  amount: number;",
   "}",
   "",
+  "interface SiblingMonetaryAmount extends MonetaryAmount {",
+  "  label?: string;",
+  "}",
+  "",
   "export class Order {",
   "  subtotal!: MonetaryAmount;",
   "  total!: StrictMonetaryAmount;",
+  "  sibling!: SiblingMonetaryAmount;",
+  "}",
+].join("\n");
+
+/**
+ * Multi-level chain: `Base ← Mid ← Leaf`. Only `Base` carries `@format`.
+ * The leaf's `$defs` entry must transitively inherit the base's format
+ * through the intermediate interface.
+ */
+const MULTI_LEVEL_SOURCE = [
+  "/** @format monetary-amount */",
+  "interface BaseMonetary {",
+  "  amount: number;",
+  "}",
+  "",
+  "interface MidMonetary extends BaseMonetary {",
+  "  currency: string;",
+  "}",
+  "",
+  "interface LeafMonetary extends MidMonetary {",
+  "  label?: string;",
+  "}",
+  "",
+  "export class Order {",
+  "  leaf!: LeafMonetary;",
+  "}",
+].join("\n");
+
+/**
+ * `implements` does NOT propagate type-level annotations. A class that
+ * `implements` an interface with `@format` must not inherit the format on
+ * its own `$defs` entry.
+ */
+const IMPLEMENTS_NEGATIVE_SOURCE = [
+  "/** @format monetary-amount */",
+  "interface IMonetary {",
+  "  amount: number;",
+  "  currency: string;",
+  "}",
+  "",
+  "export class PlainAmount implements IMonetary {",
+  "  amount!: number;",
+  "  currency!: string;",
+  "}",
+  "",
+  "export class Order {",
+  "  amount!: PlainAmount;",
+  "}",
+].join("\n");
+
+/**
+ * Cyclic inheritance — two interfaces extending each other. TypeScript
+ * accepts this at the AST level (it only diagnoses at check time), so the
+ * analyzer's BFS must not hang.
+ */
+const CYCLIC_SOURCE = [
+  "/** @format monetary-amount */",
+  "interface CycleA extends CycleB {",
+  "  a: number;",
+  "}",
+  "",
+  "interface CycleB extends CycleA {",
+  "  b: number;",
+  "}",
+  "",
+  "export class Order {",
+  "  value!: CycleA;",
+  "}",
+].join("\n");
+
+/**
+ * Empty-value `@format` on the derived type — the base-declared value must
+ * still flow through. An empty payload is not an override.
+ *
+ * Documented semantics (issue #367 review): a derived type whose `@format`
+ * has no / whitespace-only value is treated as "no local override", so
+ * heritage inheritance still fills in the base value.
+ */
+const EMPTY_OVERRIDE_SOURCE = [
+  "/** @format monetary-amount */",
+  "interface MonetaryAmount {",
+  "  amount: number;",
+  "  currency: string;",
+  "}",
+  "",
+  "/** @format */",
+  "interface EmptyOverrideAmount extends MonetaryAmount {",
+  "  amount: number;",
+  "}",
+  "",
+  "export class Order {",
+  "  value!: EmptyOverrideAmount;",
+  "}",
+].join("\n");
+
+/**
+ * Diamond / multi-base conflict: interface `Derived extends Left, Right`
+ * where both bases declare a different `@format`. BFS order is declaration
+ * order in the `extends` clause — the first-listed base wins. Locks in
+ * policy so a future refactor can't silently flip resolution order.
+ */
+const DIAMOND_CONFLICT_SOURCE = [
+  "/** @format fmt-left */",
+  "interface LeftBase {",
+  "  amount: number;",
+  "}",
+  "",
+  "/** @format fmt-right */",
+  "interface RightBase {",
+  "  amount: number;",
+  "}",
+  "",
+  "interface Merged extends LeftBase, RightBase {",
+  "  label?: string;",
+  "}",
+  "",
+  "export class Order {",
+  "  value!: Merged;",
+  "}",
+].join("\n");
+
+/**
+ * Negative: non-`@format` type-level annotations (e.g. `@remarks`) must NOT
+ * inherit. The fix is deliberately scoped to `@format`; if a future change
+ * broadens inheritance it should be an explicit decision, not a silent
+ * regression.
+ */
+const NON_FORMAT_ANNOTATION_SOURCE = [
+  "/**",
+  " * @remarks base-level remarks that should not inherit",
+  " */",
+  "interface BaseWithRemarks {",
+  "  amount: number;",
+  "}",
+  "",
+  "interface DerivedNoAnnotation extends BaseWithRemarks {",
+  "  label?: string;",
+  "}",
+  "",
+  "export class Order {",
+  "  value!: DerivedNoAnnotation;",
   "}",
 ].join("\n");
 
@@ -103,6 +252,12 @@ let tmpDir: string;
 let interfaceInheritanceFixturePath: string;
 let overrideFixturePath: string;
 let classInheritanceFixturePath: string;
+let multiLevelFixturePath: string;
+let implementsNegativeFixturePath: string;
+let cyclicFixturePath: string;
+let emptyOverrideFixturePath: string;
+let diamondConflictFixturePath: string;
+let nonFormatAnnotationFixturePath: string;
 
 beforeAll(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-fmt-inherit-"));
@@ -130,6 +285,24 @@ beforeAll(() => {
 
   classInheritanceFixturePath = path.join(tmpDir, "class-inheritance.ts");
   fs.writeFileSync(classInheritanceFixturePath, CLASS_INHERITANCE_SOURCE);
+
+  multiLevelFixturePath = path.join(tmpDir, "multi-level.ts");
+  fs.writeFileSync(multiLevelFixturePath, MULTI_LEVEL_SOURCE);
+
+  implementsNegativeFixturePath = path.join(tmpDir, "implements-negative.ts");
+  fs.writeFileSync(implementsNegativeFixturePath, IMPLEMENTS_NEGATIVE_SOURCE);
+
+  cyclicFixturePath = path.join(tmpDir, "cyclic.ts");
+  fs.writeFileSync(cyclicFixturePath, CYCLIC_SOURCE);
+
+  emptyOverrideFixturePath = path.join(tmpDir, "empty-override.ts");
+  fs.writeFileSync(emptyOverrideFixturePath, EMPTY_OVERRIDE_SOURCE);
+
+  diamondConflictFixturePath = path.join(tmpDir, "diamond-conflict.ts");
+  fs.writeFileSync(diamondConflictFixturePath, DIAMOND_CONFLICT_SOURCE);
+
+  nonFormatAnnotationFixturePath = path.join(tmpDir, "non-format-annotation.ts");
+  fs.writeFileSync(nonFormatAnnotationFixturePath, NON_FORMAT_ANNOTATION_SOURCE);
 });
 
 afterAll(() => {
@@ -151,30 +324,29 @@ describe("type-level @format inheritance on derived types — issue #367", () =>
 
     const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
     const base = expectRecord(defs["MonetaryAmount"], "$defs.MonetaryAmount");
-    const derived = expectRecord(
-      defs["PositiveMonetaryAmount"],
-      "$defs.PositiveMonetaryAmount"
-    );
+    const derived = expectRecord(defs["PositiveMonetaryAmount"], "$defs.PositiveMonetaryAmount");
 
     // spec: issue #367 — base-declared @format must flow to derived $defs entry.
     expect(base["format"]).toBe("monetary-amount");
     expect(derived["format"]).toBe("monetary-amount");
   });
 
-  it("explicit @format on derived interface overrides inherited base format", () => {
+  it("explicit @format on derived interface overrides inherited base format, while a sibling with no local @format still inherits the base format", () => {
     const result = generateSchemasOrThrow({
       filePath: overrideFixturePath,
       typeName: "Order",
     });
 
     const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
-    const derived = expectRecord(
-      defs["StrictMonetaryAmount"],
-      "$defs.StrictMonetaryAmount"
-    );
+    const derived = expectRecord(defs["StrictMonetaryAmount"], "$defs.StrictMonetaryAmount");
+    const sibling = expectRecord(defs["SiblingMonetaryAmount"], "$defs.SiblingMonetaryAmount");
 
     // spec: issue #367 — explicit override wins over inherited annotation.
     expect(derived["format"]).toBe("strict-monetary-amount");
+    // spec: issue #367 — sibling without a local @format must still inherit
+    // the base value in the same run. Guards against regressions where the
+    // override path short-circuits inheritance for all siblings.
+    expect(sibling["format"]).toBe("monetary-amount");
   });
 
   it("derived class's $defs entry inherits @format from base class", () => {
@@ -184,12 +356,101 @@ describe("type-level @format inheritance on derived types — issue #367", () =>
     });
 
     const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
-    const derived = expectRecord(
-      defs["PositiveMonetaryAmount"],
-      "$defs.PositiveMonetaryAmount"
-    );
+    const derived = expectRecord(defs["PositiveMonetaryAmount"], "$defs.PositiveMonetaryAmount");
 
     // spec: issue #367 — the same semantics apply to class inheritance.
     expect(derived["format"]).toBe("monetary-amount");
+  });
+
+  it("transitively inherits @format across a multi-level heritage chain (Base ← Mid ← Leaf)", () => {
+    const result = generateSchemasOrThrow({
+      filePath: multiLevelFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const leaf = expectRecord(defs["LeafMonetary"], "$defs.LeafMonetary");
+
+    // spec: issue #367 — BFS walks the full heritage chain, so the leaf
+    // inherits the base's @format through an intermediate interface that
+    // carries no local annotation.
+    expect(leaf["format"]).toBe("monetary-amount");
+  });
+
+  it("does not inherit @format from interfaces via `implements`", () => {
+    const result = generateSchemasOrThrow({
+      filePath: implementsNegativeFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const plain = expectRecord(defs["PlainAmount"], "$defs.PlainAmount");
+
+    // spec: issue #367 — `implements` carries no type-level annotation
+    // inheritance. A class that implements an @format-tagged interface
+    // must not emit that format on its own $defs entry.
+    expect(plain["format"]).toBeUndefined();
+  });
+
+  it("terminates on cyclic heritage (interface A extends B extends A)", () => {
+    // spec: issue #367 — BFS must terminate even if the heritage graph
+    // contains a cycle (TS accepts cyclic extends at the AST level).
+    const result = generateSchemasOrThrow({
+      filePath: cyclicFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const cycleA = expectRecord(defs["CycleA"], "$defs.CycleA");
+    // The base annotation is on CycleA itself, so its own $defs entry
+    // carries the format regardless of cycle traversal.
+    expect(cycleA["format"]).toBe("monetary-amount");
+  });
+
+  it("treats an empty `@format` on the derived type as non-overriding (base value flows through)", () => {
+    const result = generateSchemasOrThrow({
+      filePath: emptyOverrideFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const derived = expectRecord(defs["EmptyOverrideAmount"], "$defs.EmptyOverrideAmount");
+
+    // spec: issue #367 — `@format` with no/whitespace payload is not a
+    // local override; inheritance must still fill in the base value.
+    expect(derived["format"]).toBe("monetary-amount");
+  });
+
+  it("resolves diamond / multi-base conflicts by declaration order (first-listed `extends` wins)", () => {
+    const result = generateSchemasOrThrow({
+      filePath: diamondConflictFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const merged = expectRecord(defs["Merged"], "$defs.Merged");
+
+    // spec: issue #367 — BFS walks `extends` clauses in source order, so
+    // the first-listed base's @format wins. This test pins the policy so
+    // a future refactor can't silently flip resolution order.
+    expect(merged["format"]).toBe("fmt-left");
+  });
+
+  it("does not inherit non-`@format` type-level annotations (e.g. @remarks)", () => {
+    // spec: issue #367 — the fix is deliberately scoped to @format.
+    // Other type-level annotations must not start inheriting as a side
+    // effect. Guards against accidental scope creep.
+    const result = generateSchemasOrThrow({
+      filePath: nonFormatAnnotationFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const derived = expectRecord(defs["DerivedNoAnnotation"], "$defs.DerivedNoAnnotation");
+
+    // @remarks on the base must not produce a description (or any inherited
+    // annotation field) on the derived type's $defs entry.
+    expect(derived["description"]).toBeUndefined();
+    expect(derived["format"]).toBeUndefined();
   });
 });

--- a/packages/build/src/__tests__/format-inheritance-derived-types.test.ts
+++ b/packages/build/src/__tests__/format-inheritance-derived-types.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Regression tests for issue #367: type-level `@format` annotations declared
+ * on a base interface must be inherited by derived interfaces / classes when
+ * the derived type is emitted as a `$defs` entry. Explicit `@format` on the
+ * derived type must win over the inherited value.
+ *
+ * @see https://github.com/mike-north/formspec/issues/367
+ * @see packages/build/src/analyzer/class-analyzer.ts — named-type annotation
+ *      extraction is the enforcement point.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { generateSchemas, type GenerateSchemasOptions } from "../generators/class-schema.js";
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({ ...options, errorReporting: "throw" });
+}
+
+function expectRecord(value: unknown, message: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`${message}: expected object, got ${typeof value}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture sources
+// ---------------------------------------------------------------------------
+
+/**
+ * Base interface carrying a type-level `@format`. A derived interface extends
+ * it and adds/overrides only a constraint. The derived type's `$defs` entry
+ * must inherit `format: "monetary-amount"`.
+ */
+const INTERFACE_INHERITANCE_SOURCE = [
+  "/** @format monetary-amount */",
+  "interface MonetaryAmount {",
+  "  amount: number;",
+  "  currency: string;",
+  "}",
+  "",
+  "interface PositiveMonetaryAmount extends MonetaryAmount {",
+  "  /** @exclusiveMinimum 0 */",
+  "  amount: number;",
+  "}",
+  "",
+  "export class Order {",
+  "  subtotal!: MonetaryAmount;",
+  "  tip!: PositiveMonetaryAmount;",
+  "}",
+].join("\n");
+
+/**
+ * Derived type overrides the base's `@format` — the override must win.
+ */
+const OVERRIDE_SOURCE = [
+  "/** @format monetary-amount */",
+  "interface MonetaryAmount {",
+  "  amount: number;",
+  "  currency: string;",
+  "}",
+  "",
+  "/** @format strict-monetary-amount */",
+  "interface StrictMonetaryAmount extends MonetaryAmount {",
+  "  amount: number;",
+  "}",
+  "",
+  "export class Order {",
+  "  subtotal!: MonetaryAmount;",
+  "  total!: StrictMonetaryAmount;",
+  "}",
+].join("\n");
+
+/**
+ * Class inheritance variant — ensures the fix applies to classes, not just
+ * interfaces.
+ */
+const CLASS_INHERITANCE_SOURCE = [
+  "/** @format monetary-amount */",
+  "export class MonetaryAmount {",
+  "  amount!: number;",
+  "  currency!: string;",
+  "}",
+  "",
+  "export class PositiveMonetaryAmount extends MonetaryAmount {",
+  "  extraNote?: string;",
+  "}",
+  "",
+  "export class Order {",
+  "  subtotal!: MonetaryAmount;",
+  "  tip!: PositiveMonetaryAmount;",
+  "}",
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let interfaceInheritanceFixturePath: string;
+let overrideFixturePath: string;
+let classInheritanceFixturePath: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-fmt-inherit-"));
+
+  const tsconfig = JSON.stringify(
+    {
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "nodenext",
+        strict: true,
+        skipLibCheck: true,
+      },
+    },
+    null,
+    2
+  );
+  fs.writeFileSync(path.join(tmpDir, "tsconfig.json"), tsconfig);
+
+  interfaceInheritanceFixturePath = path.join(tmpDir, "interface-inheritance.ts");
+  fs.writeFileSync(interfaceInheritanceFixturePath, INTERFACE_INHERITANCE_SOURCE);
+
+  overrideFixturePath = path.join(tmpDir, "override.ts");
+  fs.writeFileSync(overrideFixturePath, OVERRIDE_SOURCE);
+
+  classInheritanceFixturePath = path.join(tmpDir, "class-inheritance.ts");
+  fs.writeFileSync(classInheritanceFixturePath, CLASS_INHERITANCE_SOURCE);
+});
+
+afterAll(() => {
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests — issue #367 regression
+// ---------------------------------------------------------------------------
+
+describe("type-level @format inheritance on derived types — issue #367", () => {
+  it("derived interface's $defs entry inherits @format from base", () => {
+    const result = generateSchemasOrThrow({
+      filePath: interfaceInheritanceFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const base = expectRecord(defs["MonetaryAmount"], "$defs.MonetaryAmount");
+    const derived = expectRecord(
+      defs["PositiveMonetaryAmount"],
+      "$defs.PositiveMonetaryAmount"
+    );
+
+    // spec: issue #367 — base-declared @format must flow to derived $defs entry.
+    expect(base["format"]).toBe("monetary-amount");
+    expect(derived["format"]).toBe("monetary-amount");
+  });
+
+  it("explicit @format on derived interface overrides inherited base format", () => {
+    const result = generateSchemasOrThrow({
+      filePath: overrideFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const derived = expectRecord(
+      defs["StrictMonetaryAmount"],
+      "$defs.StrictMonetaryAmount"
+    );
+
+    // spec: issue #367 — explicit override wins over inherited annotation.
+    expect(derived["format"]).toBe("strict-monetary-amount");
+  });
+
+  it("derived class's $defs entry inherits @format from base class", () => {
+    const result = generateSchemasOrThrow({
+      filePath: classInheritanceFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const derived = expectRecord(
+      defs["PositiveMonetaryAmount"],
+      "$defs.PositiveMonetaryAmount"
+    );
+
+    // spec: issue #367 — the same semantics apply to class inheritance.
+    expect(derived["format"]).toBe("monetary-amount");
+  });
+});

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -63,7 +63,6 @@ function isIntersectionType(type: ts.Type): type is ts.IntersectionType {
   return !!(type.flags & ts.TypeFlags.Intersection);
 }
 
-
 export function isResolvableObjectLikeAliasTypeNode(typeNode: ts.TypeNode): boolean {
   if (ts.isParenthesizedTypeNode(typeNode)) {
     return isResolvableObjectLikeAliasTypeNode(typeNode.type);
@@ -316,7 +315,33 @@ function resolveNodeMetadata(
  * inherited here to keep the change surface-narrow; broader inheritance can
  * be considered as a follow-up once the semantics are confirmed.
  */
-const INHERITABLE_TYPE_ANNOTATION_KINDS = new Set<AnnotationNode["annotationKind"]>(["format"]);
+const INHERITABLE_TYPE_ANNOTATION_KINDS: ReadonlySet<AnnotationNode["annotationKind"]> = new Set<
+  AnnotationNode["annotationKind"]
+>(["format"]);
+
+/**
+ * Returns the string payload carried by an inheritable annotation, or
+ * `undefined` for annotation kinds where presence alone is the signal.
+ * Used to decide whether a locally-declared annotation counts as an
+ * override (empty/whitespace-only payloads do not — see
+ * {@link isOverridingInheritableAnnotation}).
+ */
+function getInheritableAnnotationStringValue(annotation: AnnotationNode): string | undefined {
+  if (annotation.annotationKind === "format") return annotation.value;
+  return undefined;
+}
+
+/**
+ * Returns `true` when a locally-declared annotation should suppress
+ * heritage inheritance for its kind. An annotation whose string payload is
+ * empty or whitespace-only (`/** @format * /`) is not treated as an
+ * override — the base-declared value still flows through.
+ */
+function isOverridingInheritableAnnotation(annotation: AnnotationNode): boolean {
+  const value = getInheritableAnnotationStringValue(annotation);
+  if (value === undefined) return true;
+  return value.trim().length > 0;
+}
 
 /**
  * Walks base class / interface declarations reachable from a derived
@@ -340,8 +365,11 @@ function collectInheritedTypeAnnotations(
   file: string,
   extensionRegistry: ExtensionRegistry | undefined
 ): AnnotationNode[] {
+  // A local annotation only suppresses heritage inheritance when it carries a
+  // meaningful payload. Empty/whitespace-only `@format` must fall through to
+  // the base-declared value. See issue #367 review discussion.
   const existingKinds = new Set<AnnotationNode["annotationKind"]>(
-    existingAnnotations.map((a) => a.annotationKind)
+    existingAnnotations.filter(isOverridingInheritableAnnotation).map((a) => a.annotationKind)
   );
   const needed = new Set<AnnotationNode["annotationKind"]>();
   for (const kind of INHERITABLE_TYPE_ANNOTATION_KINDS) {
@@ -357,16 +385,26 @@ function collectInheritedTypeAnnotations(
     const heritageClauses = decl.heritageClauses;
     if (!heritageClauses) return;
     for (const clause of heritageClauses) {
-      // Interfaces use `extends`; classes use `extends` for their parent and
-      // `implements` for interfaces. For inheritance semantics we treat both
-      // `extends` and `implements` as sources of type-level annotations —
-      // nominal type authors routinely express the shape through either.
-      // `HeritageClause.token` is always one of those two per TS's AST types.
+      // Only follow `extends`. `implements` does NOT propagate type-level
+      // annotations: authors use `implements` to assert structural
+      // conformance, not to adopt the interface's metadata. Following it
+      // would silently merge annotations across unrelated nominal types.
+      if (clause.token !== ts.SyntaxKind.ExtendsKeyword) continue;
       for (const typeExpr of clause.types) {
         const sym = checker.getSymbolAtLocation(typeExpr.expression);
         if (!sym) continue;
-        const target =
-          sym.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym) : sym;
+        let target: ts.Symbol = sym;
+        if ((sym.flags & ts.SymbolFlags.Alias) !== 0) {
+          try {
+            target = checker.getAliasedSymbol(sym);
+          } catch {
+            // TypeScript can throw when resolving certain alias chains
+            // (e.g., cyclic or partially resolved aliases). Fall back to
+            // the original symbol — worst case we miss an inheritance
+            // step, not a fatal error.
+            target = sym;
+          }
+        }
         for (const baseDecl of target.declarations ?? []) {
           if (seen.has(baseDecl)) continue;
           seen.add(baseDecl);
@@ -383,16 +421,22 @@ function collectInheritedTypeAnnotations(
   while (queue.length > 0 && needed.size > 0) {
     const baseDecl = queue.shift();
     if (baseDecl === undefined) break;
+    // Use the base declaration's own source file for provenance / pos-mapping.
+    // The BFS may cross file boundaries, so the derived type's `file` is not
+    // the right reference point for annotations parsed off a base declaration.
+    const baseFile = baseDecl.getSourceFile().fileName;
     const baseAnnotations = extractJSDocAnnotationNodes(
       baseDecl,
-      file,
+      baseFile,
       makeParseOptions(extensionRegistry)
     );
     for (const annotation of baseAnnotations) {
-      if (needed.has(annotation.annotationKind)) {
-        inherited.push(annotation);
-        needed.delete(annotation.annotationKind);
-      }
+      if (!needed.has(annotation.annotationKind)) continue;
+      // Skip empty-payload annotations on the base as well — they cannot
+      // meaningfully fill an inherited slot.
+      if (!isOverridingInheritableAnnotation(annotation)) continue;
+      inherited.push(annotation);
+      needed.delete(annotation.annotationKind);
     }
     // Continue up the chain if we still need kinds.
     if (needed.size > 0) {
@@ -404,50 +448,32 @@ function collectInheritedTypeAnnotations(
 }
 
 /**
- * Merges heritage-inherited annotations into a local annotation list for a
- * class or interface declaration. Returns the combined list; local
- * annotations always take precedence (see {@link collectInheritedTypeAnnotations}).
+ * Extracts type-level annotations from a named declaration (class, interface,
+ * or type alias), applying heritage-based inheritance where applicable
+ * (issue #367). For type aliases (no heritage), behaves identically to
+ * {@link extractJSDocAnnotationNodes}. For classes and interfaces, any
+ * inheritable annotation kind absent from the local declaration is filled
+ * in by walking `extends` clauses via {@link collectInheritedTypeAnnotations}.
  */
-function mergeInheritedTypeAnnotations(
-  decl: ts.ClassDeclaration | ts.InterfaceDeclaration | undefined,
-  localAnnotations: readonly AnnotationNode[],
+function extractNamedTypeAnnotations(
+  namedDecl: ts.ClassDeclaration | ts.InterfaceDeclaration | ts.TypeAliasDeclaration,
   checker: ts.TypeChecker,
   file: string,
   extensionRegistry: ExtensionRegistry | undefined
 ): AnnotationNode[] {
-  if (decl === undefined) return [...localAnnotations];
+  const local = extractJSDocAnnotationNodes(namedDecl, file, makeParseOptions(extensionRegistry));
+  if (!ts.isClassDeclaration(namedDecl) && !ts.isInterfaceDeclaration(namedDecl)) {
+    return local;
+  }
   const inherited = collectInheritedTypeAnnotations(
-    decl,
-    localAnnotations,
+    namedDecl,
+    local,
     checker,
     file,
     extensionRegistry
   );
-  if (inherited.length === 0) return [...localAnnotations];
-  return [...localAnnotations, ...inherited];
-}
-
-/**
- * Extracts type-level annotations from a named declaration (class, interface,
- * or type alias), applying heritage-based inheritance where applicable
- * (issue #367). For type aliases (no heritage), behaves identically to
- * {@link extractJSDocAnnotationNodes}.
- */
-function extractNamedTypeAnnotations(
-  namedDecl: ts.Declaration,
-  checker: ts.TypeChecker,
-  file: string,
-  extensionRegistry: ExtensionRegistry | undefined
-): AnnotationNode[] {
-  const local = extractJSDocAnnotationNodes(
-    namedDecl,
-    file,
-    makeParseOptions(extensionRegistry)
-  );
-  if (ts.isClassDeclaration(namedDecl) || ts.isInterfaceDeclaration(namedDecl)) {
-    return mergeInheritedTypeAnnotations(namedDecl, local, checker, file, extensionRegistry);
-  }
-  return local;
+  if (inherited.length === 0) return [...local];
+  return [...local, ...inherited];
 }
 
 export function analyzeDeclarationRootInfo(
@@ -521,13 +547,14 @@ export function analyzeClassToIR(
   );
   // Issue #367: type-level annotations (e.g., @format) declared on a base
   // class flow to derived classes unless the derived class overrides them.
-  const annotations = mergeInheritedTypeAnnotations(
+  const inheritedClassAnnotations = collectInheritedTypeAnnotations(
     classDecl,
     classDoc.annotations,
     checker,
     file,
     extensionRegistry
   );
+  const annotations: AnnotationNode[] = [...classDoc.annotations, ...inheritedClassAnnotations];
   diagnostics.push(...classDoc.diagnostics);
   const visiting = new Set<ts.Type>();
   const instanceMethods: MethodInfo[] = [];
@@ -628,13 +655,17 @@ export function analyzeInterfaceToIR(
   // Issue #367: type-level annotations (e.g., @format) declared on a base
   // interface flow to derived interfaces unless the derived interface
   // overrides them.
-  const annotations = mergeInheritedTypeAnnotations(
+  const inheritedInterfaceAnnotations = collectInheritedTypeAnnotations(
     interfaceDecl,
     interfaceDoc.annotations,
     checker,
     file,
     extensionRegistry
   );
+  const annotations: AnnotationNode[] = [
+    ...interfaceDoc.annotations,
+    ...inheritedInterfaceAnnotations,
+  ];
   diagnostics.push(...interfaceDoc.diagnostics);
   const visiting = new Set<ts.Type>();
 
@@ -1471,10 +1502,7 @@ function extractReferenceTypeArguments(
         ? checker.getAliasedSymbol(baseSymbol)
         : baseSymbol;
     const argumentDecl = argumentSymbol?.declarations?.[0];
-    if (
-      argumentDecl !== undefined &&
-      argumentDecl.getSourceFile().fileName !== file
-    ) {
+    if (argumentDecl !== undefined && argumentDecl.getSourceFile().fileName !== file) {
       const argumentName = argumentSymbol?.getName() ?? baseSymbol?.getName();
       if (argumentName !== undefined) {
         return {
@@ -2184,7 +2212,10 @@ function resolveNamedTypeWithSourceRecovery(
   type: ts.Type,
   sourceNode: ts.Node | undefined,
   checker: ts.TypeChecker
-): { typeName: string; namedDecl: ts.Declaration } | null {
+): {
+  typeName: string;
+  namedDecl: ts.ClassDeclaration | ts.InterfaceDeclaration | ts.TypeAliasDeclaration;
+} | null {
   const typeName = getNamedTypeName(type);
   const namedDecl = getNamedTypeDeclaration(type);
 
@@ -2313,7 +2344,11 @@ function resolveUnionType(
   // See `resolveNamedTypeWithSourceRecovery` for the fallback mechanism.
   const recovered = resolveNamedTypeWithSourceRecovery(type, sourceNode, checker);
   let typeName: string | null = null;
-  let namedDecl: ts.Declaration | undefined;
+  let namedDecl:
+    | ts.ClassDeclaration
+    | ts.InterfaceDeclaration
+    | ts.TypeAliasDeclaration
+    | undefined;
   if (recovered !== null) {
     const recoveredAliasDecl = ts.isTypeAliasDeclaration(recovered.namedDecl)
       ? recovered.namedDecl
@@ -3197,7 +3232,6 @@ function extractTypeAliasConstraintNodes(
   return constraints;
 }
 
-
 // =============================================================================
 // PROVENANCE HELPERS
 // =============================================================================
@@ -3261,7 +3295,9 @@ function getNamedTypeName(type: ts.Type): string | null {
 /**
  * Returns the declaration that defines a named type, if available.
  */
-function getNamedTypeDeclaration(type: ts.Type): ts.Declaration | undefined {
+function getNamedTypeDeclaration(
+  type: ts.Type
+): ts.ClassDeclaration | ts.InterfaceDeclaration | ts.TypeAliasDeclaration | undefined {
   const symbol = type.getSymbol();
   if (symbol?.declarations) {
     const decl = symbol.declarations[0];

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -303,6 +303,153 @@ function resolveNodeMetadata(
   return resolvedMetadata;
 }
 
+// =============================================================================
+// HERITAGE-BASED ANNOTATION INHERITANCE (issue #367)
+// =============================================================================
+
+/**
+ * Type-level annotation kinds that should be inherited from base types onto
+ * derived types when the derived type does not declare its own value.
+ *
+ * Scope (issue #367): only `@format` is inherited today. Other type-level
+ * annotations (e.g., `@description`, `@remarks`) are intentionally not
+ * inherited here to keep the change surface-narrow; broader inheritance can
+ * be considered as a follow-up once the semantics are confirmed.
+ */
+const INHERITABLE_TYPE_ANNOTATION_KINDS = new Set<AnnotationNode["annotationKind"]>(["format"]);
+
+/**
+ * Walks base class / interface declarations reachable from a derived
+ * declaration and returns any inheritable type-level annotations that the
+ * derived declaration does not already specify.
+ *
+ * The walk is breadth-first across all `extends` clauses, following through
+ * the TypeScript symbol table to the declaration(s) backing each base type.
+ * A seen-set on declarations prevents infinite loops on pathological
+ * self-referential chains.
+ *
+ * Annotations already present on the derived type (matched by
+ * `annotationKind`) always win — only missing kinds are filled in from the
+ * base chain. When multiple bases provide the same kind, the first found
+ * wins (earliest in the `extends` clause list, nearest ancestor first).
+ */
+function collectInheritedTypeAnnotations(
+  derivedDecl: ts.ClassDeclaration | ts.InterfaceDeclaration,
+  existingAnnotations: readonly AnnotationNode[],
+  checker: ts.TypeChecker,
+  file: string,
+  extensionRegistry: ExtensionRegistry | undefined
+): AnnotationNode[] {
+  const existingKinds = new Set<AnnotationNode["annotationKind"]>(
+    existingAnnotations.map((a) => a.annotationKind)
+  );
+  const needed = new Set<AnnotationNode["annotationKind"]>();
+  for (const kind of INHERITABLE_TYPE_ANNOTATION_KINDS) {
+    if (!existingKinds.has(kind)) needed.add(kind);
+  }
+  if (needed.size === 0) return [];
+
+  const inherited: AnnotationNode[] = [];
+  const seen = new Set<ts.Node>([derivedDecl]);
+  const queue: (ts.ClassDeclaration | ts.InterfaceDeclaration)[] = [];
+
+  const enqueueBasesOf = (decl: ts.ClassDeclaration | ts.InterfaceDeclaration): void => {
+    const heritageClauses = decl.heritageClauses;
+    if (!heritageClauses) return;
+    for (const clause of heritageClauses) {
+      // Interfaces use `extends`; classes use `extends` for their parent and
+      // `implements` for interfaces. For inheritance semantics we treat both
+      // `extends` and `implements` as sources of type-level annotations —
+      // nominal type authors routinely express the shape through either.
+      // `HeritageClause.token` is always one of those two per TS's AST types.
+      for (const typeExpr of clause.types) {
+        const sym = checker.getSymbolAtLocation(typeExpr.expression);
+        if (!sym) continue;
+        const target =
+          sym.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym) : sym;
+        for (const baseDecl of target.declarations ?? []) {
+          if (seen.has(baseDecl)) continue;
+          seen.add(baseDecl);
+          if (ts.isClassDeclaration(baseDecl) || ts.isInterfaceDeclaration(baseDecl)) {
+            queue.push(baseDecl);
+          }
+        }
+      }
+    }
+  };
+
+  enqueueBasesOf(derivedDecl);
+
+  while (queue.length > 0 && needed.size > 0) {
+    const baseDecl = queue.shift();
+    if (baseDecl === undefined) break;
+    const baseAnnotations = extractJSDocAnnotationNodes(
+      baseDecl,
+      file,
+      makeParseOptions(extensionRegistry)
+    );
+    for (const annotation of baseAnnotations) {
+      if (needed.has(annotation.annotationKind)) {
+        inherited.push(annotation);
+        needed.delete(annotation.annotationKind);
+      }
+    }
+    // Continue up the chain if we still need kinds.
+    if (needed.size > 0) {
+      enqueueBasesOf(baseDecl);
+    }
+  }
+
+  return inherited;
+}
+
+/**
+ * Merges heritage-inherited annotations into a local annotation list for a
+ * class or interface declaration. Returns the combined list; local
+ * annotations always take precedence (see {@link collectInheritedTypeAnnotations}).
+ */
+function mergeInheritedTypeAnnotations(
+  decl: ts.ClassDeclaration | ts.InterfaceDeclaration | undefined,
+  localAnnotations: readonly AnnotationNode[],
+  checker: ts.TypeChecker,
+  file: string,
+  extensionRegistry: ExtensionRegistry | undefined
+): AnnotationNode[] {
+  if (decl === undefined) return [...localAnnotations];
+  const inherited = collectInheritedTypeAnnotations(
+    decl,
+    localAnnotations,
+    checker,
+    file,
+    extensionRegistry
+  );
+  if (inherited.length === 0) return [...localAnnotations];
+  return [...localAnnotations, ...inherited];
+}
+
+/**
+ * Extracts type-level annotations from a named declaration (class, interface,
+ * or type alias), applying heritage-based inheritance where applicable
+ * (issue #367). For type aliases (no heritage), behaves identically to
+ * {@link extractJSDocAnnotationNodes}.
+ */
+function extractNamedTypeAnnotations(
+  namedDecl: ts.Declaration,
+  checker: ts.TypeChecker,
+  file: string,
+  extensionRegistry: ExtensionRegistry | undefined
+): AnnotationNode[] {
+  const local = extractJSDocAnnotationNodes(
+    namedDecl,
+    file,
+    makeParseOptions(extensionRegistry)
+  );
+  if (ts.isClassDeclaration(namedDecl) || ts.isInterfaceDeclaration(namedDecl)) {
+    return mergeInheritedTypeAnnotations(namedDecl, local, checker, file, extensionRegistry);
+  }
+  return local;
+}
+
 export function analyzeDeclarationRootInfo(
   declaration: ts.ClassDeclaration | ts.InterfaceDeclaration | ts.TypeAliasDeclaration,
   checker: ts.TypeChecker,
@@ -372,7 +519,15 @@ export function analyzeClassToIR(
     file,
     makeParseOptions(extensionRegistry, undefined, checker, classType, classType)
   );
-  const annotations = [...classDoc.annotations];
+  // Issue #367: type-level annotations (e.g., @format) declared on a base
+  // class flow to derived classes unless the derived class overrides them.
+  const annotations = mergeInheritedTypeAnnotations(
+    classDecl,
+    classDoc.annotations,
+    checker,
+    file,
+    extensionRegistry
+  );
   diagnostics.push(...classDoc.diagnostics);
   const visiting = new Set<ts.Type>();
   const instanceMethods: MethodInfo[] = [];
@@ -470,7 +625,16 @@ export function analyzeInterfaceToIR(
     file,
     makeParseOptions(extensionRegistry, undefined, checker, interfaceType, interfaceType)
   );
-  const annotations = [...interfaceDoc.annotations];
+  // Issue #367: type-level annotations (e.g., @format) declared on a base
+  // interface flow to derived interfaces unless the derived interface
+  // overrides them.
+  const annotations = mergeInheritedTypeAnnotations(
+    interfaceDecl,
+    interfaceDoc.annotations,
+    checker,
+    file,
+    extensionRegistry
+  );
   diagnostics.push(...interfaceDoc.diagnostics);
   const visiting = new Set<ts.Type>();
 
@@ -2219,7 +2383,7 @@ function resolveUnionType(
       return { kind: "reference", name: typeName, typeArguments: [] };
     }
     const annotations = namedDecl
-      ? extractJSDocAnnotationNodes(namedDecl, file, makeParseOptions(extensionRegistry))
+      ? extractNamedTypeAnnotations(namedDecl, checker, file, extensionRegistry)
       : undefined;
     const metadata =
       namedDecl !== undefined
@@ -2581,7 +2745,7 @@ function resolveObjectType(
         return recordNode;
       }
       const annotations = namedDecl
-        ? extractJSDocAnnotationNodes(namedDecl, file, makeParseOptions(extensionRegistry))
+        ? extractNamedTypeAnnotations(namedDecl, checker, file, extensionRegistry)
         : undefined;
       const metadata =
         namedDecl !== undefined
@@ -2719,7 +2883,7 @@ function resolveObjectType(
   // Register named types
   if (registryTypeName !== undefined && shouldRegisterNamedType) {
     const annotations = namedDecl
-      ? extractJSDocAnnotationNodes(namedDecl, file, makeParseOptions(extensionRegistry))
+      ? extractNamedTypeAnnotations(namedDecl, checker, file, extensionRegistry)
       : undefined;
     const metadata =
       namedDecl !== undefined

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -362,7 +362,6 @@ function collectInheritedTypeAnnotations(
   derivedDecl: ts.ClassDeclaration | ts.InterfaceDeclaration,
   existingAnnotations: readonly AnnotationNode[],
   checker: ts.TypeChecker,
-  file: string,
   extensionRegistry: ExtensionRegistry | undefined
 ): AnnotationNode[] {
   // A local annotation only suppresses heritage inheritance when it carries a
@@ -418,11 +417,13 @@ function collectInheritedTypeAnnotations(
 
   enqueueBasesOf(derivedDecl);
 
-  while (queue.length > 0 && needed.size > 0) {
-    const baseDecl = queue.shift();
-    if (baseDecl === undefined) break;
+  // Index-pointer traversal (vs `queue.shift()`) keeps the BFS O(n) for deep
+  // heritage graphs — array shift is O(n) in V8.
+  for (let queueIndex = 0; queueIndex < queue.length && needed.size > 0; queueIndex++) {
+    const baseDecl = queue[queueIndex];
+    if (baseDecl === undefined) continue;
     // Use the base declaration's own source file for provenance / pos-mapping.
-    // The BFS may cross file boundaries, so the derived type's `file` is not
+    // The BFS may cross file boundaries, so the derived type's file is not
     // the right reference point for annotations parsed off a base declaration.
     const baseFile = baseDecl.getSourceFile().fileName;
     const baseAnnotations = extractJSDocAnnotationNodes(
@@ -469,7 +470,6 @@ function extractNamedTypeAnnotations(
     namedDecl,
     local,
     checker,
-    file,
     extensionRegistry
   );
   if (inherited.length === 0) return [...local];
@@ -551,7 +551,6 @@ export function analyzeClassToIR(
     classDecl,
     classDoc.annotations,
     checker,
-    file,
     extensionRegistry
   );
   const annotations: AnnotationNode[] = [...classDoc.annotations, ...inheritedClassAnnotations];
@@ -659,7 +658,6 @@ export function analyzeInterfaceToIR(
     interfaceDecl,
     interfaceDoc.annotations,
     checker,
-    file,
     extensionRegistry
   );
   const annotations: AnnotationNode[] = [


### PR DESCRIPTION
## Summary

Fixes #367 — `@format` on a base interface (e.g. `MonetaryAmount`) was not inherited by derived types (`interface PositiveMonetaryAmount extends MonetaryAmount`), so the derived `$defs` entry lost its `format` keyword and downstream renderers (Stripe dashboard MonetaryAmount widget) could not identify it.

The analyzer now walks `extends` heritage clauses when building the IR for class/interface declarations and merges inheritable type-level annotations onto the derived type. Currently only `@format` is enrolled in the inheritable set — see #371 for generalization.

Semantics:
- `extends`-only (TS `implements` is a type-check constraint, not an annotation source)
- Local annotations win; empty-value annotations do NOT count as overrides
- BFS with cycle-safe `seen` set
- First-match wins for sibling bases (documented in `collectInheritedTypeAnnotations`)

## Test plan

- [x] Regression tests in `packages/build/src/__tests__/format-inheritance-derived-types.test.ts` — 9 cases including: interface→interface, class→class, multi-level chain, cyclic, `implements` (negative), empty-value override, sibling override, diamond declaration-order, non-`@format` scope guard
- [x] `pnpm run build` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm --filter @formspec/build exec vitest run` — 848 passing
- [x] `pnpm run test` — all packages + e2e passing

## Follow-ups (filed separately)

- #371 — Generalize type-level annotation inheritance beyond `@format`: move inheritability onto annotation-kind registration, unify with `resolveNodeMetadata`, type-alias intermediaries, property-level inheritance, document `extends` vs `implements` policy per kind.