### PR TITLE
test(analysis): strengthen NoTruncation regression coverage with anonymous-intersection case

### DIFF
--- a/.changeset/strengthen-notruncation-regression-test.md
+++ b/.changeset/strengthen-notruncation-regression-test.md
@@ -1,0 +1,22 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Strengthen NoTruncation regression coverage with anonymous-intersection case
+
+Follow-up to PR #357. The prior `LongIntersection` test used a named alias —
+TypeScript's `typeToString` renders those identically with or without
+`NoTruncation`, so the test passed pre- and post-fix, providing zero regression
+coverage. This adds an anonymous-intersection fixture (276 chars `NoTruncation`
+vs 228 chars default — structurally different) that actually demonstrates the
+fix. Verified by reverting the fix locally: the new test fails as expected.
+
+Also clarifies the null-guard comment in `hasExtensionBroadening` and softens
+the specific character-count claim (the truncation threshold varies by type
+structure).

--- a/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
+++ b/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
@@ -29,12 +29,10 @@
  * @see packages/build/src/__tests__/typed-parser-canaries.test.ts (build-consumer mirror)
  */
 
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 import { buildFormSpecAnalysisFileSnapshot } from "../internal.js";
-import {
-  defineCustomType,
-  defineExtension,
-} from "@formspec/core";
+import { defineCustomType, defineExtension } from "@formspec/core";
 import { createProgram } from "./helpers.js";
 
 // =============================================================================
@@ -54,10 +52,7 @@ function snapshotDiagnosticsFor(
     "}",
   ].join("\n");
 
-  const { checker, sourceFile } = createProgram(
-    source,
-    `/virtual/snapshot-canary-${label}.ts`
-  );
+  const { checker, sourceFile } = createProgram(source, `/virtual/snapshot-canary-${label}.ts`);
   const snapshot = buildFormSpecAnalysisFileSnapshot(sourceFile, { checker });
   return snapshot.diagnostics;
 }
@@ -203,12 +198,9 @@ describe("@const typed-parser Role-C canaries (snapshot consumer)", () => {
     //   The typed parser's own rejection messages say e.g. "Expected @const to be ..."
     //   so the arity message confirms that Role C passed through and the rejection
     //   came from the synthetic checker.
-    const source = [
-      "class Form {",
-      "  /** @const not-json */",
-      "  value!: number;",
-      "}",
-    ].join("\n");
+    const source = ["class Form {", "  /** @const not-json */", "  value!: number;", "}"].join(
+      "\n"
+    );
 
     const { checker, sourceFile } = createProgram(
       source,
@@ -305,38 +297,23 @@ describe("extension-broadening bypass — typed parser must not fire for broaden
     expect(snapshot.diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT")).toBe(false);
   });
 
-  it("detects broadening for a complex intersection type registered with its full NoTruncation name (regression: #354 follow-up)", () => {
-    // Regression guard for the fix that replaced checker.typeToString(effectiveType)
+  it("detects broadening for a named-alias intersection type registered by alias name (named-alias sub-path of NoTruncation fix)", () => {
+    // Sub-path guard for the fix that replaced checker.typeToString(effectiveType)
     // with typeToString(effectiveType, checker) (passing TypeFormatFlags.NoTruncation).
     //
-    // The bug: hasExtensionBroadening used checker.typeToString with default flags,
-    // which applies TypeScript's ~160-char truncation threshold. When an extension
-    // registers a complex anonymous intersection type via tsTypeNames, the full
-    // NoTruncation string is stored — but the default formatter would produce a
-    // truncated / structurally-different string that never matches the registry.
-    // Broadening detection would silently miss, causing INVALID_TAG_ARGUMENT to
-    // fire on valid extension-broadened fields with complex types.
+    // Named type aliases: TypeScript's typeToString returns the alias name ("LongIntersection")
+    // in BOTH default-flag mode AND NoTruncation mode. This test confirms the fix does not
+    // break the named-alias path — it is NOT a demonstration of the truncation bug itself.
     //
-    // The fix: use the file-local typeToString() helper which passes NoTruncation,
-    // ensuring the string matches the registry for arbitrarily complex types.
-    //
-    // This test uses a type alias whose underlying structure exceeds ~160 characters
-    // when printed inline. To make the registered name deterministic, the alias name
-    // ("LongIntersection") is used — TypeScript uses alias names for named aliases
-    // regardless of truncation, so the regression is demonstrated by registering
-    // the alias name and verifying broadening fires.
-    //
-    // NOTE: The real truncation scenario affects anonymous or expanded types. This
-    // test guards the code-path fix and documents the intended behavior. A test for
-    // pure anonymous truncation would require runtime reflection to determine the
-    // exact NoTruncation string at test-write time.
+    // The real truncation scenario (anonymous/expanded types) is exercised in the
+    // companion test below: "detects broadening for an anonymous intersection ...".
     const extension = defineExtension({
       extensionId: "x-test/complex-type-broadening",
       types: [
         defineCustomType({
           typeName: "LongIntersection",
-          // Register the alias name — TypeScript's typeToString returns alias names
-          // for named type aliases, so this is stable and deterministic.
+          // Register the alias name — TypeScript's typeToString returns the alias name
+          // for named type aliases regardless of truncation flags, so this path is stable.
           tsTypeNames: ["LongIntersection"],
           builtinConstraintBroadenings: [
             {
@@ -350,11 +327,6 @@ describe("extension-broadening bypass — typed parser must not fire for broaden
       ],
     });
 
-    // LongIntersection is a complex type whose fully-expanded inline representation
-    // would exceed TypeScript's ~160-char default truncation threshold. However,
-    // since it is a named alias, typeToString returns "LongIntersection" in both
-    // default and NoTruncation modes — confirming that the fix's use of the helper
-    // does not break the named-alias path while the code path now passes NoTruncation.
     const source = [
       "type LongIntersection = string",
       "  & { readonly propAlpha: boolean }",
@@ -380,12 +352,146 @@ describe("extension-broadening bypass — typed parser must not fire for broaden
       extensionDefinitions: [extension],
     });
 
-    // hasExtensionBroadening must detect that LongIntersection has @minimum
-    // broadening registered, and suppress the typed parser before it rejects
-    // "0x10" as an invalid hex argument.
     expect(
       snapshot.diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT"),
       "Expected no INVALID_TAG_ARGUMENT — broadening detection must fire for LongIntersection before the typed parser runs"
+    ).toBe(false);
+  });
+
+  it("detects broadening for an anonymous intersection type whose NoTruncation string differs from the default-flags string (regression: PR #357 review)", () => {
+    // TRUE regression guard for PR #357's NoTruncation fix.
+    //
+    // The bug: hasExtensionBroadening called checker.typeToString(effectiveType) with
+    // DEFAULT flags. TypeScript's default formatter truncates long inline type
+    // representations by replacing trailing members with "{ ...; }". For anonymous
+    // intersection types (no alias name), the default and NoTruncation outputs are
+    // structurally different strings — so if tsTypeNames was registered with the full
+    // NoTruncation representation, the name-match would FAIL and broadening detection
+    // would silently miss, causing INVALID_TAG_ARGUMENT to fire on valid fields.
+    //
+    // The fix: use the file-local typeToString() helper which passes
+    // TypeFormatFlags.NoTruncation, ensuring the rendered string matches the full
+    // representation stored in tsTypeNames for any type complexity.
+    //
+    // Approach: compute the full NoTruncation string at test-setup time via the
+    // TypeScript checker, then register THAT string in tsTypeNames. This makes the
+    // test TS-version-independent while still verifying the truncation path fires.
+    //
+    // The inline intersection below has 10 members (a–j). Empirically, TypeScript
+    // truncates members beyond ~7 with "{ ...; }" under default flags, producing
+    // a shorter string that does NOT match the full NoTruncation representation.
+    // This test FAILS without the NoTruncation fix because the default-flags string
+    // would not match the registered tsTypeName.
+    //
+    // References: PR #357 review feedback; fix in
+    // packages/analysis/src/file-snapshots.ts (hasExtensionBroadening)
+    // The anonymous intersection source used for BOTH the probe (type-string extraction)
+    // and the final snapshot run. It includes @minimum 0x10 so the typed parser fires
+    // when broadening detection misses (pre-fix). Without the JSDoc comment, no tags
+    // are processed and the test would pass trivially regardless of the fix.
+    const anonymousIntersectionSource = [
+      "class TestForm {",
+      "  /** @minimum 0x10 */",
+      "  value!: string",
+      "    & { readonly a: boolean } & { readonly b: boolean }",
+      "    & { readonly c: boolean } & { readonly d: boolean }",
+      "    & { readonly e: boolean } & { readonly f: boolean }",
+      "    & { readonly g: boolean } & { readonly h: boolean }",
+      "    & { readonly i: boolean } & { readonly j: boolean };",
+      "}",
+    ].join("\n");
+
+    // Step 1: compute the NoTruncation string for the anonymous intersection type.
+    const { checker: probeChecker, sourceFile: probeSf } = createProgram(
+      anonymousIntersectionSource,
+      "/virtual/probe-anonymous-intersection.ts"
+    );
+
+    // Walk to the property declaration to get its type.
+    function findPropertyDeclaration(node: ts.Node): ts.PropertyDeclaration | undefined {
+      if (ts.isPropertyDeclaration(node)) return node;
+      return ts.forEachChild(node, findPropertyDeclaration);
+    }
+    const propDecl = findPropertyDeclaration(probeSf);
+    if (propDecl === undefined) throw new Error("Expected property declaration in probe source");
+
+    const fieldType = probeChecker.getTypeAtLocation(propDecl);
+    const noTruncationName = probeChecker.typeToString(
+      fieldType,
+      undefined,
+      ts.TypeFormatFlags.NoTruncation
+    );
+    const defaultFlagsName = probeChecker.typeToString(fieldType);
+
+    // Sanity check: the default-flags string MUST differ from the NoTruncation string.
+    // If TypeScript's internal threshold changes and they become equal, this test can
+    // no longer demonstrate the truncation regression. We fail explicitly in that case.
+    if (noTruncationName === defaultFlagsName) {
+      throw new Error(
+        "Truncation check setup failed: TypeScript's typeToString produced identical strings " +
+          "in default-flags and NoTruncation mode for the anonymous intersection. " +
+          "The truncation threshold may have changed. " +
+          "NoTruncation length: " +
+          String(noTruncationName.length) +
+          ". Default: " +
+          JSON.stringify(defaultFlagsName)
+      );
+    }
+
+    // Step 2: register the FULL NoTruncation string in tsTypeNames. The pre-fix code
+    // would compute defaultFlagsName (truncated) for the match — which would never
+    // equal noTruncationName — and broadening detection would miss.
+    const extension = defineExtension({
+      extensionId: "x-test/anonymous-intersection-broadening",
+      types: [
+        defineCustomType({
+          typeName: "AnonymousIntersection",
+          // Register the full NoTruncation representation. Pre-fix code would compare
+          // this against defaultFlagsName (truncated) — they differ, so match fails.
+          // Post-fix code uses NoTruncation for both sides — they match.
+          tsTypeNames: [noTruncationName],
+          builtinConstraintBroadenings: [
+            {
+              tagName: "minimum",
+              constraintName: "AnonymousIntersectionMinimum",
+              parseValue: (raw) => Number(raw),
+            },
+          ],
+          toJsonSchema: (_payload, _prefix) => ({ type: "object" }),
+        }),
+      ],
+    });
+
+    // Step 3: run the snapshot consumer on a field whose type is the anonymous intersection.
+    const { checker, sourceFile } = createProgram(
+      anonymousIntersectionSource,
+      "/virtual/snapshot-canary-anonymous-intersection.ts"
+    );
+
+    const snapshot = buildFormSpecAnalysisFileSnapshot(sourceFile, {
+      checker,
+      extensionDefinitions: [extension],
+    });
+
+    // Post-fix: broadening detection fires (NoTruncation match succeeds) → typed
+    // parser is bypassed → no INVALID_TAG_ARGUMENT for the hex argument "0x10".
+    //
+    // Pre-fix: broadening detection misses (default-flags string doesn't match the
+    // registered noTruncationName) → typed parser fires → INVALID_TAG_ARGUMENT emitted.
+    expect(
+      snapshot.diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT"),
+      "Expected no INVALID_TAG_ARGUMENT — broadening detection must match the anonymous intersection " +
+        "via NoTruncation. " +
+        "NoTruncation name (" +
+        String(noTruncationName.length) +
+        " chars): " +
+        noTruncationName.slice(0, 80) +
+        "... " +
+        "Default-flags name (" +
+        String(defaultFlagsName.length) +
+        " chars): " +
+        defaultFlagsName.slice(0, 80) +
+        "..."
     ).toBe(false);
   });
 });

--- a/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
+++ b/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
@@ -359,36 +359,22 @@ describe("extension-broadening bypass — typed parser must not fire for broaden
   });
 
   it("detects broadening for an anonymous intersection type whose NoTruncation string differs from the default-flags string (regression: PR #357 review)", () => {
-    // TRUE regression guard for PR #357's NoTruncation fix.
+    // TRUE regression guard for PR #357's NoTruncation fix in hasExtensionBroadening.
     //
-    // The bug: hasExtensionBroadening called checker.typeToString(effectiveType) with
-    // DEFAULT flags. TypeScript's default formatter truncates long inline type
-    // representations by replacing trailing members with "{ ...; }". For anonymous
-    // intersection types (no alias name), the default and NoTruncation outputs are
-    // structurally different strings — so if tsTypeNames was registered with the full
-    // NoTruncation representation, the name-match would FAIL and broadening detection
-    // would silently miss, causing INVALID_TAG_ARGUMENT to fire on valid fields.
+    // The bug: the pre-fix call `checker.typeToString(effectiveType)` used default
+    // flags, which truncate long anonymous types by replacing trailing members with
+    // "{ ...; }". When an extension registers the FULL NoTruncation string in
+    // tsTypeNames, the truncated default-flags string never matches — broadening
+    // detection silently misses and INVALID_TAG_ARGUMENT fires on valid fields.
     //
-    // The fix: use the file-local typeToString() helper which passes
-    // TypeFormatFlags.NoTruncation, ensuring the rendered string matches the full
-    // representation stored in tsTypeNames for any type complexity.
+    // Approach: compute the full NoTruncation string at test-setup time, register
+    // that exact string in tsTypeNames, and assert no INVALID_TAG_ARGUMENT fires.
+    // This keeps the test TS-version-independent; the probe below asserts that the
+    // two renderings actually differ, so the test fails loudly rather than silently
+    // degrading if TypeScript's truncation heuristic changes.
     //
-    // Approach: compute the full NoTruncation string at test-setup time via the
-    // TypeScript checker, then register THAT string in tsTypeNames. This makes the
-    // test TS-version-independent while still verifying the truncation path fires.
-    //
-    // The inline intersection below has 10 members (a–j). Empirically, TypeScript
-    // truncates members beyond ~7 with "{ ...; }" under default flags, producing
-    // a shorter string that does NOT match the full NoTruncation representation.
-    // This test FAILS without the NoTruncation fix because the default-flags string
-    // would not match the registered tsTypeName.
-    //
-    // References: PR #357 review feedback; fix in
-    // packages/analysis/src/file-snapshots.ts (hasExtensionBroadening)
-    // The anonymous intersection source used for BOTH the probe (type-string extraction)
-    // and the final snapshot run. It includes @minimum 0x10 so the typed parser fires
-    // when broadening detection misses (pre-fix). Without the JSDoc comment, no tags
-    // are processed and the test would pass trivially regardless of the fix.
+    // The 10-member intersection (a–j) comfortably exceeds TypeScript's default
+    // truncation threshold (empirically ~7 members as of TS 5.x).
     const anonymousIntersectionSource = [
       "class TestForm {",
       "  /** @minimum 0x10 */",
@@ -401,54 +387,39 @@ describe("extension-broadening bypass — typed parser must not fire for broaden
       "}",
     ].join("\n");
 
-    // Step 1: compute the NoTruncation string for the anonymous intersection type.
-    const { checker: probeChecker, sourceFile: probeSf } = createProgram(
+    const { checker, sourceFile } = createProgram(
       anonymousIntersectionSource,
-      "/virtual/probe-anonymous-intersection.ts"
+      "/virtual/snapshot-canary-anonymous-intersection.ts"
     );
 
-    // Walk to the property declaration to get its type.
-    function findPropertyDeclaration(node: ts.Node): ts.PropertyDeclaration | undefined {
-      if (ts.isPropertyDeclaration(node)) return node;
-      return ts.forEachChild(node, findPropertyDeclaration);
-    }
-    const propDecl = findPropertyDeclaration(probeSf);
-    if (propDecl === undefined) throw new Error("Expected property declaration in probe source");
+    const classDecl = sourceFile.statements.find(ts.isClassDeclaration);
+    const propDecl = classDecl?.members.find(ts.isPropertyDeclaration);
+    if (propDecl === undefined) throw new Error("Expected property declaration in fixture source");
 
-    const fieldType = probeChecker.getTypeAtLocation(propDecl);
-    const noTruncationName = probeChecker.typeToString(
+    const fieldType = checker.getTypeAtLocation(propDecl);
+    const noTruncationName = checker.typeToString(
       fieldType,
       undefined,
       ts.TypeFormatFlags.NoTruncation
     );
-    const defaultFlagsName = probeChecker.typeToString(fieldType);
+    const defaultFlagsName = checker.typeToString(fieldType);
 
-    // Sanity check: the default-flags string MUST differ from the NoTruncation string.
-    // If TypeScript's internal threshold changes and they become equal, this test can
-    // no longer demonstrate the truncation regression. We fail explicitly in that case.
-    if (noTruncationName === defaultFlagsName) {
-      throw new Error(
-        "Truncation check setup failed: TypeScript's typeToString produced identical strings " +
-          "in default-flags and NoTruncation mode for the anonymous intersection. " +
-          "The truncation threshold may have changed. " +
-          "NoTruncation length: " +
-          String(noTruncationName.length) +
-          ". Default: " +
-          JSON.stringify(defaultFlagsName)
-      );
-    }
+    // Precondition: the two renderings must differ for this test to demonstrate
+    // the truncation bug. If TypeScript's threshold ever changes so they match,
+    // this assertion fails loudly rather than the test silently degenerating.
+    expect(
+      noTruncationName,
+      "TypeScript's truncation heuristic may have changed — anonymous intersection renders identically with and without NoTruncation; fixture needs more members"
+    ).not.toEqual(defaultFlagsName);
 
-    // Step 2: register the FULL NoTruncation string in tsTypeNames. The pre-fix code
-    // would compute defaultFlagsName (truncated) for the match — which would never
-    // equal noTruncationName — and broadening detection would miss.
+    // Register the FULL NoTruncation string. Pre-fix code compared this against
+    // the truncated default-flags string — no match, broadening missed. Post-fix
+    // code renders both sides with NoTruncation — match succeeds.
     const extension = defineExtension({
       extensionId: "x-test/anonymous-intersection-broadening",
       types: [
         defineCustomType({
           typeName: "AnonymousIntersection",
-          // Register the full NoTruncation representation. Pre-fix code would compare
-          // this against defaultFlagsName (truncated) — they differ, so match fails.
-          // Post-fix code uses NoTruncation for both sides — they match.
           tsTypeNames: [noTruncationName],
           builtinConstraintBroadenings: [
             {
@@ -462,36 +433,14 @@ describe("extension-broadening bypass — typed parser must not fire for broaden
       ],
     });
 
-    // Step 3: run the snapshot consumer on a field whose type is the anonymous intersection.
-    const { checker, sourceFile } = createProgram(
-      anonymousIntersectionSource,
-      "/virtual/snapshot-canary-anonymous-intersection.ts"
-    );
-
     const snapshot = buildFormSpecAnalysisFileSnapshot(sourceFile, {
       checker,
       extensionDefinitions: [extension],
     });
 
-    // Post-fix: broadening detection fires (NoTruncation match succeeds) → typed
-    // parser is bypassed → no INVALID_TAG_ARGUMENT for the hex argument "0x10".
-    //
-    // Pre-fix: broadening detection misses (default-flags string doesn't match the
-    // registered noTruncationName) → typed parser fires → INVALID_TAG_ARGUMENT emitted.
     expect(
       snapshot.diagnostics.some((d) => d.code === "INVALID_TAG_ARGUMENT"),
-      "Expected no INVALID_TAG_ARGUMENT — broadening detection must match the anonymous intersection " +
-        "via NoTruncation. " +
-        "NoTruncation name (" +
-        String(noTruncationName.length) +
-        " chars): " +
-        noTruncationName.slice(0, 80) +
-        "... " +
-        "Default-flags name (" +
-        String(defaultFlagsName.length) +
-        " chars): " +
-        defaultFlagsName.slice(0, 80) +
-        "..."
+      "Expected no INVALID_TAG_ARGUMENT — broadening detection must match the anonymous intersection via NoTruncation (regression in hasExtensionBroadening)"
     ).toBe(false);
   });
 });

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -242,11 +242,15 @@ function hasExtensionBroadening(
   // consistent with how the build path strips before isIntegerBrandedType.
   const effectiveType = stripNullishUnion(subjectType);
   // Use NoTruncation so that complex types (intersections, deep generics) are
-  // rendered in full. Without it, checker.typeToString uses its default truncation
-  // threshold (~160 chars) and can produce a structurally-different string than
-  // what was registered in tsTypeNames, causing broadening detection to miss.
+  // rendered in full. Without it, checker.typeToString applies TypeScript's internal
+  // truncation threshold and can produce a structurally-different string than what
+  // was registered in tsTypeNames, causing broadening detection to miss for
+  // anonymous intersection types or deeply nested generics.
   const typeName = typeToString(effectiveType, checker);
   if (typeName === null) {
+    // typeToString returns null when its type argument is undefined. stripNullishUnion
+    // always returns a ts.Type, so this branch is a defensive guard for future callers
+    // that might pass an undefined type through a different code path.
     return false;
   }
 
@@ -1384,9 +1388,7 @@ function buildTagDiagnostics(
   // the top of this function). Compute the log-friendly kind once, and only
   // when structured logging is actually enabled — describeTypeKind is cheap
   // but this runs on every snapshot diagnostic pass.
-  const subjectTypeKindForLog = snapshotLogsEnabled
-    ? describeTypeKind(subjectType, checker)
-    : "";
+  const subjectTypeKindForLog = snapshotLogsEnabled ? describeTypeKind(subjectType, checker) : "";
 
   for (const tag of commentTags) {
     const semantic = getCommentTagSemanticContext(tag, semanticOptions);
@@ -1494,17 +1496,20 @@ function buildTagDiagnostics(
           // build consumer — avoids the Lesson 3 silent-ternary-collapse pitfall.
           const mappedCode = mapTypedParserDiagnosticCode(
             typedParseResult.diagnostic.code,
-            tag.normalizedTagName,
+            tag.normalizedTagName
           );
 
           diagnostics.push(
-            createAnalysisDiagnostic(mappedCode, typedParseResult.diagnostic.message, tag.fullSpan, {
-              tagName: tag.normalizedTagName,
-              placement,
-              ...(target === null
-                ? {}
-                : { targetKind: target.kind, targetText: target.text }),
-            })
+            createAnalysisDiagnostic(
+              mappedCode,
+              typedParseResult.diagnostic.message,
+              tag.fullSpan,
+              {
+                tagName: tag.normalizedTagName,
+                placement,
+                ...(target === null ? {} : { targetKind: target.kind, targetText: target.text }),
+              }
+            )
           );
           // Skip adding to syntheticApplications — typed parser already rejected at Role C.
           continue;


### PR DESCRIPTION
## Summary

- The `LongIntersection` test added in #357 used a named type alias — TypeScript's `typeToString` returns the alias name (`"LongIntersection"`, 16 chars) in both default-flag and `NoTruncation` mode. The two strings are byte-identical, so the test passed identically pre-fix and post-fix: it was not a real regression guard.
- Adds an **anonymous-intersection** test fixture (10 inline members, `a`–`j`) where the `NoTruncation` string (276 chars) and the default-flags string (228 chars, with `{ ...; }` truncation) are structurally different. Verified to **fail** against the pre-fix code.
- Refactors the `LongIntersection` test to accurately describe what it tests (named-alias sub-path, not the truncation bug itself).
- Clarifies the null-guard comment in `file-snapshots.ts` (the `typeName === null` branch is a defensive guard; `stripNullishUnion` always returns `ts.Type` so this path is unreachable via the current call site).
- Softens the `~160 chars` truncation-threshold claim to reference "TypeScript's internal truncation threshold" without pinning a specific value.

## Test plan

- [x] New anonymous-intersection test **fails** without the `NoTruncation` fix (verified by temporarily reverting `typeToString(effectiveType, checker)` to `checker.typeToString(effectiveType)`)
- [x] All 540 `@formspec/analysis` tests pass with fix applied
- [x] `pnpm --filter @formspec/analysis run build` clean
- [x] `pnpm exec eslint` clean on changed files
- [x] `pnpm exec prettier --check` clean on changed files

Addresses review feedback on PR #357.