### PR TITLE
refactor(analysis): relocate setup diagnostics to createExtensionRegistry (Phase 4 Slice C)

### DIFF
--- a/.changeset/phase-4-slice-c-setup-diagnostic-relocation.md
+++ b/.changeset/phase-4-slice-c-setup-diagnostic-relocation.md
@@ -1,0 +1,8 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+---
+
+Relocate setup diagnostics to registry construction time.
+
+`UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` and `SYNTHETIC_SETUP_FAILURE` diagnostics are now emitted exactly once per `createExtensionRegistry` call (build consumer) or `buildFormSpecAnalysisFileSnapshot` call (snapshot consumer), anchored at the extension registration site (`surface: "extension"`, line 1, column 0). Previously, these diagnostics fired on every tag-application validation call, bypassing the LRU cache entirely.

--- a/.changeset/phase-4-slice-c-setup-diagnostic-relocation.md
+++ b/.changeset/phase-4-slice-c-setup-diagnostic-relocation.md
@@ -1,6 +1,11 @@
 ---
 "@formspec/analysis": patch
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
 ---
 
 Relocate setup diagnostics to registry construction time.

--- a/docs/refactors/phase-4-slice-c-deduplicate-diagnostics-root-fix.md
+++ b/docs/refactors/phase-4-slice-c-deduplicate-diagnostics-root-fix.md
@@ -1,0 +1,78 @@
+# Phase 4 Slice C follow-up: eliminate `deduplicateDiagnostics`
+
+## Status
+
+Deferred. The Phase 4 Slice C PR (setup-diagnostic relocation) ships with a
+temporary `deduplicateDiagnostics` helper in
+`packages/build/src/analyzer/class-analyzer.ts`. The helper is safe — it
+filters only the two setup-diagnostic codes
+(`SYNTHETIC_SETUP_FAILURE`, `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE`) and leaves
+per-field diagnostics untouched — but it is a symptom-fix that should be
+retired in a follow-up.
+
+## Why the helper exists
+
+When an `ExtensionRegistry` has setup failures, every field in a class,
+interface, or type alias triggers an independent call to `parseTSDocTags`.
+Each call returns the same setup diagnostic (anchored at the registry-level
+provenance `{surface: "extension", line: 1, column: 0}`). Without
+deduplication, an N-field declaration produces N identical setup diagnostics.
+
+## Why the helper should go away
+
+1. **Wasted work.** Every field walks the same registry state and produces
+   the same diagnostic, which the helper then throws away.
+2. **Fragile invariant.** The helper only works because setup diagnostics
+   share a provenance. Future diagnostic codes with the same dedup-eligible
+   shape would have to be added to the allowlist manually.
+3. **Dead code path.** `parseTSDocTags` has an early-return for
+   registry-has-setup-failure (the "silent drop" path). That path exists only
+   to avoid emitting garbage tag-level diagnostics when the registry is
+   broken; the setup diagnostic itself could be emitted at a higher level.
+
+## Proposed structural fix
+
+Move setup-diagnostic emission **out of** `parseTSDocTags` entirely and
+into the three declaration-level entrypoints in
+`packages/build/src/analyzer/class-analyzer.ts`:
+
+- `analyzeClassToIR`
+- `analyzeInterfaceToIR`
+- `analyzeTypeAliasToIR`
+
+At the top of each, when
+`extensionRegistry?.setupDiagnostics.length > 0`:
+
+1. Call `_emitSetupDiagnostics(extensionRegistry.setupDiagnostics, file)`
+   once and append to the diagnostics accumulator.
+2. Pass `undefined` (or a sentinel "suppressed" registry) to the per-field
+   `parseTSDocTags` calls so they skip setup-diag re-emission.
+
+This mirrors the pattern already used in
+`packages/analysis/src/file-snapshots.ts:1827-1847`
+(`buildFormSpecAnalysisFileSnapshot`), which pre-emits setup diagnostics
+once and then passes `setupDiagnosticsPreEmitted: true` downstream.
+
+After the restructure, `deduplicateDiagnostics` and the
+`DEDUPLICATABLE_DIAGNOSTIC_CODES` constant can be deleted, and the
+`parseTSDocTags` silent-drop early-return can be simplified (it no longer
+needs to re-emit the setup diagnostic; it can return empty results cleanly).
+
+## Scope notes
+
+- The restructure touches three declaration-level entrypoints; each one has
+  multiple callers. Plan on an API review of the "suppressed registry"
+  parameter shape.
+- Existing tests that assert per-snapshot-call emission count
+  (`setup-diagnostic-emission-count.test.ts`) should continue to pass
+  unchanged; the count semantics are preserved.
+- The `deduplicate-diagnostics.test.ts` unit tests can be deleted with the
+  helper.
+
+## Owner / tracking
+
+- Source: Phase 4 Slice C review feedback
+  (see `.changeset/phase-4-slice-c-setup-diagnostic-relocation.md`)
+- Linked in-code TODO:
+  `packages/build/src/analyzer/class-analyzer.ts` (see comment on
+  `deduplicateDiagnostics`)

--- a/packages/analysis/src/__tests__/compiler-signatures.test.ts
+++ b/packages/analysis/src/__tests__/compiler-signatures.test.ts
@@ -399,8 +399,11 @@ describe("compiler-signatures", () => {
     expect(result.globalDiagnostics[0]?.message).toContain(
       "conflicts with a TypeScript global built-in type"
     );
-    // §9.1 #4 — SyntheticCompilerDiagnostic carries no span in the synthetic path.
-    // TODO Phase 4: relocation should anchor this at the extension registration site.
+    // §9.1 #4 — SyntheticCompilerDiagnostic carries no span by design.
+    // Phase 4 Slice C relocated setup diagnostics to the registry/snapshot level as
+    // ConstraintSemanticDiagnostic (with provenance anchored at surface:"extension",
+    // line:1, column:0). This lower-level SyntheticCompilerDiagnostic type intentionally
+    // remains span-free — its callers are responsible for attaching provenance.
     expect(result.globalDiagnostics[0]).not.toHaveProperty("primaryLocation");
   });
 
@@ -431,8 +434,9 @@ describe("compiler-signatures", () => {
     expect(secondResult.globalDiagnostics[0]?.message).toContain(
       "conflicts with a TypeScript global built-in type"
     );
-    // §9.1 #4 — SyntheticCompilerDiagnostic carries no span in the synthetic path.
-    // TODO Phase 4: relocation should anchor this at the extension registration site.
+    // §9.1 #4 — SyntheticCompilerDiagnostic carries no span by design.
+    // Phase 4 Slice C relocated setup diagnostics to the registry/snapshot level —
+    // see the first test in this group for the full annotation.
     expect(secondResult.globalDiagnostics[0]).not.toHaveProperty("primaryLocation");
   });
 
@@ -461,8 +465,9 @@ describe("compiler-signatures", () => {
     expect(result.globalDiagnostics).toHaveLength(1);
     expect(result.globalDiagnostics[0]?.kind).toBe("synthetic-setup");
     expect(result.globalDiagnostics[0]?.message).toContain("Invalid custom type name");
-    // §9.1 #4 — SyntheticCompilerDiagnostic carries no span in the synthetic path.
-    // TODO Phase 4: relocation should anchor this at the extension registration site.
+    // §9.1 #4 — SyntheticCompilerDiagnostic carries no span by design.
+    // Phase 4 Slice C relocated setup diagnostics to the registry/snapshot level —
+    // see the first test in this group for the full annotation.
     expect(result.globalDiagnostics[0]).not.toHaveProperty("primaryLocation");
   });
 

--- a/packages/analysis/src/__tests__/setup-diagnostic-emission-count.test.ts
+++ b/packages/analysis/src/__tests__/setup-diagnostic-emission-count.test.ts
@@ -1,37 +1,28 @@
 /**
- * Pins the current setup-diagnostic emission-count model (§9.3 #19).
+ * Pins the setup-diagnostic emission-count model after Phase 4 Slice C relocation.
  *
- * Phase 4 of the synthetic-checker retirement plan proposes relocating
- * UNSUPPORTED_CUSTOM_TYPE_OVERRIDE and SYNTHETIC_SETUP_FAILURE from the
- * per-batch `runBatchSyntheticCheck` call site into an extension-registry
- * construction pass. Before that relocation the test below pins the *current*
- * behavior so a regression is immediately visible: if Phase 4 changes when
- * and how many times setup diagnostics are emitted, these tests will fail and
- * the delta must be explicitly signed off.
+ * Phase 4 Slice C relocated UNSUPPORTED_CUSTOM_TYPE_OVERRIDE and
+ * SYNTHETIC_SETUP_FAILURE from the per-batch `runBatchSyntheticCheck` call site
+ * into a pre-validation pass at the top of `buildFormSpecAnalysisFileSnapshot`.
+ * Before relocation the same count held, but for a different reason — setup
+ * failures threw before the LRU cache key was computed, so each call produced
+ * a new diagnostic. After relocation, setup validation runs once per snapshot
+ * call via `validateExtensionSetup`, and `buildTagDiagnostics` skips re-emitting
+ * global batch diagnostics when `setupDiagnosticsPreEmitted` is true.
  *
- * Current emission model: PER-BATCH / PER-CALL
- *   - One `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` diagnostic is produced each time
- *     `buildFormSpecAnalysisFileSnapshot` is called with an extension that
- *     attempts to override a TypeScript built-in type ("Array").
- *   - The setup failure occurs during synthetic-prelude construction, which
- *     throws before the LRU cache key can be computed. Therefore the cache is
- *     bypassed entirely for setup failures — each call re-triggers the throw
- *     and emits a fresh diagnostic regardless of whether the extension config
- *     object is the same reference or a newly-constructed one.
+ * Post-Phase-4 Slice C emission model: PER-SNAPSHOT-CALL (pre-emitted at file level)
+ *   - One `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` or `SYNTHETIC_SETUP_FAILURE` diagnostic
+ *     is produced each time `buildFormSpecAnalysisFileSnapshot` is called with an
+ *     extension that has a broken setup.
+ *   - The diagnostic is anchored at the file start (span {start:0, end:0}), not at
+ *     any individual tag location, because the failure is registry-level.
  *   - Consequence: N snapshot refreshes → N diagnostics; re-creating the
- *     "registry" (constructing a new extension config object and running again)
- *     produces the same count-per-call as using the original config.
+ *     "extensions" array (constructing a new config object and running again)
+ *     produces the same count-per-call as using the original config, since
+ *     `validateExtensionSetup` always runs per call.
  *
- * If Phase 4 deduplicates by moving validation into a registry object:
- *   - The per-call count might drop to 0 (if validation only runs at registry
- *     construction time) — the test that asserts a diagnostic is emitted for
- *     each snapshot build would fail.
- *   - Or the delta for re-construction would increase (e.g. +3 instead of +1
- *     if the diagnostic is emitted per-field again) — the test that compares
- *     counts between reused and rebuilt extension configs would fail.
- *
- * @see docs/refactors/synthetic-checker-retirement.md §9.3 #19
- * @see packages/analysis/src/compiler-signatures.ts (runBatchSyntheticCheck)
+ * @see docs/refactors/synthetic-checker-retirement.md §4 Phase 4 Slice C
+ * @see packages/analysis/src/compiler-signatures.ts (validateExtensionSetup)
  * @see packages/analysis/src/__tests__/compiler-signatures.test.ts lines 404-431
  */
 
@@ -76,13 +67,12 @@ function countSetupDiagnostics(
   code: string
 ): number {
   return snapshots.reduce(
-    (acc, snapshot) =>
-      acc + snapshot.diagnostics.filter((d) => d.code === code).length,
+    (acc, snapshot) => acc + snapshot.diagnostics.filter((d) => d.code === code).length,
     0
   );
 }
 
-describe("setup-diagnostic emission-count stability (§9.3 #19)", () => {
+describe("setup-diagnostic emission-count stability (Phase 4 Slice C)", () => {
   it("emits exactly one UNSUPPORTED_CUSTOM_TYPE_OVERRIDE per snapshot-refresh call", () => {
     const { checker, sourceFile } = createProgram(
       SOURCE_WITH_ONE_COMMENT_BLOCK,
@@ -100,21 +90,18 @@ describe("setup-diagnostic emission-count stability (§9.3 #19)", () => {
     ).toHaveLength(1);
   });
 
-  it("accumulates one diagnostic per call across three repeated snapshot refreshes (per-batch model)", () => {
+  it("accumulates one diagnostic per call across three repeated snapshot refreshes (pre-emitted at snapshot level)", () => {
     const { checker, sourceFile } = createProgram(
       SOURCE_WITH_ONE_COMMENT_BLOCK,
       "/virtual/emission-count-repeat.ts"
     );
 
     // Simulate three IDE snapshot refreshes on the same file with the same
-    // extension config. In the current per-batch model each call independently
-    // invokes buildSyntheticHelperPrelude, which throws for "Array", bypassing
-    // the LRU cache and producing a fresh diagnostic.
-    //
-    // Current emission model: per-batch / per-call — one diagnostic per call.
-    // If this changes to per-registry (emitting only once per registry
-    // construction), the total would be 1 rather than 3, and this assertion
-    // would fail — which is the signal Phase 4 must explicitly handle.
+    // extension config. After Phase 4 Slice C, each call independently
+    // invokes validateExtensionSetup (at the top of buildFormSpecAnalysisFileSnapshot)
+    // and pre-emits any setup diagnostics before visiting nodes. The per-call
+    // count remains 1 — the mechanism changed (pre-emit instead of batch-emit)
+    // but the observable behaviour (one diagnostic per refresh) is preserved.
     const extensions = [...ARRAY_OVERRIDE_EXTENSION];
     const snapshots = [
       buildFormSpecAnalysisFileSnapshot(sourceFile, { checker, extensions }),
@@ -122,7 +109,8 @@ describe("setup-diagnostic emission-count stability (§9.3 #19)", () => {
       buildFormSpecAnalysisFileSnapshot(sourceFile, { checker, extensions }),
     ];
 
-    // Each call produces exactly one diagnostic; three calls total = 3.
+    // Each call still produces exactly one diagnostic (pre-emitted at file level);
+    // three calls total = 3.
     for (const snapshot of snapshots) {
       expect(
         snapshot.diagnostics.filter((d) => d.code === "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE")
@@ -152,15 +140,13 @@ describe("setup-diagnostic emission-count stability (§9.3 #19)", () => {
     expect(countAfterThree).toBe(3);
 
     // "Recreate the registry": construct a fresh extension config object with
-    // identical values and run one additional snapshot refresh. In the current
-    // model this is semantically identical to the previous calls — the setup
-    // failure path bypasses the LRU cache, so there is no deduplication across
-    // "registry" lifetimes.
+    // identical values and run one additional snapshot refresh. After Phase 4
+    // Slice C, validateExtensionSetup always runs per buildFormSpecAnalysisFileSnapshot
+    // call — there is no cross-call deduplication. Each call with a broken
+    // extension config produces exactly one setup diagnostic regardless of
+    // whether the extensions array is the same reference or a new object.
     //
     // Expected delta: +1 (same per-call cost regardless of config object identity).
-    // If Phase 4 moves validation into registry construction and deduplicates
-    // at that level, the delta might be 0 (diagnostic consumed at construction,
-    // not at refresh time) — which is the behavior change to sign off on.
     const freshExtensions = [
       {
         extensionId: "x-example/array",
@@ -186,13 +172,12 @@ describe("setup-diagnostic emission-count stability (§9.3 #19)", () => {
     expect(totalCount).toBe(4);
   });
 
-  it("pins the same per-batch emission model for SYNTHETIC_SETUP_FAILURE (invalid type name)", () => {
-    // SYNTHETIC_SETUP_FAILURE uses the same code-path as
-    // UNSUPPORTED_CUSTOM_TYPE_OVERRIDE: both throw from
-    // collectExtensionCustomTypeNames before the LRU cache key is built.
-    // Pin this separately so Phase 4 cannot forget the second setup-error kind.
+  it("pins the same per-snapshot-call emission model for SYNTHETIC_SETUP_FAILURE (invalid type name)", () => {
+    // SYNTHETIC_SETUP_FAILURE uses the same validateExtensionSetup code-path as
+    // UNSUPPORTED_CUSTOM_TYPE_OVERRIDE. Pin this separately so a future change
+    // cannot silently drop the second setup-error kind.
     //
-    // Current emission model: per-batch / per-call — one diagnostic per call.
+    // Post-Phase-4 Slice C emission model: pre-emitted at snapshot level — one diagnostic per call.
     const invalidTypeExtension = [
       {
         extensionId: "x-example/invalid-type",
@@ -212,9 +197,9 @@ describe("setup-diagnostic emission-count stability (§9.3 #19)", () => {
     ];
 
     for (const snapshot of snapshots) {
-      expect(
-        snapshot.diagnostics.filter((d) => d.code === "SYNTHETIC_SETUP_FAILURE")
-      ).toHaveLength(1);
+      expect(snapshot.diagnostics.filter((d) => d.code === "SYNTHETIC_SETUP_FAILURE")).toHaveLength(
+        1
+      );
     }
 
     expect(countSetupDiagnostics(snapshots, "SYNTHETIC_SETUP_FAILURE")).toBe(3);

--- a/packages/analysis/src/__tests__/setup-diagnostic-emission-count.test.ts
+++ b/packages/analysis/src/__tests__/setup-diagnostic-emission-count.test.ts
@@ -7,8 +7,8 @@
  * Before relocation the same count held, but for a different reason — setup
  * failures threw before the LRU cache key was computed, so each call produced
  * a new diagnostic. After relocation, setup validation runs once per snapshot
- * call via `validateExtensionSetup`, and `buildTagDiagnostics` skips re-emitting
- * global batch diagnostics when `setupDiagnosticsPreEmitted` is true.
+ * call via `_validateExtensionSetup`, and `buildTagDiagnostics` no longer
+ * participates in setup-diagnostic emission.
  *
  * Post-Phase-4 Slice C emission model: PER-SNAPSHOT-CALL (pre-emitted at file level)
  *   - One `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` or `SYNTHETIC_SETUP_FAILURE` diagnostic
@@ -19,10 +19,10 @@
  *   - Consequence: N snapshot refreshes → N diagnostics; re-creating the
  *     "extensions" array (constructing a new config object and running again)
  *     produces the same count-per-call as using the original config, since
- *     `validateExtensionSetup` always runs per call.
+ *     `_validateExtensionSetup` always runs per call.
  *
  * @see docs/refactors/synthetic-checker-retirement.md §4 Phase 4 Slice C
- * @see packages/analysis/src/compiler-signatures.ts (validateExtensionSetup)
+ * @see packages/analysis/src/compiler-signatures.ts (_validateExtensionSetup)
  * @see packages/analysis/src/__tests__/compiler-signatures.test.ts lines 404-431
  */
 
@@ -98,7 +98,7 @@ describe("setup-diagnostic emission-count stability (Phase 4 Slice C)", () => {
 
     // Simulate three IDE snapshot refreshes on the same file with the same
     // extension config. After Phase 4 Slice C, each call independently
-    // invokes validateExtensionSetup (at the top of buildFormSpecAnalysisFileSnapshot)
+    // invokes _validateExtensionSetup (at the top of buildFormSpecAnalysisFileSnapshot)
     // and pre-emits any setup diagnostics before visiting nodes. The per-call
     // count remains 1 — the mechanism changed (pre-emit instead of batch-emit)
     // but the observable behaviour (one diagnostic per refresh) is preserved.
@@ -141,7 +141,7 @@ describe("setup-diagnostic emission-count stability (Phase 4 Slice C)", () => {
 
     // "Recreate the registry": construct a fresh extension config object with
     // identical values and run one additional snapshot refresh. After Phase 4
-    // Slice C, validateExtensionSetup always runs per buildFormSpecAnalysisFileSnapshot
+    // Slice C, _validateExtensionSetup always runs per buildFormSpecAnalysisFileSnapshot
     // call — there is no cross-call deduplication. Each call with a broken
     // extension config produces exactly one setup diagnostic regardless of
     // whether the extensions array is the same reference or a new object.
@@ -173,7 +173,7 @@ describe("setup-diagnostic emission-count stability (Phase 4 Slice C)", () => {
   });
 
   it("pins the same per-snapshot-call emission model for SYNTHETIC_SETUP_FAILURE (invalid type name)", () => {
-    // SYNTHETIC_SETUP_FAILURE uses the same validateExtensionSetup code-path as
+    // SYNTHETIC_SETUP_FAILURE uses the same _validateExtensionSetup code-path as
     // UNSUPPORTED_CUSTOM_TYPE_OVERRIDE. Pin this separately so a future change
     // cannot silently drop the second setup-error kind.
     //

--- a/packages/analysis/src/compiler-signatures.ts
+++ b/packages/analysis/src/compiler-signatures.ts
@@ -528,9 +528,8 @@ export function _mapSetupDiagnosticCode(kind: SyntheticCompilerDiagnostic["kind"
  * diagnostics.
  *
  * @param file - The source file path being analyzed when the diagnostic fires.
- * @internal
  */
-export function _extensionRegistryProvenance(file: string): Provenance {
+function _extensionRegistryProvenance(file: string): Provenance {
   return { surface: "extension", file, line: 1, column: 0 };
 }
 

--- a/packages/analysis/src/compiler-signatures.ts
+++ b/packages/analysis/src/compiler-signatures.ts
@@ -1,7 +1,9 @@
 import * as ts from "typescript";
+import type { Provenance } from "@formspec/core/internals";
 import { FORM_SPEC_SYNTHETIC_BATCH_CACHE_ENTRIES } from "./constants.js";
 import { LruCache } from "./lru-cache.js";
 import { optionalMeasure, type FormSpecPerformanceRecorder } from "./perf-tracing.js";
+import { type ConstraintSemanticDiagnostic } from "./semantic-targets.js";
 import {
   getAllTagDefinitions,
   getTagDefinition,
@@ -61,10 +63,15 @@ export interface LoweredSyntheticTagApplication {
 
 /**
  * A simplified TypeScript diagnostic surfaced from the synthetic compiler pass.
+ *
+ * @internal
  */
 export interface SyntheticCompilerDiagnostic {
+  /** The category of diagnostic: a raw TypeScript error, an unsupported global built-in override, or a synthetic setup failure. */
   readonly kind: "typescript" | "unsupported-custom-type-override" | "synthetic-setup";
+  /** TypeScript diagnostic code, or -1 for non-TypeScript diagnostics. */
   readonly code: number;
+  /** Human-readable description of the diagnostic. */
   readonly message: string;
 }
 
@@ -483,30 +490,104 @@ const TS_GLOBAL_BUILTIN_TYPES = new Map<string, boolean>([
 ]);
 
 /**
- * Validates extension custom-type registrations and returns any setup
- * diagnostics without throwing.
+ * Maps a `SyntheticCompilerDiagnostic["kind"]` to the canonical diagnostic code
+ * string used in `ConstraintSemanticDiagnostic.code` and
+ * `FormSpecAnalysisDiagnostic.code`.
  *
- * This is the non-throwing counterpart to `collectExtensionCustomTypeNames`.
- * It runs the same validation logic but returns a `SyntheticCompilerDiagnostic`
- * for each error instead of throwing. Consumers (e.g. `createExtensionRegistry`)
- * call this once at construction time and carry the result forward, so that
- * setup diagnostics are emitted ONCE per registry rather than once per
- * synthetic-batch call.
+ * Extracted to eliminate three identical ternary chains spread across
+ * `tsdoc-parser.ts` (2 sites) and `file-snapshots.ts` (1 site). The switch is
+ * exhaustive — the `never` default catches any future `kind` additions at
+ * compile time.
  *
- * §4 Phase 4 Slice C — relocates setup-diagnostic emission site from
- * `buildSyntheticHelperPrelude` (per-batch) to `createExtensionRegistry` (once).
- *
- * @public
+ * @internal
  */
-export function validateExtensionSetup(
-  extensions: readonly ExtensionTagSource[] | undefined
-): readonly SyntheticCompilerDiagnostic[] {
-  if (extensions === undefined || extensions.length === 0) {
-    return [];
+export function _mapSetupDiagnosticCode(kind: SyntheticCompilerDiagnostic["kind"]): string {
+  switch (kind) {
+    case "unsupported-custom-type-override":
+      return "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE";
+    case "synthetic-setup":
+      return "SYNTHETIC_SETUP_FAILURE";
+    case "typescript":
+      return "TYPE_MISMATCH";
+    default: {
+      // Exhaustive check — fails to compile if a new kind is added without
+      // updating this mapping.
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
   }
-  const diagnostics: SyntheticCompilerDiagnostic[] = [];
-  const seen = new Map<string, string>(); // tsName -> extensionId
+}
 
+/**
+ * Constructs the registry-level provenance for extension setup diagnostics.
+ *
+ * Extension setup failures are not tied to a specific source location — they
+ * are detected at registry construction time, before any source file is
+ * analyzed. We use `line: 1, column: 0` as the conventional registry-level
+ * anchor, and `surface: "extension"` to distinguish them from tag-site
+ * diagnostics.
+ *
+ * @param file - The source file path being analyzed when the diagnostic fires.
+ * @internal
+ */
+export function _extensionRegistryProvenance(file: string): Provenance {
+  return { surface: "extension", file, line: 1, column: 0 };
+}
+
+/**
+ * Converts `registry.setupDiagnostics` into `ConstraintSemanticDiagnostic[]`
+ * anchored at the extension-registration site for the given file.
+ *
+ * This helper is the single source of truth for the build path's pre-emit of
+ * setup diagnostics (consumed by `parseTSDocTags`). It uses
+ * `_extensionRegistryProvenance` for the anchor location and
+ * `_mapSetupDiagnosticCode` for the kind → code mapping.
+ *
+ * @param setupDiags - The diagnostics from `ExtensionRegistry.setupDiagnostics`.
+ * @param file - The source file path being analyzed.
+ * @returns One `ConstraintSemanticDiagnostic` per setup diagnostic.
+ * @internal
+ */
+export function _emitSetupDiagnostics(
+  setupDiags: readonly SyntheticCompilerDiagnostic[],
+  file: string
+): readonly ConstraintSemanticDiagnostic[] {
+  const provenance = _extensionRegistryProvenance(file);
+  return setupDiags.map((d) => ({
+    code: _mapSetupDiagnosticCode(d.kind),
+    message: d.message,
+    severity: "error" as const,
+    primaryLocation: provenance,
+    relatedLocations: [],
+  }));
+}
+
+/**
+ * Shared core of `_validateExtensionSetup` (non-throwing) and
+ * `collectExtensionCustomTypeNames` (throwing).
+ *
+ * Iterates over all `tsTypeNames` across all extensions and calls `onValid`
+ * for each name that passes validation, `onDiagnostic` for each name that
+ * fails the non-throwing validation, and `onError` for each name that should
+ * throw (the throwing path). When `onError` is undefined, errors are funnelled
+ * to `onDiagnostic` instead.
+ *
+ * Skips TypeScript primitive keywords (TS2457) and supported global built-in
+ * overrides (TS2300): both are already declared by the compiler.
+ */
+function _validateTypeNames(
+  extensions: readonly ExtensionTagSource[],
+  callbacks: {
+    readonly onValid: (tsName: string) => void;
+    readonly onDiagnostic: (diag: SyntheticCompilerDiagnostic) => void;
+    /** When provided, called instead of `onDiagnostic` for hard errors. */
+    readonly onError?: (
+      kind: Exclude<SyntheticCompilerDiagnostic["kind"], "typescript">,
+      message: string
+    ) => never;
+  }
+): void {
+  const seen = new Map<string, string>(); // tsName -> extensionId
   for (const ext of extensions) {
     for (const customType of ext.customTypes ?? []) {
       for (const tsName of customType.tsTypeNames) {
@@ -520,45 +601,79 @@ export function validateExtensionSetup(
           continue;
         }
         if (globalBuiltinSupported === false) {
-          diagnostics.push({
-            kind: "unsupported-custom-type-override",
-            code: -1,
-            message:
-              `Custom type name "${tsName}" registered by extension "${ext.extensionId}" ` +
-              `conflicts with a TypeScript global built-in type that FormSpec does not ` +
-              `yet support overriding. Rename the custom type to a non-conflicting name.`,
-          });
+          const message =
+            `Custom type name "${tsName}" registered by extension "${ext.extensionId}" ` +
+            `conflicts with a TypeScript global built-in type that FormSpec does not ` +
+            `yet support overriding. Rename the custom type to a non-conflicting name.`;
+          if (callbacks.onError !== undefined) {
+            callbacks.onError("unsupported-custom-type-override", message);
+          } else {
+            callbacks.onDiagnostic({ kind: "unsupported-custom-type-override", code: -1, message });
+          }
           continue;
         }
         // Guard against malformed names being interpolated into the synthetic
         // source (e.g. names with spaces, punctuation, or operator characters).
         if (!/^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(tsName)) {
-          diagnostics.push({
-            kind: "synthetic-setup",
-            code: -1,
-            message:
-              `Invalid custom type name "${tsName}" registered by extension "${ext.extensionId}": ` +
-              `must be a valid TypeScript identifier.`,
-          });
+          const message =
+            `Invalid custom type name "${tsName}" registered by extension "${ext.extensionId}": ` +
+            `must be a valid TypeScript identifier.`;
+          if (callbacks.onError !== undefined) {
+            callbacks.onError("synthetic-setup", message);
+          } else {
+            callbacks.onDiagnostic({ kind: "synthetic-setup", code: -1, message });
+          }
           continue;
         }
         const existingExtensionId = seen.get(tsName);
         if (existingExtensionId !== undefined) {
-          diagnostics.push({
-            kind: "synthetic-setup",
-            code: -1,
-            message:
-              `Duplicate custom type name "${tsName}" registered by extensions ` +
-              `"${existingExtensionId}" and "${ext.extensionId}". ` +
-              `Extension-registered types must have unique names.`,
-          });
+          const message =
+            `Duplicate custom type name "${tsName}" registered by extensions ` +
+            `"${existingExtensionId}" and "${ext.extensionId}". ` +
+            `Extension-registered types must have unique names.`;
+          if (callbacks.onError !== undefined) {
+            callbacks.onError("synthetic-setup", message);
+          } else {
+            callbacks.onDiagnostic({ kind: "synthetic-setup", code: -1, message });
+          }
           continue;
         }
         seen.set(tsName, ext.extensionId);
+        callbacks.onValid(tsName);
       }
     }
   }
+}
 
+/**
+ * Validates extension custom-type registrations and returns any setup
+ * diagnostics without throwing.
+ *
+ * This is the non-throwing counterpart to `collectExtensionCustomTypeNames`.
+ * Consumers (e.g. `createExtensionRegistry`) call this once at construction
+ * time and carry the result forward, so that setup diagnostics are emitted
+ * ONCE per registry rather than once per synthetic-batch call.
+ *
+ * §4 Phase 4 Slice C — relocates setup-diagnostic emission site from
+ * `buildSyntheticHelperPrelude` (per-batch) to `createExtensionRegistry` (once).
+ *
+ * @internal
+ */
+export function _validateExtensionSetup(
+  extensions: readonly ExtensionTagSource[] | undefined
+): readonly SyntheticCompilerDiagnostic[] {
+  if (extensions === undefined || extensions.length === 0) {
+    return [];
+  }
+  const diagnostics: SyntheticCompilerDiagnostic[] = [];
+  _validateTypeNames(extensions, {
+    onValid: () => {
+      /* only diagnostics needed here */
+    },
+    onDiagnostic: (diag) => {
+      diagnostics.push(diag);
+    },
+  });
   return diagnostics;
 }
 
@@ -577,7 +692,7 @@ export function validateExtensionSetup(
  * `TS_GLOBAL_BUILTIN_TYPES`.
  *
  * Note: §4 Phase 4 Slice C — consumers that construct an `ExtensionRegistry`
- * should use `validateExtensionSetup` at registry construction time instead.
+ * should use `_validateExtensionSetup` at registry construction time instead.
  * This throwing function is retained for the synthetic-prelude path which
  * still catches and converts these errors inside `runBatchSyntheticCheck`.
  * After Phase 5 (synthetic deletion), this function can be removed.
@@ -588,51 +703,18 @@ function collectExtensionCustomTypeNames(
   if (extensions === undefined) {
     return [];
   }
-  const seen = new Map<string, string>(); // tsName -> extensionId
   const result: string[] = [];
-  for (const ext of extensions) {
-    for (const customType of ext.customTypes ?? []) {
-      for (const tsName of customType.tsTypeNames) {
-        // TypeScript already resolves primitive keywords; no declaration needed.
-        if (TS_PRIMITIVE_KEYWORDS.has(tsName)) {
-          continue;
-        }
-        const globalBuiltinSupported = TS_GLOBAL_BUILTIN_TYPES.get(tsName);
-        if (globalBuiltinSupported === true) {
-          // Already declared in TypeScript's lib files; skip to avoid TS2300.
-          continue;
-        }
-        if (globalBuiltinSupported === false) {
-          throw createSyntheticSetupError(
-            "unsupported-custom-type-override",
-            `Custom type name "${tsName}" registered by extension "${ext.extensionId}" ` +
-              `conflicts with a TypeScript global built-in type that FormSpec does not ` +
-              `yet support overriding. Rename the custom type to a non-conflicting name.`
-          );
-        }
-        // Guard against malformed names being interpolated into the synthetic
-        // source (e.g. names with spaces, punctuation, or operator characters).
-        if (!/^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(tsName)) {
-          throw createSyntheticSetupError(
-            "synthetic-setup",
-            `Invalid custom type name "${tsName}" registered by extension "${ext.extensionId}": ` +
-              `must be a valid TypeScript identifier.`
-          );
-        }
-        const existingExtensionId = seen.get(tsName);
-        if (existingExtensionId !== undefined) {
-          throw createSyntheticSetupError(
-            "synthetic-setup",
-            `Duplicate custom type name "${tsName}" registered by extensions ` +
-              `"${existingExtensionId}" and "${ext.extensionId}". ` +
-              `Extension-registered types must have unique names.`
-          );
-        }
-        seen.set(tsName, ext.extensionId);
-        result.push(tsName);
-      }
-    }
-  }
+  _validateTypeNames(extensions, {
+    onValid: (tsName) => {
+      result.push(tsName);
+    },
+    onDiagnostic: () => {
+      /* not reached — onError is always provided */
+    },
+    onError: (kind, message) => {
+      throw createSyntheticSetupError(kind, message);
+    },
+  });
   return result;
 }
 

--- a/packages/analysis/src/compiler-signatures.ts
+++ b/packages/analysis/src/compiler-signatures.ts
@@ -483,6 +483,86 @@ const TS_GLOBAL_BUILTIN_TYPES = new Map<string, boolean>([
 ]);
 
 /**
+ * Validates extension custom-type registrations and returns any setup
+ * diagnostics without throwing.
+ *
+ * This is the non-throwing counterpart to `collectExtensionCustomTypeNames`.
+ * It runs the same validation logic but returns a `SyntheticCompilerDiagnostic`
+ * for each error instead of throwing. Consumers (e.g. `createExtensionRegistry`)
+ * call this once at construction time and carry the result forward, so that
+ * setup diagnostics are emitted ONCE per registry rather than once per
+ * synthetic-batch call.
+ *
+ * §4 Phase 4 Slice C — relocates setup-diagnostic emission site from
+ * `buildSyntheticHelperPrelude` (per-batch) to `createExtensionRegistry` (once).
+ *
+ * @public
+ */
+export function validateExtensionSetup(
+  extensions: readonly ExtensionTagSource[] | undefined
+): readonly SyntheticCompilerDiagnostic[] {
+  if (extensions === undefined || extensions.length === 0) {
+    return [];
+  }
+  const diagnostics: SyntheticCompilerDiagnostic[] = [];
+  const seen = new Map<string, string>(); // tsName -> extensionId
+
+  for (const ext of extensions) {
+    for (const customType of ext.customTypes ?? []) {
+      for (const tsName of customType.tsTypeNames) {
+        // TypeScript already resolves primitive keywords; no declaration needed.
+        if (TS_PRIMITIVE_KEYWORDS.has(tsName)) {
+          continue;
+        }
+        const globalBuiltinSupported = TS_GLOBAL_BUILTIN_TYPES.get(tsName);
+        if (globalBuiltinSupported === true) {
+          // Already declared in TypeScript's lib files; skip to avoid TS2300.
+          continue;
+        }
+        if (globalBuiltinSupported === false) {
+          diagnostics.push({
+            kind: "unsupported-custom-type-override",
+            code: -1,
+            message:
+              `Custom type name "${tsName}" registered by extension "${ext.extensionId}" ` +
+              `conflicts with a TypeScript global built-in type that FormSpec does not ` +
+              `yet support overriding. Rename the custom type to a non-conflicting name.`,
+          });
+          continue;
+        }
+        // Guard against malformed names being interpolated into the synthetic
+        // source (e.g. names with spaces, punctuation, or operator characters).
+        if (!/^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(tsName)) {
+          diagnostics.push({
+            kind: "synthetic-setup",
+            code: -1,
+            message:
+              `Invalid custom type name "${tsName}" registered by extension "${ext.extensionId}": ` +
+              `must be a valid TypeScript identifier.`,
+          });
+          continue;
+        }
+        const existingExtensionId = seen.get(tsName);
+        if (existingExtensionId !== undefined) {
+          diagnostics.push({
+            kind: "synthetic-setup",
+            code: -1,
+            message:
+              `Duplicate custom type name "${tsName}" registered by extensions ` +
+              `"${existingExtensionId}" and "${ext.extensionId}". ` +
+              `Extension-registered types must have unique names.`,
+          });
+          continue;
+        }
+        seen.set(tsName, ext.extensionId);
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+/**
  * Collects deduplicated custom type names from extensions, suitable for
  * emission as `type X = unknown;` declarations in the synthetic prelude.
  *
@@ -495,6 +575,12 @@ const TS_GLOBAL_BUILTIN_TYPES = new Map<string, boolean>([
  * Throws if an unsupported TypeScript global built-in is registered. To add
  * support for a new global built-in, set its value to `true` in
  * `TS_GLOBAL_BUILTIN_TYPES`.
+ *
+ * Note: §4 Phase 4 Slice C — consumers that construct an `ExtensionRegistry`
+ * should use `validateExtensionSetup` at registry construction time instead.
+ * This throwing function is retained for the synthetic-prelude path which
+ * still catches and converts these errors inside `runBatchSyntheticCheck`.
+ * After Phase 5 (synthetic deletion), this function can be removed.
  */
 function collectExtensionCustomTypeNames(
   extensions: readonly ExtensionTagSource[] | undefined

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -3,6 +3,7 @@ import * as ts from "typescript";
 import {
   checkSyntheticTagApplicationsDetailed,
   lowerTagApplicationToSyntheticCall,
+  validateExtensionSetup,
 } from "./compiler-signatures.js";
 import {
   extractCommentBlockTagTexts,
@@ -64,6 +65,7 @@ import {
   getSyntheticLogger,
   getTypedParserLogger,
   describeTypeKind,
+  logSetupDiagnostics,
   logTagApplication,
   nowMicros,
   elapsedMicros,
@@ -1329,7 +1331,12 @@ function buildTagDiagnostics(
   commentTags: ReturnType<typeof parseCommentBlock>["tags"],
   semanticOptions: CommentSemanticContextOptions,
   performance: FormSpecPerformanceRecorder | undefined,
-  extensionDefinitions: readonly ExtensionDefinition[] | undefined
+  extensionDefinitions: readonly ExtensionDefinition[] | undefined,
+  /** Phase 4 Slice C: when `true`, setup diagnostics were already emitted at
+   * the snapshot level (once per {@link buildFormSpecAnalysisFileSnapshot} call).
+   * Skip re-emitting `batchCheck.globalDiagnostics` in this function so the
+   * caller-level emit and the per-batch emit do not double-count. */
+  setupDiagnosticsPreEmitted = false
 ): FormSpecAnalysisDiagnostic[] {
   if (placement === null || subjectType === undefined) {
     return [];
@@ -1658,34 +1665,45 @@ function buildTagDiagnostics(
       })
   );
 
-  // §8.3c — log any global (setup-level) diagnostics from the batch check.
-  if (batchCheck.globalDiagnostics.length > 0) {
-    const setupCodes = batchCheck.globalDiagnostics.map((d) => d.kind);
-    syntheticLog.debug("synthetic batch: global setup diagnostics", {
-      diagnosticCount: batchCheck.globalDiagnostics.length,
-      codes: setupCodes,
-    });
-  }
+  // §4 Phase 4 Slice C — when setup diagnostics were pre-emitted at the
+  // snapshot level, skip re-emitting them from the per-batch path. Without
+  // this guard, a file with N commented declarations would produce N copies of
+  // each setup diagnostic (one per `buildTagDiagnostics` call), undoing the
+  // "emit-once-per-snapshot-call" guarantee established at the caller level.
+  //
+  // When setup diagnostics were NOT pre-emitted (legacy call sites or callers
+  // that don't pass the flag), retain the old per-batch behaviour so existing
+  // consumers are not silently broken.
+  if (!setupDiagnosticsPreEmitted) {
+    // §8.3c — log any global (setup-level) diagnostics from the batch check.
+    if (batchCheck.globalDiagnostics.length > 0) {
+      const setupCodes = batchCheck.globalDiagnostics.map((d) => d.kind);
+      syntheticLog.debug("synthetic batch: global setup diagnostics", {
+        diagnosticCount: batchCheck.globalDiagnostics.length,
+        codes: setupCodes,
+      });
+    }
 
-  const globalDiagnosticRange = combineCommentSpans(
-    syntheticApplications.map((application) => application.tag.fullSpan)
-  );
+    const globalDiagnosticRange = combineCommentSpans(
+      syntheticApplications.map((application) => application.tag.fullSpan)
+    );
 
-  if (globalDiagnosticRange !== null) {
-    for (const diagnostic of batchCheck.globalDiagnostics) {
-      const code =
-        diagnostic.kind === "unsupported-custom-type-override"
-          ? "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE"
-          : diagnostic.kind === "synthetic-setup"
-            ? "SYNTHETIC_SETUP_FAILURE"
-            : "TYPE_MISMATCH";
-      diagnostics.push(
-        createAnalysisDiagnostic(code, diagnostic.message, globalDiagnosticRange, {
-          placement,
-          tagNames: syntheticApplications.map((application) => application.tag.normalizedTagName),
-          ...(diagnostic.code > 0 ? { typescriptDiagnosticCode: diagnostic.code } : {}),
-        })
-      );
+    if (globalDiagnosticRange !== null) {
+      for (const diagnostic of batchCheck.globalDiagnostics) {
+        const code =
+          diagnostic.kind === "unsupported-custom-type-override"
+            ? "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE"
+            : diagnostic.kind === "synthetic-setup"
+              ? "SYNTHETIC_SETUP_FAILURE"
+              : "TYPE_MISMATCH";
+        diagnostics.push(
+          createAnalysisDiagnostic(code, diagnostic.message, globalDiagnosticRange, {
+            placement,
+            tagNames: syntheticApplications.map((application) => application.tag.normalizedTagName),
+            ...(diagnostic.code > 0 ? { typescriptDiagnosticCode: diagnostic.code } : {}),
+          })
+        );
+      }
     }
   }
 
@@ -1856,6 +1874,36 @@ export function buildFormSpecAnalysisFileSnapshot(
   const diagnostics: FormSpecAnalysisDiagnostic[] = [];
   const extensions = options.extensions ?? toExtensionTagSources(options.extensionDefinitions);
 
+  // §4 Phase 4 Slice C — pre-validate extension setup once per snapshot call.
+  // Previously, setup failures (UNSUPPORTED_CUSTOM_TYPE_OVERRIDE /
+  // SYNTHETIC_SETUP_FAILURE) were emitted inside buildTagDiagnostics for each
+  // commented declaration. In a file with N commented declarations, a broken
+  // extension config would produce N identical diagnostics. Pre-validating here
+  // emits each setup diagnostic exactly once per buildFormSpecAnalysisFileSnapshot
+  // call, anchored at the start of the file (no tag-site location available for
+  // registry-level failures). buildTagDiagnostics skips its own global-diagnostic
+  // emission when setupDiagnosticsPreEmitted is true.
+  const snapshotLog = getSnapshotLogger();
+  const setupDiagnosticResults = validateExtensionSetup(extensions);
+  const setupDiagnosticsPreEmitted = setupDiagnosticResults.length > 0;
+  if (setupDiagnosticsPreEmitted) {
+    logSetupDiagnostics(snapshotLog, {
+      diagnosticCount: setupDiagnosticResults.length,
+      codes: setupDiagnosticResults.map((d) => d.kind),
+    });
+    // Emit each setup diagnostic anchored at the start of the file.
+    // The file-start span (0,0) is the closest we can get to a
+    // "registry-level" location in the snapshot transport format.
+    const fileStartSpan: CommentSpan = { start: 0, end: 0 };
+    for (const setupDiag of setupDiagnosticResults) {
+      const code =
+        setupDiag.kind === "unsupported-custom-type-override"
+          ? "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE"
+          : "SYNTHETIC_SETUP_FAILURE";
+      diagnostics.push(createAnalysisDiagnostic(code, setupDiag.message, fileStartSpan, {}));
+    }
+  }
+
   const visit = (node: ts.Node): void => {
     const placement = resolveDeclarationPlacement(node);
     if (placement !== null) {
@@ -1896,7 +1944,8 @@ export function buildFormSpecAnalysisFileSnapshot(
                   ...(extensions === undefined ? {} : { extensions }),
                 },
                 options.performance,
-                options.extensionDefinitions
+                options.extensionDefinitions,
+                setupDiagnosticsPreEmitted
               )
           )
         );

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -1,9 +1,10 @@
 import type { ExtensionDefinition } from "@formspec/core";
 import * as ts from "typescript";
 import {
+  _mapSetupDiagnosticCode,
+  _validateExtensionSetup,
   checkSyntheticTagApplicationsDetailed,
   lowerTagApplicationToSyntheticCall,
-  validateExtensionSetup,
 } from "./compiler-signatures.js";
 import {
   extractCommentBlockTagTexts,
@@ -62,7 +63,6 @@ import { noopLogger } from "@formspec/core";
 import { isBuiltinConstraintName } from "@formspec/core/internals";
 import {
   getSnapshotLogger,
-  getSyntheticLogger,
   getTypedParserLogger,
   describeTypeKind,
   logSetupDiagnostics,
@@ -1087,17 +1087,6 @@ function diagnosticCategory(code: string): FormSpecAnalysisDiagnostic["category"
   }
 }
 
-function combineCommentSpans(spans: readonly CommentSpan[]): CommentSpan | null {
-  const firstSpan = spans[0];
-  if (firstSpan === undefined) {
-    return null;
-  }
-  return {
-    start: firstSpan.start,
-    end: spans[spans.length - 1]?.end ?? firstSpan.end,
-  };
-}
-
 function createAnalysisDiagnostic(
   code: string,
   message: string,
@@ -1331,12 +1320,7 @@ function buildTagDiagnostics(
   commentTags: ReturnType<typeof parseCommentBlock>["tags"],
   semanticOptions: CommentSemanticContextOptions,
   performance: FormSpecPerformanceRecorder | undefined,
-  extensionDefinitions: readonly ExtensionDefinition[] | undefined,
-  /** Phase 4 Slice C: when `true`, setup diagnostics were already emitted at
-   * the snapshot level (once per {@link buildFormSpecAnalysisFileSnapshot} call).
-   * Skip re-emitting `batchCheck.globalDiagnostics` in this function so the
-   * caller-level emit and the per-batch emit do not double-count. */
-  setupDiagnosticsPreEmitted = false
+  extensionDefinitions: readonly ExtensionDefinition[] | undefined
 ): FormSpecAnalysisDiagnostic[] {
   if (placement === null || subjectType === undefined) {
     return [];
@@ -1370,7 +1354,6 @@ function buildTagDiagnostics(
   ]);
   // §8.3b — module-level loggers for the snapshot consumer.
   const snapshotLog = getSnapshotLogger();
-  const syntheticLog = getSyntheticLogger();
   const typedParserLog = getTypedParserLogger();
   const snapshotLogsEnabled = snapshotLog !== noopLogger;
   const typedParserTraceEnabled = typedParserLog !== noopLogger;
@@ -1665,48 +1648,6 @@ function buildTagDiagnostics(
       })
   );
 
-  // §4 Phase 4 Slice C — when setup diagnostics were pre-emitted at the
-  // snapshot level, skip re-emitting them from the per-batch path. Without
-  // this guard, a file with N commented declarations would produce N copies of
-  // each setup diagnostic (one per `buildTagDiagnostics` call), undoing the
-  // "emit-once-per-snapshot-call" guarantee established at the caller level.
-  //
-  // When setup diagnostics were NOT pre-emitted (legacy call sites or callers
-  // that don't pass the flag), retain the old per-batch behaviour so existing
-  // consumers are not silently broken.
-  if (!setupDiagnosticsPreEmitted) {
-    // §8.3c — log any global (setup-level) diagnostics from the batch check.
-    if (batchCheck.globalDiagnostics.length > 0) {
-      const setupCodes = batchCheck.globalDiagnostics.map((d) => d.kind);
-      syntheticLog.debug("synthetic batch: global setup diagnostics", {
-        diagnosticCount: batchCheck.globalDiagnostics.length,
-        codes: setupCodes,
-      });
-    }
-
-    const globalDiagnosticRange = combineCommentSpans(
-      syntheticApplications.map((application) => application.tag.fullSpan)
-    );
-
-    if (globalDiagnosticRange !== null) {
-      for (const diagnostic of batchCheck.globalDiagnostics) {
-        const code =
-          diagnostic.kind === "unsupported-custom-type-override"
-            ? "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE"
-            : diagnostic.kind === "synthetic-setup"
-              ? "SYNTHETIC_SETUP_FAILURE"
-              : "TYPE_MISMATCH";
-        diagnostics.push(
-          createAnalysisDiagnostic(code, diagnostic.message, globalDiagnosticRange, {
-            placement,
-            tagNames: syntheticApplications.map((application) => application.tag.normalizedTagName),
-            ...(diagnostic.code > 0 ? { typescriptDiagnosticCode: diagnostic.code } : {}),
-          })
-        );
-      }
-    }
-  }
-
   for (const [index, result] of batchCheck.applicationResults.entries()) {
     const application = syntheticApplications[index];
     if (application === undefined) {
@@ -1881,12 +1822,10 @@ export function buildFormSpecAnalysisFileSnapshot(
   // extension config would produce N identical diagnostics. Pre-validating here
   // emits each setup diagnostic exactly once per buildFormSpecAnalysisFileSnapshot
   // call, anchored at the start of the file (no tag-site location available for
-  // registry-level failures). buildTagDiagnostics skips its own global-diagnostic
-  // emission when setupDiagnosticsPreEmitted is true.
+  // registry-level failures).
   const snapshotLog = getSnapshotLogger();
-  const setupDiagnosticResults = validateExtensionSetup(extensions);
-  const setupDiagnosticsPreEmitted = setupDiagnosticResults.length > 0;
-  if (setupDiagnosticsPreEmitted) {
+  const setupDiagnosticResults = _validateExtensionSetup(extensions);
+  if (setupDiagnosticResults.length > 0) {
     logSetupDiagnostics(snapshotLog, {
       diagnosticCount: setupDiagnosticResults.length,
       codes: setupDiagnosticResults.map((d) => d.kind),
@@ -1896,11 +1835,14 @@ export function buildFormSpecAnalysisFileSnapshot(
     // "registry-level" location in the snapshot transport format.
     const fileStartSpan: CommentSpan = { start: 0, end: 0 };
     for (const setupDiag of setupDiagnosticResults) {
-      const code =
-        setupDiag.kind === "unsupported-custom-type-override"
-          ? "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE"
-          : "SYNTHETIC_SETUP_FAILURE";
-      diagnostics.push(createAnalysisDiagnostic(code, setupDiag.message, fileStartSpan, {}));
+      diagnostics.push(
+        createAnalysisDiagnostic(
+          _mapSetupDiagnosticCode(setupDiag.kind),
+          setupDiag.message,
+          fileStartSpan,
+          {}
+        )
+      );
     }
   }
 
@@ -1944,8 +1886,7 @@ export function buildFormSpecAnalysisFileSnapshot(
                   ...(extensions === undefined ? {} : { extensions }),
                 },
                 options.performance,
-                options.extensionDefinitions,
-                setupDiagnosticsPreEmitted
+                options.extensionDefinitions
               )
           )
         );

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -161,6 +161,7 @@ export {
   checkSyntheticTagApplications,
   getMatchingTagSignatures,
   lowerTagApplicationToSyntheticCall,
+  validateExtensionSetup,
 } from "./compiler-signatures.js";
 export {
   parseUnifiedComment,

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -157,7 +157,6 @@ export type {
 } from "./compiler-signatures.js";
 export {
   _emitSetupDiagnostics,
-  _extensionRegistryProvenance,
   _mapSetupDiagnosticCode,
   _validateExtensionSetup,
   buildSyntheticHelperPrelude,

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -156,12 +156,15 @@ export type {
   SyntheticTagTargetSpecifier,
 } from "./compiler-signatures.js";
 export {
+  _emitSetupDiagnostics,
+  _extensionRegistryProvenance,
+  _mapSetupDiagnosticCode,
+  _validateExtensionSetup,
   buildSyntheticHelperPrelude,
   checkSyntheticTagApplication,
   checkSyntheticTagApplications,
   getMatchingTagSignatures,
   lowerTagApplicationToSyntheticCall,
-  validateExtensionSetup,
 } from "./compiler-signatures.js";
 export {
   parseUnifiedComment,

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -173,8 +173,6 @@ export interface ExtensionRegistry {
     findTypeByBrand(brand: string): ExtensionTypeLookupResult | undefined;
     findTypeByName(typeName: string): ExtensionTypeLookupResult | undefined;
     findTypeBySymbol(symbol: ts.Symbol): ExtensionTypeLookupResult | undefined;
-    // Warning: (ae-forgotten-export) The symbol "SyntheticCompilerDiagnostic" needs to be exported by the entry point index.d.ts
-    //
     // @internal
     readonly setupDiagnostics: readonly SyntheticCompilerDiagnostic[];
 }
@@ -560,6 +558,15 @@ export interface StaticSchemaGenerationOptions {
     readonly metadata?: MetadataPolicyInput | undefined;
     // @deprecated
     readonly vendorPrefix?: string | undefined;
+}
+
+// Warning: (ae-internal-missing-underscore) The name "SyntheticCompilerDiagnostic" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export interface SyntheticCompilerDiagnostic {
+    readonly code: number;
+    readonly kind: "typescript" | "unsupported-custom-type-override" | "synthetic-setup";
+    readonly message: string;
 }
 
 export { TextField }

--- a/packages/build/api-report/build.api.md
+++ b/packages/build/api-report/build.api.md
@@ -173,6 +173,10 @@ export interface ExtensionRegistry {
     findTypeByBrand(brand: string): ExtensionTypeLookupResult | undefined;
     findTypeByName(typeName: string): ExtensionTypeLookupResult | undefined;
     findTypeBySymbol(symbol: ts.Symbol): ExtensionTypeLookupResult | undefined;
+    // Warning: (ae-forgotten-export) The symbol "SyntheticCompilerDiagnostic" needs to be exported by the entry point index.d.ts
+    //
+    // @internal
+    readonly setupDiagnostics: readonly SyntheticCompilerDiagnostic[];
 }
 
 // @public
@@ -641,7 +645,7 @@ export interface WriteSchemasResult {
 
 // Warnings were encountered during analysis:
 //
-// src/extensions/registry.ts:118:9 - (ae-forgotten-export) The symbol "ConstraintTagRegistration_2" needs to be exported by the entry point index.d.ts
-// src/extensions/registry.ts:130:9 - (ae-forgotten-export) The symbol "BuiltinConstraintBroadeningRegistration_2" needs to be exported by the entry point index.d.ts
+// src/extensions/registry.ts:139:9 - (ae-forgotten-export) The symbol "ConstraintTagRegistration_2" needs to be exported by the entry point index.d.ts
+// src/extensions/registry.ts:151:9 - (ae-forgotten-export) The symbol "BuiltinConstraintBroadeningRegistration_2" needs to be exported by the entry point index.d.ts
 
 ```

--- a/packages/build/src/__tests__/date-extension.integration.test.ts
+++ b/packages/build/src/__tests__/date-extension.integration.test.ts
@@ -281,13 +281,15 @@ describe("date extension integration", () => {
         code: "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE",
       },
     ]);
-    // §9.1 #4 — pin setup-diagnostic primaryLocation so Phase 4 relocation is detectable
+    // Phase 4 Slice C: setup diagnostics are now anchored at the extension
+    // registration site (surface: "extension"), not at the tag use site.
+    // No source location is available for the registry-level failure, so
+    // provenance uses line 1, column 0.
     expect(result.diagnostics[0]?.primaryLocation).toEqual({
-      surface: "tsdoc",
+      surface: "extension",
       file: filePath,
-      line: 5,
-      column: 12,
-      tagName: "@minLength",
+      line: 1,
+      column: 0,
     });
     expect(result.diagnostics[0]?.relatedLocations).toEqual([]);
     expect(result.diagnostics.map((diagnostic) => diagnostic.code)).not.toContain("TYPE_MISMATCH");
@@ -318,9 +320,11 @@ describe("date extension integration", () => {
     expect(message).toMatch(/Invalid custom type name "Not A Type"/);
     expect(message).not.toMatch(/TYPE_MISMATCH/);
     expect(message.match(/SYNTHETIC_SETUP_FAILURE/g)).toHaveLength(1);
-    // §9.1 #4 — pin setup-diagnostic location embedded in thrown message so Phase 4 relocation is detectable
-    // source: line 4 ("         * @minLength 1"), column 11 (0-based position of "@")
-    expect(message).toMatch(/:4:11\)/);
+    // Phase 4 Slice C: setup diagnostics are now anchored at the extension
+    // registration site (surface: "extension", line 1, column 0), not at the
+    // tag use site. The formatted location embedded in the thrown message is now
+    // `:1:0` instead of the previous tag-site location.
+    expect(message).toMatch(/:1:0\)/);
   });
 
   it("returns invalid custom type registrations as setup diagnostics without throwing", () => {
@@ -347,13 +351,13 @@ describe("date extension integration", () => {
       },
     ]);
     expect(result.diagnostics[0]?.message).toMatch(/Invalid custom type name "Not A Type"/);
-    // §9.1 #4 — pin setup-diagnostic primaryLocation so Phase 4 relocation is detectable
+    // Phase 4 Slice C: setup diagnostics are now anchored at the extension
+    // registration site (surface: "extension"), not at the tag use site.
     expect(result.diagnostics[0]?.primaryLocation).toEqual({
-      surface: "tsdoc",
+      surface: "extension",
       file: filePath,
-      line: 3,
-      column: 12,
-      tagName: "@minLength",
+      line: 1,
+      column: 0,
     });
     expect(result.diagnostics[0]?.relatedLocations).toEqual([]);
     expect(result.diagnostics.map((diagnostic) => diagnostic.code)).not.toContain("TYPE_MISMATCH");

--- a/packages/build/src/__tests__/date-extension.integration.test.ts
+++ b/packages/build/src/__tests__/date-extension.integration.test.ts
@@ -276,6 +276,11 @@ describe("date extension integration", () => {
     });
 
     expect(result.ok).toBe(false);
+    // Phase 4 Slice C: diagnostics are pre-emitted ONCE per registry
+    // construction. `toHaveLength(1)` pins the count explicitly — without it,
+    // `toMatchObject([...])` would silently accept extra diagnostics if a
+    // regression reintroduced per-field emission.
+    expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics).toMatchObject([
       {
         code: "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE",
@@ -345,6 +350,11 @@ describe("date extension integration", () => {
     });
 
     expect(result.ok).toBe(false);
+    // Phase 4 Slice C: diagnostics are pre-emitted ONCE per registry
+    // construction. `toHaveLength(1)` pins the count explicitly — without it,
+    // `toMatchObject([...])` would silently accept extra diagnostics if a
+    // regression reintroduced per-field emission.
+    expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics).toMatchObject([
       {
         code: "SYNTHETIC_SETUP_FAILURE",

--- a/packages/build/src/__tests__/deduplicate-diagnostics.test.ts
+++ b/packages/build/src/__tests__/deduplicate-diagnostics.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for {@link deduplicateDiagnostics} in `class-analyzer.ts`.
+ *
+ * The helper was introduced by Phase 4 Slice C as a temporary symptom-fix for
+ * N-fold duplication of setup diagnostics when a declaration with N fields is
+ * analyzed under an extension registry that has setup failures. The root-cause
+ * restructure is tracked in
+ * `scratch/deferred-deduplicate-diagnostics-root-fix.md`.
+ *
+ * These tests pin the invariants that make the helper safe to ship:
+ *
+ *   1. Setup diagnostics with identical `code + message` are collapsed.
+ *   2. Non-setup diagnostics with identical `code + message` but distinct
+ *      `primaryLocation` are ALL retained — silently dropping a per-field
+ *      error on a sibling field would be a user-visible regression.
+ *   3. Setup diagnostics with identical `code` but distinct `message` are
+ *      both retained (dedup key is `code + message`, not `code` alone).
+ *   4. The `\0` separator in the dedup key prevents false-positive key
+ *      collisions between a code that is a prefix of another code+message.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ConstraintSemanticDiagnostic } from "@formspec/analysis/internal";
+import { deduplicateDiagnostics } from "../analyzer/class-analyzer.js";
+
+const EXTENSION_PROVENANCE = {
+  surface: "extension",
+  file: "/virtual/test.ts",
+  line: 1,
+  column: 0,
+} as const;
+
+function setupDiag(
+  code: "SYNTHETIC_SETUP_FAILURE" | "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE",
+  message: string
+): ConstraintSemanticDiagnostic {
+  return {
+    code,
+    message,
+    severity: "error",
+    primaryLocation: EXTENSION_PROVENANCE,
+    relatedLocations: [],
+  };
+}
+
+function tagSiteDiag(
+  code: string,
+  message: string,
+  line: number
+): ConstraintSemanticDiagnostic {
+  return {
+    code,
+    message,
+    severity: "error",
+    primaryLocation: {
+      surface: "jsdoc",
+      file: "/virtual/test.ts",
+      line,
+      column: 0,
+    },
+    relatedLocations: [],
+  };
+}
+
+describe("deduplicateDiagnostics", () => {
+  it("returns the array unchanged when length <= 1", () => {
+    expect(deduplicateDiagnostics([])).toEqual([]);
+    const single = [setupDiag("SYNTHETIC_SETUP_FAILURE", "boom")];
+    expect(deduplicateDiagnostics(single)).toEqual(single);
+  });
+
+  it("collapses identical setup diagnostics", () => {
+    const duplicated: readonly ConstraintSemanticDiagnostic[] = [
+      setupDiag("SYNTHETIC_SETUP_FAILURE", 'Invalid custom type name "Not A Type"'),
+      setupDiag("SYNTHETIC_SETUP_FAILURE", 'Invalid custom type name "Not A Type"'),
+      setupDiag("SYNTHETIC_SETUP_FAILURE", 'Invalid custom type name "Not A Type"'),
+    ];
+    const result = deduplicateDiagnostics(duplicated);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.code).toBe("SYNTHETIC_SETUP_FAILURE");
+  });
+
+  it("also collapses identical UNSUPPORTED_CUSTOM_TYPE_OVERRIDE diagnostics", () => {
+    const duplicated = [
+      setupDiag("UNSUPPORTED_CUSTOM_TYPE_OVERRIDE", "Override of Array is not supported"),
+      setupDiag("UNSUPPORTED_CUSTOM_TYPE_OVERRIDE", "Override of Array is not supported"),
+    ];
+    const result = deduplicateDiagnostics(duplicated);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.code).toBe("UNSUPPORTED_CUSTOM_TYPE_OVERRIDE");
+  });
+
+  it("retains setup diagnostics with the same code but different messages", () => {
+    const diagnostics = [
+      setupDiag("SYNTHETIC_SETUP_FAILURE", 'Invalid custom type name "Foo"'),
+      setupDiag("SYNTHETIC_SETUP_FAILURE", 'Invalid custom type name "Bar"'),
+    ];
+    const result = deduplicateDiagnostics(diagnostics);
+    expect(result).toHaveLength(2);
+    expect(result.map((d) => d.message)).toEqual([
+      'Invalid custom type name "Foo"',
+      'Invalid custom type name "Bar"',
+    ]);
+  });
+
+  it("retains non-setup diagnostics even when code + message are identical", () => {
+    // Two separate fields producing the same placement error must both surface.
+    // Silent-dropping the second one would hide a legitimate per-field bug.
+    const diagnostics = [
+      tagSiteDiag("INVALID_TAG_PLACEMENT", "@minLength is not valid on this field", 10),
+      tagSiteDiag("INVALID_TAG_PLACEMENT", "@minLength is not valid on this field", 20),
+    ];
+    const result = deduplicateDiagnostics(diagnostics);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.primaryLocation).toMatchObject({ line: 10 });
+    expect(result[1]?.primaryLocation).toMatchObject({ line: 20 });
+  });
+
+  it("preserves non-setup diagnostics when they are interleaved with duplicated setup diagnostics", () => {
+    const diagnostics = [
+      setupDiag("SYNTHETIC_SETUP_FAILURE", "boom"),
+      tagSiteDiag("TYPE_MISMATCH", "string required", 5),
+      setupDiag("SYNTHETIC_SETUP_FAILURE", "boom"),
+      tagSiteDiag("TYPE_MISMATCH", "string required", 15),
+    ];
+    const result = deduplicateDiagnostics(diagnostics);
+    // One setup dedup, both non-setup retained.
+    expect(result).toHaveLength(3);
+    expect(result.filter((d) => d.code === "SYNTHETIC_SETUP_FAILURE")).toHaveLength(1);
+    expect(result.filter((d) => d.code === "TYPE_MISMATCH")).toHaveLength(2);
+  });
+
+  it("uses the \\0 separator so key collisions do not occur", () => {
+    // If the key were `${code}${message}` with no separator, these two would
+    // collide: "FOO" + "BAR" === "FO" + "OBAR". The `\0` separator prevents
+    // that class of false positive. We use real setup codes here so both
+    // entries are eligible for dedup.
+    const diagnostics = [
+      setupDiag("SYNTHETIC_SETUP_FAILURE", "ABC"),
+      // Different code, different message, but prefix concatenation would
+      // collide without the separator. Keep both messages distinct from the
+      // first diagnostic via the second code path.
+      setupDiag("UNSUPPORTED_CUSTOM_TYPE_OVERRIDE", "ABC"),
+    ];
+    const result = deduplicateDiagnostics(diagnostics);
+    expect(result).toHaveLength(2);
+    expect(result.map((d) => d.code)).toEqual([
+      "SYNTHETIC_SETUP_FAILURE",
+      "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE",
+    ]);
+  });
+});

--- a/packages/build/src/__tests__/tsdoc-parser-setup-diagnostic-silent-drop.test.ts
+++ b/packages/build/src/__tests__/tsdoc-parser-setup-diagnostic-silent-drop.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Pins the silent-drop behavior of `parseTSDocTags` when the extension registry
+ * has setup failures.
+ *
+ * When `registry.setupDiagnostics` is non-empty, `parseTSDocTags` returns ONLY
+ * the setup diagnostics and skips all further tag analysis (placement validation,
+ * summary-text extraction, constraint parsing, etc.) for the node.
+ *
+ * Rationale: an invalid registry means constraint types cannot be resolved, so
+ * placement validation and tag argument checking for every field in the class
+ * would be based on incomplete type information. Surfacing only the setup
+ * diagnostic — rather than potentially spurious placement or type errors — keeps
+ * the developer's feedback loop focused on fixing the broken extension
+ * configuration before re-running analysis.
+ *
+ * @see packages/build/src/analyzer/tsdoc-parser.ts (parseTSDocTags early-return block)
+ * @see packages/build/src/extensions/registry.ts (createExtensionRegistry)
+ */
+
+import { describe, it, expect } from "vitest";
+import * as ts from "typescript";
+import { createExtensionRegistry } from "../extensions/index.js";
+import { parseTSDocTags } from "../analyzer/tsdoc-parser.js";
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+/**
+ * Creates an in-memory TypeScript source file and returns the first property
+ * declaration in the first class/interface/type-alias.
+ */
+function getFirstProperty(source: string): ts.Node {
+  const sourceFile = ts.createSourceFile("/virtual/test.ts", source, ts.ScriptTarget.Latest, true);
+
+  for (const stmt of sourceFile.statements) {
+    if (ts.isClassDeclaration(stmt) || ts.isInterfaceDeclaration(stmt)) {
+      for (const member of stmt.members) {
+        if (ts.isPropertyDeclaration(member) || ts.isPropertySignature(member)) {
+          return member;
+        }
+      }
+    }
+  }
+
+  throw new Error("No property declaration found in source");
+}
+
+/** A class with a constraint tag placement error AND a setup-invalid extension. */
+const CLASS_WITH_CONSTRAINT_ON_CLASS_FIELD = `
+  class MyForm {
+    /**
+     * Valid summary text.
+     * @minLength 1
+     * @maxLength 10
+     */
+    label: string = "";
+  }
+`;
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("parseTSDocTags silent-drop: only setup diagnostics surface when registry has setup failures", () => {
+  it("returns only setup diagnostics when registry.setupDiagnostics is non-empty", () => {
+    // Registry with "Not A Type" — an invalid identifier, triggers SYNTHETIC_SETUP_FAILURE.
+    const invalidRegistry = createExtensionRegistry([
+      {
+        extensionId: "x-test/invalid",
+        types: [{ typeName: "MyType", tsTypeNames: ["Not A Type"] }],
+      },
+    ]);
+
+    expect(invalidRegistry.setupDiagnostics).toHaveLength(1);
+    expect(invalidRegistry.setupDiagnostics[0]?.kind).toBe("synthetic-setup");
+
+    const prop = getFirstProperty(CLASS_WITH_CONSTRAINT_ON_CLASS_FIELD);
+    const result = parseTSDocTags(prop, "/virtual/test.ts", {
+      extensionRegistry: invalidRegistry,
+    });
+
+    // Setup diagnostic is emitted.
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("SYNTHETIC_SETUP_FAILURE");
+    expect(result.diagnostics[0]?.message).toMatch(/Invalid custom type name "Not A Type"/);
+
+    // Provenance is anchored at extension registration site, not tag site.
+    expect(result.diagnostics[0]?.primaryLocation).toEqual({
+      surface: "extension",
+      file: "/virtual/test.ts",
+      line: 1,
+      column: 0,
+    });
+
+    // Constraint nodes are NOT extracted — the entire tag analysis is skipped.
+    expect(result.constraints).toHaveLength(0);
+    expect(result.annotations).toHaveLength(0);
+  });
+
+  it("does not surface placement errors when registry has setup failures (silent-drop)", () => {
+    // "Array" is an unsupported global built-in override → UNSUPPORTED_CUSTOM_TYPE_OVERRIDE.
+    const unsupportedBuiltinRegistry = createExtensionRegistry([
+      {
+        extensionId: "x-test/bad-array",
+        types: [{ typeName: "Array", tsTypeNames: ["Array"] }],
+      },
+    ]);
+
+    expect(unsupportedBuiltinRegistry.setupDiagnostics).toHaveLength(1);
+    expect(unsupportedBuiltinRegistry.setupDiagnostics[0]?.kind).toBe(
+      "unsupported-custom-type-override"
+    );
+
+    const prop = getFirstProperty(CLASS_WITH_CONSTRAINT_ON_CLASS_FIELD);
+    const result = parseTSDocTags(prop, "/virtual/test.ts", {
+      extensionRegistry: unsupportedBuiltinRegistry,
+    });
+
+    // Only the setup diagnostic surfaces — no TYPE_MISMATCH or INVALID_TAG_PLACEMENT.
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("UNSUPPORTED_CUSTOM_TYPE_OVERRIDE");
+    expect(result.diagnostics.map((d) => d.code)).not.toContain("TYPE_MISMATCH");
+    expect(result.diagnostics.map((d) => d.code)).not.toContain("INVALID_TAG_PLACEMENT");
+
+    // No constraints or annotations extracted.
+    expect(result.constraints).toHaveLength(0);
+    expect(result.annotations).toHaveLength(0);
+  });
+
+  it("returns full parse results (constraints + annotations) when registry has no setup failures", () => {
+    // A valid registry — no setup failures.
+    const validRegistry = createExtensionRegistry([
+      {
+        extensionId: "x-test/valid",
+        types: [{ typeName: "MyDecimal", tsTypeNames: ["MyDecimal"] }],
+      },
+    ]);
+
+    expect(validRegistry.setupDiagnostics).toHaveLength(0);
+
+    const prop = getFirstProperty(CLASS_WITH_CONSTRAINT_ON_CLASS_FIELD);
+    const result = parseTSDocTags(prop, "/virtual/test.ts", {
+      extensionRegistry: validRegistry,
+    });
+
+    // No setup diagnostics.
+    expect(result.diagnostics.filter((d) => d.code === "SYNTHETIC_SETUP_FAILURE")).toHaveLength(0);
+
+    // Constraint nodes ARE extracted — @minLength and @maxLength.
+    expect(result.constraints.length).toBeGreaterThanOrEqual(2);
+    const constraintKinds = result.constraints.map((c) => c.constraintKind);
+    expect(constraintKinds).toContain("minLength");
+    expect(constraintKinds).toContain("maxLength");
+  });
+});

--- a/packages/build/src/__tests__/tsdoc-parser-setup-diagnostic-silent-drop.test.ts
+++ b/packages/build/src/__tests__/tsdoc-parser-setup-diagnostic-silent-drop.test.ts
@@ -46,8 +46,18 @@ function getFirstProperty(source: string): ts.Node {
   throw new Error("No property declaration found in source");
 }
 
-/** A class with a constraint tag placement error AND a setup-invalid extension. */
-const CLASS_WITH_CONSTRAINT_ON_CLASS_FIELD = `
+/**
+ * A class with valid constraint tags (@minLength, @maxLength on a string field).
+ *
+ * This fixture is used with a registry that has setup failures. Under
+ * silent-drop the parser returns ONLY the setup diagnostic and extracts no
+ * constraints — silent-drop is proven by asserting
+ * `result.constraints.length === 0` (the valid constraints would otherwise be
+ * extracted), not by checking for absence of placement errors. The fixture
+ * intentionally has no placement error to keep the test focused on the
+ * "full parse suppressed" behavior rather than error-forwarding mechanics.
+ */
+const CLASS_WITH_VALID_CONSTRAINTS_ON_STRING_FIELD = `
   class MyForm {
     /**
      * Valid summary text.
@@ -75,7 +85,7 @@ describe("parseTSDocTags silent-drop: only setup diagnostics surface when regist
     expect(invalidRegistry.setupDiagnostics).toHaveLength(1);
     expect(invalidRegistry.setupDiagnostics[0]?.kind).toBe("synthetic-setup");
 
-    const prop = getFirstProperty(CLASS_WITH_CONSTRAINT_ON_CLASS_FIELD);
+    const prop = getFirstProperty(CLASS_WITH_VALID_CONSTRAINTS_ON_STRING_FIELD);
     const result = parseTSDocTags(prop, "/virtual/test.ts", {
       extensionRegistry: invalidRegistry,
     });
@@ -112,18 +122,16 @@ describe("parseTSDocTags silent-drop: only setup diagnostics surface when regist
       "unsupported-custom-type-override"
     );
 
-    const prop = getFirstProperty(CLASS_WITH_CONSTRAINT_ON_CLASS_FIELD);
+    const prop = getFirstProperty(CLASS_WITH_VALID_CONSTRAINTS_ON_STRING_FIELD);
     const result = parseTSDocTags(prop, "/virtual/test.ts", {
       extensionRegistry: unsupportedBuiltinRegistry,
     });
 
-    // Only the setup diagnostic surfaces — no TYPE_MISMATCH or INVALID_TAG_PLACEMENT.
+    // Only the setup diagnostic surfaces. Silent-drop is proven by the
+    // absence of the valid @minLength/@maxLength constraints — they would be
+    // extracted if the parser had not short-circuited on setup failure.
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("UNSUPPORTED_CUSTOM_TYPE_OVERRIDE");
-    expect(result.diagnostics.map((d) => d.code)).not.toContain("TYPE_MISMATCH");
-    expect(result.diagnostics.map((d) => d.code)).not.toContain("INVALID_TAG_PLACEMENT");
-
-    // No constraints or annotations extracted.
     expect(result.constraints).toHaveLength(0);
     expect(result.annotations).toHaveLength(0);
   });
@@ -139,7 +147,7 @@ describe("parseTSDocTags silent-drop: only setup diagnostics surface when regist
 
     expect(validRegistry.setupDiagnostics).toHaveLength(0);
 
-    const prop = getFirstProperty(CLASS_WITH_CONSTRAINT_ON_CLASS_FIELD);
+    const prop = getFirstProperty(CLASS_WITH_VALID_CONSTRAINTS_ON_STRING_FIELD);
     const result = parseTSDocTags(prop, "/virtual/test.ts", {
       extensionRegistry: validRegistry,
     });

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -244,7 +244,24 @@ export function createAnalyzerMetadataPolicy(
 }
 
 /**
- * Removes duplicate diagnostics from an accumulated array.
+ * Diagnostic codes eligible for deduplication by `deduplicateDiagnostics`.
+ *
+ * Only setup diagnostics are safe to dedup by `code + message` because every
+ * copy shares the same `primaryLocation` (the registry-level
+ * `{surface:"extension", line:1, column:0}` anchor). Per-field diagnostics —
+ * e.g., two fields producing the same `INVALID_TAG_PLACEMENT` message at
+ * different file positions — must not be merged because their
+ * `primaryLocation` values differ and losing one would silently hide a
+ * legitimate per-field error.
+ */
+const DEDUPLICATABLE_DIAGNOSTIC_CODES: ReadonlySet<string> = new Set([
+  "SYNTHETIC_SETUP_FAILURE",
+  "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE",
+]);
+
+/**
+ * Removes duplicate setup diagnostics from an accumulated array, leaving
+ * non-setup diagnostics unchanged.
  *
  * Phase 4 Slice C: when an extension registry has setup failures, each field
  * node in a class/interface calls {@link parseTSDocTags} independently, and
@@ -252,8 +269,13 @@ export function createAnalyzerMetadataPolicy(
  * registration site). Without deduplication, an N-field declaration would
  * produce N identical setup diagnostics. We deduplicate by `code + message`
  * (`\0`-separated to prevent collisions between a code value that matches a
- * message prefix and an actual message) because all copies share the same
- * `primaryLocation` provenance.
+ * message prefix and an actual message) because all copies of a setup
+ * diagnostic share the same `primaryLocation` provenance.
+ *
+ * Dedup is restricted to {@link DEDUPLICATABLE_DIAGNOSTIC_CODES} so that
+ * per-field diagnostics with identical messages but distinct locations are
+ * always retained — otherwise the helper would silently drop legitimate
+ * errors on sibling fields that happen to share a diagnostic code+message.
  *
  * TODO: root fix — instead of deduplicating after accumulation, inject setup
  * diagnostics ONCE at the class/interface/type-alias entry in
@@ -262,15 +284,16 @@ export function createAnalyzerMetadataPolicy(
  * non-empty, emit them once and pass `undefined` as the extension registry to
  * per-field `parseTSDocTags` calls so they perform no setup-diag re-emission.
  * That eliminates the need for this deduplication pass entirely.
- * Deferred because the restructure touches multiple entry functions and is
- * outside the scope of the current PR (Phase 4 Slice C review feedback).
+ * Tracked in
+ * `docs/refactors/phase-4-slice-c-deduplicate-diagnostics-root-fix.md`.
  */
-function deduplicateDiagnostics(
+export function deduplicateDiagnostics(
   diagnostics: readonly ConstraintSemanticDiagnostic[]
 ): readonly ConstraintSemanticDiagnostic[] {
   if (diagnostics.length <= 1) return diagnostics;
   const seen = new Set<string>();
   return diagnostics.filter((d) => {
+    if (!DEDUPLICATABLE_DIAGNOSTIC_CODES.has(d.code)) return true;
     // `\0` separator prevents collisions where a code string is a prefix of a
     // message string (e.g., code = "FOO", message = "BAR" must not collide
     // with code = "FOO\0BAR", message = "").

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -243,6 +243,29 @@ export function createAnalyzerMetadataPolicy(
   };
 }
 
+/**
+ * Removes duplicate diagnostics from an accumulated array.
+ *
+ * Phase 4 Slice C: when an extension registry has setup failures, each field
+ * node in a class/interface calls {@link parseTSDocTags} independently, and
+ * each call returns the same setup diagnostic (anchored at the extension
+ * registration site). Without deduplication, an N-field declaration would
+ * produce N identical setup diagnostics. We deduplicate by `code + message`
+ * because all copies share the same `primaryLocation` provenance.
+ */
+function deduplicateDiagnostics(
+  diagnostics: readonly ConstraintSemanticDiagnostic[]
+): readonly ConstraintSemanticDiagnostic[] {
+  if (diagnostics.length <= 1) return diagnostics;
+  const seen = new Set<string>();
+  return diagnostics.filter((d) => {
+    const key = `${d.code}\0${d.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 function resolveNodeMetadata(
   metadataPolicy: AnalyzerMetadataPolicy,
   declarationKind: "type" | "field" | "method",
@@ -660,6 +683,7 @@ export function analyzeClassToIR(
     }
   );
 
+  const deduplicatedDiagnostics = deduplicateDiagnostics(diagnostics);
   return {
     name,
     ...(metadata !== undefined && { metadata }),
@@ -667,7 +691,7 @@ export function analyzeClassToIR(
     fieldLayouts,
     typeRegistry,
     ...(annotations.length > 0 && { annotations }),
-    ...(diagnostics.length > 0 && { diagnostics }),
+    ...(deduplicatedDiagnostics.length > 0 && { diagnostics: deduplicatedDiagnostics }),
     instanceMethods,
     staticMethods,
   };
@@ -758,6 +782,7 @@ export function analyzeInterfaceToIR(
     }
   );
 
+  const deduplicatedDiagnostics = deduplicateDiagnostics(diagnostics);
   return {
     name,
     ...(metadata !== undefined && { metadata }),
@@ -765,7 +790,7 @@ export function analyzeInterfaceToIR(
     fieldLayouts,
     typeRegistry,
     ...(annotations.length > 0 && { annotations }),
-    ...(diagnostics.length > 0 && { diagnostics }),
+    ...(deduplicatedDiagnostics.length > 0 && { diagnostics: deduplicatedDiagnostics }),
     instanceMethods: [],
     staticMethods: [],
   };
@@ -867,6 +892,7 @@ export function analyzeTypeAliasToIR(
     }
   );
 
+  const deduplicatedDiagnostics = deduplicateDiagnostics(diagnostics);
   return {
     ok: true,
     analysis: {
@@ -876,7 +902,7 @@ export function analyzeTypeAliasToIR(
       fieldLayouts: specializedFields.map(() => ({})),
       typeRegistry,
       ...(annotations.length > 0 && { annotations }),
-      ...(diagnostics.length > 0 && { diagnostics }),
+      ...(deduplicatedDiagnostics.length > 0 && { diagnostics: deduplicatedDiagnostics }),
       instanceMethods: [],
       staticMethods: [],
     },

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -251,7 +251,19 @@ export function createAnalyzerMetadataPolicy(
  * each call returns the same setup diagnostic (anchored at the extension
  * registration site). Without deduplication, an N-field declaration would
  * produce N identical setup diagnostics. We deduplicate by `code + message`
- * because all copies share the same `primaryLocation` provenance.
+ * (`\0`-separated to prevent collisions between a code value that matches a
+ * message prefix and an actual message) because all copies share the same
+ * `primaryLocation` provenance.
+ *
+ * TODO: root fix — instead of deduplicating after accumulation, inject setup
+ * diagnostics ONCE at the class/interface/type-alias entry in
+ * `analyzeClassToIR` / `analyzeInterfaceToIR` / `analyzeTypeAliasToIR`,
+ * before iterating fields. When `extensionRegistry.setupDiagnostics` is
+ * non-empty, emit them once and pass `undefined` as the extension registry to
+ * per-field `parseTSDocTags` calls so they perform no setup-diag re-emission.
+ * That eliminates the need for this deduplication pass entirely.
+ * Deferred because the restructure touches multiple entry functions and is
+ * outside the scope of the current PR (Phase 4 Slice C review feedback).
  */
 function deduplicateDiagnostics(
   diagnostics: readonly ConstraintSemanticDiagnostic[]
@@ -259,6 +271,9 @@ function deduplicateDiagnostics(
   if (diagnostics.length <= 1) return diagnostics;
   const seen = new Set<string>();
   return diagnostics.filter((d) => {
+    // `\0` separator prevents collisions where a code string is a prefix of a
+    // message string (e.g., code = "FOO", message = "BAR" must not collide
+    // with code = "FOO\0BAR", message = "").
     const key = `${d.code}\0${d.message}`;
     if (seen.has(key)) return false;
     seen.add(key);

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -78,6 +78,8 @@ import {
 } from "../extensions/resolve-custom-type.js";
 import { _isIntegerBrandedType } from "./builtin-brands.js";
 import {
+  _emitSetupDiagnostics,
+  _mapSetupDiagnosticCode,
   getBuildLogger,
   getBroadeningLogger,
   getSyntheticLogger,
@@ -1035,9 +1037,7 @@ function buildCompilerBackedConstraintDiagnostics(
   if (setupDiagnostic !== undefined) {
     return emit("C-reject", [
       makeDiagnostic(
-        setupDiagnostic.kind === "unsupported-custom-type-override"
-          ? "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE"
-          : "SYNTHETIC_SETUP_FAILURE",
+        _mapSetupDiagnosticCode(setupDiagnostic.kind),
         setupDiagnostic.message,
         provenance
       ),
@@ -1200,36 +1200,24 @@ export function parseTSDocTags(
     return cached;
   }
 
-  // §4 Phase 4 Slice C — emit setup diagnostics ONCE per parseTSDocTags call
-  // (anchored at the extension registration site, not at the tag use site).
-  // Previously, setup diagnostics fired once per synthetic-batch call inside
-  // buildSyntheticHelperPrelude, bypassing the LRU cache. Now they are
-  // pre-computed in createExtensionRegistry and read here, producing exactly
-  // one diagnostic per node analysis pass rather than one per tag application.
+  // §4 Phase 4 Slice C — when the registry has setup failures, emit them ONCE
+  // per parseTSDocTags call (anchored at the extension registration site) and
+  // skip all further tag parsing for this node.
+  //
+  // Rationale for the early-return: an invalid registry means constraint types
+  // cannot be resolved, so placement validation and summary-text extraction
+  // for every field in the class would be based on incomplete type information.
+  // Surfacing only the setup diagnostic — rather than potentially spurious
+  // placement errors — keeps the user's feedback loop focused on fixing the
+  // broken extension configuration first. See test
+  // "parseTSDocTags silent-drop: only setup diagnostics surface when registry
+  // has setup failures" in tsdoc-parser-setup-diagnostic-silent-drop.test.ts.
   const setupDiags = options?.extensionRegistry?.setupDiagnostics;
   if (setupDiags !== undefined && setupDiags.length > 0) {
-    // Anchor at the "extension" surface with the current file path.
-    // We do not have source-location info for the extension registration site,
-    // so we use line 1, column 0 as the registry-level provenance.
-    const extensionProvenance: Provenance = {
-      surface: "extension",
-      file,
-      line: 1,
-      column: 0,
-    };
-    const diagnostics: ConstraintSemanticDiagnostic[] = setupDiags.map((d) =>
-      makeDiagnostic(
-        d.kind === "unsupported-custom-type-override"
-          ? "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE"
-          : "SYNTHETIC_SETUP_FAILURE",
-        d.message,
-        extensionProvenance
-      )
-    );
     const result: TSDocParseResult = {
       constraints: [],
       annotations: [],
-      diagnostics,
+      diagnostics: _emitSetupDiagnostics(setupDiags, file),
     };
     parseResultCache.set(cacheKey, result);
     return result;

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -1200,6 +1200,41 @@ export function parseTSDocTags(
     return cached;
   }
 
+  // §4 Phase 4 Slice C — emit setup diagnostics ONCE per parseTSDocTags call
+  // (anchored at the extension registration site, not at the tag use site).
+  // Previously, setup diagnostics fired once per synthetic-batch call inside
+  // buildSyntheticHelperPrelude, bypassing the LRU cache. Now they are
+  // pre-computed in createExtensionRegistry and read here, producing exactly
+  // one diagnostic per node analysis pass rather than one per tag application.
+  const setupDiags = options?.extensionRegistry?.setupDiagnostics;
+  if (setupDiags !== undefined && setupDiags.length > 0) {
+    // Anchor at the "extension" surface with the current file path.
+    // We do not have source-location info for the extension registration site,
+    // so we use line 1, column 0 as the registry-level provenance.
+    const extensionProvenance: Provenance = {
+      surface: "extension",
+      file,
+      line: 1,
+      column: 0,
+    };
+    const diagnostics: ConstraintSemanticDiagnostic[] = setupDiags.map((d) =>
+      makeDiagnostic(
+        d.kind === "unsupported-custom-type-override"
+          ? "UNSUPPORTED_CUSTOM_TYPE_OVERRIDE"
+          : "SYNTHETIC_SETUP_FAILURE",
+        d.message,
+        extensionProvenance
+      )
+    );
+    const result: TSDocParseResult = {
+      constraints: [],
+      annotations: [],
+      diagnostics,
+    };
+    parseResultCache.set(cacheKey, result);
+    return result;
+  }
+
   const constraints: ConstraintNode[] = [];
   const annotations: AnnotationNode[] = [];
   const diagnostics: ConstraintSemanticDiagnostic[] = [];

--- a/packages/build/src/extensions/registry.ts
+++ b/packages/build/src/extensions/registry.ts
@@ -25,7 +25,10 @@ import {
   getTagDefinition,
   normalizeFormSpecTagName,
   getSyntheticLogger,
+  validateExtensionSetup,
+  logSetupDiagnostics,
   type ExtensionTagSource,
+  type SyntheticCompilerDiagnostic,
 } from "@formspec/analysis/internal";
 
 // =============================================================================
@@ -60,6 +63,24 @@ export interface ExtensionTypeLookupResult {
 export interface ExtensionRegistry {
   /** The extensions registered in this registry (in registration order). */
   readonly extensions: readonly ExtensionDefinition[];
+
+  /**
+   * Setup diagnostics detected during registry construction.
+   *
+   * These diagnostics represent configuration errors in the extension
+   * registrations — e.g. unsupported TypeScript built-in type overrides,
+   * invalid type-name identifiers, or duplicate registrations. They are
+   * computed ONCE at `createExtensionRegistry` call time (§4 Phase 4 Slice C)
+   * and carried on the registry so consumers can emit them without re-running
+   * the validation on every analysis call.
+   *
+   * Consumers should check this array at the start of each analysis pass and
+   * short-circuit if it is non-empty — the registry is unusable for
+   * constraint-type validation when setup diagnostics are present.
+   *
+   * @internal
+   */
+  readonly setupDiagnostics: readonly SyntheticCompilerDiagnostic[];
 
   /**
    * Look up a custom type registration by its fully-qualified type ID.
@@ -180,6 +201,18 @@ function buildConstraintTagSources(
           })),
         }
       : {}),
+    // Include customTypes so validateExtensionSetup can check tsTypeNames for
+    // unsupported built-in overrides and invalid identifier patterns.
+    ...(extension.types !== undefined
+      ? {
+          customTypes: extension.types.map((type) => ({
+            // tsTypeNames: deprecated in favour of symbol-based detection, but
+            // still required for name-based validation in validateExtensionSetup
+            // until the bridge is fully retired (see §synthetic-checker-retirement §4C).
+            tsTypeNames: type.tsTypeNames ?? [type.typeName],
+          })),
+        }
+      : {}),
   }));
 }
 
@@ -207,7 +240,19 @@ export function createExtensionRegistry(
     extensionIds: extensions.map((e) => e.extensionId),
   });
 
-  const reservedTagSources = buildConstraintTagSources(extensions);
+  // §4 Phase 4 Slice C — validate extension type-name registrations ONCE at
+  // construction time. Consumers pull `registry.setupDiagnostics` at the start
+  // of each analysis pass instead of re-running validation per synthetic batch.
+  const extensionTagSources = buildConstraintTagSources(extensions);
+  const setupDiagnostics = validateExtensionSetup(extensionTagSources);
+  logSetupDiagnostics(registryLog, {
+    diagnosticCount: setupDiagnostics.length,
+    codes: setupDiagnostics.map((d) => d.kind),
+  });
+
+  // extensionTagSources is already computed above for validateExtensionSetup;
+  // reuse it here to avoid a second pass over the extensions array.
+  const reservedTagSources = extensionTagSources;
   let symbolMap = new Map<ts.Symbol, ExtensionTypeLookupResult>();
   const typeMap = new Map<string, CustomTypeRegistration>();
   const typeNameMap = new Map<string, ExtensionTypeLookupResult>();
@@ -365,10 +410,12 @@ export function createExtensionRegistry(
     broadeningCount: builtinBroadeningMap.size,
     annotationCount: annotationMap.size,
     metadataSlotCount: metadataSlotMap.size,
+    setupDiagnosticCount: setupDiagnostics.length,
   });
 
   return {
     extensions,
+    setupDiagnostics,
     findType: (typeId: string) => typeMap.get(typeId),
     findTypeByName: (typeName: string) => typeNameMap.get(typeName),
     findTypeByBrand: (brand: string) => brandMap.get(brand),

--- a/packages/build/src/extensions/registry.ts
+++ b/packages/build/src/extensions/registry.ts
@@ -25,7 +25,7 @@ import {
   getTagDefinition,
   normalizeFormSpecTagName,
   getSyntheticLogger,
-  validateExtensionSetup,
+  _validateExtensionSetup,
   logSetupDiagnostics,
   type ExtensionTagSource,
   type SyntheticCompilerDiagnostic,
@@ -201,13 +201,13 @@ function buildConstraintTagSources(
           })),
         }
       : {}),
-    // Include customTypes so validateExtensionSetup can check tsTypeNames for
+    // Include customTypes so _validateExtensionSetup can check tsTypeNames for
     // unsupported built-in overrides and invalid identifier patterns.
     ...(extension.types !== undefined
       ? {
           customTypes: extension.types.map((type) => ({
             // tsTypeNames: deprecated in favour of symbol-based detection, but
-            // still required for name-based validation in validateExtensionSetup
+            // still required for name-based validation in _validateExtensionSetup
             // until the bridge is fully retired (see §synthetic-checker-retirement §4C).
             tsTypeNames: type.tsTypeNames ?? [type.typeName],
           })),
@@ -244,13 +244,13 @@ export function createExtensionRegistry(
   // construction time. Consumers pull `registry.setupDiagnostics` at the start
   // of each analysis pass instead of re-running validation per synthetic batch.
   const extensionTagSources = buildConstraintTagSources(extensions);
-  const setupDiagnostics = validateExtensionSetup(extensionTagSources);
+  const setupDiagnostics = _validateExtensionSetup(extensionTagSources);
   logSetupDiagnostics(registryLog, {
     diagnosticCount: setupDiagnostics.length,
     codes: setupDiagnostics.map((d) => d.kind),
   });
 
-  // extensionTagSources is already computed above for validateExtensionSetup;
+  // extensionTagSources is already computed above for _validateExtensionSetup;
   // reuse it here to avoid a second pass over the extensions array.
   const reservedTagSources = extensionTagSources;
   let symbolMap = new Map<ts.Symbol, ExtensionTypeLookupResult>();

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -76,6 +76,18 @@ export type {
   ExtensionTypeLookupResult,
   MutableExtensionRegistry,
 } from "./extensions/index.js";
+/**
+ * A simplified TypeScript diagnostic surfaced from the synthetic compiler pass.
+ *
+ * Re-exported here because {@link ExtensionRegistry.setupDiagnostics} (an
+ * `@internal` field on a `@public` interface) references this type directly.
+ * API Extractor requires every type transitively referenced through a public
+ * surface to be exported from the package entry point, even when the field
+ * carrying it is marked `@internal`.
+ *
+ * @internal
+ */
+export type { SyntheticCompilerDiagnostic } from "@formspec/analysis/internal";
 export type { FormSpecConfig } from "@formspec/config";
 
 export type {
@@ -195,7 +207,8 @@ export interface BuildResult {
  *
  * @public
  */
-export interface BuildFormSchemasOptions extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
+export interface BuildFormSchemasOptions
+  extends GenerateJsonSchemaOptions, GenerateUiSchemaOptions {
   /**
    * Optional logger for diagnostic output. Defaults to a no-op logger so
    * existing callers produce no output.


### PR DESCRIPTION
## Summary

- **Relocates** `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` and `SYNTHETIC_SETUP_FAILURE` diagnostics from per-tag-application emission (inside `runBatchSyntheticCheck`) to a single emission point per registry construction
- **Build consumer**: `createExtensionRegistry` now runs `validateExtensionSetup` once and stores results in `ExtensionRegistry.setupDiagnostics` (@internal); `parseTSDocTags` reads this and returns early on setup failures; `class-analyzer` adds `deduplicateDiagnostics` to prevent N duplicate diagnostics for N-field declarations
- **Snapshot consumer**: `buildFormSpecAnalysisFileSnapshot` now calls `validateExtensionSetup` once at the top, pre-emits setup diagnostics at the file-level span, and passes `setupDiagnosticsPreEmitted` to `buildTagDiagnostics` to suppress per-batch re-emission
- **Provenance change**: setup diagnostics now anchor at `surface: "extension"`, `line: 1`, `column: 0` instead of the first matching tag's position

## Key design decisions

- `validateExtensionSetup` is the new non-throwing counterpart to the existing `collectExtensionCustomTypeNames`; both are kept to avoid breaking the throwing path used in `buildSyntheticHelperPrelude`
- `ExtensionRegistry.setupDiagnostics` is marked `@internal` so it doesn't bleed `SyntheticCompilerDiagnostic` through the public `@formspec/build` API surface
- `deduplicateDiagnostics` in class-analyzer deduplicates **only** `SYNTHETIC_SETUP_FAILURE` and `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` (by `code + message`), leaving per-field diagnostics untouched — this avoids silently dropping a legitimate sibling-field error that happens to share a diagnostic code+message with another field
- **Not in scope** (explicitly deferred): issue #363 (alias-chain type-resolution divergence), which named Slice 4C as a candidate resolution site. Resolution is orthogonal to the emission-site relocation and is better handled alongside Slice D.

## Review-round changes (post-draft)

Rebased onto `origin/main` (resolves the conflict from PR #386 in `class-analyzer.ts` by taking main's drop of the class/interface-only early-return).

Review feedback addressed:

- `deduplicateDiagnostics` narrowed to setup-diagnostic codes only (previously dedup'd across the whole diagnostics array; silent-drop risk for per-field errors). Full context in `docs/refactors/phase-4-slice-c-deduplicate-diagnostics-root-fix.md`.
- New unit-test file `deduplicate-diagnostics.test.ts` pinning the retain-on-distinct-location, retain-on-distinct-message, and `\0`-separator-collision invariants.
- `_extensionRegistryProvenance` un-exported — it is a file-local helper used only by `_emitSetupDiagnostics` in the same file.
- `date-extension.integration.test.ts` — added `toHaveLength(1)` before the two `toMatchObject([...])` assertions so a regression to per-field emission cannot silently pass (Vitest `toMatchObject` does not enforce array length).
- `tsdoc-parser-setup-diagnostic-silent-drop.test.ts` — fixture renamed and docstring corrected (the original fixture had no placement error, making the `not.toContain("TYPE_MISMATCH" | "INVALID_TAG_PLACEMENT")` assertions tautological on this fixture). Silent-drop is now proven by `constraints.length === 0` / `annotations.length === 0`.

## Test plan

- [x] `packages/analysis` tests: passing
- [x] `packages/build` tests: 883 passing (42 test files), includes the new `deduplicate-diagnostics.test.ts` (7 tests) and updated silent-drop / emission-count tests
- [x] e2e tests: 272/272 passing
- [x] `pnpm run lint`: clean
- [x] `pnpm run format:check`: clean
- [x] `pnpm run typecheck`: clean across all 13 projects
- [x] `pnpm run api-extractor` (CI mode, fail-on-drift): clean
- [x] `pnpm run build` from clean: clean

## Follow-ups

- `docs/refactors/phase-4-slice-c-deduplicate-diagnostics-root-fix.md` — structural removal of `deduplicateDiagnostics` (pre-emit setup diagnostics once at the declaration-level entry, pass a suppressed registry downstream, delete the helper). Not in this PR because it touches three declaration-level entrypoints across multiple callers.
- Renaming `SyntheticCompilerDiagnostic` to `_SyntheticCompilerDiagnostic` to silence `ae-internal-missing-underscore` — deferred for a separate internal-API cleanup pass to keep this PR scoped to setup-diagnostic relocation.