### PR TITLE
fix(build): inherit @format when interface extends a type-alias base (#376)

### DIFF
--- a/.changeset/fix-376-interface-extends-type-alias-format.md
+++ b/.changeset/fix-376-interface-extends-type-alias-format.md
@@ -1,0 +1,8 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Fix `@format` inheritance when an interface (or class) `extends` a type-alias base. The BFS walker in `collectInheritedTypeAnnotations` previously enqueued only `ClassDeclaration` and `InterfaceDeclaration` bases, silently dropping any `TypeAliasDeclaration` base whose resolved type is object-shaped. The walker now also traverses type-alias bases, extracting JSDoc annotations from them and, when the alias's RHS is a named type, continuing up the heritage chain through the alias.

--- a/packages/build/src/__tests__/format-inheritance-derived-types.test.ts
+++ b/packages/build/src/__tests__/format-inheritance-derived-types.test.ts
@@ -6,6 +6,7 @@
  *
  * @see https://github.com/mike-north/formspec/issues/367
  * @see https://github.com/mike-north/formspec/issues/374 — type-alias derivation gap (skipped tests below)
+ * @see https://github.com/mike-north/formspec/issues/376 — interface extends type-alias base (covered below)
  * @see packages/build/src/analyzer/class-analyzer.ts — named-type annotation
  *      extraction is the enforcement point.
  */
@@ -358,6 +359,48 @@ const TYPE_ALIAS_OWN_OVERRIDE_SOURCE = [
   "}",
 ].join("\n");
 
+/**
+ * Issue #376 repro. Derived is an `interface extends TypeAlias` where the
+ * base is a type-alias whose resolved type is object-shaped. The BFS in
+ * `collectInheritedTypeAnnotations` must traverse the type-alias base so
+ * that the derived interface inherits the alias-level `@format`.
+ */
+const INTERFACE_EXTENDS_TYPE_ALIAS_SOURCE = [
+  "/** @format monetary-amount */",
+  "type MonetaryAmount = { amount: number; currency: string };",
+  "",
+  "interface PositiveAmount extends MonetaryAmount {",
+  "  /** @exclusiveMinimum 0 */",
+  "  amount: number;",
+  "}",
+  "",
+  "export class Order {",
+  "  tip!: PositiveAmount;",
+  "}",
+].join("\n");
+
+/**
+ * Issue #376 — multi-level chain where the type-alias base sits in the
+ * middle of the BFS. The BFS must cross the type-alias node to reach the
+ * @format declared on a deeper base.
+ */
+const INTERFACE_EXTENDS_TYPE_ALIAS_MULTI_LEVEL_SOURCE = [
+  "/** @format monetary-amount */",
+  "interface BaseMonetary {",
+  "  amount: number;",
+  "}",
+  "",
+  "type AliasMonetary = BaseMonetary;",
+  "",
+  "interface LeafMonetary extends AliasMonetary {",
+  "  currency: string;",
+  "}",
+  "",
+  "export class Order {",
+  "  tip!: LeafMonetary;",
+  "}",
+].join("\n");
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -377,6 +420,8 @@ let typeAliasPrimitiveChainFixturePath: string;
 let typeAliasObjectChainFixturePath: string;
 let typeAliasOfInterfaceFixturePath: string;
 let typeAliasOwnOverrideFixturePath: string;
+let interfaceExtendsTypeAliasFixturePath: string;
+let interfaceExtendsTypeAliasMultiLevelFixturePath: string;
 
 beforeAll(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-fmt-inherit-"));
@@ -437,6 +482,18 @@ beforeAll(() => {
 
   typeAliasOwnOverrideFixturePath = path.join(tmpDir, "type-alias-own-override.ts");
   fs.writeFileSync(typeAliasOwnOverrideFixturePath, TYPE_ALIAS_OWN_OVERRIDE_SOURCE);
+
+  interfaceExtendsTypeAliasFixturePath = path.join(tmpDir, "interface-extends-type-alias.ts");
+  fs.writeFileSync(interfaceExtendsTypeAliasFixturePath, INTERFACE_EXTENDS_TYPE_ALIAS_SOURCE);
+
+  interfaceExtendsTypeAliasMultiLevelFixturePath = path.join(
+    tmpDir,
+    "interface-extends-type-alias-multi-level.ts"
+  );
+  fs.writeFileSync(
+    interfaceExtendsTypeAliasMultiLevelFixturePath,
+    INTERFACE_EXTENDS_TYPE_ALIAS_MULTI_LEVEL_SOURCE
+  );
 });
 
 afterAll(() => {
@@ -637,6 +694,52 @@ describe("issue #367 — bug-report verbatim scenario", () => {
       "$defs.PositiveMonetaryAmount.properties.amount"
     );
     expect(amount["exclusiveMinimum"]).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — issue #376: interface extends a type-alias base
+//
+// PR #369 added the BFS walker for heritage-chain @format inheritance, but
+// gated the enqueue step on `ClassDeclaration | InterfaceDeclaration` only.
+// When the base in an `extends` clause resolves to a `TypeAliasDeclaration`
+// (object-shaped), the walker silently dropped the base and no inherited
+// annotation flowed through. See the post-merge-audit note on #369.
+// ---------------------------------------------------------------------------
+
+describe("interface extends a type-alias base — issue #376", () => {
+  it("inherits @format from an object-shaped type-alias base in an interface `extends` clause", () => {
+    // spec: issue #376 repro — `interface PositiveAmount extends MonetaryAmount`
+    // where MonetaryAmount is `type MonetaryAmount = { ... }` carrying a
+    // type-level `@format`. The BFS must follow the TypeAliasDeclaration
+    // base so the derived interface's $defs entry picks up the annotation.
+    const result = generateSchemasOrThrow({
+      filePath: interfaceExtendsTypeAliasFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const derived = expectRecord(defs["PositiveAmount"], "$defs.PositiveAmount");
+
+    // Core assertion: the type-alias base's @format reaches the derived
+    // interface's $defs entry.
+    expect(derived["format"]).toBe("monetary-amount");
+  });
+
+  it("traverses a type-alias node mid-chain to reach an @format declared deeper in the heritage graph", () => {
+    // spec: issue #376 — the fix must handle a type-alias sitting between
+    // two heritage-bearing declarations, not just as an immediate base. Here
+    // the chain is `LeafMonetary (interface) → AliasMonetary (type alias) →
+    // BaseMonetary (interface, @format-tagged)`. The BFS must cross the
+    // alias node to reach BaseMonetary.
+    const result = generateSchemasOrThrow({
+      filePath: interfaceExtendsTypeAliasMultiLevelFixturePath,
+      typeName: "Order",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const leaf = expectRecord(defs["LeafMonetary"], "$defs.LeafMonetary");
+    expect(leaf["format"]).toBe("monetary-amount");
   });
 });
 

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -376,11 +376,71 @@ function collectInheritedTypeAnnotations(
   }
   if (needed.size === 0) return [];
 
+  type HeritageBearingDecl =
+    | ts.ClassDeclaration
+    | ts.InterfaceDeclaration
+    | ts.TypeAliasDeclaration;
+
   const inherited: AnnotationNode[] = [];
   const seen = new Set<ts.Node>([derivedDecl]);
-  const queue: (ts.ClassDeclaration | ts.InterfaceDeclaration)[] = [];
+  const queue: HeritageBearingDecl[] = [];
 
-  const enqueueBasesOf = (decl: ts.ClassDeclaration | ts.InterfaceDeclaration): void => {
+  const resolveSymbolTarget = (sym: ts.Symbol): ts.Symbol => {
+    if ((sym.flags & ts.SymbolFlags.Alias) === 0) return sym;
+    try {
+      return checker.getAliasedSymbol(sym);
+    } catch {
+      // TypeScript can throw when resolving certain alias chains (e.g.,
+      // cyclic or partially resolved aliases). Fall back to the original
+      // symbol — worst case we miss an inheritance step, not a fatal error.
+      return sym;
+    }
+  };
+
+  const isObjectShapedTypeAlias = (alias: ts.TypeAliasDeclaration): boolean => {
+    // An interface can only legally extend an object-shaped alias (the TS
+    // compiler rejects `interface X extends StringAlias`), but we guard here
+    // so a misuse higher in the chain cannot pull in annotations from a
+    // primitive-typed alias whose semantics do not match. The check uses
+    // the alias's resolved type, not its syntactic RHS, so aliases of
+    // aliases-of-interfaces are covered.
+    const type = checker.getTypeFromTypeNode(alias.type);
+    if ((type.flags & ts.TypeFlags.Object) !== 0) return true;
+    if (type.isIntersection()) return true;
+    return false;
+  };
+
+  const enqueueCandidate = (baseDecl: ts.Declaration): void => {
+    if (seen.has(baseDecl)) return;
+    if (ts.isClassDeclaration(baseDecl) || ts.isInterfaceDeclaration(baseDecl)) {
+      seen.add(baseDecl);
+      queue.push(baseDecl);
+      return;
+    }
+    if (ts.isTypeAliasDeclaration(baseDecl) && isObjectShapedTypeAlias(baseDecl)) {
+      seen.add(baseDecl);
+      queue.push(baseDecl);
+    }
+  };
+
+  const enqueueBasesOf = (decl: HeritageBearingDecl): void => {
+    if (ts.isTypeAliasDeclaration(decl)) {
+      // Type aliases have no heritage clauses. Instead, follow the alias's
+      // RHS when it resolves to another named type (alias-of-alias or
+      // alias-of-interface chains). This lets `@format` declared on a
+      // deeper ancestor reach a derived interface whose immediate base is
+      // a type alias (issue #376, mid-chain case).
+      const rhs = decl.type;
+      if (!ts.isTypeReferenceNode(rhs)) return;
+      const sym = checker.getSymbolAtLocation(rhs.typeName);
+      if (!sym) return;
+      const target = resolveSymbolTarget(sym);
+      for (const baseDecl of target.declarations ?? []) {
+        enqueueCandidate(baseDecl);
+      }
+      return;
+    }
+
     const heritageClauses = decl.heritageClauses;
     if (!heritageClauses) return;
     for (const clause of heritageClauses) {
@@ -392,24 +452,9 @@ function collectInheritedTypeAnnotations(
       for (const typeExpr of clause.types) {
         const sym = checker.getSymbolAtLocation(typeExpr.expression);
         if (!sym) continue;
-        let target: ts.Symbol = sym;
-        if ((sym.flags & ts.SymbolFlags.Alias) !== 0) {
-          try {
-            target = checker.getAliasedSymbol(sym);
-          } catch {
-            // TypeScript can throw when resolving certain alias chains
-            // (e.g., cyclic or partially resolved aliases). Fall back to
-            // the original symbol — worst case we miss an inheritance
-            // step, not a fatal error.
-            target = sym;
-          }
-        }
+        const target = resolveSymbolTarget(sym);
         for (const baseDecl of target.declarations ?? []) {
-          if (seen.has(baseDecl)) continue;
-          seen.add(baseDecl);
-          if (ts.isClassDeclaration(baseDecl) || ts.isInterfaceDeclaration(baseDecl)) {
-            queue.push(baseDecl);
-          }
+          enqueueCandidate(baseDecl);
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes [#376](https://github.com/mike-north/formspec/issues/376). PR #369's heritage-chain BFS enqueued only `ClassDeclaration | InterfaceDeclaration` bases, so any `TypeAliasDeclaration` base in an `extends` clause was silently dropped and the alias-level `@format` never reached the derived type.

## Repro (from the issue)

```ts
/** @format monetary-amount */
type MonetaryAmount = { amount: Decimal; currency: Currency };

interface PositiveAmount extends MonetaryAmount {
  amount: Decimal;
}
```

Before: `$defs.PositiveAmount.format` missing. After: `"monetary-amount"`.

## Change

`collectInheritedTypeAnnotations` in [`packages/build/src/analyzer/class-analyzer.ts`](packages/build/src/analyzer/class-analyzer.ts) now treats object-shaped type-alias bases as first-class heritage nodes:

- `enqueueBasesOf` accepts `ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration`. For class/interface inputs it walks `heritageClauses` as before. For type-alias inputs it follows the alias's RHS when the RHS is a `TypeReferenceNode`, so the BFS can cross an alias node mid-chain to reach deeper ancestors.
- New `enqueueCandidate` helper centralises the seen-set + shape guard. Type-alias bases are only enqueued when the alias's resolved type is object-shaped (`ts.TypeFlags.Object`) or an intersection — primitive-typed aliases (which TS already rejects in `extends`) are ignored defensively.
- `resolveSymbolTarget` extracts the module-alias unwrap logic so it's reused from both the class/interface and type-alias paths.
- `isObjectShapedTypeAlias` checks the alias's *resolved* type via the checker, so aliases-of-aliases-of-interfaces are correctly recognised.

## Scope note

The *derived*-side-is-a-type-alias case (i.e. `type Derived = Base`) is tracked separately by [#374](https://github.com/mike-north/formspec/issues/374) and remains covered by existing `.skip`ped tests in the same file. This PR does not unskip or change them — #376 is specifically about the *base* being a type alias.

## Test plan

- [x] New regression tests in [`packages/build/src/__tests__/format-inheritance-derived-types.test.ts`](packages/build/src/__tests__/format-inheritance-derived-types.test.ts):
  - Exact #376 repro (interface extends object-shaped type alias).
  - Mid-chain variant: `LeafMonetary (interface) → AliasMonetary (type alias) → BaseMonetary (interface, @format)`.
- [x] Both tests fail on pre-fix `main` and pass with the change.
- [x] Full suite green: `pnpm run clean && pnpm install && pnpm run build && pnpm run lint && pnpm run test && pnpm run test:e2e`.
- [x] `pnpm run api-extractor` — no public API change.
- [x] Existing `@format` inheritance tests (10 cases for #367) unchanged.