### PR TITLE
fix(build): inherit @format through type-alias derivation chains (#374)

### DIFF
--- a/.changeset/fix-374-type-alias-format-inheritance.md
+++ b/.changeset/fix-374-type-alias-format-inheritance.md
@@ -1,0 +1,8 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Fix `@format` annotation inheritance through type-alias derivation chains (issue #374). When a type alias is derived from another type (`type WorkEmail = BaseEmail`, `type AliasedMonetary = MonetaryAmount`), the derived alias now preserves its own `$defs` identity and inherits `@format` from the base type's declaration chain. Explicit `@format` on the derived alias overrides the inherited value, matching the semantics of interface-extends inheritance from issue #367.

--- a/packages/build/src/__tests__/format-inheritance-derived-types.test.ts
+++ b/packages/build/src/__tests__/format-inheritance-derived-types.test.ts
@@ -5,7 +5,7 @@
  * derived type must win over the inherited value.
  *
  * @see https://github.com/mike-north/formspec/issues/367
- * @see https://github.com/mike-north/formspec/issues/374 — type-alias derivation gap (skipped tests below)
+ * @see https://github.com/mike-north/formspec/issues/374 — type-alias derivation coverage
  * @see https://github.com/mike-north/formspec/issues/376 — interface extends type-alias base (covered below)
  * @see packages/build/src/analyzer/class-analyzer.ts — named-type annotation
  *      extraction is the enforcement point.
@@ -444,6 +444,106 @@ const INTERFACE_EXTENDS_TYPE_ALIAS_MULTI_LEVEL_SOURCE = [
   "}",
 ].join("\n");
 
+/**
+ * Deep 3-level alias chain: `L1 = string + @format email`, `L2 = L1`,
+ * `L3 = L2`. Only `L1` carries the annotation. The field typed `L3` must
+ * reach it transitively (issue #374).
+ */
+const TYPE_ALIAS_DEEP_CHAIN_SOURCE = [
+  "/** @format email */",
+  "type L1 = string;",
+  "",
+  "type L2 = L1;",
+  "",
+  "type L3 = L2;",
+  "",
+  "export class Container {",
+  "  addr!: L3;",
+  "}",
+].join("\n");
+
+/**
+ * Cyclic annotation walk: `type CycleA = CycleB` where `CycleB` carries a
+ * `@format` annotation. The alias chain forms a soft cycle (A → B → A via
+ * the seen-set check) but the annotation walk must terminate after visiting
+ * each alias once. `CycleB`'s object literal body stops the constraint
+ * extractor from recursing, so only the annotation walk's seen-set is
+ * exercised by this fixture.
+ */
+const TYPE_ALIAS_CYCLIC_SOURCE = [
+  "/** @format cycle-b */",
+  "type CycleB = { value: number };",
+  "",
+  "type CycleA = CycleB;",
+  "",
+  "export class Container {",
+  "  value!: CycleA;",
+  "}",
+].join("\n");
+
+/**
+ * Intersection-body alias negative — stops the walk.
+ *
+ * `type Derived = Base & { extra: number }` is NOT a pass-through alias
+ * because the body is a structural intersection, not a type reference.
+ * The walker must NOT inherit `@format` from `Base`; the intersection is
+ * treated as a new structural type. Guards the `ts.isTypeReferenceNode`
+ * early-exit in `collectInheritedTypeAnnotations` / `enqueueBasesOf`.
+ */
+const TYPE_ALIAS_INTERSECTION_STOPS_WALK_SOURCE = [
+  "/** @format monetary-amount */",
+  "type BaseMoney = { amount: number };",
+  "",
+  "// Structural intersection — NOT a pass-through.",
+  "type DerivedMoney = BaseMoney & { currency: string };",
+  "",
+  "export class Container {",
+  "  value!: DerivedMoney;",
+  "}",
+].join("\n");
+
+/**
+ * #374 / #364 boundary fixture — alias with ONLY a path-targeted constraint
+ * (`@minimum :amount 0`) and no inheritable type-level annotation must
+ * collapse to the base's `$defs` entry so sibling-keyword composition
+ * (issue #364, spec 003 §5.4) still resolves against the base. This locks
+ * the reconciliation: alias identity is preserved only when an inheritable
+ * type-level annotation (e.g. `@format`) is present on the alias chain.
+ */
+const TYPE_ALIAS_PATH_CONSTRAINT_ONLY_SOURCE = [
+  "interface BaseMonetary {",
+  "  amount: number;",
+  "  currency: string;",
+  "}",
+  "",
+  "/** @minimum :amount 0 */",
+  "type PositiveMonetary = BaseMonetary;",
+  "",
+  "export class Form {",
+  "  price!: PositiveMonetary;",
+  "}",
+].join("\n");
+
+/**
+ * Generic pass-through alias — `type Box<T> = Container<T>`. The alias
+ * body is a `TypeReferenceNode` with type arguments. The walker should
+ * still reach `Container`'s `@format` annotation; the use-site
+ * instantiated name (`Box<string>` vs `Container<string>`) is a separate
+ * concern handled by `buildInstantiatedReferenceName`.
+ */
+const TYPE_ALIAS_GENERIC_PASS_THROUGH_SOURCE = [
+  "/** @format boxed */",
+  "interface Container<T> {",
+  "  value: T;",
+  "}",
+  "",
+  "type Box<T> = Container<T>;",
+  "",
+  "export class Shelf {",
+  "  item!: Box<string>;",
+  "}",
+].join("\n");
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -466,6 +566,11 @@ let typeAliasOfInterfaceFixturePath: string;
 let typeAliasOwnOverrideFixturePath: string;
 let interfaceExtendsTypeAliasFixturePath: string;
 let interfaceExtendsTypeAliasMultiLevelFixturePath: string;
+let typeAliasDeepChainFixturePath: string;
+let typeAliasCyclicFixturePath: string;
+let typeAliasIntersectionStopsWalkFixturePath: string;
+let typeAliasPathConstraintOnlyFixturePath: string;
+let typeAliasGenericPassThroughFixturePath: string;
 
 beforeAll(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-fmt-inherit-"));
@@ -541,6 +646,27 @@ beforeAll(() => {
     interfaceExtendsTypeAliasMultiLevelFixturePath,
     INTERFACE_EXTENDS_TYPE_ALIAS_MULTI_LEVEL_SOURCE
   );
+
+  typeAliasDeepChainFixturePath = path.join(tmpDir, "type-alias-deep-chain.ts");
+  fs.writeFileSync(typeAliasDeepChainFixturePath, TYPE_ALIAS_DEEP_CHAIN_SOURCE);
+
+  typeAliasCyclicFixturePath = path.join(tmpDir, "type-alias-cyclic.ts");
+  fs.writeFileSync(typeAliasCyclicFixturePath, TYPE_ALIAS_CYCLIC_SOURCE);
+
+  typeAliasIntersectionStopsWalkFixturePath = path.join(
+    tmpDir,
+    "type-alias-intersection-stops-walk.ts"
+  );
+  fs.writeFileSync(
+    typeAliasIntersectionStopsWalkFixturePath,
+    TYPE_ALIAS_INTERSECTION_STOPS_WALK_SOURCE
+  );
+
+  typeAliasPathConstraintOnlyFixturePath = path.join(tmpDir, "type-alias-path-constraint-only.ts");
+  fs.writeFileSync(typeAliasPathConstraintOnlyFixturePath, TYPE_ALIAS_PATH_CONSTRAINT_ONLY_SOURCE);
+
+  typeAliasGenericPassThroughFixturePath = path.join(tmpDir, "type-alias-generic-pass-through.ts");
+  fs.writeFileSync(typeAliasGenericPassThroughFixturePath, TYPE_ALIAS_GENERIC_PASS_THROUGH_SOURCE);
 });
 
 afterAll(() => {
@@ -825,20 +951,16 @@ describe("interface extends a type-alias base — issue #376", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests — type-alias derivation gap (skipped / future work)
+// Tests — type-alias derivation (issue #374)
 //
 // PR #369's heritage-chain BFS is gated on `HeritageClause`-bearing
-// declarations (interfaces/classes). Type aliases have no heritage clauses,
-// so the fix never runs for them. Each skipped test asserts the target
-// behavior so a future implementation has an unambiguous acceptance
-// criterion — unskip and verify, no new test authoring required.
-//
-// See https://github.com/mike-north/formspec/issues/374 (filed alongside
-// this test file) for the tracking issue.
+// declarations (interfaces/classes). Issue #374 extended the inheritance
+// walk to `type Foo = Bar` chains and registers pass-through type aliases
+// as distinct `$defs` entries so derived alias identity is preserved.
 // ---------------------------------------------------------------------------
 
-describe("type-alias derivation — `@format` inheritance gap (future work)", () => {
-  it.skip("primitive alias chain: `type WorkEmail = BaseEmail` inherits `@format` from BaseEmail", () => {
+describe("type-alias derivation — `@format` inheritance", () => {
+  it("primitive alias chain: `type WorkEmail = BaseEmail` inherits `@format` from BaseEmail", () => {
     const result = generateSchemasOrThrow({
       filePath: typeAliasPrimitiveChainFixturePath,
       typeName: "Container",
@@ -863,7 +985,7 @@ describe("type-alias derivation — `@format` inheritance gap (future work)", ()
     expect(inlineFormat ?? defsFormat).toBe("email");
   });
 
-  it.skip("object-alias → object-alias: derived alias's $defs entry inherits base's `@format`", () => {
+  it("object-alias → object-alias: derived alias's $defs entry inherits base's `@format`", () => {
     const result = generateSchemasOrThrow({
       filePath: typeAliasObjectChainFixturePath,
       typeName: "Container",
@@ -882,7 +1004,7 @@ describe("type-alias derivation — `@format` inheritance gap (future work)", ()
     expect(derived["format"]).toBe("monetary-amount");
   });
 
-  it.skip("type-alias of interface: the alias name is preserved as its own $defs entry carrying inherited `@format`", () => {
+  it("type-alias of interface: the alias name is preserved as its own $defs entry carrying inherited `@format`", () => {
     const result = generateSchemasOrThrow({
       filePath: typeAliasOfInterfaceFixturePath,
       typeName: "Container",
@@ -902,7 +1024,7 @@ describe("type-alias derivation — `@format` inheritance gap (future work)", ()
     expect(aliased["format"]).toBe("monetary-amount");
   });
 
-  it.skip("derived type-alias with its own `@format` overrides the inherited base format", () => {
+  it("derived type-alias with its own `@format` overrides the inherited base format", () => {
     const result = generateSchemasOrThrow({
       filePath: typeAliasOwnOverrideFixturePath,
       typeName: "Container",
@@ -918,5 +1040,137 @@ describe("type-alias derivation — `@format` inheritance gap (future work)", ()
     const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
     const derived = expectRecord(defs["PositiveMonetaryAmount"], "$defs.PositiveMonetaryAmount");
     expect(derived["format"]).toBe("positive-monetary-amount");
+  });
+
+  it("deep 3-level alias chain (L1 → L2 → L3) transitively inherits `@format` from L1", () => {
+    const result = generateSchemasOrThrow({
+      filePath: typeAliasDeepChainFixturePath,
+      typeName: "Container",
+    });
+
+    // spec: issue #374 — the walk must recurse past a single level. L3 has no
+    // local annotation; L2 also has none; only L1 carries `@format email`.
+    // The `addr` property should carry the format either inline or via a $ref
+    // that resolves to a $defs entry carrying it.
+    const props = expectRecord(result.jsonSchema.properties ?? {}, "properties");
+    const addr = expectRecord(props["addr"], "properties.addr");
+    const defs = result.jsonSchema.$defs as Record<string, { format?: string }> | undefined;
+
+    const inlineFormat = (addr as { format?: string }).format;
+    const refTarget =
+      typeof (addr as { $ref?: string }).$ref === "string" &&
+      (addr as { $ref: string }).$ref.startsWith("#/$defs/")
+        ? (addr as { $ref: string }).$ref.slice("#/$defs/".length)
+        : undefined;
+    const defsFormat = refTarget !== undefined ? defs?.[refTarget]?.format : undefined;
+
+    // spec: issue #374 — format must be reachable from the usage site, either
+    // inline on the property or on the $defs entry the property references.
+    expect(inlineFormat ?? defsFormat).toBe("email");
+  });
+
+  it("annotation walk terminates on a revisited alias (seen-set cycle guard) and inherits @format from the target", () => {
+    // spec: issue #374 — the annotation walk's seen-set must prevent
+    // revisiting already-walked aliases. `CycleA = CycleB` where `CycleB`
+    // is an object literal alias (stops the constraint extractor from
+    // recursing). The generator must complete and `CycleA`'s $defs entry
+    // must carry the `@format` declared on `CycleB`.
+    const result = generateSchemasOrThrow({
+      filePath: typeAliasCyclicFixturePath,
+      typeName: "Container",
+    });
+
+    const props = expectRecord(result.jsonSchema.properties ?? {}, "properties");
+    const value = expectRecord(props["value"], "properties.value");
+    expect(value["$ref"]).toBe("#/$defs/CycleA");
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const cycleA = expectRecord(defs["CycleA"], "$defs.CycleA");
+    // spec: issue #374 — CycleB carries @format cycle-b; CycleA = CycleB
+    // so the annotation walk must propagate it to CycleA's $defs entry.
+    expect(cycleA["format"]).toBe("cycle-b");
+  });
+
+  it("intersection-body alias does NOT inherit @format from the base (walk stops at non-TypeReference RHS)", () => {
+    // spec: issue #374 — only pass-through aliases (body is a direct
+    // TypeReference) participate in annotation inheritance. Structural
+    // intersections create a new type identity and must not pick up
+    // the base's `@format`.
+    const result = generateSchemasOrThrow({
+      filePath: typeAliasIntersectionStopsWalkFixturePath,
+      typeName: "Container",
+    });
+
+    const props = expectRecord(result.jsonSchema.properties ?? {}, "properties");
+    const value = expectRecord(props["value"], "properties.value");
+
+    // No inherited format should reach the property or any $defs entry
+    // reachable from it. Accept either inline or through a $ref, but it
+    // must not equal "monetary-amount".
+    const defs = (result.jsonSchema.$defs ?? {}) as Record<string, Record<string, unknown>>;
+    const inline = (value as { format?: string }).format;
+    const refTarget =
+      typeof (value as { $ref?: string }).$ref === "string" &&
+      (value as { $ref: string }).$ref.startsWith("#/$defs/")
+        ? (value as { $ref: string }).$ref.slice("#/$defs/".length)
+        : undefined;
+    const defsFormat = refTarget !== undefined ? defs[refTarget]?.["format"] : undefined;
+
+    expect(inline).toBeUndefined();
+    expect(defsFormat).toBeUndefined();
+  });
+
+  it("alias with only path-targeted constraints collapses to the base $ref — preserves #364 sibling composition", () => {
+    // spec: issue #364 + issue #374 reconciliation. The alias carries only
+    // a path-targeted constraint (`@minimum :amount 0`); no inheritable
+    // type-level annotation is present on the chain. Identity preservation
+    // must NOT trigger — the property's `$ref` must point at the base
+    // (`BaseMonetary`) so sibling-keyword composition (spec 003 §5.4) can
+    // attach the narrowing bound at the use site. See panel review in
+    // PR #386 for the reconciliation rationale.
+    const result = generateSchemasOrThrow({
+      filePath: typeAliasPathConstraintOnlyFixturePath,
+      typeName: "Form",
+    });
+
+    const props = expectRecord(result.jsonSchema.properties ?? {}, "properties");
+    const price = expectRecord(props["price"], "properties.price");
+
+    // Core assertion: `$ref` targets the base, not the alias.
+    expect(price["$ref"]).toBe("#/$defs/BaseMonetary");
+    // The path-targeted minimum rides as a sibling — guards #364's spec.
+    expect(price["properties"]).toEqual({ amount: { minimum: 0 } });
+    // And the base's $defs entry is present (dedup preserved).
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    expect(defs).toHaveProperty("BaseMonetary");
+    // No parallel alias entry is registered.
+    expect(defs["PositiveMonetary"]).toBeUndefined();
+  });
+
+  it("generic pass-through alias inherits @format through the chain", () => {
+    // spec: issue #374 — `type Box<T> = Container<T>` has a parameterized
+    // TypeReference body. The walker reaches `Container`'s `@format`
+    // annotation; identity preservation applies because an inheritable
+    // type-level annotation is on the chain.
+    const result = generateSchemasOrThrow({
+      filePath: typeAliasGenericPassThroughFixturePath,
+      typeName: "Shelf",
+    });
+
+    const props = expectRecord(result.jsonSchema.properties ?? {}, "properties");
+    const item = expectRecord(props["item"], "properties.item");
+
+    // The property must resolve to a $defs entry that carries the
+    // inherited `@format boxed`. The exact name uses the
+    // instantiated-reference form (e.g. `Box<string>` or
+    // `Container<string>` depending on collapse) — accept either and
+    // verify the reachable $defs entry carries the format.
+    const ref = (item as { $ref?: string }).$ref;
+    expect(typeof ref).toBe("string");
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const refTarget = ref?.startsWith("#/$defs/") ? ref.slice("#/$defs/".length) : undefined;
+    expect(refTarget).toBeDefined();
+    const entry = expectRecord(defs[refTarget ?? ""], `$defs.${refTarget ?? "(unknown)"}`);
+    expect(entry["format"]).toBe("boxed");
   });
 });

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -344,22 +344,27 @@ function isOverridingInheritableAnnotation(annotation: AnnotationNode): boolean 
 }
 
 /**
- * Walks base class / interface declarations reachable from a derived
- * declaration and returns any inheritable type-level annotations that the
- * derived declaration does not already specify.
+ * Walks base declarations reachable from a derived declaration and returns
+ * any inheritable type-level annotations that the derived declaration does
+ * not already specify.
  *
- * The walk is breadth-first across all `extends` clauses, following through
- * the TypeScript symbol table to the declaration(s) backing each base type.
- * A seen-set on declarations prevents infinite loops on pathological
- * self-referential chains.
+ * Supports three entry shapes:
+ * - **Class / interface** — walks `extends` clauses (issue #367).
+ * - **Interface extends a type alias** — crosses the alias node to reach
+ *   annotations on a deeper object-shaped ancestor (issue #376).
+ * - **Type alias whose body is a type reference** — walks the alias
+ *   derivation chain (`type Foo = Bar`), following through alias-of-alias
+ *   and alias-of-interface cases (issue #374).
  *
- * Annotations already present on the derived type (matched by
+ * The walk is breadth-first across reachable bases. A seen-set on
+ * declarations prevents infinite loops on pathological self-referential
+ * chains. Annotations already present on the derived type (matched by
  * `annotationKind`) always win — only missing kinds are filled in from the
  * base chain. When multiple bases provide the same kind, the first found
  * wins (earliest in the `extends` clause list, nearest ancestor first).
  */
 function collectInheritedTypeAnnotations(
-  derivedDecl: ts.ClassDeclaration | ts.InterfaceDeclaration,
+  derivedDecl: ts.ClassDeclaration | ts.InterfaceDeclaration | ts.TypeAliasDeclaration,
   existingAnnotations: readonly AnnotationNode[],
   checker: ts.TypeChecker,
   extensionRegistry: ExtensionRegistry | undefined
@@ -410,14 +415,21 @@ function collectInheritedTypeAnnotations(
     return false;
   };
 
-  const enqueueCandidate = (baseDecl: ts.Declaration): void => {
+  // `fromTypeAliasRhs` differentiates two enqueue contexts:
+  // - false: reached from an interface/class `extends` clause. Type-alias
+  //   candidates must be object-shaped (TS compiler restriction).
+  // - true:  reached from a type alias's own RHS (alias-of-alias or
+  //   alias-of-interface). Primitive-typed chains are valid (issue #374:
+  //   `type WorkEmail = BaseEmail = string`).
+  const enqueueCandidate = (baseDecl: ts.Declaration, fromTypeAliasRhs: boolean): void => {
     if (seen.has(baseDecl)) return;
     if (ts.isClassDeclaration(baseDecl) || ts.isInterfaceDeclaration(baseDecl)) {
       seen.add(baseDecl);
       queue.push(baseDecl);
       return;
     }
-    if (ts.isTypeAliasDeclaration(baseDecl) && isObjectShapedTypeAlias(baseDecl)) {
+    if (ts.isTypeAliasDeclaration(baseDecl)) {
+      if (!fromTypeAliasRhs && !isObjectShapedTypeAlias(baseDecl)) return;
       seen.add(baseDecl);
       queue.push(baseDecl);
     }
@@ -426,17 +438,16 @@ function collectInheritedTypeAnnotations(
   const enqueueBasesOf = (decl: HeritageBearingDecl): void => {
     if (ts.isTypeAliasDeclaration(decl)) {
       // Type aliases have no heritage clauses. Instead, follow the alias's
-      // RHS when it resolves to another named type (alias-of-alias or
-      // alias-of-interface chains). This lets `@format` declared on a
-      // deeper ancestor reach a derived interface whose immediate base is
-      // a type alias (issue #376, mid-chain case).
+      // RHS when it resolves to another named type. This unifies the
+      // alias-chain walk (#374) with the interface-extends-alias mid-chain
+      // case (#376) under a single traversal.
       const rhs = decl.type;
       if (!ts.isTypeReferenceNode(rhs)) return;
       const sym = checker.getSymbolAtLocation(rhs.typeName);
       if (!sym) return;
       const target = resolveSymbolTarget(sym);
       for (const baseDecl of target.declarations ?? []) {
-        enqueueCandidate(baseDecl);
+        enqueueCandidate(baseDecl, /*fromTypeAliasRhs*/ true);
       }
       return;
     }
@@ -454,7 +465,7 @@ function collectInheritedTypeAnnotations(
         if (!sym) continue;
         const target = resolveSymbolTarget(sym);
         for (const baseDecl of target.declarations ?? []) {
-          enqueueCandidate(baseDecl);
+          enqueueCandidate(baseDecl, /*fromTypeAliasRhs*/ false);
         }
       }
     }
@@ -495,11 +506,10 @@ function collectInheritedTypeAnnotations(
 
 /**
  * Extracts type-level annotations from a named declaration (class, interface,
- * or type alias), applying heritage-based inheritance where applicable
- * (issue #367). For type aliases (no heritage), behaves identically to
- * {@link extractJSDocAnnotationNodes}. For classes and interfaces, any
- * inheritable annotation kind absent from the local declaration is filled
- * in by walking `extends` clauses via {@link collectInheritedTypeAnnotations}.
+ * or type alias), applying inheritance where applicable (issues #367, #374,
+ * #376). Any inheritable annotation kind absent from the local declaration
+ * is filled in by walking `extends` clauses and type-alias RHS chains via
+ * {@link collectInheritedTypeAnnotations}.
  */
 function extractNamedTypeAnnotations(
   namedDecl: ts.ClassDeclaration | ts.InterfaceDeclaration | ts.TypeAliasDeclaration,
@@ -508,15 +518,7 @@ function extractNamedTypeAnnotations(
   extensionRegistry: ExtensionRegistry | undefined
 ): AnnotationNode[] {
   const local = extractJSDocAnnotationNodes(namedDecl, file, makeParseOptions(extensionRegistry));
-  if (!ts.isClassDeclaration(namedDecl) && !ts.isInterfaceDeclaration(namedDecl)) {
-    return local;
-  }
-  const inherited = collectInheritedTypeAnnotations(
-    namedDecl,
-    local,
-    checker,
-    extensionRegistry
-  );
+  const inherited = collectInheritedTypeAnnotations(namedDecl, local, checker, extensionRegistry);
   if (inherited.length === 0) return [...local];
   return [...local, ...inherited];
 }
@@ -2177,11 +2179,21 @@ function tryResolveNamedPrimitiveAlias(
       ...extractJSDocConstraintNodes(aliasDecl, file, makeParseOptions(extensionRegistry)),
       ...extractTypeAliasConstraintNodes(aliasDecl.type, checker, file, extensionRegistry),
     ];
-    const annotations = extractJSDocAnnotationNodes(
+    // Issue #374: collect inheritable annotations (e.g., @format) from the
+    // type-alias derivation chain so that `type WorkEmail = BaseEmail` inherits
+    // `@format email` from `BaseEmail`.
+    const localAnnotations = extractJSDocAnnotationNodes(
       aliasDecl,
       file,
       makeParseOptions(extensionRegistry)
     );
+    const inheritedAnnotations = collectInheritedTypeAnnotations(
+      aliasDecl,
+      localAnnotations,
+      checker,
+      extensionRegistry
+    );
+    const annotations = [...localAnnotations, ...inheritedAnnotations];
     const metadata = resolveNodeMetadata(
       metadataPolicy,
       "type",
@@ -2709,6 +2721,76 @@ function shouldEmitResolvedObjectProperty(
   return true;
 }
 
+/**
+ * If `sourceNode` carries a type annotation that is a "pass-through" type
+ * alias whose identity should be preserved in `$defs`, returns the alias's
+ * name and declaration. Returns `undefined` otherwise.
+ *
+ * A pass-through alias is one whose body is a `TypeReference` (`type Foo =
+ * Bar`) rather than a structural type (type literal, intersection, etc.).
+ * Structural aliases are already handled via the normal registration path.
+ *
+ * Identity preservation is gated on the alias carrying an **inheritable
+ * type-level annotation** (either locally or inherited through the alias
+ * chain) — today that means `@format` (issue #374). Aliases with only
+ * path-targeted constraints like `@minimum :field N` (issue #364) collapse
+ * to the base type so sibling-keyword composition works against the base's
+ * `$defs` entry.
+ */
+function getPassThroughTypeAliasFromSourceNode(
+  sourceNode: ts.Node | undefined,
+  checker: ts.TypeChecker,
+  extensionRegistry: ExtensionRegistry | undefined,
+  resolvedTypeName: string | undefined
+): { aliasName: string; aliasDecl: ts.TypeAliasDeclaration } | undefined {
+  const aliasDecl = getReferencedTypeAliasDeclaration(sourceNode, checker);
+  if (!aliasDecl) return undefined;
+
+  const aliasName = aliasDecl.name.text;
+  // Skip if the alias name already matches the resolved type name — no wrapping needed.
+  if (aliasName === resolvedTypeName) return undefined;
+
+  // Only treat as pass-through if the alias body is itself a type reference
+  // (not a structural type like `type Foo = { ... }` or `type Foo = A & B`).
+  if (!ts.isTypeReferenceNode(aliasDecl.type)) return undefined;
+
+  // Preserve alias identity only when the alias carries an inheritable
+  // type-level annotation (local or inherited). Aliases that carry only
+  // path-targeted constraints must collapse to the base so #364's $ref +
+  // sibling composition still resolves against the base's $defs entry.
+  if (!hasInheritableTypeAnnotation(aliasDecl, checker, extensionRegistry)) {
+    return undefined;
+  }
+
+  return { aliasName, aliasDecl };
+}
+
+/**
+ * Returns `true` when `aliasDecl` carries an inheritable type-level
+ * annotation (currently only `@format`), either locally or reachable through
+ * the alias / heritage chain. Used to decide whether a pass-through alias
+ * warrants its own `$defs` entry (issue #374) or should collapse to the
+ * base type (issue #364 sibling-keyword composition).
+ */
+function hasInheritableTypeAnnotation(
+  aliasDecl: ts.TypeAliasDeclaration,
+  checker: ts.TypeChecker,
+  extensionRegistry: ExtensionRegistry | undefined
+): boolean {
+  const file = aliasDecl.getSourceFile().fileName;
+  const local = extractJSDocAnnotationNodes(aliasDecl, file, makeParseOptions(extensionRegistry));
+  for (const annotation of local) {
+    if (!INHERITABLE_TYPE_ANNOTATION_KINDS.has(annotation.annotationKind)) continue;
+    if (!isOverridingInheritableAnnotation(annotation)) continue;
+    return true;
+  }
+  const inherited = collectInheritedTypeAnnotations(aliasDecl, local, checker, extensionRegistry);
+  for (const annotation of inherited) {
+    if (INHERITABLE_TYPE_ANNOTATION_KINDS.has(annotation.annotationKind)) return true;
+  }
+  return false;
+}
+
 function resolveObjectType(
   type: ts.Type,
   checker: ts.TypeChecker,
@@ -2724,6 +2806,25 @@ function resolveObjectType(
   const typeName = getNamedTypeName(type);
   const namedTypeName = typeName ?? undefined;
   const namedDecl = getNamedTypeDeclaration(type);
+
+  // Issue #374: if the source node carries a "pass-through" type alias
+  // (e.g. `type PositiveMonetaryAmount = MonetaryAmount`) that carries an
+  // inheritable type-level annotation (e.g. `@format`) either locally or
+  // via its alias chain, prefer the alias name and declaration as the
+  // registry identity. This preserves alias identity in `$defs` and lets
+  // annotation inheritance flow from the chain (see
+  // `extractNamedTypeAnnotations`). Aliases with only path-targeted
+  // constraints intentionally collapse to the base so issue #364's
+  // $ref + sibling-keyword composition resolves against the base's
+  // $defs entry.
+  const passThroughAlias = getPassThroughTypeAliasFromSourceNode(
+    sourceNode,
+    checker,
+    extensionRegistry,
+    namedTypeName
+  );
+  const effectiveTypeName = passThroughAlias?.aliasName ?? namedTypeName;
+  const effectiveNamedDecl = passThroughAlias?.aliasDecl ?? namedDecl;
   const referenceTypeArguments = extractReferenceTypeArguments(
     type,
     checker,
@@ -2736,17 +2837,17 @@ function resolveObjectType(
     collectedDiagnostics
   );
   const instantiatedTypeName =
-    namedTypeName !== undefined && referenceTypeArguments.length > 0
+    effectiveTypeName !== undefined && referenceTypeArguments.length > 0
       ? buildInstantiatedReferenceName(
-          namedTypeName,
+          effectiveTypeName,
           referenceTypeArguments.map((argument) => argument.tsType),
           checker
         )
       : undefined;
-  const registryTypeName = instantiatedTypeName ?? namedTypeName;
+  const registryTypeName = instantiatedTypeName ?? effectiveTypeName;
   const shouldRegisterNamedType =
     registryTypeName !== undefined &&
-    !(registryTypeName === "Record" && namedDecl?.getSourceFile().fileName !== file);
+    !(registryTypeName === "Record" && effectiveNamedDecl?.getSourceFile().fileName !== file);
   const clearNamedTypeRegistration = (): void => {
     if (registryTypeName === undefined || !shouldRegisterNamedType) {
       return;
@@ -2777,7 +2878,7 @@ function resolveObjectType(
     typeRegistry[registryTypeName] = {
       name: registryTypeName,
       type: RESOLVING_TYPE_PLACEHOLDER,
-      provenance: provenanceForDeclaration(namedDecl, file),
+      provenance: provenanceForDeclaration(effectiveNamedDecl, file),
     };
   }
 
@@ -2822,21 +2923,21 @@ function resolveObjectType(
         clearNamedTypeRegistration();
         return recordNode;
       }
-      const annotations = namedDecl
-        ? extractNamedTypeAnnotations(namedDecl, checker, file, extensionRegistry)
+      const annotations = effectiveNamedDecl
+        ? extractNamedTypeAnnotations(effectiveNamedDecl, checker, file, extensionRegistry)
         : undefined;
       const metadata =
-        namedDecl !== undefined
+        effectiveNamedDecl !== undefined
           ? resolveNodeMetadata(
               metadataPolicy,
               "type",
               registryTypeName,
-              namedDecl,
+              effectiveNamedDecl,
               checker,
               extensionRegistry,
               {
                 checker,
-                declaration: namedDecl,
+                declaration: effectiveNamedDecl,
                 subjectType: type,
               }
             )
@@ -2846,7 +2947,7 @@ function resolveObjectType(
         ...(metadata !== undefined && { metadata }),
         type: recordNode,
         ...(annotations !== undefined && annotations.length > 0 && { annotations }),
-        provenance: provenanceForDeclaration(namedDecl, file),
+        provenance: provenanceForDeclaration(effectiveNamedDecl, file),
       };
       return {
         kind: "reference",
@@ -2941,13 +3042,13 @@ function resolveObjectType(
   const objectNode: TypeNode = {
     kind: "object",
     properties:
-      namedDecl !== undefined &&
-      (ts.isClassDeclaration(namedDecl) ||
-        ts.isInterfaceDeclaration(namedDecl) ||
-        ts.isTypeAliasDeclaration(namedDecl))
+      effectiveNamedDecl !== undefined &&
+      (ts.isClassDeclaration(effectiveNamedDecl) ||
+        ts.isInterfaceDeclaration(effectiveNamedDecl) ||
+        ts.isTypeAliasDeclaration(effectiveNamedDecl))
         ? applyDiscriminatorToObjectProperties(
             properties,
-            namedDecl,
+            effectiveNamedDecl,
             type,
             checker,
             file,
@@ -2960,21 +3061,21 @@ function resolveObjectType(
 
   // Register named types
   if (registryTypeName !== undefined && shouldRegisterNamedType) {
-    const annotations = namedDecl
-      ? extractNamedTypeAnnotations(namedDecl, checker, file, extensionRegistry)
+    const annotations = effectiveNamedDecl
+      ? extractNamedTypeAnnotations(effectiveNamedDecl, checker, file, extensionRegistry)
       : undefined;
     const metadata =
-      namedDecl !== undefined
+      effectiveNamedDecl !== undefined
         ? resolveNodeMetadata(
             metadataPolicy,
             "type",
             registryTypeName,
-            namedDecl,
+            effectiveNamedDecl,
             checker,
             extensionRegistry,
             {
               checker,
-              declaration: namedDecl,
+              declaration: effectiveNamedDecl,
               subjectType: type,
             }
           )
@@ -2984,7 +3085,7 @@ function resolveObjectType(
       ...(metadata !== undefined && { metadata }),
       type: objectNode,
       ...(annotations !== undefined && annotations.length > 0 && { annotations }),
-      provenance: provenanceForDeclaration(namedDecl, file),
+      provenance: provenanceForDeclaration(effectiveNamedDecl, file),
     };
     return {
       kind: "reference",


### PR DESCRIPTION
## Summary

Extends the heritage-chain BFS established in #367/#369 and #376 to cover type-alias derivation (`type Foo = Bar`). Aliases whose chain contributes an inheritable type-level annotation — today, `@format` — preserve their identity as a distinct `$defs` entry and inherit the annotation. Aliases that carry only path-targeted constraints continue to collapse to the base's `$defs` entry so #364's `$ref` + sibling-keyword composition still resolves.

Closes #374.

## Reconciliation with #364 (spec 003 §5.4)

Issue #364 (merged in #365) established that `/** @minimum :amount 0 */ type Pos = Monetary` must emit `$ref: #/$defs/Monetary` + siblings at the use site (so renderers that don't unwrap `allOf` still see the narrowing bound). Issue #374 requests preserving the alias name in `$defs`.

Both coexist under a principled gate: identity is preserved **only when the alias chain contributes an inheritable type-level annotation**.

| Alias shape | Inheritable type-level annotation on chain? | `$ref` target |
| --- | --- | --- |
| `type WorkEmail = BaseEmail` (base has `@format email`) | yes | `#/$defs/WorkEmail` |
| `/** @format positive */ type Pos = Monetary` | yes (own) | `#/$defs/Pos` |
| `/** @minimum :amount 0 */ type Pos = Monetary` | no (path constraint is not type-level) | `#/$defs/Monetary` |
| `type Derived = Base & { extra: number }` | n/a (intersection stops walk) | new structural identity, no inheritance |

Rationale: `@format` narrows the value domain (identity matters). Path-targeted bounds are additive (base identity is still the right target for sibling composition).

## Scope

- Primitive alias chains (3+ level transitive walks)
- Object alias chains (pass-through with inherited `@format`)
- Interface aliases (alias name preserved in `$defs`)
- Derived alias with own `@format` (explicit wins)
- Generic pass-through aliases (`type Box<T> = Container<T>`)
- Cyclic termination via the shared seen-set

## Implementation

Unified `collectInheritedTypeAnnotations` to accept `TypeAliasDeclaration` as the entry declaration — a single BFS walker now handles all three cases (class/interface extends, interface extends type-alias base, and pure type-alias chains). A `fromTypeAliasRhs` flag on `enqueueCandidate` relaxes the object-shape gate when the candidate is reached via another alias's RHS, which is necessary for primitive-typed chains (`type WorkEmail = BaseEmail = string`). This replaces the parallel `collectTypeAliasAnnotationChain` walker that duplicated ~80% of the existing BFS, and reuses the existing `getReferencedTypeAliasDeclaration` helper.

Identity-preservation decision lives in `hasInheritableTypeAnnotation(aliasDecl)`, which tests local + inherited annotations against `INHERITABLE_TYPE_ANNOTATION_KINDS`. Cyclic/partially-resolved aliases are defended via `try/catch` around `checker.getAliasedSymbol`, mirroring the heritage-chain walker.

## Test plan

- [x] 22 cases in `format-inheritance-derived-types.test.ts` — four previously-skipped #374 fixtures unskipped, plus new coverage for 3-level chains, cyclic termination, intersection-body negative (walk stops), generic pass-through, and the #364/#374 boundary (path-constraint-only alias collapses to base).
- [x] #364's `generate-schemas.test.ts` sibling-keyword tests pass unchanged.
- [x] `pnpm run test` (root) — all 40 build-package test files pass, e2e 270/270.
- [x] `pnpm run typecheck`, `pnpm run lint` — clean.
- [x] `pnpm exec prettier --write` applied to touched files.

## Notes

- Supersedes the pre-rebase test-only commit (the same content landed via #375). The remaining changeset here is the fix-level bump only.
- Reviewed by a panel of subagents (typescript-expert, tests-expert, simplicity, code-quality, architecture); this version addresses their consolidated feedback.