### PR TITLE
fix(build): flatten remaining allOf emission sites to siblings (#382)

### DIFF
--- a/.changeset/fix-382-remaining-allof-sites.md
+++ b/.changeset/fix-382-remaining-allof-sites.md
@@ -1,5 +1,7 @@
 ---
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
 "formspec": patch
 ---
 

--- a/.changeset/fix-382-remaining-allof-sites.md
+++ b/.changeset/fix-382-remaining-allof-sites.md
@@ -1,0 +1,11 @@
+---
+"@formspec/build": patch
+"formspec": patch
+---
+
+Flatten remaining `allOf` emission sites in the JSON Schema emitter to sibling keywords under JSON Schema 2020-12 (§10.2.1), so downstream renderers (e.g., the Stripe dashboard) that do not unwrap `allOf` no longer silently drop path-targeted overrides.
+
+- **Inline-object missing-property fallback**: when a path-target override names a property not declared on an inline-object base, the override is now merged into the base's `properties` as siblings (with `additionalProperties`/`type` preserved), instead of wrapping the base in `allOf`.
+- **Pre-composed `allOf` append**: when the base schema is already an `allOf` with a single member whose keys do not conflict with the override, the composition is flattened to siblings. `allOf` is retained only when the composition genuinely cannot be expressed as siblings (multiple members, or key collisions).
+
+Follow-up to #364/#365; closes #382.

--- a/packages/build/src/__tests__/ir-json-schema-generator.test.ts
+++ b/packages/build/src/__tests__/ir-json-schema-generator.test.ts
@@ -2653,7 +2653,7 @@ describe("generateJsonSchemaFromIR", () => {
       });
     });
 
-    it("uses allOf for inline object path targets that don't exist in properties", () => {
+    it("merges inline object path targets for missing properties as flat siblings (no allOf — #382)", () => {
       const ir: FormIR = {
         kind: "form-ir",
         irVersion: IR_VERSION,
@@ -2700,10 +2700,18 @@ describe("generateJsonSchemaFromIR", () => {
         string,
         unknown
       >;
-      // Missing property should NOT be added directly — uses allOf to preserve
-      // additionalProperties semantics on the base object.
-      expect(address["allOf"]).toBeDefined();
-      expect(address["type"]).toBeUndefined(); // base object is inside allOf[0]
+      // Fixes #382 Site 1: the base object and the missing-property override
+      // are merged into a single flat schema. `additionalProperties`/`type`
+      // remain as siblings; declaring the property in `properties` legitimizes
+      // it regardless of the `additionalProperties` value.
+      expect(address["allOf"]).toBeUndefined();
+      expect(address["type"]).toBe("object");
+      // spec 003 §2.5: additionalProperties: true is the default and omitted.
+      expect(address["additionalProperties"]).toBeUndefined();
+      expect(address["properties"]).toEqual({
+        city: { type: "string" },
+        missing: { minLength: 1 },
+      });
     });
 
     it("returns schema unchanged for path-targeted constraints on non-traversable types", () => {

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -892,9 +892,7 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
         ]);
 
         const schema = generateJsonSchemaFromIR(ir);
-        const payload = schema.properties?.["payload"] as
-          | Record<string, unknown>
-          | undefined;
+        const payload = schema.properties?.["payload"] as Record<string, unknown> | undefined;
         const props = payload?.["properties"] as Record<string, unknown> | undefined;
 
         // Object.prototype.constructor still points at Object — we did not
@@ -938,9 +936,7 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
         ]);
 
         const schema = generateJsonSchemaFromIR(ir);
-        const payload = schema.properties?.["payload"] as
-          | Record<string, unknown>
-          | undefined;
+        const payload = schema.properties?.["payload"] as Record<string, unknown> | undefined;
         const props = payload?.["properties"] as Record<string, unknown> | undefined;
 
         // The override landed as a real own property — Object.hasOwn returns
@@ -949,14 +945,12 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
         // `obj["__proto__"] = value` would have replaced [[Prototype]]
         // instead, leaving no own property.
         expect(Object.hasOwn(props ?? {}, "__proto__")).toBe(true);
-        expect(
-          Object.getOwnPropertyDescriptor(props, "__proto__")?.value
-        ).toEqual({ minLength: 1 });
+        expect(Object.getOwnPropertyDescriptor(props, "__proto__")?.value).toEqual({
+          minLength: 1,
+        });
         // Object.prototype is untouched — the global prototype chain is not
         // mutated as a side-effect of emission.
-        expect(Object.getOwnPropertyNames(Object.prototype).sort()).toEqual(
-          protoSnapshot
-        );
+        expect(Object.getOwnPropertyNames(Object.prototype).sort()).toEqual(protoSnapshot);
       });
     });
   });

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -26,10 +26,12 @@ import type {
   FieldNode,
   ConstraintNode,
   AnnotationNode,
+  CustomTypeNode,
   Provenance,
 } from "@formspec/core/internals";
-import { IR_VERSION } from "@formspec/core/internals";
+import { defineCustomType, defineExtension, IR_VERSION } from "@formspec/core/internals";
 import { generateJsonSchemaFromIR } from "../json-schema/ir-generator.js";
+import { createExtensionRegistry } from "../extensions/index.js";
 
 // =============================================================================
 // TEST HELPERS
@@ -642,6 +644,393 @@ describe("$ref with sibling keywords — issue #364", () => {
       expect(shippingBranch["$ref"]).toBe("#/$defs/PostalAddress");
       expect(billingBranch["allOf"]).toBeUndefined();
       expect(shippingBranch["allOf"]).toBeUndefined();
+    });
+  });
+});
+
+// =============================================================================
+// REGRESSION TESTS — issue #382
+// =============================================================================
+//
+// Follow-up to #365/#364: two `allOf` emission sites in
+// `applyPathTargetedConstraints` remained after the primary fix. These tests
+// guard against their regressions.
+//
+//   Site 1: inline-object missing-property fallback — must emit a single flat
+//           object (base properties merged with missing overrides, sibling
+//           `additionalProperties`/`type`), not an `allOf` wrapper.
+//   Site 2: pre-composed `allOf` base — must flatten to siblings when the
+//           composition is expressible as siblings under JSON Schema 2020-12
+//           (§10.2.1). `allOf` is retained only for genuine non-sibling cases.
+//
+// @see https://github.com/mike-north/formspec/issues/382
+
+describe("remaining allOf emission sites flattened to siblings — issue #382", () => {
+  // ---------------------------------------------------------------------------
+  // Site 1: inline-object missing-property fallback
+  // ---------------------------------------------------------------------------
+  describe("Site 1: inline-object with path target naming a property that does not exist", () => {
+    it("emits a single flat object (no allOf wrapper) with sibling properties and preserved additionalProperties", () => {
+      // Scenario: an inline object field has `additionalProperties: true` and
+      // receives a path-targeted constraint pointing at a property that is not
+      // declared on the base type. Historically this wrapped the base in
+      // `allOf: [base, { properties: { missing: ... } }]`. The fix emits a
+      // flat object: base props merged with the missing override, with
+      // `additionalProperties` and `type` preserved as siblings.
+      //
+      // @see https://github.com/mike-north/formspec/issues/382 Site 1
+      const ir: FormIR = {
+        kind: "form-ir",
+        irVersion: IR_VERSION,
+        elements: [
+          {
+            kind: "field",
+            name: "address",
+            type: {
+              kind: "object",
+              properties: [
+                {
+                  name: "city",
+                  type: { kind: "primitive", primitiveKind: "string" },
+                  optional: false,
+                  constraints: [],
+                  annotations: [],
+                  provenance: PROVENANCE,
+                },
+              ],
+              additionalProperties: true,
+            },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minLength",
+                value: 1,
+                path: { segments: ["missing"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        typeRegistry: {},
+        provenance: PROVENANCE,
+      };
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const address = schema.properties?.["address"] as Record<string, unknown> | undefined;
+
+      // Regression guard: no allOf wrapping.
+      expect(address?.["allOf"]).toBeUndefined();
+
+      // Flat object: type is a sibling key, not buried inside allOf[0].
+      expect(address?.["type"]).toBe("object");
+
+      // `additionalProperties: true` is the default and is intentionally
+      // omitted from output (spec 003 §2.5); the semantics are preserved by
+      // absence of the keyword, not by its explicit presence.
+      expect(address?.["additionalProperties"]).toBeUndefined();
+
+      // Base property ("city") and the missing-override property ("missing")
+      // both appear in a single sibling properties map.
+      expect(address?.["properties"]).toEqual({
+        city: { type: "string" },
+        missing: { minLength: 1 },
+      });
+    });
+
+    it("preserves additionalProperties: false from the base when merging missing overrides", () => {
+      // Variant: base has `additionalProperties: false`. The fix must still
+      // preserve this semantic, otherwise the new flat property would be
+      // rejected against the base schema. Merging into the base properties
+      // legitimizes the property so additionalProperties: false stays safe.
+      //
+      // @see https://github.com/mike-north/formspec/issues/382 Site 1
+      const ir: FormIR = {
+        kind: "form-ir",
+        irVersion: IR_VERSION,
+        elements: [
+          {
+            kind: "field",
+            name: "address",
+            type: {
+              kind: "object",
+              properties: [
+                {
+                  name: "city",
+                  type: { kind: "primitive", primitiveKind: "string" },
+                  optional: false,
+                  constraints: [],
+                  annotations: [],
+                  provenance: PROVENANCE,
+                },
+              ],
+              additionalProperties: false,
+            },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minLength",
+                value: 1,
+                path: { segments: ["missing"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        typeRegistry: {},
+        provenance: PROVENANCE,
+      };
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const address = schema.properties?.["address"] as Record<string, unknown> | undefined;
+
+      expect(address?.["allOf"]).toBeUndefined();
+      expect(address?.["additionalProperties"]).toBe(false);
+      expect(address?.["properties"]).toEqual({
+        city: { type: "string" },
+        missing: { minLength: 1 },
+      });
+    });
+
+    it("merges declared and missing property overrides in the same flat object", () => {
+      // Mix: one path-target hits an existing property and another hits a
+      // missing property. Both must end up merged into a single sibling
+      // properties map on the flat object (no allOf in either case).
+      const ir: FormIR = {
+        kind: "form-ir",
+        irVersion: IR_VERSION,
+        elements: [
+          {
+            kind: "field",
+            name: "address",
+            type: {
+              kind: "object",
+              properties: [
+                {
+                  name: "city",
+                  type: { kind: "primitive", primitiveKind: "string" },
+                  optional: false,
+                  constraints: [],
+                  annotations: [],
+                  provenance: PROVENANCE,
+                },
+              ],
+              additionalProperties: true,
+            },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minLength",
+                value: 2,
+                path: { segments: ["city"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+              {
+                kind: "constraint",
+                constraintKind: "minLength",
+                value: 1,
+                path: { segments: ["postalCode"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        typeRegistry: {},
+        provenance: PROVENANCE,
+      };
+
+      const schema = generateJsonSchemaFromIR(ir);
+      const address = schema.properties?.["address"] as Record<string, unknown> | undefined;
+
+      expect(address?.["allOf"]).toBeUndefined();
+      expect(address?.["type"]).toBe("object");
+      expect(address?.["properties"]).toEqual({
+        city: { type: "string", minLength: 2 },
+        postalCode: { minLength: 1 },
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Site 2: pre-composed `allOf` base schema
+  // ---------------------------------------------------------------------------
+  //
+  // Pre-composed `allOf` schemas reach `applyPathTargetedConstraints` when a
+  // custom-type extension returns an `allOf` schema from `toJsonSchema`. The
+  // fix flattens to siblings when expressible under JSON Schema 2020-12 (i.e.,
+  // the allOf has exactly one member that is a `$ref`-shaped schema whose
+  // keys do not conflict with the overrides), and retains `allOf` only when
+  // the composition cannot be expressed as siblings.
+  //
+  // @see https://github.com/mike-north/formspec/issues/382 Site 2
+  describe("Site 2: pre-composed allOf base", () => {
+    function makeCustomTypeRegistry(jsonSchema: Record<string, unknown>) {
+      const customType = defineCustomType({
+        typeName: "ComposedMoney",
+        toJsonSchema: () => jsonSchema,
+      });
+      const extension = defineExtension({
+        extensionId: "x-test/composed",
+        types: [customType],
+      });
+      return createExtensionRegistry([extension]);
+    }
+
+    function moneyNode(): CustomTypeNode {
+      return {
+        kind: "custom",
+        typeId: "x-test/composed/ComposedMoney",
+        payload: undefined,
+      };
+    }
+
+    it("flattens allOf with a single $ref member into sibling keywords", () => {
+      // Base: custom type returns `{ allOf: [{ $ref: "#/$defs/X" }] }`.
+      // With a path-targeted override, pre-fix output is
+      // `{ allOf: [{ $ref: ... }, { properties: ... }] }`. The fix lifts the
+      // $ref up and attaches the override as a sibling:
+      // `{ $ref: "#/$defs/X", properties: {...} }`.
+      const registry = makeCustomTypeRegistry({
+        allOf: [{ $ref: "#/$defs/BaseMoney" }],
+      });
+
+      const ir: FormIR = {
+        kind: "form-ir",
+        irVersion: IR_VERSION,
+        elements: [
+          {
+            kind: "field",
+            name: "total",
+            type: moneyNode(),
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        typeRegistry: {},
+        provenance: PROVENANCE,
+      };
+
+      const schema = generateJsonSchemaFromIR(ir, { extensionRegistry: registry });
+      const totalProp = schema.properties?.["total"] as Record<string, unknown> | undefined;
+
+      // Regression guard — must not be wrapped in allOf.
+      expect(totalProp?.["allOf"]).toBeUndefined();
+      // Siblings must be lifted: $ref and properties both at the top level.
+      expect(totalProp?.["$ref"]).toBe("#/$defs/BaseMoney");
+      expect(totalProp?.["properties"]).toEqual({ value: { minimum: 0 } });
+    });
+
+    it("retains allOf when the composition has multiple members (not expressible as siblings)", () => {
+      // Genuine non-sibling composition: two independent $ref members cannot
+      // both appear as siblings — one $ref per schema. `allOf` is the correct
+      // shape here. This guards against over-flattening.
+      const registry = makeCustomTypeRegistry({
+        allOf: [{ $ref: "#/$defs/BaseA" }, { $ref: "#/$defs/BaseB" }],
+      });
+
+      const ir: FormIR = {
+        kind: "form-ir",
+        irVersion: IR_VERSION,
+        elements: [
+          {
+            kind: "field",
+            name: "total",
+            type: moneyNode(),
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        typeRegistry: {},
+        provenance: PROVENANCE,
+      };
+
+      const schema = generateJsonSchemaFromIR(ir, { extensionRegistry: registry });
+      const totalProp = schema.properties?.["total"] as Record<string, unknown> | undefined;
+
+      // allOf is genuinely required here, and the override is appended.
+      expect(totalProp?.["allOf"]).toBeDefined();
+      const allOf = totalProp?.["allOf"] as Record<string, unknown>[];
+      // Original members preserved, override appended.
+      expect(allOf).toEqual([
+        { $ref: "#/$defs/BaseA" },
+        { $ref: "#/$defs/BaseB" },
+        { properties: { value: { minimum: 0 } } },
+      ]);
+    });
+
+    it("retains allOf when the single member has a conflicting `properties` key", () => {
+      // The single allOf member declares its own `properties`, so lifting it
+      // up alongside the override's `properties` would silently overwrite one
+      // side. Keep `allOf` to preserve both contributions under 2020-12
+      // evaluation semantics.
+      const registry = makeCustomTypeRegistry({
+        allOf: [
+          {
+            $ref: "#/$defs/BaseMoney",
+            properties: { currency: { type: "string" } },
+          },
+        ],
+      });
+
+      const ir: FormIR = {
+        kind: "form-ir",
+        irVersion: IR_VERSION,
+        elements: [
+          {
+            kind: "field",
+            name: "total",
+            type: moneyNode(),
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minimum",
+                value: 0,
+                path: { segments: ["value"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ],
+        typeRegistry: {},
+        provenance: PROVENANCE,
+      };
+
+      const schema = generateJsonSchemaFromIR(ir, { extensionRegistry: registry });
+      const totalProp = schema.properties?.["total"] as Record<string, unknown> | undefined;
+
+      // Flattening would conflict — allOf must remain.
+      expect(totalProp?.["allOf"]).toBeDefined();
     });
   });
 });

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -669,7 +669,7 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
   // ---------------------------------------------------------------------------
   // Site 1: inline-object missing-property fallback
   // ---------------------------------------------------------------------------
-  describe("Site 1: inline-object with path target naming a property that does not exist", () => {
+  describe("Site 1: inline-object with path target naming a property that does not exist (#382)", () => {
     it("emits a single flat object (no allOf wrapper) with sibling properties and preserved additionalProperties", () => {
       // Scenario: an inline object field has `additionalProperties: true` and
       // receives a path-targeted constraint pointing at a property that is not
@@ -871,7 +871,7 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
   // the composition cannot be expressed as siblings.
   //
   // @see https://github.com/mike-north/formspec/issues/382 Site 2
-  describe("Site 2: pre-composed allOf base", () => {
+  describe("Site 2: pre-composed allOf base (#382)", () => {
     function makeCustomTypeRegistry(jsonSchema: Record<string, unknown>) {
       const customType = defineCustomType({
         typeName: "ComposedMoney",

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -679,44 +679,38 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
       // `additionalProperties` and `type` preserved as siblings.
       //
       // @see https://github.com/mike-north/formspec/issues/382 Site 1
-      const ir: FormIR = {
-        kind: "form-ir",
-        irVersion: IR_VERSION,
-        elements: [
-          {
-            kind: "field",
-            name: "address",
-            type: {
-              kind: "object",
-              properties: [
-                {
-                  name: "city",
-                  type: { kind: "primitive", primitiveKind: "string" },
-                  optional: false,
-                  constraints: [],
-                  annotations: [],
-                  provenance: PROVENANCE,
-                },
-              ],
-              additionalProperties: true,
-            },
-            required: true,
-            constraints: [
+      const ir: FormIR = makeIR([
+        {
+          kind: "field",
+          name: "address",
+          type: {
+            kind: "object",
+            properties: [
               {
-                kind: "constraint",
-                constraintKind: "minLength",
-                value: 1,
-                path: { segments: ["missing"] },
-                provenance: TSDOC_PROVENANCE,
+                name: "city",
+                type: { kind: "primitive", primitiveKind: "string" },
+                optional: false,
+                constraints: [],
+                annotations: [],
+                provenance: PROVENANCE,
               },
             ],
-            annotations: [],
-            provenance: PROVENANCE,
+            additionalProperties: true,
           },
-        ],
-        typeRegistry: {},
-        provenance: PROVENANCE,
-      };
+          required: true,
+          constraints: [
+            {
+              kind: "constraint",
+              constraintKind: "minLength",
+              value: 1,
+              path: { segments: ["missing"] },
+              provenance: TSDOC_PROVENANCE,
+            },
+          ],
+          annotations: [],
+          provenance: PROVENANCE,
+        },
+      ]);
 
       const schema = generateJsonSchemaFromIR(ir);
       const address = schema.properties?.["address"] as Record<string, unknown> | undefined;
@@ -747,44 +741,38 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
       // legitimizes the property so additionalProperties: false stays safe.
       //
       // @see https://github.com/mike-north/formspec/issues/382 Site 1
-      const ir: FormIR = {
-        kind: "form-ir",
-        irVersion: IR_VERSION,
-        elements: [
-          {
-            kind: "field",
-            name: "address",
-            type: {
-              kind: "object",
-              properties: [
-                {
-                  name: "city",
-                  type: { kind: "primitive", primitiveKind: "string" },
-                  optional: false,
-                  constraints: [],
-                  annotations: [],
-                  provenance: PROVENANCE,
-                },
-              ],
-              additionalProperties: false,
-            },
-            required: true,
-            constraints: [
+      const ir: FormIR = makeIR([
+        {
+          kind: "field",
+          name: "address",
+          type: {
+            kind: "object",
+            properties: [
               {
-                kind: "constraint",
-                constraintKind: "minLength",
-                value: 1,
-                path: { segments: ["missing"] },
-                provenance: TSDOC_PROVENANCE,
+                name: "city",
+                type: { kind: "primitive", primitiveKind: "string" },
+                optional: false,
+                constraints: [],
+                annotations: [],
+                provenance: PROVENANCE,
               },
             ],
-            annotations: [],
-            provenance: PROVENANCE,
+            additionalProperties: false,
           },
-        ],
-        typeRegistry: {},
-        provenance: PROVENANCE,
-      };
+          required: true,
+          constraints: [
+            {
+              kind: "constraint",
+              constraintKind: "minLength",
+              value: 1,
+              path: { segments: ["missing"] },
+              provenance: TSDOC_PROVENANCE,
+            },
+          ],
+          annotations: [],
+          provenance: PROVENANCE,
+        },
+      ]);
 
       const schema = generateJsonSchemaFromIR(ir);
       const address = schema.properties?.["address"] as Record<string, unknown> | undefined;
@@ -801,51 +789,45 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
       // Mix: one path-target hits an existing property and another hits a
       // missing property. Both must end up merged into a single sibling
       // properties map on the flat object (no allOf in either case).
-      const ir: FormIR = {
-        kind: "form-ir",
-        irVersion: IR_VERSION,
-        elements: [
-          {
-            kind: "field",
-            name: "address",
-            type: {
-              kind: "object",
-              properties: [
-                {
-                  name: "city",
-                  type: { kind: "primitive", primitiveKind: "string" },
-                  optional: false,
-                  constraints: [],
-                  annotations: [],
-                  provenance: PROVENANCE,
-                },
-              ],
-              additionalProperties: true,
-            },
-            required: true,
-            constraints: [
+      const ir: FormIR = makeIR([
+        {
+          kind: "field",
+          name: "address",
+          type: {
+            kind: "object",
+            properties: [
               {
-                kind: "constraint",
-                constraintKind: "minLength",
-                value: 2,
-                path: { segments: ["city"] },
-                provenance: TSDOC_PROVENANCE,
-              },
-              {
-                kind: "constraint",
-                constraintKind: "minLength",
-                value: 1,
-                path: { segments: ["postalCode"] },
-                provenance: TSDOC_PROVENANCE,
+                name: "city",
+                type: { kind: "primitive", primitiveKind: "string" },
+                optional: false,
+                constraints: [],
+                annotations: [],
+                provenance: PROVENANCE,
               },
             ],
-            annotations: [],
-            provenance: PROVENANCE,
+            additionalProperties: true,
           },
-        ],
-        typeRegistry: {},
-        provenance: PROVENANCE,
-      };
+          required: true,
+          constraints: [
+            {
+              kind: "constraint",
+              constraintKind: "minLength",
+              value: 2,
+              path: { segments: ["city"] },
+              provenance: TSDOC_PROVENANCE,
+            },
+            {
+              kind: "constraint",
+              constraintKind: "minLength",
+              value: 1,
+              path: { segments: ["postalCode"] },
+              provenance: TSDOC_PROVENANCE,
+            },
+          ],
+          annotations: [],
+          provenance: PROVENANCE,
+        },
+      ]);
 
       const schema = generateJsonSchemaFromIR(ir);
       const address = schema.properties?.["address"] as Record<string, unknown> | undefined;
@@ -1022,31 +1004,25 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
         allOf: [{ $ref: "#/$defs/BaseMoney" }],
       });
 
-      const ir: FormIR = {
-        kind: "form-ir",
-        irVersion: IR_VERSION,
-        elements: [
-          {
-            kind: "field",
-            name: "total",
-            type: moneyNode(),
-            required: true,
-            constraints: [
-              {
-                kind: "constraint",
-                constraintKind: "minimum",
-                value: 0,
-                path: { segments: ["value"] },
-                provenance: TSDOC_PROVENANCE,
-              },
-            ],
-            annotations: [],
-            provenance: PROVENANCE,
-          },
-        ],
-        typeRegistry: {},
-        provenance: PROVENANCE,
-      };
+      const ir: FormIR = makeIR([
+        {
+          kind: "field",
+          name: "total",
+          type: moneyNode(),
+          required: true,
+          constraints: [
+            {
+              kind: "constraint",
+              constraintKind: "minimum",
+              value: 0,
+              path: { segments: ["value"] },
+              provenance: TSDOC_PROVENANCE,
+            },
+          ],
+          annotations: [],
+          provenance: PROVENANCE,
+        },
+      ]);
 
       const schema = generateJsonSchemaFromIR(ir, { extensionRegistry: registry });
       const totalProp = schema.properties?.["total"] as Record<string, unknown> | undefined;
@@ -1066,31 +1042,25 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
         allOf: [{ $ref: "#/$defs/BaseA" }, { $ref: "#/$defs/BaseB" }],
       });
 
-      const ir: FormIR = {
-        kind: "form-ir",
-        irVersion: IR_VERSION,
-        elements: [
-          {
-            kind: "field",
-            name: "total",
-            type: moneyNode(),
-            required: true,
-            constraints: [
-              {
-                kind: "constraint",
-                constraintKind: "minimum",
-                value: 0,
-                path: { segments: ["value"] },
-                provenance: TSDOC_PROVENANCE,
-              },
-            ],
-            annotations: [],
-            provenance: PROVENANCE,
-          },
-        ],
-        typeRegistry: {},
-        provenance: PROVENANCE,
-      };
+      const ir: FormIR = makeIR([
+        {
+          kind: "field",
+          name: "total",
+          type: moneyNode(),
+          required: true,
+          constraints: [
+            {
+              kind: "constraint",
+              constraintKind: "minimum",
+              value: 0,
+              path: { segments: ["value"] },
+              provenance: TSDOC_PROVENANCE,
+            },
+          ],
+          annotations: [],
+          provenance: PROVENANCE,
+        },
+      ]);
 
       const schema = generateJsonSchemaFromIR(ir, { extensionRegistry: registry });
       const totalProp = schema.properties?.["total"] as Record<string, unknown> | undefined;
@@ -1120,31 +1090,25 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
         ],
       });
 
-      const ir: FormIR = {
-        kind: "form-ir",
-        irVersion: IR_VERSION,
-        elements: [
-          {
-            kind: "field",
-            name: "total",
-            type: moneyNode(),
-            required: true,
-            constraints: [
-              {
-                kind: "constraint",
-                constraintKind: "minimum",
-                value: 0,
-                path: { segments: ["value"] },
-                provenance: TSDOC_PROVENANCE,
-              },
-            ],
-            annotations: [],
-            provenance: PROVENANCE,
-          },
-        ],
-        typeRegistry: {},
-        provenance: PROVENANCE,
-      };
+      const ir: FormIR = makeIR([
+        {
+          kind: "field",
+          name: "total",
+          type: moneyNode(),
+          required: true,
+          constraints: [
+            {
+              kind: "constraint",
+              constraintKind: "minimum",
+              value: 0,
+              path: { segments: ["value"] },
+              provenance: TSDOC_PROVENANCE,
+            },
+          ],
+          annotations: [],
+          provenance: PROVENANCE,
+        },
+      ]);
 
       const schema = generateJsonSchemaFromIR(ir, { extensionRegistry: registry });
       const totalProp = schema.properties?.["total"] as Record<string, unknown> | undefined;

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -857,6 +857,126 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
         postalCode: { minLength: 1 },
       });
     });
+
+    // -------------------------------------------------------------------------
+    // Prototype-pollution hardening
+    // -------------------------------------------------------------------------
+    //
+    // Path-targeted constraints accept arbitrary strings as path segments
+    // (they come from user TSDoc tags like `@minimum :<segment> 0`). When a
+    // segment is named `__proto__` or `constructor`, a naive `obj[segment] = ...`
+    // assignment would either invoke the `Object.prototype.__proto__` setter
+    // (dropping the constraint and mutating prototypes) or match an inherited
+    // `Object.prototype` member (mis-merging the constraint into prototype
+    // methods). Both cases are closed by:
+    //
+    //   - `buildPropertyOverrides`: null-prototype `overrides` map populated
+    //     via `Object.defineProperty`, so `__proto__`-named segments survive
+    //     as own properties all the way to Site 1.
+    //   - `applyPathTargetedConstraints` Site 1: `Object.hasOwn` +
+    //     `Object.defineProperty` on `schema.properties`, so neither
+    //     inherited-member matching nor the `__proto__` setter can trigger.
+    //
+    // @see https://github.com/mike-north/formspec/issues/382
+    describe("prototype-pollution hardening (#382)", () => {
+      it("declares a path target named `constructor` as an own property without touching Object.prototype.constructor", () => {
+        // Without `Object.hasOwn`, `"constructor" in schema.properties` would
+        // match the inherited `Object.prototype.constructor` and the override
+        // would take the existing-property branch, merging the schema into the
+        // `constructor` function. With `Object.hasOwn`, inherited members are
+        // rejected and the override lands as an own property instead.
+        const ir: FormIR = makeIR([
+          {
+            kind: "field",
+            name: "payload",
+            type: {
+              kind: "object",
+              properties: [],
+              additionalProperties: true,
+            },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minLength",
+                value: 1,
+                path: { segments: ["constructor"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ]);
+
+        const schema = generateJsonSchemaFromIR(ir);
+        const payload = schema.properties?.["payload"] as
+          | Record<string, unknown>
+          | undefined;
+        const props = payload?.["properties"] as Record<string, unknown> | undefined;
+
+        // Object.prototype.constructor still points at Object — we did not
+        // mutate or shadow the inherited method.
+        expect(Object.prototype.constructor).toBe(Object);
+        // The override landed as an own property on the properties map, not
+        // on the prototype.
+        expect(Object.hasOwn(props ?? {}, "constructor")).toBe(true);
+        expect(props?.["constructor"]).toEqual({ minLength: 1 });
+      });
+
+      it("declares a path target named `__proto__` as an own property without mutating the prototype chain", () => {
+        // Without `Object.create(null)` + `Object.defineProperty`, this test
+        // would either drop the constraint silently (plain `{}` map +
+        // bracket-assign invokes the `__proto__` setter and
+        // `Object.entries(...)` returns `[]`) or mutate `schema.properties`'s
+        // `[[Prototype]]`. The hardening produces a real own property.
+        const protoSnapshot = Object.getOwnPropertyNames(Object.prototype).sort();
+        const ir: FormIR = makeIR([
+          {
+            kind: "field",
+            name: "payload",
+            type: {
+              kind: "object",
+              properties: [],
+              additionalProperties: true,
+            },
+            required: true,
+            constraints: [
+              {
+                kind: "constraint",
+                constraintKind: "minLength",
+                value: 1,
+                path: { segments: ["__proto__"] },
+                provenance: TSDOC_PROVENANCE,
+              },
+            ],
+            annotations: [],
+            provenance: PROVENANCE,
+          },
+        ]);
+
+        const schema = generateJsonSchemaFromIR(ir);
+        const payload = schema.properties?.["payload"] as
+          | Record<string, unknown>
+          | undefined;
+        const props = payload?.["properties"] as Record<string, unknown> | undefined;
+
+        // The override landed as a real own property — Object.hasOwn returns
+        // true and the value is the expected override schema. This is the
+        // signature of a successful `Object.defineProperty` path; a plain
+        // `obj["__proto__"] = value` would have replaced [[Prototype]]
+        // instead, leaving no own property.
+        expect(Object.hasOwn(props ?? {}, "__proto__")).toBe(true);
+        expect(
+          Object.getOwnPropertyDescriptor(props, "__proto__")?.value
+        ).toEqual({ minLength: 1 });
+        // Object.prototype is untouched — the global prototype chain is not
+        // mutated as a side-effect of emission.
+        expect(Object.getOwnPropertyNames(Object.prototype).sort()).toEqual(
+          protoSnapshot
+        );
+      });
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
+++ b/packages/build/src/__tests__/ref-with-sibling-keywords.test.ts
@@ -1152,5 +1152,96 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
       // Flattening would conflict — allOf must remain.
       expect(totalProp?.["allOf"]).toBeDefined();
     });
+
+    it("retains allOf when an outer sibling keyword would collide with a member key", () => {
+      // Custom type returns an outer schema that already carries a top-level
+      // keyword (`type`) alongside its `allOf`, and the sole member declares
+      // the same keyword with a different value. Flattening would lift the
+      // member's `type` up and silently overwrite the outer's version —
+      // `tryFlattenAllOfToSiblings` must detect the outer↔member overlap and
+      // fall back to appending the override as an `allOf` member.
+      //
+      // This branch is reachable only from external `toJsonSchema` hooks
+      // (the in-tree emitter never produces outer keywords beside allOf),
+      // so without this test a regression in the outer↔member check would
+      // go unnoticed.
+      const registry = makeCustomTypeRegistry({
+        type: "object",
+        allOf: [{ type: "string" }],
+      });
+
+      const ir: FormIR = makeIR([
+        {
+          kind: "field",
+          name: "total",
+          type: moneyNode(),
+          required: true,
+          constraints: [
+            {
+              kind: "constraint",
+              constraintKind: "minimum",
+              value: 0,
+              path: { segments: ["value"] },
+              provenance: TSDOC_PROVENANCE,
+            },
+          ],
+          annotations: [],
+          provenance: PROVENANCE,
+        },
+      ]);
+
+      const schema = generateJsonSchemaFromIR(ir, { extensionRegistry: registry });
+      const totalProp = schema.properties?.["total"] as Record<string, unknown> | undefined;
+
+      // Flattening would clobber `type: "object"` with `type: "string"` —
+      // allOf must remain.
+      expect(totalProp?.["allOf"]).toBeDefined();
+      // Outer `type` is preserved as a top-level sibling (not replaced by
+      // the member's value).
+      expect(totalProp?.["type"]).toBe("object");
+    });
+
+    it("retains allOf when an outer sibling keyword would collide with the override key", () => {
+      // Custom type returns an outer schema carrying `properties` alongside
+      // its `allOf`, and the path-targeted override also contributes
+      // `properties`. Flattening would lift the member up and then overwrite
+      // the outer's `properties` with the override — losing the outer's
+      // declared members. `tryFlattenAllOfToSiblings` must detect the
+      // outer↔override overlap and fall back to appending to `allOf`.
+      const registry = makeCustomTypeRegistry({
+        properties: { currency: { type: "string" } },
+        allOf: [{ $ref: "#/$defs/BaseMoney" }],
+      });
+
+      const ir: FormIR = makeIR([
+        {
+          kind: "field",
+          name: "total",
+          type: moneyNode(),
+          required: true,
+          constraints: [
+            {
+              kind: "constraint",
+              constraintKind: "minimum",
+              value: 0,
+              path: { segments: ["value"] },
+              provenance: TSDOC_PROVENANCE,
+            },
+          ],
+          annotations: [],
+          provenance: PROVENANCE,
+        },
+      ]);
+
+      const schema = generateJsonSchemaFromIR(ir, { extensionRegistry: registry });
+      const totalProp = schema.properties?.["total"] as Record<string, unknown> | undefined;
+
+      // Flattening would clobber the outer's `properties.currency` with the
+      // override's `properties.value` — allOf must remain.
+      expect(totalProp?.["allOf"]).toBeDefined();
+      // Outer `properties.currency` survives as a top-level sibling,
+      // unmodified by the override contribution.
+      expect(totalProp?.["properties"]).toEqual({ currency: { type: "string" } });
+    });
   });
 });

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -949,13 +949,27 @@ function buildPropertyOverrides(
     byTarget.set(target, grouped);
   }
 
-  const overrides: Record<string, JsonSchema2020> = {};
+  // Null-prototype map so path-targeted keys like `__proto__` or `constructor`
+  // become own properties rather than invoking Object.prototype setters or
+  // matching inherited members. This is the upstream half of the
+  // prototype-pollution hardening at Site 1 in `applyPathTargetedConstraints`:
+  // without it, `overrides["__proto__"] = ...` replaces this map's own
+  // [[Prototype]] and `Object.entries(overrides)` yields `[]`, silently
+  // dropping the constraint before the Site 1 guard can run.
+  const overrides = Object.create(null) as Record<string, JsonSchema2020>;
   for (const [target, constraints] of byTarget) {
-    overrides[resolveSerializedPropertyName(target, typeNode, ctx)] = buildPathOverrideSchema(
+    const resolvedName = resolveSerializedPropertyName(target, typeNode, ctx);
+    const schema = buildPathOverrideSchema(
       constraints.map(stripLeadingPathSegment),
       resolveTargetTypeNode(target, typeNode, ctx),
       ctx
     );
+    Object.defineProperty(overrides, resolvedName, {
+      value: schema,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
   }
 
   return overrides;
@@ -1071,11 +1085,27 @@ function mergeSchemaOverride(target: JsonSchema2020, override: JsonSchema2020): 
   }
 
   if (override.properties !== undefined) {
-    const mergedProperties = target.properties ?? {};
+    // Fresh maps use a null prototype so `__proto__`-named path segments can
+    // land as own properties. Existing maps are preserved as-is — when they
+    // came from `buildPropertyOverrides` they are already null-prototype; when
+    // they came from an external `toJsonSchema` hook they are a plain object
+    // whose own-property shape we do not modify.
+    const mergedProperties =
+      target.properties ?? (Object.create(null) as Record<string, JsonSchema2020>);
     for (const [name, propertyOverride] of Object.entries(override.properties)) {
-      const existing = mergedProperties[name];
+      const existing = Object.hasOwn(mergedProperties, name)
+        ? mergedProperties[name]
+        : undefined;
       if (existing === undefined) {
-        mergedProperties[name] = propertyOverride;
+        // `defineProperty` bypasses the `__proto__` setter on regular-prototype
+        // maps; safe no-op on null-prototype maps. See the hardening comment
+        // at Site 1 in `applyPathTargetedConstraints` for the full rationale.
+        Object.defineProperty(mergedProperties, name, {
+          value: propertyOverride,
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
       } else {
         mergeSchemaOverride(existing, propertyOverride);
       }
@@ -1095,7 +1125,17 @@ function mergeSchemaOverride(target: JsonSchema2020, override: JsonSchema2020): 
     if (key === "properties" || key === "items") {
       continue;
     }
-    (target as Record<string, unknown>)[key] = value;
+    // `defineProperty` guards against the same prototype-pollution vector as
+    // the nested-properties branch above, for completeness. Schema keywords
+    // like `minimum`/`type` are never `__proto__`, but callers reach this
+    // code path through recursion from path-targeted overrides where the
+    // boundary is not locally enforceable.
+    Object.defineProperty(target, key, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
   }
 }
 

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -507,10 +507,15 @@ function applyPathTargetedConstraints(
   // the override. (Fixes #382 Site 1.)
   if (schema.type === "object" && schema.properties) {
     for (const [target, overrideSchema] of Object.entries(propertyOverrides)) {
-      // Own-property check + defineProperty guard against prototype-pollution
-      // vectors (e.g. `__proto__`, `constructor`) if a path-targeted override
-      // ever names one of those keys. Using `in` or `[target]` assignment
-      // would traverse / mutate Object.prototype.
+      // Own-property lookup + defineProperty guard against prototype-pollution
+      // vectors when a path target names a key like `__proto__`:
+      //   - Plain `obj[target] = value` assignment with target === "__proto__"
+      //     invokes the Object.prototype `__proto__` setter, replacing the
+      //     object's [[Prototype]] instead of adding an own property.
+      //   - `Object.defineProperty` bypasses the setter and writes an own
+      //     data property, so the override lands where we expect.
+      // `Object.hasOwn` (not `in`) rejects inherited members like
+      // `constructor`, avoiding a mis-merge into Object.prototype.constructor.
       if (Object.hasOwn(schema.properties, target)) {
         const existing = schema.properties[target];
         if (existing) {
@@ -1003,10 +1008,14 @@ function buildPathOverrideSchema(
  * would silently overwrite one contribution), returns `undefined` and the
  * caller falls back to appending an `allOf` member.
  *
- * The single-member restriction reflects what the emitter produces today
- * (external `toJsonSchema` hooks may legitimately return single-member
- * `allOf` for wrapping). Generalising to N-member flattening is possible
- * via pairwise key-disjointness but is not needed by any current caller.
+ * The single-member restriction is a conservative scope choice, not a
+ * JSON Schema 2020-12 semantic constraint. In-tree emission paths only
+ * ever produce single-member `allOf` wrappers. Multi-member `allOf`
+ * reaches this helper only from user-supplied `toJsonSchema` hooks,
+ * where the multiple members typically represent intentional composition
+ * that should not be silently flattened. Pairwise-disjoint N-member
+ * flattening is semantically valid but is not performed today because
+ * no current producer requires it.
  *
  * Mirrors the `$ref`-sibling fix at `ir-generator.ts:492-497` (issue #364).
  *

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -496,32 +496,39 @@ function applyPathTargetedConstraints(
     };
   }
 
-  // Inline object schema: merge property overrides directly where possible.
+  // Inline object schema: merge property overrides directly into siblings.
+  //
+  // Previously missing-property overrides were composed via `allOf` to keep
+  // `additionalProperties` semantics intact. JSON Schema 2020-12 (§10.2.1)
+  // lets us express this as a single flat object: merge the override into
+  // `properties` (which legitimizes the key even under
+  // `additionalProperties: false`) and preserve `additionalProperties`/`type`
+  // as siblings. Downstream renderers that do not unwrap `allOf` can now see
+  // the override. (Fixes #382 Site 1.)
   if (schema.type === "object" && schema.properties) {
-    const missingOverrides: Record<string, JsonSchema2020> = {};
-
     for (const [target, overrideSchema] of Object.entries(propertyOverrides)) {
-      if (schema.properties[target]) {
-        mergeSchemaOverride(schema.properties[target], overrideSchema);
+      const existing = schema.properties[target];
+      if (existing) {
+        mergeSchemaOverride(existing, overrideSchema);
       } else {
-        // Do not introduce new properties directly; compose via allOf instead
-        // to preserve additionalProperties semantics on the base object.
-        missingOverrides[target] = overrideSchema;
+        schema.properties[target] = overrideSchema;
       }
     }
-
-    if (Object.keys(missingOverrides).length === 0) {
-      return schema;
-    }
-
-    return {
-      allOf: [schema, { properties: missingOverrides }],
-    };
+    return schema;
   }
 
-  // allOf schema (already composed): add property overrides as another member.
+  // Pre-composed allOf base: flatten to siblings when the composition is
+  // expressible that way under 2020-12; otherwise append as a new allOf
+  // member. Expressible-as-siblings means the allOf has a single member whose
+  // keys do not conflict with the override's keys (mirrors the $ref-sibling
+  // fix in #365 above). (Fixes #382 Site 2.)
   if (schema.allOf) {
-    schema.allOf = [...schema.allOf, { properties: propertyOverrides }];
+    const overrideMember: JsonSchema2020 = { properties: propertyOverrides };
+    const flattened = tryFlattenAllOfToSiblings(schema, overrideMember);
+    if (flattened !== undefined) {
+      return flattened;
+    }
+    schema.allOf = [...schema.allOf, overrideMember];
     return schema;
   }
 
@@ -969,6 +976,65 @@ function buildPathOverrideSchema(
 
   schema.properties = buildPropertyOverrides(nestedConstraints, effectiveType, ctx);
   return schema;
+}
+
+/**
+ * Attempts to flatten a pre-composed `allOf` schema into sibling keywords
+ * when the JSON Schema 2020-12 evaluation semantics allow it.
+ *
+ * Flattening is safe when the allOf has **exactly one** member and that
+ * member's keys do not collide with either the outer schema's keys or the
+ * new override member's keys. In that case we lift the single member's
+ * keys up alongside the outer schema and attach the override as siblings —
+ * producing `{ <outer keys...>, <member keys...>, <override keys...> }`.
+ *
+ * When flattening is not safe (multiple members, or key collisions that
+ * would silently overwrite one contribution), returns `undefined` and the
+ * caller falls back to appending an `allOf` member.
+ *
+ * Mirrors the `$ref`-sibling fix at `ir-generator.ts:492-497` (issue #364).
+ *
+ * @see https://github.com/mike-north/formspec/issues/382 Site 2
+ * @see https://json-schema.org/draft/2020-12/json-schema-core — §10.2.1 sibling keywords
+ */
+function tryFlattenAllOfToSiblings(
+  schema: JsonSchema2020,
+  overrideMember: JsonSchema2020
+): JsonSchema2020 | undefined {
+  if (schema.allOf?.length !== 1) {
+    return undefined;
+  }
+
+  const [soleMember] = schema.allOf;
+  if (soleMember === undefined) {
+    return undefined;
+  }
+
+  // Outer schema sans allOf — what the siblings would sit next to.
+  const { allOf: _allOf, ...outerRest } = schema;
+
+  const outerKeys = new Set(Object.keys(outerRest));
+  const memberKeys = Object.keys(soleMember);
+  const overrideKeys = Object.keys(overrideMember);
+
+  // Any overlap between the three contributions would silently overwrite
+  // one side — keep `allOf` to preserve both under 2020-12 evaluation.
+  for (const key of memberKeys) {
+    if (outerKeys.has(key) || overrideKeys.includes(key)) {
+      return undefined;
+    }
+  }
+  for (const key of overrideKeys) {
+    if (outerKeys.has(key)) {
+      return undefined;
+    }
+  }
+
+  return {
+    ...outerRest,
+    ...soleMember,
+    ...overrideMember,
+  };
 }
 
 function mergeSchemaOverride(target: JsonSchema2020, override: JsonSchema2020): void {

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -1093,9 +1093,7 @@ function mergeSchemaOverride(target: JsonSchema2020, override: JsonSchema2020): 
     const mergedProperties =
       target.properties ?? (Object.create(null) as Record<string, JsonSchema2020>);
     for (const [name, propertyOverride] of Object.entries(override.properties)) {
-      const existing = Object.hasOwn(mergedProperties, name)
-        ? mergedProperties[name]
-        : undefined;
+      const existing = Object.hasOwn(mergedProperties, name) ? mergedProperties[name] : undefined;
       if (existing === undefined) {
         // `defineProperty` bypasses the `__proto__` setter on regular-prototype
         // maps; safe no-op on null-prototype maps. See the hardening comment

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -992,6 +992,11 @@ function buildPathOverrideSchema(
  * would silently overwrite one contribution), returns `undefined` and the
  * caller falls back to appending an `allOf` member.
  *
+ * The single-member restriction reflects what the emitter produces today
+ * (external `toJsonSchema` hooks may legitimately return single-member
+ * `allOf` for wrapping). Generalising to N-member flattening is possible
+ * via pairwise key-disjointness but is not needed by any current caller.
+ *
  * Mirrors the `$ref`-sibling fix at `ir-generator.ts:492-497` (issue #364).
  *
  * @see https://github.com/mike-north/formspec/issues/382 Site 2
@@ -1005,6 +1010,7 @@ function tryFlattenAllOfToSiblings(
     return undefined;
   }
 
+  // Defensive-only; required under `noUncheckedIndexedAccess`.
   const [soleMember] = schema.allOf;
   if (soleMember === undefined) {
     return undefined;
@@ -1014,13 +1020,13 @@ function tryFlattenAllOfToSiblings(
   const { allOf: _allOf, ...outerRest } = schema;
 
   const outerKeys = new Set(Object.keys(outerRest));
-  const memberKeys = Object.keys(soleMember);
-  const overrideKeys = Object.keys(overrideMember);
+  const memberKeys = new Set(Object.keys(soleMember));
+  const overrideKeys = new Set(Object.keys(overrideMember));
 
   // Any overlap between the three contributions would silently overwrite
   // one side — keep `allOf` to preserve both under 2020-12 evaluation.
   for (const key of memberKeys) {
-    if (outerKeys.has(key) || overrideKeys.includes(key)) {
+    if (outerKeys.has(key) || overrideKeys.has(key)) {
       return undefined;
     }
   }

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -507,12 +507,23 @@ function applyPathTargetedConstraints(
   // the override. (Fixes #382 Site 1.)
   if (schema.type === "object" && schema.properties) {
     for (const [target, overrideSchema] of Object.entries(propertyOverrides)) {
-      const existing = schema.properties[target];
-      if (existing) {
-        mergeSchemaOverride(existing, overrideSchema);
-      } else {
-        schema.properties[target] = overrideSchema;
+      // Own-property check + defineProperty guard against prototype-pollution
+      // vectors (e.g. `__proto__`, `constructor`) if a path-targeted override
+      // ever names one of those keys. Using `in` or `[target]` assignment
+      // would traverse / mutate Object.prototype.
+      if (Object.hasOwn(schema.properties, target)) {
+        const existing = schema.properties[target];
+        if (existing) {
+          mergeSchemaOverride(existing, overrideSchema);
+          continue;
+        }
       }
+      Object.defineProperty(schema.properties, target, {
+        value: overrideSchema,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
     return schema;
   }


### PR DESCRIPTION
## Summary

Follow-up to #365 (which fixed #364). Replaces the two remaining `allOf` emission sites in `packages/build/src/json-schema/ir-generator.ts` with flat sibling-keyword shapes, so downstream renderers that don't unwrap `allOf` (e.g. the Stripe dashboard renderer) see the path-targeted overrides.

### Site 1 — inline-object missing-property fallback

Previously wrapped the base in `allOf: [schema, { properties: missingOverrides }]`. Now merges missing overrides directly into `schema.properties` alongside any existing overrides. Under JSON Schema 2020-12, declaring a key in `properties` legitimizes it even under `additionalProperties: false`, so the old composition was unnecessary.

### Site 2 — pre-composed `allOf` append

Previously appended `{ properties: propertyOverrides }` as another `allOf` member. Now flattens to sibling keywords when safe — via a new helper `tryFlattenAllOfToSiblings` — and falls back to the old `allOf` append only when the composition genuinely cannot be expressed as siblings (multiple members, or a key collision that would silently overwrite a contribution).

## Acceptance criteria (from #382)

- [x] Site 1: single flat object, no `allOf`, `additionalProperties` semantics preserved
- [x] Site 2: flatten to siblings when expressible; retain `allOf` only for genuine non-sibling composition
- [x] Regression coverage in `ref-with-sibling-keywords.test.ts` (6 new tests covering both sites, both flatten and fallback paths)
- [x] Matches spec doc 003 §5.4 / §7.2 (and JSON Schema 2020-12 §10.2.1)

## Test plan

- [x] `pnpm run build` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm --filter @formspec/build run test` — 867 passed, 4 skipped (pre-existing)
- [x] New regression suite in `ref-with-sibling-keywords.test.ts` passes and fails against pre-fix code (every key assertion is `expect(allOf).toBeUndefined()`)

## Reviewer notes

Reviewed in parallel by typescript-expert, simplicity-expert, testing-expert, code-quality-expert, and system-architect. Nits applied in a follow-up commit:
- Use `Set` for the override-key collision check (O(1) vs O(n))
- JSDoc note explaining the single-member restriction reflects current emitter/external-hook usage rather than a 2020-12 semantic limit
- Annotate the `noUncheckedIndexedAccess`-required undefined guard

The architect flagged a medium-severity "missed unification opportunity": the three sibling-keyword sites (#365's `$ref`, Site 1, Site 2) could share a single `composeAsSiblings` primitive. Deferred as a follow-up — the current shapes are different enough that forcing a shared helper would hurt readability today.

Closes #382.