### PR TITLE
docs(002): spec coverage for @format inheritance through extends heritage (#378)

### DIFF
--- a/.changeset/docs-378-format-inheritance-spec.md
+++ b/.changeset/docs-378-format-inheritance-spec.md
@@ -1,0 +1,8 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Document `@format` inheritance through `extends` heritage in `docs/002-tsdoc-grammar.md`. The new "Inheritance through `extends` heritage" subsection under `@format` covers the inheritable-kinds allow-list, heritage-clause scope (`extends` yes, `implements` no), the "nearest annotation by BFS wins, ties broken by declaration order" precedence rule, empty-payload non-override semantics, a worked asymmetric-diamond example, and known limitations (derived-side type-alias case tracked in #374; allow-list expansion tracked in #380). No code change.

--- a/docs/002-tsdoc-grammar.md
+++ b/docs/002-tsdoc-grammar.md
@@ -502,6 +502,49 @@ Unknown format values are accepted (with an info diagnostic D4) for extensibilit
 
 **Note on read-only fields:** TypeScript's `readonly` modifier already conveys read-only semantics and is inferred by the analyzer (PP2). A separate `@readOnly` tag is unnecessary. `@writeOnly` is a rare use case that can be added in a future version if demand materializes.
 
+##### Inheritance through `extends` heritage
+
+Type-level `@format` flows from a base declaration to a derived class or interface along `extends` clauses. This lets authors declare a semantic format once on a domain base and have every derived narrowing type carry it through without repetition.
+
+**Allow-list:** Only a curated set of type-level annotations inherit through heritage. The current membership is `{ @format }`. Other type-level annotations — `@remarks`, `@deprecated`, `@displayName`, `@placeholder`, `@defaultValue`, `@description` (via summary text) — do **not** inherit through `extends`. The allow-list is intentionally narrow; expanding it is a deliberate spec decision, not a silent side effect of touching the walker.
+
+**Scope — `extends` only:**
+
+- Interface `extends` interface / class `extends` class: `@format` on the base flows to the derived type's `$defs` entry.
+- Interface `extends` type-alias (whose resolved type is object-shaped or an intersection): `@format` on the type alias flows to the derived interface's `$defs` entry. The walker follows the alias's RHS when it is a type reference, so aliases-of-interfaces and multi-level alias chains are covered.
+- Class `implements` interface: annotations do **not** inherit. `implements` is a structural-conformance assertion, not a semantic-adoption declaration, and silently merging annotations across unrelated nominal types would be misleading.
+
+**Precedence — "nearest annotation by BFS wins, ties broken by declaration order":**
+
+The analyzer walks the heritage graph breadth-first from the derived type. The walker maintains a shared `seen` set, so each declaration is visited at most once. As annotations are found, the kinds that still need values are tracked in a `needed` set; once a kind is filled, the walker never overwrites it later in the walk.
+
+Consequences:
+
+1. A shallower annotation always beats a deeper one. If a directly-listed base provides `@format`, deeper ancestors reachable through an earlier-listed but un-annotated base do **not** overwrite it.
+2. At equal depth, declaration order in the `extends` clause is the tie-breaker — the first-listed base's `@format` wins.
+3. A local `@format` on the derived type always wins — inheritance only fills in missing kinds on the derived declaration itself.
+4. A local `@format` with an empty or whitespace-only value is **not** an override; the base-declared value still flows through. This lets authors retain the tag's location (for intent signaling) without dropping the inherited value.
+
+**Worked example (asymmetric diamond):**
+
+```ts
+/** @format deep-A */
+interface A {}
+
+interface B extends A {} // no local @format
+
+/** @format direct-C */
+interface C {}
+
+interface D extends B, C {}
+// D.format === "direct-C"  — C is directly listed at depth 1, A is depth 2
+```
+
+**Known limitations:**
+
+- The inheritance walker targets the case where the *derived* declaration is a class or interface. When the *derived* declaration is itself a type alias — e.g. `type Derived = Base` — the walker never runs and `@format` on the base does not propagate to a `$defs` entry for `Derived`. Tracked in [issue #374](https://github.com/mike-north/formspec/issues/374).
+- Only `@format` currently participates. Proposals to broaden the allow-list should address override semantics, conflict resolution, and emission coverage for each new kind (see [issue #380](https://github.com/mike-north/formspec/issues/380)).
+
 #### `@defaultValue`
 
 ```


### PR DESCRIPTION
## Summary

Fixes [#378](https://github.com/mike-north/formspec/issues/378). The user-visible semantic added in #369 (and extended in #385 to cover type-alias bases) — `@format` flowing from a base declaration to a derived class/interface through `extends` — was documented only in test and source comments. This PR adds a spec-doc section so the behavior is discoverable without reading the implementation.

## Change

New subsection in [`docs/002-tsdoc-grammar.md`](docs/002-tsdoc-grammar.md) under `@format`: **"Inheritance through `extends` heritage"**. Covers:

- **Allow-list** — `INHERITABLE_TYPE_ANNOTATION_KINDS` is `{ @format }` today; other type-level annotations (`@remarks`, `@deprecated`, `@displayName`, `@placeholder`, `@defaultValue`, `@description` via summary) do NOT inherit. Expansion is a deliberate spec decision.
- **Scope** — class/interface `extends` class/interface: yes. Interface `extends` object-shaped type-alias (post #385): yes. Class `implements` interface: no.
- **Precedence** — "nearest annotation by BFS wins, with ties broken by declaration order in the `extends` clause" (aligned with the test-docs clarification in [#388](https://github.com/mike-north/formspec/pull/388)).
- **Override semantics** — local `@format` on the derived type wins; an empty/whitespace-only payload is NOT an override (base value still flows through).
- **Worked example** — asymmetric diamond (Case D) showing why a directly-listed base's annotation beats a deeper ancestor of an earlier-listed base.
- **Known limitations** — derived-side-type-alias case ([#374](https://github.com/mike-north/formspec/issues/374)); allow-list expansion proposal criteria ([#380](https://github.com/mike-north/formspec/issues/380)).

## Scope note

No code change. The spec doc ratifies behavior already implemented and tested; it does not propose new semantics.

Docs/003 is also listed as a candidate location in the issue but has no existing `@format` or heritage-inheritance section to extend; its role is JSON-Schema vocabulary rather than TSDoc-source-of-truth, so adding inheritance coverage there would duplicate 002. Left for a future revision if JSON-Schema-side emission semantics need their own coverage.

## Test plan

- [x] `pnpm run clean && pnpm install && pnpm run build && pnpm run lint && pnpm run test && pnpm run test:e2e` — green (docs-only change; no behavior impact).
- [x] Rebased onto current `origin/main` (includes #385).