### PR TITLE
fix(e2e): stabilize vitest worker RPC under CI load

### DIFF
--- a/e2e/tests/cli-subprocess.test.ts
+++ b/e2e/tests/cli-subprocess.test.ts
@@ -23,10 +23,8 @@ export class SecondaryReport {
     tempDir = fs.mkdtempSync(path.join(__dirname, "..", ".cli-subprocess-"));
   });
 
-  afterAll(() => {
-    if (fs.existsSync(tempDir)) {
-      fs.rmSync(tempDir, { recursive: true });
-    }
+  afterAll(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 
   describe("help", () => {

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -5,5 +5,17 @@ export default defineConfig({
     hookTimeout: 60_000,
     testTimeout: 30_000,
     include: ["tests/**/*.test.ts"],
+    // Cap worker concurrency. The suite spawns long-running CLI subprocesses
+    // (cli-subprocess.test.ts alone takes ~67s). With the default parallelism
+    // on GitHub runners, the main process gets saturated with onTaskUpdate RPC
+    // calls from many workers at once and birpc's 60s call timeout can fire.
+    // Capping maxForks relieves main-process RPC pressure.
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks: 2,
+        minForks: 1,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

Fixes the intermittent e2e CI failure where all 272 tests pass but the run exits 1 with:

\`\`\`
Error: [vitest-worker]: Timeout calling "onTaskUpdate"
\`\`\`

Observed 3x in a row on #356 (runs 24700897501 / 24701718208 / 24706924309).

## Root cause

- \`cli-subprocess.test.ts\` runs 20 sequential CLI subprocess tests totaling ~67s — alone this exceeds birpc's hardcoded 60s RPC timeout.
- With default parallelism on the 4-core \`ubuntu-latest\` runner, ~4 workers all post \`onTaskUpdate\` calls to the main process at once. Under saturation, a worker's ack misses the 60s window and throws after all tests have passed.
- Already on the latest 3.x patch (3.2.4); upgrading isn't an option until a Vitest 4 bump.

## Fix

Two small, targeted changes:

1. **`e2e/vitest.config.ts`** — cap `maxForks: 2`. Halves concurrent RPC pressure on the main process so acks return within the 60s window.
2. **`e2e/tests/cli-subprocess.test.ts`** — replace sync `fs.rmSync` with async `fs.promises.rm` in `afterAll`. Keeps the worker event loop responsive during teardown so it can keep servicing RPC.

## Test plan

- [x] `pnpm exec vitest run` passes locally 3× in a row (34 files, ~23s each) with no RPC timeout.
- [x] `pnpm -w run typecheck` clean.
- [x] `pnpm -w run lint` clean.
- [ ] CI on this branch passes; rerun a few times to confirm stability.

## References

- [vitest-dev/vitest#4497](https://github.com/vitest-dev/vitest/issues/4497) — birpc \`onTaskUpdate\` timeout on CI under load
- [vitest-dev/vitest#6479](https://github.com/vitest-dev/vitest/issues/6479)
- [vitest-dev/vitest#8164](https://github.com/vitest-dev/vitest/issues/8164)