### PR TITLE
fix(analysis): restore TYPE_MISMATCH for batch-level TS diagnostics (#384 follow-up)

### DIFF
--- a/.changeset/pr-384-followup-global-ts-diagnostics.md
+++ b/.changeset/pr-384-followup-global-ts-diagnostics.md
@@ -1,0 +1,13 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Restore emission of `TYPE_MISMATCH` diagnostics for batch-level synthetic TypeScript errors.
+
+The Phase 4 Slice C refactor (#384) unintentionally dropped the emission of `kind: "typescript"` diagnostics from `batchCheck.globalDiagnostics` — any TypeScript diagnostic produced by the synthetic check that had no source position or fell outside every tag application's line range was silently dropped instead of surfacing as `TYPE_MISMATCH`. This restores the emission via a new `_mapGlobalSyntheticTsDiagnostics` helper, anchored at a span covering every tag application in the batch. Setup-kind globals continue to be pre-emitted at the file-level span by the snapshot entry path and are filtered out of this secondary emission to prevent double-surface.

--- a/packages/analysis/src/__tests__/map-global-synthetic-ts-diagnostics.test.ts
+++ b/packages/analysis/src/__tests__/map-global-synthetic-ts-diagnostics.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for `_mapGlobalSyntheticTsDiagnostics` in `file-snapshots.ts`.
+ *
+ * Regression coverage for post-merge review feedback on PR #384: the Phase 4
+ * Slice C refactor unintentionally dropped the emission of TS-kind global
+ * diagnostics from the synthetic batch check — any TypeScript diagnostic in
+ * `batchCheck.globalDiagnostics` (no file/start info or outside every tag
+ * application's line range) used to surface as `TYPE_MISMATCH` and disappeared
+ * from snapshots after the relocation.
+ *
+ * The helper:
+ *   1. Passes through `kind: "typescript"` globals as `TYPE_MISMATCH`
+ *      diagnostics anchored at the supplied span.
+ *   2. Drops setup-kind globals (`synthetic-setup`,
+ *      `unsupported-custom-type-override`), which the snapshot entry path
+ *      pre-emits at the file-level span via `_validateExtensionSetup`.
+ *   3. Threads `typescriptDiagnosticCode` into `data` only when the diagnostic
+ *      code is positive (negative/zero codes come from synthetic wrapper
+ *      paths and are not real TS codes).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { SyntheticCompilerDiagnostic } from "../compiler-signatures.js";
+import { _mapGlobalSyntheticTsDiagnostics } from "../file-snapshots.js";
+
+const ANCHOR_SPAN = { start: 10, end: 42 };
+
+function tsGlobal(message: string, code = 2322): SyntheticCompilerDiagnostic {
+  return { kind: "typescript", code, message };
+}
+
+function setupGlobal(
+  kind: "synthetic-setup" | "unsupported-custom-type-override",
+  message: string
+): SyntheticCompilerDiagnostic {
+  return { kind, code: -1, message };
+}
+
+describe("_mapGlobalSyntheticTsDiagnostics", () => {
+  it("maps every kind: 'typescript' diagnostic to a TYPE_MISMATCH analysis diagnostic", () => {
+    const globals = [tsGlobal("Type 'string' is not assignable to type 'number'.")];
+    const result = _mapGlobalSyntheticTsDiagnostics(globals, ANCHOR_SPAN, {});
+    expect(result).toHaveLength(1);
+    expect(result[0]?.code).toBe("TYPE_MISMATCH");
+    expect(result[0]?.message).toBe(
+      "Type 'string' is not assignable to type 'number'."
+    );
+    expect(result[0]?.range).toEqual(ANCHOR_SPAN);
+  });
+
+  it("drops setup-kind globals (pre-emitted at file level by the snapshot entry path)", () => {
+    const globals = [
+      setupGlobal("synthetic-setup", 'Invalid custom type name "Not A Type"'),
+      setupGlobal("unsupported-custom-type-override", "Override of Array is not supported"),
+    ];
+    const result = _mapGlobalSyntheticTsDiagnostics(globals, ANCHOR_SPAN, {});
+    expect(result).toHaveLength(0);
+  });
+
+  it("preserves TS-kind emissions while dropping interleaved setup-kind globals", () => {
+    const globals = [
+      setupGlobal("synthetic-setup", "first"),
+      tsGlobal("real TS error", 2345),
+      setupGlobal("unsupported-custom-type-override", "second"),
+      tsGlobal("another TS error"),
+    ];
+    const result = _mapGlobalSyntheticTsDiagnostics(globals, ANCHOR_SPAN, {});
+    expect(result).toHaveLength(2);
+    expect(result.map((d) => d.message)).toEqual([
+      "real TS error",
+      "another TS error",
+    ]);
+    expect(result.every((d) => d.code === "TYPE_MISMATCH")).toBe(true);
+  });
+
+  it("threads typescriptDiagnosticCode into data only when code > 0", () => {
+    const globals = [
+      tsGlobal("has real code", 2345),
+      tsGlobal("has zero code", 0),
+      tsGlobal("has negative code", -1),
+    ];
+    const result = _mapGlobalSyntheticTsDiagnostics(globals, ANCHOR_SPAN, {
+      placement: "class-field",
+    });
+    expect(result).toHaveLength(3);
+    expect(result[0]?.data).toMatchObject({
+      placement: "class-field",
+      typescriptDiagnosticCode: 2345,
+    });
+    expect(result[1]?.data).toEqual({ placement: "class-field" });
+    expect(result[2]?.data).toEqual({ placement: "class-field" });
+  });
+
+  it("merges caller-provided data (placement, tagNames) with the TS-code field", () => {
+    const globals = [tsGlobal("error", 2322)];
+    const result = _mapGlobalSyntheticTsDiagnostics(globals, ANCHOR_SPAN, {
+      placement: "type-alias",
+      tagNames: ["@minimum", "@maximum"],
+    });
+    expect(result[0]?.data).toEqual({
+      placement: "type-alias",
+      tagNames: ["@minimum", "@maximum"],
+      typescriptDiagnosticCode: 2322,
+    });
+  });
+
+  it("returns an empty array when given an empty globals list", () => {
+    expect(_mapGlobalSyntheticTsDiagnostics([], ANCHOR_SPAN, {})).toEqual([]);
+  });
+});

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -5,6 +5,7 @@ import {
   _validateExtensionSetup,
   checkSyntheticTagApplicationsDetailed,
   lowerTagApplicationToSyntheticCall,
+  type SyntheticCompilerDiagnostic,
 } from "./compiler-signatures.js";
 import {
   extractCommentBlockTagTexts,
@@ -1310,6 +1311,69 @@ function buildDiscriminatorDiagnostics(
   return diagnostics;
 }
 
+/**
+ * Combines a sequence of comment spans into a single span covering from the
+ * first span's start to the last span's end. Returns `null` when the input is
+ * empty (no meaningful span to anchor a diagnostic at).
+ *
+ * Used to anchor batch-level (global) synthetic diagnostics at a span that
+ * covers every tag application in a batch — the diagnostic is not tied to any
+ * single application, so the combined span is the closest meaningful location.
+ */
+function combineCommentSpans(spans: readonly CommentSpan[]): CommentSpan | null {
+  const firstSpan = spans[0];
+  if (firstSpan === undefined) {
+    return null;
+  }
+  return {
+    start: firstSpan.start,
+    end: spans[spans.length - 1]?.end ?? firstSpan.end,
+  };
+}
+
+/**
+ * Maps `kind: "typescript"` global synthetic diagnostics to
+ * `TYPE_MISMATCH`-coded {@link FormSpecAnalysisDiagnostic}s anchored at the
+ * given span.
+ *
+ * Setup-kind globals (`unsupported-custom-type-override`, `synthetic-setup`)
+ * are pre-emitted at the file-level span by
+ * {@link buildFormSpecAnalysisFileSnapshot} via `_validateExtensionSetup`
+ * before tag diagnostics run, so this helper filters them out to prevent
+ * double-emission.
+ *
+ * TS-kind globals arise when the synthetic TypeScript program produces a
+ * diagnostic that either (a) has no file/start position or (b) falls outside
+ * every tag application's line range — see `mapBatchDiagnostics` in
+ * `compiler-signatures.ts`. These used to surface as `TYPE_MISMATCH` before
+ * Phase 4 Slice C; the original refactor removed the emission path by
+ * mistake. Restoring it closes the silent-drop regression flagged in
+ * post-merge review feedback for #384.
+ *
+ * @internal
+ */
+export function _mapGlobalSyntheticTsDiagnostics(
+  globalDiagnostics: readonly SyntheticCompilerDiagnostic[],
+  anchorSpan: CommentSpan,
+  data: FormSpecAnalysisDiagnostic["data"]
+): FormSpecAnalysisDiagnostic[] {
+  const result: FormSpecAnalysisDiagnostic[] = [];
+  for (const diagnostic of globalDiagnostics) {
+    if (diagnostic.kind !== "typescript") {
+      // Setup-kind globals are already emitted at the file-level span by the
+      // snapshot entry path. Skip to avoid double-emission.
+      continue;
+    }
+    result.push(
+      createAnalysisDiagnostic("TYPE_MISMATCH", diagnostic.message, anchorSpan, {
+        ...data,
+        ...(diagnostic.code > 0 ? { typescriptDiagnosticCode: diagnostic.code } : {}),
+      })
+    );
+  }
+  return result;
+}
+
 function buildTagDiagnostics(
   node: ts.Node,
   sourceFile: ts.SourceFile,
@@ -1706,6 +1770,26 @@ function buildTagDiagnostics(
         })
       );
     }
+  }
+
+  // §4 Phase 4 Slice C follow-up — batch-level diagnostics that were not tied
+  // to any single application (either position-less or outside all tag line
+  // ranges; see `mapBatchDiagnostics` in `compiler-signatures.ts`) previously
+  // surfaced as TYPE_MISMATCH. Emission was dropped by the original refactor
+  // and is restored here. Setup-kind globals are filtered out because they
+  // are pre-emitted at the file-level span by the snapshot entry path.
+  const globalAnchorSpan = combineCommentSpans(
+    syntheticApplications.map((application) => application.tag.fullSpan)
+  );
+  if (globalAnchorSpan !== null && batchCheck.globalDiagnostics.length > 0) {
+    diagnostics.push(
+      ..._mapGlobalSyntheticTsDiagnostics(batchCheck.globalDiagnostics, globalAnchorSpan, {
+        placement,
+        tagNames: syntheticApplications.map(
+          (application) => application.tag.normalizedTagName
+        ),
+      })
+    );
   }
 
   return diagnostics;

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -91,6 +91,7 @@ export {
   getFormSpecWorkspaceRuntimeDirectory,
 } from "./workspace-runtime.js";
 export {
+  _mapGlobalSyntheticTsDiagnostics,
   buildFormSpecAnalysisFileSnapshot,
   type BuildFormSpecAnalysisFileSnapshotOptions,
 } from "./file-snapshots.js";

--- a/packages/build/src/__tests__/deduplicate-diagnostics.test.ts
+++ b/packages/build/src/__tests__/deduplicate-diagnostics.test.ts
@@ -5,7 +5,7 @@
  * N-fold duplication of setup diagnostics when a declaration with N fields is
  * analyzed under an extension registry that has setup failures. The root-cause
  * restructure is tracked in
- * `scratch/deferred-deduplicate-diagnostics-root-fix.md`.
+ * `docs/refactors/phase-4-slice-c-deduplicate-diagnostics-root-fix.md`.
  *
  * These tests pin the invariants that make the helper safe to ship:
  *

--- a/packages/build/src/__tests__/tsdoc-parser-setup-diagnostic-silent-drop.test.ts
+++ b/packages/build/src/__tests__/tsdoc-parser-setup-diagnostic-silent-drop.test.ts
@@ -27,8 +27,11 @@ import { parseTSDocTags } from "../analyzer/tsdoc-parser.js";
 // =============================================================================
 
 /**
+/**
  * Creates an in-memory TypeScript source file and returns the first property
- * declaration in the first class/interface/type-alias.
+ * declaration in the first class or interface. Type-alias declarations do not
+ * have `members` with `PropertyDeclaration` / `PropertySignature` nodes, so
+ * they are intentionally excluded.
  */
 function getFirstProperty(source: string): ts.Node {
   const sourceFile = ts.createSourceFile("/virtual/test.ts", source, ts.ScriptTarget.Latest, true);

--- a/packages/build/src/__tests__/tsdoc-parser-setup-diagnostic-silent-drop.test.ts
+++ b/packages/build/src/__tests__/tsdoc-parser-setup-diagnostic-silent-drop.test.ts
@@ -27,7 +27,6 @@ import { parseTSDocTags } from "../analyzer/tsdoc-parser.js";
 // =============================================================================
 
 /**
-/**
  * Creates an in-memory TypeScript source file and returns the first property
  * declaration in the first class or interface. Type-alias declarations do not
  * have `members` with `PropertyDeclaration` / `PropertySignature` nodes, so


### PR DESCRIPTION
## Summary

Follow-up to #384 addressing Copilot's post-merge review comments.

- **Restores emission of `TYPE_MISMATCH` for batch-level synthetic TS diagnostics** that were silently dropped by the Phase 4 Slice C refactor. This is a real — if rare — correctness regression: any TS diagnostic from `checkSyntheticTagApplicationsDetailed` without a source position, or outside every tag application's line range, disappeared from snapshots after #384.
- **Fixes two test-file docstrings** flagged in the Copilot review: a dead-link path reference and a misleading helper comment.

## Why the fix is needed

Before #384, `buildTagDiagnostics` in `file-snapshots.ts` processed `batchCheck.globalDiagnostics` after the per-application loop with this mapping:

- `kind: "unsupported-custom-type-override"` → `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE`
- `kind: "synthetic-setup"` → `SYNTHETIC_SETUP_FAILURE`
- `kind: "typescript"` → `TYPE_MISMATCH`

#384 correctly relocated the two setup-kind branches to the snapshot entry path (pre-emitted at the file-level span) but removed the entire block, which also killed the `TYPE_MISMATCH` branch.

`mapBatchDiagnostics` in `compiler-signatures.ts` produces `kind: "typescript"` globals when a TS diagnostic either (a) has no `file`/`start`, or (b) its line doesn't fall within any tag application's line range. These were the ones that used to surface as `TYPE_MISMATCH` and are now lost.

## Approach

- Introduce a file-local helper `_mapGlobalSyntheticTsDiagnostics(globalDiagnostics, anchorSpan, data)` that maps only `kind: "typescript"` globals to `TYPE_MISMATCH` analysis diagnostics. Setup-kind globals are filtered because the snapshot entry path already pre-emits them at the file-level span via `_validateExtensionSetup`; re-emitting would double-surface in the edge case where `runBatchSyntheticCheck`'s `buildBatchSource` also throws and serializes to `globalDiagnostics`.
- Restore `combineCommentSpans` (removed by #384) to anchor the emission at a span covering every tag application in the batch — matching the pre-Slice-C anchoring.
- Wire the helper into `buildTagDiagnostics` after the applicationResults loop.
- Export the helper via `@formspec/analysis/internal` so it can be unit-tested directly without constructing a full synthetic program.

## Addresses Copilot review on #384

| Item | File | Status |
|---|---|---|
| #1 TS-kind global diagnostics silently dropped | `file-snapshots.ts:1847` | **Fixed** here (commit 1) |
| #2 `createExtensionRegistry` short-circuit when `setupDiagnostics.length > 0` | `registry.ts:255` | **Deferred** — design change, separate PR |
| #3 PR description mentions `setupDiagnosticsPreEmitted` flag that was removed | `file-snapshots.ts:1821` | **Acknowledged** — the in-tree code and comments are accurate; drift was in the #384 PR description only and can't be fixed retroactively |
| #4 `_mapSetupDiagnosticCode` name misleading (also handles `kind: "typescript"`) | `compiler-signatures.ts:519` | **Deferred** — naming question, separate PR |
| #5 Dead-link `scratch/...` reference in test docstring | `deduplicate-diagnostics.test.ts:8` | **Fixed** here (commit 2) |
| #6 `getFirstProperty` docstring claims type-alias support the impl lacks | `tsdoc-parser-setup-diagnostic-silent-drop.test.ts:44` | **Fixed** here (commit 2) |
| #7 `SyntheticCompilerDiagnostic` missing underscore prefix | `build/src/index.ts:90` | **Deferred** — internal-API naming pass, separate PR |

## Test plan

- [x] `packages/analysis` tests: **565 passed** (was 559; +6 new for `_mapGlobalSyntheticTsDiagnostics`)
- [x] `packages/build` tests: **893 passed**
- [x] e2e tests: passed
- [x] `pnpm run lint`: clean
- [x] `pnpm run format:check`: clean
- [x] `pnpm run typecheck`: clean across all 13 projects
- [x] `pnpm run api-extractor` (CI mode, fail-on-drift): clean
- [x] Clean build from scratch: succeeds

## Commits

1. `fix(analysis): restore TYPE_MISMATCH emission for batch-level TS diagnostics` — the actual fix + regression tests + changeset
2. `docs(build): fix two test-file docstrings flagged in #384 Copilot review` — trivial, no-behavior-change docstring fixes