### PR TITLE
fix(build): broaden path-targeted constraints on custom types (#395)

### DIFF
--- a/.changeset/path-target-custom-type-broadening.md
+++ b/.changeset/path-target-custom-type-broadening.md
@@ -1,9 +1,15 @@
 ---
 "@formspec/analysis": patch
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
 "formspec": patch
 ---
 
 Fix path-targeted built-in constraint tags so they participate in custom-type broadening. `@exclusiveMinimum :amount 0` on a `MonetaryAmount` field whose `amount` is a registered Decimal now emits the broadened custom-constraint keyword (e.g. `decimalExclusiveMinimum: "0"`) instead of the semantically-invalid raw `exclusiveMinimum: 0` sibling of `$ref`.
 
 Also unblocks path traversal through nullable intermediates at the IR level — `@minimum :money.amount 0` on `LineItem { money: MonetaryAmount | null }` now resolves cleanly, closing an asymmetry with the compiler-backed TS resolver that already stripped nullable unions.
+
+The snapshot consumer used by `@formspec/ts-plugin` and `@formspec/language-server` will receive the same fix in a follow-up (#396); until then, IDE diagnostics for path-targeted constraints on custom types remain unbroadened.

--- a/.changeset/path-target-custom-type-broadening.md
+++ b/.changeset/path-target-custom-type-broadening.md
@@ -1,0 +1,9 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"formspec": patch
+---
+
+Fix path-targeted built-in constraint tags so they participate in custom-type broadening. `@exclusiveMinimum :amount 0` on a `MonetaryAmount` field whose `amount` is a registered Decimal now emits the broadened custom-constraint keyword (e.g. `decimalExclusiveMinimum: "0"`) instead of the semantically-invalid raw `exclusiveMinimum: 0` sibling of `$ref`.
+
+Also unblocks path traversal through nullable intermediates at the IR level — `@minimum :money.amount 0` on `LineItem { money: MonetaryAmount | null }` now resolves cleanly, closing an asymmetry with the compiler-backed TS resolver that already stripped nullable unions.

--- a/packages/analysis/src/__tests__/tag-value-parser.test.ts
+++ b/packages/analysis/src/__tests__/tag-value-parser.test.ts
@@ -159,7 +159,7 @@ describe("tag-value-parser", () => {
       });
     });
 
-    it("successfully parses Unicode escape sequences in strings (@const \"\\u00e9\")", () => {
+    it('successfully parses Unicode escape sequences in strings (@const "\\u00e9")', () => {
       // JSON.parse resolves \u00e9 to "é", so the try branch wins.
       // The stored value must be the resolved character, not the escape sequence.
       const parsed = parseConstraintTagValue("const", '"\\u00e9"', PROVENANCE);

--- a/packages/analysis/src/__tests__/tag-value-parser.test.ts
+++ b/packages/analysis/src/__tests__/tag-value-parser.test.ts
@@ -213,4 +213,114 @@ describe("tag-value-parser", () => {
       provenance: PROVENANCE,
     });
   });
+
+  describe("path-targeted broadening (issue #395)", () => {
+    // Regression tests for the contract between the build consumer and the
+    // analysis layer: when a constraint tag carries a path target
+    // (`@minimum :amount 1.25`), the field's own IR type describes the wrong
+    // thing. The build consumer is the only layer with compiler-level access
+    // to resolve what type the terminal path segment points at, and it
+    // communicates that via `pathResolvedCustomTypeId`. Without this option,
+    // path-targeted constraints on custom types (e.g. Decimal-valued
+    // sub-fields) emit raw numeric constraints, which are invalid under JSON
+    // Schema 2020-12 when the terminal type is not numeric.
+
+    it("broadens path-targeted built-in tags onto the path-resolved custom type", () => {
+      const parsed = parseConstraintTagValue("minimum", ":amount 1.25", PROVENANCE, {
+        registry: createRegistry(),
+        pathResolvedCustomTypeId: "Decimal",
+      });
+
+      expect(parsed).toEqual({
+        kind: "constraint",
+        constraintKind: "custom",
+        constraintId: "x-test/decimal/MinScaled",
+        payload: 125,
+        compositionRule: "override",
+        path: { segments: ["amount"] },
+        provenance: PROVENANCE,
+      });
+    });
+
+    it("falls back to a raw numeric constraint when pathResolvedCustomTypeId is omitted", () => {
+      // Without the build-consumer-supplied type ID, the analysis layer has
+      // no way to look up broadening for the path-resolved terminal type.
+      // Emitting a raw NumericConstraintNode is the documented fallback
+      // behavior (the build consumer is responsible for path-aware broadening).
+      const parsed = parseConstraintTagValue("minimum", ":amount 1.25", PROVENANCE, {
+        registry: createRegistry(),
+      });
+
+      expect(parsed).toEqual({
+        kind: "constraint",
+        constraintKind: "minimum",
+        value: 1.25,
+        path: { segments: ["amount"] },
+        provenance: PROVENANCE,
+      });
+    });
+
+    it("falls back to a raw numeric constraint when the tag has no broadening registration", () => {
+      // The fixture registry only registers `Decimal` + `minimum`. When the
+      // terminal type has a registered custom type ID but no broadening for
+      // this specific tag, behavior must match "no broadening" — a raw
+      // NumericConstraintNode with the path preserved.
+      const parsed = parseConstraintTagValue("maximum", ":amount 10", PROVENANCE, {
+        registry: createRegistry(),
+        pathResolvedCustomTypeId: "Decimal",
+      });
+
+      expect(parsed).toEqual({
+        kind: "constraint",
+        constraintKind: "maximum",
+        value: 10,
+        path: { segments: ["amount"] },
+        provenance: PROVENANCE,
+      });
+    });
+
+    it("direct (non-path) tags still use fieldType, ignoring pathResolvedCustomTypeId", () => {
+      // Regression pin: passing `pathResolvedCustomTypeId` alongside a
+      // direct-field tag must not shadow the existing direct-field broadening
+      // path. The direct-tag case uses `fieldType` exactly as before.
+      const parsed = parseConstraintTagValue("minimum", "1.25", PROVENANCE, {
+        registry: createRegistry(),
+        fieldType: { kind: "custom", typeId: "Decimal", payload: null },
+        // This value is irrelevant for direct tags and must be ignored.
+        pathResolvedCustomTypeId: "SomeOtherType",
+      });
+
+      expect(parsed).toEqual({
+        kind: "constraint",
+        constraintKind: "custom",
+        constraintId: "x-test/decimal/MinScaled",
+        payload: 125,
+        compositionRule: "override",
+        provenance: PROVENANCE,
+      });
+    });
+
+    it("path-targeted tags use pathResolvedCustomTypeId, ignoring fieldType", () => {
+      // When both are supplied and the tag has a path, `pathResolvedCustomTypeId`
+      // wins. `fieldType` describes the enclosing field (e.g. a MonetaryAmount
+      // object/reference type), which is the wrong thing to broaden against
+      // for a path-targeted tag.
+      const parsed = parseConstraintTagValue("minimum", ":amount 1.25", PROVENANCE, {
+        registry: createRegistry(),
+        // Enclosing field type — not a custom type that would broaden.
+        fieldType: { kind: "reference", name: "MonetaryAmount", typeArguments: [] },
+        pathResolvedCustomTypeId: "Decimal",
+      });
+
+      expect(parsed).toEqual({
+        kind: "constraint",
+        constraintKind: "custom",
+        constraintId: "x-test/decimal/MinScaled",
+        payload: 125,
+        compositionRule: "override",
+        path: { segments: ["amount"] },
+        provenance: PROVENANCE,
+      });
+    });
+  });
 });

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -664,6 +664,12 @@ function buildDeclarationSummary(
 
   for (const tag of parsed.tags) {
     const payloadText = getTagPayloadText(parsed, tag);
+    // Intentionally omits `fieldType` and `pathResolvedCustomTypeId`: the
+    // snapshot consumer does not currently apply custom-type broadening for
+    // direct OR path-targeted constraints. Downstream LSP/natural-language
+    // summarizers therefore receive un-broadened `NumericConstraintNode`/
+    // `LengthConstraintNode` IR. Parity with the build consumer (PR #398,
+    // issue #395) is tracked in issue #396.
     const constraint = parseConstraintTagValue(
       tag.normalizedTagName,
       payloadText,
@@ -1785,9 +1791,7 @@ function buildTagDiagnostics(
     diagnostics.push(
       ..._mapGlobalSyntheticTsDiagnostics(batchCheck.globalDiagnostics, globalAnchorSpan, {
         placement,
-        tagNames: syntheticApplications.map(
-          (application) => application.tag.normalizedTagName
-        ),
+        tagNames: syntheticApplications.map((application) => application.tag.normalizedTagName),
       })
     );
   }

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -35,7 +35,11 @@ export type {
   ConstraintTagParseRegistryLike,
   ParseConstraintTagValueOptions,
 } from "./tag-value-parser.js";
-export { parseConstraintTagValue, parseDefaultValueTagValue } from "./tag-value-parser.js";
+export {
+  parseConstraintTagValue,
+  parseDefaultValueTagValue,
+  getBroadenedCustomTypeId,
+} from "./tag-value-parser.js";
 export { extractPathTarget, formatPathTarget, type ParsedPathTarget } from "./path-target.js";
 export type {
   AnalysisTypeDefinition,

--- a/packages/analysis/src/semantic-targets.ts
+++ b/packages/analysis/src/semantic-targets.ts
@@ -132,14 +132,21 @@ export function dereferenceAnalysisType(
 }
 
 /**
- * Unwraps a `T | null | undefined` nullable union down to its single non-null
- * member. Unions with multiple non-null members are returned unchanged.
+ * Unwraps a `T | null` nullable union down to its single non-null member.
+ * Unions with multiple non-null members are returned unchanged.
  *
- * Mirrors the TS-level behavior of `stripNullishUnion` in `ts-binding.ts` so
- * IR-level path traversal matches what the compiler-backed resolver already
- * does. Without this, a path walking through a nullable intermediate (e.g.
- * `LineItem { money: MonetaryAmount | null }` with `:money.amount`) would be
- * rejected at the union boundary even though the TS resolver accepts it.
+ * IR-only: the canonical `TypeNode` has no `"undefined"` primitive kind —
+ * optionality is carried by the `ObjectProperty.optional` flag, not by
+ * a union member. So only `null` participates here; any attempt to "sync"
+ * this helper with the TS-level `stripNullishUnion` by adding an `undefined`
+ * check would be dead code.
+ *
+ * Mirrors the nullable-stripping behavior of `stripNullishUnion` in
+ * `ts-binding.ts` so IR-level path traversal matches what the compiler-backed
+ * resolver already does. Without this, a path walking through a nullable
+ * intermediate (e.g. `LineItem { money: MonetaryAmount | null }` with
+ * `:money.amount`) would be rejected at the union boundary even though the
+ * TS resolver accepts it.
  */
 function stripNullableUnion(type: TypeNode): TypeNode {
   if (type.kind !== "union") {
@@ -1209,9 +1216,7 @@ function checkConstraintOnType(
   const isArray = unwrapped.kind === "array";
   const isEnum = unwrapped.kind === "enum";
   const arrayItemType =
-    unwrapped.kind === "array"
-      ? dereferenceAnalysisType(unwrapped.items, typeRegistry)
-      : undefined;
+    unwrapped.kind === "array" ? dereferenceAnalysisType(unwrapped.items, typeRegistry) : undefined;
   const isStringArray =
     arrayItemType?.kind === "primitive" && arrayItemType.primitiveKind === "string";
 

--- a/packages/analysis/src/semantic-targets.ts
+++ b/packages/analysis/src/semantic-targets.ts
@@ -131,6 +131,47 @@ export function dereferenceAnalysisType(
   return current;
 }
 
+/**
+ * Unwraps a `T | null | undefined` nullable union down to its single non-null
+ * member. Unions with multiple non-null members are returned unchanged.
+ *
+ * Mirrors the TS-level behavior of `stripNullishUnion` in `ts-binding.ts` so
+ * IR-level path traversal matches what the compiler-backed resolver already
+ * does. Without this, a path walking through a nullable intermediate (e.g.
+ * `LineItem { money: MonetaryAmount | null }` with `:money.amount`) would be
+ * rejected at the union boundary even though the TS resolver accepts it.
+ */
+function stripNullableUnion(type: TypeNode): TypeNode {
+  if (type.kind !== "union") {
+    return type;
+  }
+  const nonNullMembers = type.members.filter(
+    (member) => !(member.kind === "primitive" && member.primitiveKind === "null")
+  );
+  if (nonNullMembers.length === 1) {
+    const [sole] = nonNullMembers;
+    return sole ?? type;
+  }
+  return type;
+}
+
+/**
+ * Combined dereference + nullable-unwrap used before path traversal.
+ *
+ * References are dereferenced first (the body may itself be a nullable union),
+ * then nullable wrappers are stripped, then dereferenced once more in case the
+ * non-null member was itself a reference (e.g. `MonetaryAmount | null` where
+ * `MonetaryAmount` is a `ReferenceTypeNode`).
+ */
+function resolveTraversable(type: TypeNode, typeRegistry: AnalysisTypeRegistry): TypeNode {
+  const dereffed = dereferenceAnalysisType(type, typeRegistry);
+  const unwrapped = stripNullableUnion(dereffed);
+  if (unwrapped === dereffed) {
+    return dereffed;
+  }
+  return dereferenceAnalysisType(unwrapped, typeRegistry);
+}
+
 export function collectReferencedTypeConstraints(
   type: TypeNode,
   typeRegistry: AnalysisTypeRegistry
@@ -202,7 +243,12 @@ function resolveProperty(
     }
   | { readonly kind: "missing-property"; readonly segment: string }
   | { readonly kind: "unresolvable"; readonly type: TypeNode } {
-  const effectiveType = dereferenceAnalysisType(type, typeRegistry);
+  // resolveTraversable strips both reference indirection and nullable unions.
+  // The latter keeps IR-level path resolution in parity with the TS-level
+  // resolver (`stripNullishUnion` in ts-binding.ts), so nullable intermediate
+  // segments in a path (e.g. `:money.amount` on `LineItem { money: MonetaryAmount | null }`)
+  // traverse through to the non-null member instead of erroring on the union.
+  const effectiveType = resolveTraversable(type, typeRegistry);
 
   if (segments.length === 0) {
     return { kind: "resolved", property: null, rawType: type, type: effectiveType };
@@ -231,7 +277,7 @@ function resolveProperty(
       kind: "resolved",
       property,
       rawType: property.type,
-      type: dereferenceAnalysisType(property.type, typeRegistry),
+      type: resolveTraversable(property.type, typeRegistry),
     };
   }
 

--- a/packages/analysis/src/tag-value-parser.ts
+++ b/packages/analysis/src/tag-value-parser.ts
@@ -62,6 +62,17 @@ export interface ConstraintTagParseRegistryLike {
 export interface ParseConstraintTagValueOptions {
   readonly registry?: ConstraintTagParseRegistryLike;
   readonly fieldType?: TypeNode;
+  /**
+   * For path-targeted built-in constraint tags, the custom type ID that the
+   * path resolves to (if the terminal sub-type is a registered custom type).
+   * When present, this is consulted for built-in constraint broadening in
+   * place of `fieldType` — the field's own type describes the wrong thing
+   * for a path-targeted tag.
+   *
+   * Only the build consumer has the compiler-level resolution needed to
+   * compute this value; other consumers may safely omit it.
+   */
+  readonly pathResolvedCustomTypeId?: string;
 }
 
 function syntaxOptions(
@@ -274,7 +285,17 @@ function parseExtensionConstraintTagValue(
     return null;
   }
 
-  const broadenedTypeId = getBroadenedCustomTypeId(options?.fieldType);
+  // For path-targeted built-in tags, the field's own type describes the
+  // wrong thing — the broadening lookup must target the path-resolved
+  // terminal type. The caller (the build consumer) is the only layer with
+  // compiler-level access to resolve this, and supplies the result via
+  // `pathResolvedCustomTypeId`. When `path` is present we consult only
+  // that input; when `path` is absent (direct-field case) we consult the
+  // IR `fieldType` as before.
+  const broadenedTypeId =
+    path !== undefined
+      ? options?.pathResolvedCustomTypeId
+      : getBroadenedCustomTypeId(options?.fieldType);
   if (broadenedTypeId === undefined) {
     return null;
   }

--- a/packages/analysis/src/tag-value-parser.ts
+++ b/packages/analysis/src/tag-value-parser.ts
@@ -315,7 +315,18 @@ function parseExtensionConstraintTagValue(
   );
 }
 
-function getBroadenedCustomTypeId(fieldType: TypeNode | undefined): string | undefined {
+/**
+ * Resolves the broadening-eligible custom type ID for a field's IR type.
+ *
+ * Returns the `CustomTypeNode.typeId` when the field type is directly custom,
+ * OR when it's a nullable-single-custom union (`T | null`). Returns `undefined`
+ * for any other shape — the caller's broadening lookup then falls through.
+ *
+ * Exported from `@formspec/analysis/internal` so the build consumer can reuse
+ * exactly the same "what counts as a broadenable custom field type" rule
+ * without maintaining a drift-prone duplicate. See PR #398 / issue #395.
+ */
+export function getBroadenedCustomTypeId(fieldType: TypeNode | undefined): string | undefined {
   if (fieldType?.kind === "custom") {
     return fieldType.typeId;
   }

--- a/packages/build/src/__tests__/fixtures/example-vocabulary-decimal-extension.ts
+++ b/packages/build/src/__tests__/fixtures/example-vocabulary-decimal-extension.ts
@@ -12,13 +12,13 @@
  *
  * Two variants are exported:
  *
- * - **Name-based** (`createVocabularyDecimalByNameRegistry`): the custom type
- *   is registered via `tsTypeNames: ["VocabDecimal"]` so the build resolves
- *   it by source-level type alias name.
+ * - **Name-based** (`vocabDecimalByNameExtension`): the custom type is
+ *   registered via `tsTypeNames: ["VocabDecimal", "Decimal"]` so the build
+ *   resolves it by either source-level type alias name.
  *
- * - **Brand-based** (`createVocabularyDecimalByBrandRegistry`): the custom
- *   type is registered via `brand: "__vocabDecimalBrand"` so the build
- *   resolves it structurally through the unique-symbol computed property key.
+ * - **Brand-based** (`vocabDecimalByBrandExtension`): the custom type is
+ *   registered via `brand: "__vocabDecimalBrand"` so the build resolves it
+ *   structurally through the unique-symbol computed property key.
  *
  * Both variants use the same 5 constraint broadenings and the same vocabulary
  * constraint registrations; only the type detection mechanism differs.
@@ -33,13 +33,12 @@ import {
   type CustomConstraintRegistration,
   type CustomTypeRegistration,
 } from "@formspec/core/internals";
-import { createExtensionRegistry } from "../../extensions/index.js";
 
 // ---------------------------------------------------------------------------
 // Extension ID
 // ---------------------------------------------------------------------------
 
-export const VOCAB_DECIMAL_EXTENSION_ID = "x-test/vocabulary-decimal";
+const VOCAB_DECIMAL_EXTENSION_ID = "x-test/vocabulary-decimal";
 
 // ---------------------------------------------------------------------------
 // Constraint payload identity parser
@@ -129,7 +128,11 @@ const BUILTIN_BROADENINGS = [
     constraintName: "DecimalExclusiveMaximum",
     parseValue: trimmedString,
   },
-  { tagName: "multipleOf" as const, constraintName: "DecimalMultipleOf", parseValue: trimmedString },
+  {
+    tagName: "multipleOf" as const,
+    constraintName: "DecimalMultipleOf",
+    parseValue: trimmedString,
+  },
 ] as const;
 
 // ---------------------------------------------------------------------------
@@ -138,7 +141,9 @@ const BUILTIN_BROADENINGS = [
 
 const vocabDecimalByNameType: CustomTypeRegistration = defineCustomType({
   typeName: "VocabDecimal",
-  tsTypeNames: ["VocabDecimal"],
+  // Accept both "VocabDecimal" and "Decimal" source aliases so all path-target
+  // and schema-generation tests can share this single registration.
+  tsTypeNames: ["VocabDecimal", "Decimal"],
   builtinConstraintBroadenings: [...BUILTIN_BROADENINGS],
   toJsonSchema: () => ({ type: "string", format: "decimal" }),
 });
@@ -154,14 +159,6 @@ export const vocabDecimalByNameExtension = defineExtension({
     decimalMultipleOfConstraint,
   ],
 });
-
-/**
- * Create an extension registry containing the name-based vocabulary-decimal
- * extension. Custom type `VocabDecimal` is resolved by `tsTypeNames`.
- */
-export function createVocabularyDecimalByNameRegistry() {
-  return createExtensionRegistry([vocabDecimalByNameExtension]);
-}
 
 // ---------------------------------------------------------------------------
 // Brand-based custom type (resolved by unique-symbol computed property key)
@@ -187,12 +184,3 @@ export const vocabDecimalByBrandExtension = defineExtension({
     decimalMultipleOfConstraint,
   ],
 });
-
-/**
- * Create an extension registry containing the brand-based vocabulary-decimal
- * extension. Custom type `VocabDecimalBranded` is resolved by the
- * `__vocabDecimalBrand` unique-symbol brand key.
- */
-export function createVocabularyDecimalByBrandRegistry() {
-  return createExtensionRegistry([vocabDecimalByBrandExtension]);
-}

--- a/packages/build/src/__tests__/fixtures/example-vocabulary-decimal-extension.ts
+++ b/packages/build/src/__tests__/fixtures/example-vocabulary-decimal-extension.ts
@@ -1,0 +1,198 @@
+/**
+ * Vocabulary-mode Decimal extension for build-layer tests.
+ *
+ * Unlike the `example-numeric-extension` fixture (which uses vendor-prefixed
+ * keywords like `x-formspec-decimal-minimum`), this extension registers
+ * constraints with `emitsVocabularyKeywords: true` so each constraint emits a
+ * camelCase vocabulary keyword directly (e.g. `decimalMinimum`, `decimalMaximum`).
+ *
+ * This makes path-targeted broadening assertions straightforward: tests can
+ * assert the literal camelCase keyword name and a string-typed payload rather
+ * than having to account for vendor-prefix construction.
+ *
+ * Two variants are exported:
+ *
+ * - **Name-based** (`createVocabularyDecimalByNameRegistry`): the custom type
+ *   is registered via `tsTypeNames: ["VocabDecimal"]` so the build resolves
+ *   it by source-level type alias name.
+ *
+ * - **Brand-based** (`createVocabularyDecimalByBrandRegistry`): the custom
+ *   type is registered via `brand: "__vocabDecimalBrand"` so the build
+ *   resolves it structurally through the unique-symbol computed property key.
+ *
+ * Both variants use the same 5 constraint broadenings and the same vocabulary
+ * constraint registrations; only the type detection mechanism differs.
+ *
+ * @see https://github.com/mike-north/formspec/issues/395
+ */
+
+import {
+  defineConstraint,
+  defineCustomType,
+  defineExtension,
+  type CustomConstraintRegistration,
+  type CustomTypeRegistration,
+} from "@formspec/core/internals";
+import { createExtensionRegistry } from "../../extensions/index.js";
+
+// ---------------------------------------------------------------------------
+// Extension ID
+// ---------------------------------------------------------------------------
+
+export const VOCAB_DECIMAL_EXTENSION_ID = "x-test/vocabulary-decimal";
+
+// ---------------------------------------------------------------------------
+// Constraint payload identity parser
+//
+// For the vocabulary-mode fixture we intentionally keep the payload as the raw
+// trimmed string rather than parsing it into a structured Decimal value. This
+// keeps the fixture lightweight and makes test assertions simple: the emitted
+// JSON Schema value is always the original tag argument as a string (e.g. "0",
+// "100", "0.01").
+// ---------------------------------------------------------------------------
+
+function trimmedString(raw: string): string {
+  return raw.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Vocabulary constraint registrations (shared by both name and brand variants)
+//
+// Each constraint uses `emitsVocabularyKeywords: true` so the build pipeline
+// does not require the vendor-prefix guard. The `toJsonSchema` callback emits
+// a plain camelCase keyword with the raw string payload.
+// ---------------------------------------------------------------------------
+
+const decimalMinimumConstraint: CustomConstraintRegistration = defineConstraint({
+  constraintName: "DecimalMinimum",
+  compositionRule: "intersect",
+  applicableTypes: ["custom"],
+  isApplicableToType: (type) => type.kind === "custom",
+  emitsVocabularyKeywords: true,
+  semanticRole: { family: "vocab-decimal-bound", bound: "lower", inclusive: true },
+  toJsonSchema: (payload) => ({ decimalMinimum: payload }),
+});
+
+const decimalMaximumConstraint: CustomConstraintRegistration = defineConstraint({
+  constraintName: "DecimalMaximum",
+  compositionRule: "intersect",
+  applicableTypes: ["custom"],
+  isApplicableToType: (type) => type.kind === "custom",
+  emitsVocabularyKeywords: true,
+  semanticRole: { family: "vocab-decimal-bound", bound: "upper", inclusive: true },
+  toJsonSchema: (payload) => ({ decimalMaximum: payload }),
+});
+
+const decimalExclusiveMinimumConstraint: CustomConstraintRegistration = defineConstraint({
+  constraintName: "DecimalExclusiveMinimum",
+  compositionRule: "intersect",
+  applicableTypes: ["custom"],
+  isApplicableToType: (type) => type.kind === "custom",
+  emitsVocabularyKeywords: true,
+  semanticRole: { family: "vocab-decimal-bound", bound: "lower", inclusive: false },
+  toJsonSchema: (payload) => ({ decimalExclusiveMinimum: payload }),
+});
+
+const decimalExclusiveMaximumConstraint: CustomConstraintRegistration = defineConstraint({
+  constraintName: "DecimalExclusiveMaximum",
+  compositionRule: "intersect",
+  applicableTypes: ["custom"],
+  isApplicableToType: (type) => type.kind === "custom",
+  emitsVocabularyKeywords: true,
+  semanticRole: { family: "vocab-decimal-bound", bound: "upper", inclusive: false },
+  toJsonSchema: (payload) => ({ decimalExclusiveMaximum: payload }),
+});
+
+const decimalMultipleOfConstraint: CustomConstraintRegistration = defineConstraint({
+  constraintName: "DecimalMultipleOf",
+  compositionRule: "intersect",
+  applicableTypes: ["custom"],
+  isApplicableToType: (type) => type.kind === "custom",
+  emitsVocabularyKeywords: true,
+  toJsonSchema: (payload) => ({ decimalMultipleOf: payload }),
+});
+
+// ---------------------------------------------------------------------------
+// Shared broadening registrations (same set for both name and brand variants)
+// ---------------------------------------------------------------------------
+
+const BUILTIN_BROADENINGS = [
+  { tagName: "minimum" as const, constraintName: "DecimalMinimum", parseValue: trimmedString },
+  { tagName: "maximum" as const, constraintName: "DecimalMaximum", parseValue: trimmedString },
+  {
+    tagName: "exclusiveMinimum" as const,
+    constraintName: "DecimalExclusiveMinimum",
+    parseValue: trimmedString,
+  },
+  {
+    tagName: "exclusiveMaximum" as const,
+    constraintName: "DecimalExclusiveMaximum",
+    parseValue: trimmedString,
+  },
+  { tagName: "multipleOf" as const, constraintName: "DecimalMultipleOf", parseValue: trimmedString },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Name-based custom type (resolved by tsTypeNames)
+// ---------------------------------------------------------------------------
+
+const vocabDecimalByNameType: CustomTypeRegistration = defineCustomType({
+  typeName: "VocabDecimal",
+  tsTypeNames: ["VocabDecimal"],
+  builtinConstraintBroadenings: [...BUILTIN_BROADENINGS],
+  toJsonSchema: () => ({ type: "string", format: "decimal" }),
+});
+
+export const vocabDecimalByNameExtension = defineExtension({
+  extensionId: VOCAB_DECIMAL_EXTENSION_ID,
+  types: [vocabDecimalByNameType],
+  constraints: [
+    decimalMinimumConstraint,
+    decimalMaximumConstraint,
+    decimalExclusiveMinimumConstraint,
+    decimalExclusiveMaximumConstraint,
+    decimalMultipleOfConstraint,
+  ],
+});
+
+/**
+ * Create an extension registry containing the name-based vocabulary-decimal
+ * extension. Custom type `VocabDecimal` is resolved by `tsTypeNames`.
+ */
+export function createVocabularyDecimalByNameRegistry() {
+  return createExtensionRegistry([vocabDecimalByNameExtension]);
+}
+
+// ---------------------------------------------------------------------------
+// Brand-based custom type (resolved by unique-symbol computed property key)
+// ---------------------------------------------------------------------------
+
+const vocabDecimalByBrandType: CustomTypeRegistration = defineCustomType({
+  typeName: "VocabDecimalBranded",
+  brand: "__vocabDecimalBrand",
+  builtinConstraintBroadenings: [...BUILTIN_BROADENINGS],
+  toJsonSchema: () => ({ type: "string", format: "decimal" }),
+});
+
+const VOCAB_DECIMAL_BRAND_EXTENSION_ID = "x-test/vocabulary-decimal-brand";
+
+export const vocabDecimalByBrandExtension = defineExtension({
+  extensionId: VOCAB_DECIMAL_BRAND_EXTENSION_ID,
+  types: [vocabDecimalByBrandType],
+  constraints: [
+    decimalMinimumConstraint,
+    decimalMaximumConstraint,
+    decimalExclusiveMinimumConstraint,
+    decimalExclusiveMaximumConstraint,
+    decimalMultipleOfConstraint,
+  ],
+});
+
+/**
+ * Create an extension registry containing the brand-based vocabulary-decimal
+ * extension. Custom type `VocabDecimalBranded` is resolved by the
+ * `__vocabDecimalBrand` unique-symbol brand key.
+ */
+export function createVocabularyDecimalByBrandRegistry() {
+  return createExtensionRegistry([vocabDecimalByBrandExtension]);
+}

--- a/packages/build/src/__tests__/fixtures/example-vocabulary-string-extension.ts
+++ b/packages/build/src/__tests__/fixtures/example-vocabulary-string-extension.ts
@@ -1,0 +1,99 @@
+/**
+ * Vocabulary-mode string-backed custom type extension for build-layer tests.
+ *
+ * Provides a `PostalCode` custom type whose JSON Schema representation is
+ * `{ type: "string", format: "postal-code" }`. The extension registers
+ * broadenings for `@minLength`, `@maxLength`, and `@pattern` onto
+ * vocabulary keywords (`postalMinLength`, `postalMaxLength`, `postalPattern`)
+ * so path-targeted broadening tests can assert the literal keyword and a
+ * string-typed payload.
+ *
+ * The type is registered by name (`tsTypeNames: ["PostalCode"]`).
+ *
+ * @see https://github.com/mike-north/formspec/issues/395
+ */
+
+import {
+  defineConstraint,
+  defineCustomType,
+  defineExtension,
+  type CustomConstraintRegistration,
+  type CustomTypeRegistration,
+} from "@formspec/core/internals";
+import { createExtensionRegistry } from "../../extensions/index.js";
+
+// ---------------------------------------------------------------------------
+// Extension ID
+// ---------------------------------------------------------------------------
+
+export const VOCAB_STRING_EXTENSION_ID = "x-test/vocabulary-string";
+
+// ---------------------------------------------------------------------------
+// Payload parsers
+// ---------------------------------------------------------------------------
+
+function trimmedString(raw: string): string {
+  return raw.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Vocabulary constraint registrations
+// ---------------------------------------------------------------------------
+
+const postalMinLengthConstraint: CustomConstraintRegistration = defineConstraint({
+  constraintName: "PostalMinLength",
+  compositionRule: "intersect",
+  applicableTypes: ["custom"],
+  isApplicableToType: (type) => type.kind === "custom",
+  emitsVocabularyKeywords: true,
+  semanticRole: { family: "postal-length", bound: "lower", inclusive: true },
+  toJsonSchema: (payload) => ({ postalMinLength: payload }),
+});
+
+const postalMaxLengthConstraint: CustomConstraintRegistration = defineConstraint({
+  constraintName: "PostalMaxLength",
+  compositionRule: "intersect",
+  applicableTypes: ["custom"],
+  isApplicableToType: (type) => type.kind === "custom",
+  emitsVocabularyKeywords: true,
+  semanticRole: { family: "postal-length", bound: "upper", inclusive: true },
+  toJsonSchema: (payload) => ({ postalMaxLength: payload }),
+});
+
+const postalPatternConstraint: CustomConstraintRegistration = defineConstraint({
+  constraintName: "PostalPattern",
+  compositionRule: "override",
+  applicableTypes: ["custom"],
+  isApplicableToType: (type) => type.kind === "custom",
+  emitsVocabularyKeywords: true,
+  toJsonSchema: (payload) => ({ postalPattern: payload }),
+});
+
+// ---------------------------------------------------------------------------
+// PostalCode custom type (name-based resolution)
+// ---------------------------------------------------------------------------
+
+const postalCodeType: CustomTypeRegistration = defineCustomType({
+  typeName: "PostalCode",
+  tsTypeNames: ["PostalCode"],
+  builtinConstraintBroadenings: [
+    { tagName: "minLength", constraintName: "PostalMinLength", parseValue: trimmedString },
+    { tagName: "maxLength", constraintName: "PostalMaxLength", parseValue: trimmedString },
+    { tagName: "pattern", constraintName: "PostalPattern", parseValue: trimmedString },
+  ],
+  toJsonSchema: () => ({ type: "string", format: "postal-code" }),
+});
+
+export const vocabStringExtension = defineExtension({
+  extensionId: VOCAB_STRING_EXTENSION_ID,
+  types: [postalCodeType],
+  constraints: [postalMinLengthConstraint, postalMaxLengthConstraint, postalPatternConstraint],
+});
+
+/**
+ * Create an extension registry containing the vocabulary-mode string extension.
+ * Custom type `PostalCode` is resolved by `tsTypeNames`.
+ */
+export function createVocabularyStringExtensionRegistry() {
+  return createExtensionRegistry([vocabStringExtension]);
+}

--- a/packages/build/src/__tests__/fixtures/example-vocabulary-string-extension.ts
+++ b/packages/build/src/__tests__/fixtures/example-vocabulary-string-extension.ts
@@ -20,13 +20,12 @@ import {
   type CustomConstraintRegistration,
   type CustomTypeRegistration,
 } from "@formspec/core/internals";
-import { createExtensionRegistry } from "../../extensions/index.js";
 
 // ---------------------------------------------------------------------------
 // Extension ID
 // ---------------------------------------------------------------------------
 
-export const VOCAB_STRING_EXTENSION_ID = "x-test/vocabulary-string";
+const VOCAB_STRING_EXTENSION_ID = "x-test/vocabulary-string";
 
 // ---------------------------------------------------------------------------
 // Payload parsers
@@ -89,11 +88,3 @@ export const vocabStringExtension = defineExtension({
   types: [postalCodeType],
   constraints: [postalMinLengthConstraint, postalMaxLengthConstraint, postalPatternConstraint],
 });
-
-/**
- * Create an extension registry containing the vocabulary-mode string extension.
- * Custom type `PostalCode` is resolved by `tsTypeNames`.
- */
-export function createVocabularyStringExtensionRegistry() {
-  return createExtensionRegistry([vocabStringExtension]);
-}

--- a/packages/build/src/__tests__/generate-schemas-config.test.ts
+++ b/packages/build/src/__tests__/generate-schemas-config.test.ts
@@ -3,10 +3,15 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { FormSpecConfig } from "@formspec/config";
-import { defineCustomType, defineExtension } from "@formspec/core/internals";
+import { defineConstraint, defineCustomType, defineExtension } from "@formspec/core/internals";
 import { type ClassSchemas, generateSchemas } from "../generators/class-schema.js";
 import type { JsonSchema2020 } from "../json-schema/ir-generator.js";
 import { numericExtension } from "./fixtures/example-numeric-extension.js";
+import {
+  vocabDecimalByNameExtension,
+  vocabDecimalByBrandExtension,
+} from "./fixtures/example-vocabulary-decimal-extension.js";
+import { vocabStringExtension } from "./fixtures/example-vocabulary-string-extension.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -228,53 +233,54 @@ describe("generateSchemas with FormSpecConfig", () => {
   // Path-targeted broadening on extension-registered custom types.
   //
   // A built-in constraint tag (e.g. `@exclusiveMinimum`) applied through a
-  // path target (`@exclusiveMinimum :amount 0`) must defer to the IR-layer
-  // validator when the path resolves to an extension-registered custom type
-  // that has broadening for that tag. Previously the compiler-backed
-  // validator rejected these at the capability check, silently shadowing
-  // legitimate broadening.
+  // path target (`@exclusiveMinimum :amount 0`) must defer to the broadening
+  // registration when the path resolves to an extension-registered custom type
+  // that has broadening for that tag.
   //
-  // This suite exercises the full matrix of registration mechanisms
-  // (name / brand) × tag kinds × wrapping shapes.
+  // After the fix (issue #395), the emitted schema must use the custom
+  // constraint's vocabulary keyword (e.g. `decimalExclusiveMinimum: "0"`)
+  // rather than the raw built-in keyword (`exclusiveMinimum: 0`). The payload
+  // is a string because the vocabulary-mode fixture's `parseValue` is
+  // `trimmedString` — no numeric coercion.
+  //
+  // This suite uses the vocabulary-decimal fixture (`example-vocabulary-decimal-
+  // extension.ts`) so assertions can pin the exact camelCase keyword without
+  // accounting for vendor-prefix construction. The existing `numericExtension`
+  // is preserved for non-path-broadening tests elsewhere.
+  //
+  // Matrix: registration mechanism (name / brand / symbol) × tag kind × shape
+  // (direct, nullable, nested).
   // =========================================================================
   describe("path-targeted broadening on registered custom types", () => {
-    // Separate `Decimal` extension registered via `brand`. Same broadenings
-    // as `numericExtension`'s name-registered Decimal, but detected
-    // structurally through the computed-property brand key rather than the
-    // alias identifier.
-    const brandedDecimalExtension = defineExtension({
-      extensionId: "x-test/branded-decimal",
-      types: [
-        defineCustomType({
-          typeName: "Decimal",
-          brand: "__decimalBrand",
-          builtinConstraintBroadenings: [
-            { tagName: "minimum", constraintName: "DecimalMinimum" },
-            { tagName: "maximum", constraintName: "DecimalMaximum" },
-            { tagName: "exclusiveMinimum", constraintName: "DecimalExclusiveMinimum" },
-            { tagName: "exclusiveMaximum", constraintName: "DecimalExclusiveMaximum" },
-            { tagName: "multipleOf", constraintName: "DecimalMultipleOf" },
-          ],
-          toJsonSchema: () => ({ type: "string" }),
-        }),
-      ],
-    });
+    // -----------------------------------------------------------------------
+    // Source declarations under each registration mechanism
+    // -----------------------------------------------------------------------
+
+    /**
+     * Name-based: resolved via `tsTypeNames: ["VocabDecimal"]`.
+     * The alias name matches the registered `tsTypeName` exactly.
+     */
+    const nameBasedDecimal =
+      `export type VocabDecimal = string & { readonly __brand: "VocabDecimal" };`;
+
+    /**
+     * Brand-based: resolved structurally via `brand: "__vocabDecimalBrand"`.
+     * The unique-symbol computed property key is what the extension registry
+     * detects, not the alias name.
+     */
+    const brandBasedDecimal = [
+      "declare const __vocabDecimalBrand: unique symbol;",
+      "export type Decimal = string & { readonly [__vocabDecimalBrand]: true };",
+    ].join("\n");
 
     const nameBasedConfig: FormSpecConfig = {
-      extensions: [numericExtension],
-      vendorPrefix: "x-formspec",
-    };
-    const brandBasedConfig: FormSpecConfig = {
-      extensions: [brandedDecimalExtension],
+      extensions: [vocabDecimalByNameExtension],
       vendorPrefix: "x-test",
     };
-
-    // Source declarations for Decimal under each registration mechanism.
-    const nameBasedDecimal = `export type Decimal = string & { readonly __brand: "Decimal" };`;
-    const brandBasedDecimal = [
-      "declare const __decimalBrand: unique symbol;",
-      "export type Decimal = string & { readonly [__decimalBrand]: true };",
-    ].join("\n");
+    const brandBasedConfig: FormSpecConfig = {
+      extensions: [vocabDecimalByBrandExtension],
+      vendorPrefix: "x-test",
+    };
 
     function runSchema(source: string, config: FormSpecConfig) {
       const filePath = writeTempSource(source);
@@ -290,12 +296,19 @@ describe("generateSchemas with FormSpecConfig", () => {
       }
     }
 
+    // -----------------------------------------------------------------------
+    // Path-override navigation helpers
+    //
     // Path-target overrides are emitted as sibling keywords alongside `$ref`
     // (JSON Schema 2020-12 §10.2.1). The `properties` override appears directly
-    // on the field schema, not wrapped in `allOf`. Asserting via the sibling
-    // `properties` key keeps the Jest matcher types clean while using the real
-    // `JsonSchema2020` typing for property access.
+    // on the field schema, not wrapped in `allOf`.
     // See: https://github.com/mike-north/formspec/issues/364
+    // -----------------------------------------------------------------------
+
+    /**
+     * Locate the first field schema that satisfies `predicate`. Returns the
+     * field schema object, or `undefined` if the predicate never matches.
+     */
     function findPathOverride(
       result: ClassSchemas,
       fieldName: string,
@@ -303,15 +316,17 @@ describe("generateSchemas with FormSpecConfig", () => {
     ): JsonSchema2020 | undefined {
       const field = result.jsonSchema.properties?.[fieldName];
       expect(field, `expected a schema for property '${fieldName}'`).toBeDefined();
-      // The field schema itself is the "override container" — sibling keywords
-      // sit directly on it alongside $ref. Wrap in an array to keep the predicate
-      // interface compatible with callers that previously scanned allOf entries.
       if (field !== undefined && predicate(field)) {
         return field;
       }
       return undefined;
     }
 
+    /**
+     * Assert that `result.jsonSchema.properties[fieldName].properties[segment][keyword] === value`.
+     *
+     * Used for one-segment path targets (`:amount`).
+     */
     function expectPathOverride(
       result: ClassSchemas,
       fieldName: string,
@@ -332,66 +347,114 @@ describe("generateSchemas with FormSpecConfig", () => {
       ).toBe(value);
     }
 
-    // Path-target overrides emit the standard JSON Schema keyword directly
-    // on the sub-path — not the vendor-prefixed custom-constraint keyword
-    // that's used for the type's own direct-target broadening. The emitted
-    // shape is `{ "$ref": "#/$defs/X", "properties": { amount: { minimum: 0 } } }`
-    // per JSON Schema 2020-12 §10.2.1 (sibling keywords next to $ref are valid).
-    // See: https://github.com/mike-north/formspec/issues/364
+    /**
+     * Assert that a broadened vocabulary keyword appears on the path-override
+     * segment schema. This is the post-fix form: the keyword is the camelCase
+     * vocabulary keyword (e.g. `decimalExclusiveMinimum`) and the payload is
+     * a string (e.g. `"0"`).
+     *
+     * This helper is a named alias for `expectPathOverride` with clearer
+     * intent at the call site when asserting broadened output.
+     *
+     * @param result - The schema generation result.
+     * @param fieldName - The field whose path override is being checked.
+     * @param segment - The final path segment (e.g. `"amount"`).
+     * @param vocabularyKeyword - The camelCase vocabulary keyword (e.g. `"decimalExclusiveMinimum"`).
+     * @param payload - The string payload (e.g. `"0"`).
+     */
+    function expectBroadenedPathOverride(
+      result: ClassSchemas,
+      fieldName: string,
+      segment: string,
+      vocabularyKeyword: string,
+      payload: string
+    ) {
+      expectPathOverride(result, fieldName, segment, vocabularyKeyword, payload);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tag test matrix
+    //
+    // Each entry describes one built-in tag and its expected broadened output
+    // after the fix (issue #395). The `vocabKeyword` is the camelCase keyword
+    // emitted by the vocabulary-decimal extension; `payload` is the string
+    // value from `trimmedString(argument)`.
+    // -----------------------------------------------------------------------
     const numericTagCases: readonly {
       tag: string;
       argument: string;
-      jsonKeyword: string;
-      jsonValue: number;
+      vocabKeyword: string;
+      payload: string;
     }[] = [
-      { tag: "minimum", argument: "0", jsonKeyword: "minimum", jsonValue: 0 },
-      { tag: "maximum", argument: "100", jsonKeyword: "maximum", jsonValue: 100 },
-      { tag: "exclusiveMinimum", argument: "0", jsonKeyword: "exclusiveMinimum", jsonValue: 0 },
+      // @see https://github.com/mike-north/formspec/issues/395
+      // Each tag must produce the broadened vocabulary keyword (not the raw
+      // built-in keyword) when the path terminal type is a registered custom
+      // type with a broadening for that tag.
+      { tag: "minimum", argument: "0", vocabKeyword: "decimalMinimum", payload: "0" },
+      { tag: "maximum", argument: "100", vocabKeyword: "decimalMaximum", payload: "100" },
+      {
+        tag: "exclusiveMinimum",
+        argument: "0",
+        vocabKeyword: "decimalExclusiveMinimum",
+        payload: "0",
+      },
       {
         tag: "exclusiveMaximum",
         argument: "1000",
-        jsonKeyword: "exclusiveMaximum",
-        jsonValue: 1000,
+        vocabKeyword: "decimalExclusiveMaximum",
+        payload: "1000",
       },
-      { tag: "multipleOf", argument: "0.01", jsonKeyword: "multipleOf", jsonValue: 0.01 },
+      {
+        tag: "multipleOf",
+        argument: "0.01",
+        vocabKeyword: "decimalMultipleOf",
+        payload: "0.01",
+      },
     ];
 
+    // -----------------------------------------------------------------------
+    // Name-based registration
+    // -----------------------------------------------------------------------
     describe("name-based registration (tsTypeNames)", () => {
       it.each(numericTagCases)(
-        "broadens @$tag through a path target onto a Decimal subfield",
-        ({ tag, argument, jsonKeyword, jsonValue }) => {
+        "broadens @$tag through a path target onto a VocabDecimal subfield",
+        ({ tag, argument, vocabKeyword, payload }) => {
           const source = `
             ${nameBasedDecimal}
-            export interface MonetaryAmount { amount: Decimal; currency: string; }
+            export interface MonetaryAmount { amount: VocabDecimal; currency: string; }
             export interface PaymentForm {
               /** @${tag} :amount ${argument} */
               total: MonetaryAmount;
             }
           `;
           const result = runSchema(source, nameBasedConfig);
-          expectPathOverride(result, "total", "amount", jsonKeyword, jsonValue);
+          // Post-fix (#395): must emit the broadened vocabulary keyword, not
+          // the raw built-in keyword.
+          expectBroadenedPathOverride(result, "total", "amount", vocabKeyword, payload);
         }
       );
 
-      it("broadens across a nullable Decimal", () => {
+      it("broadens across a nullable VocabDecimal", () => {
+        // Nullability of the path-terminal type must not suppress broadening.
         const source = `
           ${nameBasedDecimal}
-          export interface MonetaryAmount { amount: Decimal | null; currency: string; }
+          export interface MonetaryAmount { amount: VocabDecimal | null; currency: string; }
           export interface PaymentForm {
             /** @exclusiveMinimum :amount 0 */
             total: MonetaryAmount;
           }
         `;
         const result = runSchema(source, nameBasedConfig);
-        expectPathOverride(result, "total", "amount", "exclusiveMinimum", 0);
+        expectBroadenedPathOverride(result, "total", "amount", "decimalExclusiveMinimum", "0");
       });
 
       it("broadens through a deeply-nested path with a distinctive value", () => {
         // Use 42 (distinctive) rather than 0 to guard against an override
         // that happens to match a default.
+        // Post-fix (#395): nested path terminals must also produce broadened keywords.
         const source = `
           ${nameBasedDecimal}
-          export interface Nested { inner: { amount: Decimal }; }
+          export interface Nested { inner: { amount: VocabDecimal }; }
           export interface PaymentForm {
             /** @minimum :inner.amount 42 */
             total: Nested;
@@ -401,19 +464,23 @@ describe("generateSchemas with FormSpecConfig", () => {
         const override = findPathOverride(result, "total", (entry) => {
           const inner = entry.properties?.["inner"];
           const amount = inner?.properties?.["amount"];
-          return amount?.minimum === 42;
+          // Post-fix: broadened keyword with string payload, not numeric minimum
+          return (amount as Record<string, unknown> | undefined)?.["decimalMinimum"] === "42";
         });
         expect(
           override,
-          "expected nested path override properties.inner.properties.amount.minimum === 42"
+          "expected nested path override properties.inner.properties.amount.decimalMinimum === '42'"
         ).toBeDefined();
       });
     });
 
+    // -----------------------------------------------------------------------
+    // Brand-based registration
+    // -----------------------------------------------------------------------
     describe("brand-based registration", () => {
       it.each(numericTagCases)(
-        "broadens @$tag through a path target onto a brand-registered Decimal",
-        ({ tag, argument }) => {
+        "broadens @$tag through a path target onto a brand-registered VocabDecimal",
+        ({ tag, argument, vocabKeyword, payload }) => {
           const source = `
             ${brandBasedDecimal}
             export interface MonetaryAmount { amount: Decimal; currency: string; }
@@ -422,25 +489,14 @@ describe("generateSchemas with FormSpecConfig", () => {
               total: MonetaryAmount;
             }
           `;
-          // Vendor-prefix-agnostic smoke: we don't assert the keyword value
-          // because the branded extension uses a different prefix, but we
-          // DO require an allOf entry that targets `amount`. A regression
-          // that silently drops the override (no throw, no entry) would
-          // otherwise pass.
           const result = runSchema(source, brandBasedConfig);
-          const override = findPathOverride(
-            result,
-            "total",
-            (entry) => entry.properties?.["amount"] !== undefined
-          );
-          expect(
-            override,
-            `expected a path override entry targeting 'amount' for @${tag}`
-          ).toBeDefined();
+          // Post-fix (#395): brand-registered custom types must also produce
+          // the broadened vocabulary keyword, not a raw built-in keyword.
+          expectBroadenedPathOverride(result, "total", "amount", vocabKeyword, payload);
         }
       );
 
-      it("broadens across a nullable brand-registered Decimal", () => {
+      it("broadens across a nullable brand-registered VocabDecimal", () => {
         const source = `
           ${brandBasedDecimal}
           export interface MonetaryAmount { amount: Decimal | null; currency: string; }
@@ -450,20 +506,20 @@ describe("generateSchemas with FormSpecConfig", () => {
           }
         `;
         const result = runSchema(source, brandBasedConfig);
-        const override = findPathOverride(
-          result,
-          "total",
-          (entry) => entry.properties?.["amount"] !== undefined
-        );
-        expect(override).toBeDefined();
+        expectBroadenedPathOverride(result, "total", "amount", "decimalExclusiveMinimum", "0");
       });
     });
 
+    // -----------------------------------------------------------------------
+    // Negative cases (fix must not paper over real type mismatches)
+    // -----------------------------------------------------------------------
     describe("negative cases (fix must not paper over real type mismatches)", () => {
       it("rejects numeric constraints when the path resolves to a non-custom string", () => {
+        // `currency: string` has no broadening registered — the fix must NOT
+        // silently fall through when the terminal type is a plain string.
         const source = `
           ${nameBasedDecimal}
-          export interface MonetaryAmount { amount: Decimal; currency: string; }
+          export interface MonetaryAmount { amount: VocabDecimal; currency: string; }
           export interface PaymentForm {
             /** @exclusiveMinimum :currency 0 */
             total: MonetaryAmount;
@@ -476,13 +532,13 @@ describe("generateSchemas with FormSpecConfig", () => {
         );
       });
 
-      it("rejects a string-only tag (@pattern) on a numeric-only Decimal path", () => {
-        // `@pattern` is a string-like constraint. Decimal has numeric
+      it("rejects a string-only tag (@pattern) on a numeric-only VocabDecimal path", () => {
+        // `@pattern` is a string-like constraint. VocabDecimal has numeric
         // broadenings registered but no string-pattern broadening, so the
         // deferral must not kick in and the capability check must reject.
         const source = `
           ${nameBasedDecimal}
-          export interface MonetaryAmount { amount: Decimal; currency: string; }
+          export interface MonetaryAmount { amount: VocabDecimal; currency: string; }
           export interface PaymentForm {
             /** @pattern :amount ^[0-9]+$ */
             total: MonetaryAmount;
@@ -509,6 +565,9 @@ describe("generateSchemas with FormSpecConfig", () => {
       });
     });
 
+    // -----------------------------------------------------------------------
+    // Symbol-based registration
+    //
     // Symbol-based registration is a separate shape from name / brand: it
     // pairs a `defineCustomType<T>()` type parameter in the config file with
     // the user-visible alias in the source. `generateSchemas` resolves the
@@ -516,6 +575,7 @@ describe("generateSchemas with FormSpecConfig", () => {
     // requires a multi-file fixture (decimal.ts + formspec.config.ts +
     // model.ts). Uses a `typeName` that does NOT match the alias identifier
     // so name-based lookup cannot accidentally satisfy the test.
+    // -----------------------------------------------------------------------
     describe("symbol-based registration (defineCustomType<T>())", () => {
       let tmpDir: string;
       let modelPath: string;
@@ -565,8 +625,8 @@ describe("generateSchemas with FormSpecConfig", () => {
             // symbol map rather than the name map.
             '      typeName: "OpaqueDecimal",',
             "      builtinConstraintBroadenings: [",
-            '        { tagName: "minimum", constraintName: "DecimalMinimum" },',
-            '        { tagName: "exclusiveMinimum", constraintName: "DecimalExclusiveMinimum" },',
+            '        { tagName: "minimum", constraintName: "DecimalMinimum", parseValue: (raw) => raw.trim() },',
+            '        { tagName: "exclusiveMinimum", constraintName: "DecimalExclusiveMinimum", parseValue: (raw) => raw.trim() },',
             "      ],",
             '      toJsonSchema: () => ({ type: "string" }),',
             "    }),",
@@ -609,14 +669,33 @@ describe("generateSchemas with FormSpecConfig", () => {
         const opaqueDecimal = defineCustomType({
           typeName: "OpaqueDecimal",
           builtinConstraintBroadenings: [
-            { tagName: "minimum", constraintName: "DecimalMinimum" },
-            { tagName: "exclusiveMinimum", constraintName: "DecimalExclusiveMinimum" },
+            { tagName: "minimum", constraintName: "DecimalMinimum", parseValue: (raw: string) => raw.trim() },
+            { tagName: "exclusiveMinimum", constraintName: "DecimalExclusiveMinimum", parseValue: (raw: string) => raw.trim() },
           ],
           toJsonSchema: () => ({ type: "string" }),
         });
         const extension = defineExtension({
           extensionId: "x-symtest",
           types: [opaqueDecimal],
+          // Constraints must be registered for the broadening to complete — the
+          // broadening references constraintName and the registry must find the
+          // constraint definition to build the constraint node.
+          constraints: [
+            defineConstraint({
+              constraintName: "DecimalMinimum",
+              compositionRule: "intersect",
+              applicableTypes: ["custom"],
+              emitsVocabularyKeywords: true,
+              toJsonSchema: (payload) => ({ symDecimalMinimum: payload }),
+            }),
+            defineConstraint({
+              constraintName: "DecimalExclusiveMinimum",
+              compositionRule: "intersect",
+              applicableTypes: ["custom"],
+              emitsVocabularyKeywords: true,
+              toJsonSchema: (payload) => ({ symDecimalExclusiveMinimum: payload }),
+            }),
+          ],
         });
         const result = generateSchemas({
           filePath: modelPath,
@@ -635,6 +714,141 @@ describe("generateSchemas with FormSpecConfig", () => {
           "expected a path override entry targeting 'amount' on the symbol-registered custom type"
         ).toBeDefined();
       });
+    });
+
+    // -----------------------------------------------------------------------
+    // Mixed direct + path constraints
+    //
+    // When a field has both a direct constraint and a path-targeted constraint,
+    // both must broaden independently.
+    // -----------------------------------------------------------------------
+    describe("mixed direct and path constraints", () => {
+      it("applies both a path-targeted broadened constraint and a custom constraint tag independently", () => {
+        // `@exclusiveMinimum :amount 0` broadens to decimalExclusiveMinimum on the amount path.
+        // `@maximum :amount 100` broadens to decimalMaximum on the amount path.
+        // Both must appear on the same amount segment schema.
+        const source = `
+          ${nameBasedDecimal}
+          export interface MonetaryAmount { amount: VocabDecimal; currency: string; }
+          export interface PaymentForm {
+            /** @exclusiveMinimum :amount 0 @maximum :amount 100 */
+            total: MonetaryAmount;
+          }
+        `;
+        const result = runSchema(source, nameBasedConfig);
+        const amountSchema = result.jsonSchema.properties?.["total"]?.properties?.["amount"];
+        expect(amountSchema, "expected properties.total.properties.amount").toBeDefined();
+        expect(
+          (amountSchema as Record<string, unknown>)["decimalExclusiveMinimum"],
+          "expected decimalExclusiveMinimum: '0'"
+        ).toBe("0");
+        expect(
+          (amountSchema as Record<string, unknown>)["decimalMaximum"],
+          "expected decimalMaximum: '100'"
+        ).toBe("100");
+      });
+    });
+  });
+
+  // =========================================================================
+  // Path-targeted broadening on string-backed custom types.
+  //
+  // The `@minLength`, `@maxLength`, and `@pattern` built-in tags must also
+  // broadened when the path terminal resolves to a string-backed custom type
+  // with broadenings registered (here: `PostalCode`).
+  // =========================================================================
+  describe("path-targeted broadening on string-backed custom types", () => {
+    const postalCodeDecl =
+      `export type PostalCode = string & { readonly __brand: "PostalCode" };`;
+
+    const postalConfig: FormSpecConfig = {
+      extensions: [vocabStringExtension],
+      vendorPrefix: "x-test",
+    };
+
+    function runPostalSchema(source: string) {
+      const filePath = writeTempSource(source);
+      try {
+        return generateSchemas({
+          filePath,
+          typeName: "DeliveryForm",
+          config: postalConfig,
+          errorReporting: "throw",
+        });
+      } finally {
+        fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+      }
+    }
+
+    it("broadens @minLength through a path target onto a PostalCode subfield", () => {
+      // @minLength :code 5 on Envelope.code: PostalCode should emit
+      // postalMinLength: "5" (vocabulary keyword, string payload).
+      const source = `
+        ${postalCodeDecl}
+        export interface Envelope { code: PostalCode; name: string; }
+        export interface DeliveryForm {
+          /** @minLength :code 5 */
+          address: Envelope;
+        }
+      `;
+      const result = runPostalSchema(source);
+      const codeSchema = result.jsonSchema.properties?.["address"]?.properties?.["code"];
+      expect(codeSchema, "expected properties.address.properties.code").toBeDefined();
+      expect((codeSchema as Record<string, unknown>)["postalMinLength"]).toBe("5");
+    });
+
+    it("broadens @maxLength through a path target onto a PostalCode subfield", () => {
+      const source = `
+        ${postalCodeDecl}
+        export interface Envelope { code: PostalCode; name: string; }
+        export interface DeliveryForm {
+          /** @maxLength :code 10 */
+          address: Envelope;
+        }
+      `;
+      const result = runPostalSchema(source);
+      const codeSchema = result.jsonSchema.properties?.["address"]?.properties?.["code"];
+      expect((codeSchema as Record<string, unknown>)["postalMaxLength"]).toBe("10");
+    });
+
+    it("broadens @pattern through a path target onto a PostalCode subfield", () => {
+      const source = `
+        ${postalCodeDecl}
+        export interface Envelope { code: PostalCode; name: string; }
+        export interface DeliveryForm {
+          /** @pattern :code ^\\\\d{5}$ */
+          address: Envelope;
+        }
+      `;
+      const result = runPostalSchema(source);
+      const codeSchema = result.jsonSchema.properties?.["address"]?.properties?.["code"];
+      expect((codeSchema as Record<string, unknown>)["postalPattern"]).toBeDefined();
+    });
+
+    it("does not broadens @minimum (numeric) onto a string-backed PostalCode (no registration)", () => {
+      // PostalCode has no broadening for `@minimum`, so this must produce a
+      // TYPE_MISMATCH — not silent fallthrough, not raw keyword emission.
+      const source = `
+        ${postalCodeDecl}
+        export interface Envelope { code: PostalCode; name: string; }
+        export interface DeliveryForm {
+          /** @minimum :code 0 */
+          address: Envelope;
+        }
+      `;
+      const filePath = writeTempSource(source);
+      try {
+        expect(() =>
+          generateSchemas({
+            filePath,
+            typeName: "DeliveryForm",
+            config: postalConfig,
+            errorReporting: "throw",
+          })
+        ).toThrow(/TYPE_MISMATCH/);
+      } finally {
+        fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/build/src/__tests__/generate-schemas-config.test.ts
+++ b/packages/build/src/__tests__/generate-schemas-config.test.ts
@@ -260,8 +260,7 @@ describe("generateSchemas with FormSpecConfig", () => {
      * Name-based: resolved via `tsTypeNames: ["VocabDecimal"]`.
      * The alias name matches the registered `tsTypeName` exactly.
      */
-    const nameBasedDecimal =
-      `export type VocabDecimal = string & { readonly __brand: "VocabDecimal" };`;
+    const nameBasedDecimal = `export type VocabDecimal = string & { readonly __brand: "VocabDecimal" };`;
 
     /**
      * Brand-based: resolved structurally via `brand: "__vocabDecimalBrand"`.
@@ -669,8 +668,16 @@ describe("generateSchemas with FormSpecConfig", () => {
         const opaqueDecimal = defineCustomType({
           typeName: "OpaqueDecimal",
           builtinConstraintBroadenings: [
-            { tagName: "minimum", constraintName: "DecimalMinimum", parseValue: (raw: string) => raw.trim() },
-            { tagName: "exclusiveMinimum", constraintName: "DecimalExclusiveMinimum", parseValue: (raw: string) => raw.trim() },
+            {
+              tagName: "minimum",
+              constraintName: "DecimalMinimum",
+              parseValue: (raw: string) => raw.trim(),
+            },
+            {
+              tagName: "exclusiveMinimum",
+              constraintName: "DecimalExclusiveMinimum",
+              parseValue: (raw: string) => raw.trim(),
+            },
           ],
           toJsonSchema: () => ({ type: "string" }),
         });
@@ -713,6 +720,19 @@ describe("generateSchemas with FormSpecConfig", () => {
           override,
           "expected a path override entry targeting 'amount' on the symbol-registered custom type"
         ).toBeDefined();
+        // Pin the broadened keyword + payload rather than just presence — a regression to
+        // raw `exclusiveMinimum: 0` emission would otherwise pass the shape-only check.
+        const amountSchema = override?.properties?.["amount"] as
+          | Record<string, unknown>
+          | undefined;
+        expect(
+          amountSchema?.["symDecimalExclusiveMinimum"],
+          "expected broadened vocabulary keyword symDecimalExclusiveMinimum === '0'"
+        ).toBe("0");
+        expect(
+          amountSchema?.["exclusiveMinimum"],
+          "raw numeric `exclusiveMinimum` must NOT appear — path broadening regressed"
+        ).toBeUndefined();
       });
     });
 
@@ -758,8 +778,7 @@ describe("generateSchemas with FormSpecConfig", () => {
   // with broadenings registered (here: `PostalCode`).
   // =========================================================================
   describe("path-targeted broadening on string-backed custom types", () => {
-    const postalCodeDecl =
-      `export type PostalCode = string & { readonly __brand: "PostalCode" };`;
+    const postalCodeDecl = `export type PostalCode = string & { readonly __brand: "PostalCode" };`;
 
     const postalConfig: FormSpecConfig = {
       extensions: [vocabStringExtension],
@@ -812,20 +831,31 @@ describe("generateSchemas with FormSpecConfig", () => {
     });
 
     it("broadens @pattern through a path target onto a PostalCode subfield", () => {
+      // Source-level @pattern arg: ^\d{5}$ — doubled in the source template so it
+      // reaches the tag parser as a single backslash before the `d`. Per spec 002,
+      // the raw tag text after stripping the leading `:code ` segment is the
+      // pattern payload; the fixture's parseValue is `raw.trim()`, so the payload
+      // is the exact JSON-Schema-style regex literal.
       const source = `
         ${postalCodeDecl}
         export interface Envelope { code: PostalCode; name: string; }
         export interface DeliveryForm {
-          /** @pattern :code ^\\\\d{5}$ */
+          /** @pattern :code ^\\d{5}$ */
           address: Envelope;
         }
       `;
       const result = runPostalSchema(source);
-      const codeSchema = result.jsonSchema.properties?.["address"]?.properties?.["code"];
-      expect((codeSchema as Record<string, unknown>)["postalPattern"]).toBeDefined();
+      const codeSchema = result.jsonSchema.properties?.["address"]?.properties?.["code"] as
+        | Record<string, unknown>
+        | undefined;
+      // Pin the exact payload so a payload-mangling regression (e.g. lost
+      // backslash, accidental JSON-stringification) is caught.
+      expect(codeSchema?.["postalPattern"]).toBe("^\\d{5}$");
+      // Raw `pattern` keyword must NOT appear — that would mean broadening regressed.
+      expect(codeSchema?.["pattern"]).toBeUndefined();
     });
 
-    it("does not broadens @minimum (numeric) onto a string-backed PostalCode (no registration)", () => {
+    it("does not broaden @minimum (numeric) onto a string-backed PostalCode (no registration)", () => {
       // PostalCode has no broadening for `@minimum`, so this must produce a
       // TYPE_MISMATCH — not silent fallthrough, not raw keyword emission.
       const source = `

--- a/packages/build/src/__tests__/path-target-custom-type-broadening.test.ts
+++ b/packages/build/src/__tests__/path-target-custom-type-broadening.test.ts
@@ -22,8 +22,8 @@
  *     `(raw) => raw.trim()`.
  *   - "Correct terminal" means the keyword lands on `properties.<last-segment>`
  *     within any intermediate `properties` nesting, not on an enclosing level.
- *   - Array traversal via path-targeting (`:items.amount`) is not currently
- *     supported; tests for that feature are deferred.
+ *   - Array traversal is transparent: path segments walk through `items`
+ *     without consuming a segment — see the "mixed shape composition" tests.
  *   - Records/dictionaries are not currently traversable via path targeting;
  *     a TODO is included below.
  *
@@ -35,236 +35,54 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
-import { defineConstraint, defineCustomType, defineExtension } from "@formspec/core/internals";
 import type { FormSpecConfig } from "@formspec/config";
 import { type ClassSchemas, generateSchemas } from "../generators/class-schema.js";
 import type { JsonSchema2020 } from "../json-schema/ir-generator.js";
-
-// =============================================================================
-// EXTENSION FIXTURES
-//
-// All fixtures use `emitsVocabularyKeywords: true` so broadened output is a
-// camelCase keyword + string payload. This lets tests pin exact values without
-// accounting for vendor-prefix construction.
-// =============================================================================
-
-/** Identity parser: returns the raw tag argument as a trimmed string. */
-const trimmedString = (raw: string): string => raw.trim();
-
-/**
- * Name-based Decimal: detected by the TypeScript alias name "Decimal".
- * Broadenings map @minimum → decimalMinimum, @maximum → decimalMaximum, etc.
- * Payload is a string (the raw tag argument).
- */
-const nameBasedDecimalExtension = defineExtension({
-  extensionId: "x-test/decimal-name",
-  types: [
-    defineCustomType({
-      typeName: "Decimal",
-      tsTypeNames: ["Decimal"],
-      builtinConstraintBroadenings: [
-        { tagName: "minimum", constraintName: "DecimalMinimum", parseValue: trimmedString },
-        { tagName: "maximum", constraintName: "DecimalMaximum", parseValue: trimmedString },
-        {
-          tagName: "exclusiveMinimum",
-          constraintName: "DecimalExclusiveMinimum",
-          parseValue: trimmedString,
-        },
-        {
-          tagName: "exclusiveMaximum",
-          constraintName: "DecimalExclusiveMaximum",
-          parseValue: trimmedString,
-        },
-        { tagName: "multipleOf", constraintName: "DecimalMultipleOf", parseValue: trimmedString },
-      ],
-      toJsonSchema: () => ({ type: "string", format: "decimal" }),
-    }),
-  ],
-  constraints: [
-    defineConstraint({
-      constraintName: "DecimalMinimum",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      isApplicableToType: (t) => t.kind === "custom",
-      emitsVocabularyKeywords: true,
-      semanticRole: { family: "decimal-bound", bound: "lower", inclusive: true },
-      toJsonSchema: (payload) => ({ decimalMinimum: payload }),
-    }),
-    defineConstraint({
-      constraintName: "DecimalMaximum",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      isApplicableToType: (t) => t.kind === "custom",
-      emitsVocabularyKeywords: true,
-      semanticRole: { family: "decimal-bound", bound: "upper", inclusive: true },
-      toJsonSchema: (payload) => ({ decimalMaximum: payload }),
-    }),
-    defineConstraint({
-      constraintName: "DecimalExclusiveMinimum",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      isApplicableToType: (t) => t.kind === "custom",
-      emitsVocabularyKeywords: true,
-      semanticRole: { family: "decimal-bound", bound: "lower", inclusive: false },
-      toJsonSchema: (payload) => ({ decimalExclusiveMinimum: payload }),
-    }),
-    defineConstraint({
-      constraintName: "DecimalExclusiveMaximum",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      isApplicableToType: (t) => t.kind === "custom",
-      emitsVocabularyKeywords: true,
-      semanticRole: { family: "decimal-bound", bound: "upper", inclusive: false },
-      toJsonSchema: (payload) => ({ decimalExclusiveMaximum: payload }),
-    }),
-    defineConstraint({
-      constraintName: "DecimalMultipleOf",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      isApplicableToType: (t) => t.kind === "custom",
-      emitsVocabularyKeywords: true,
-      toJsonSchema: (payload) => ({ decimalMultipleOf: payload }),
-    }),
-  ],
-});
-
-/**
- * Brand-based Decimal: detected via the `__decimalBrand` unique-symbol
- * computed property key. Same broadenings as the name-based version.
- */
-const brandBasedDecimalExtension = defineExtension({
-  extensionId: "x-test/decimal-brand",
-  types: [
-    defineCustomType({
-      typeName: "Decimal",
-      brand: "__decimalBrand",
-      builtinConstraintBroadenings: [
-        { tagName: "minimum", constraintName: "DecimalMinimum", parseValue: trimmedString },
-        { tagName: "maximum", constraintName: "DecimalMaximum", parseValue: trimmedString },
-        {
-          tagName: "exclusiveMinimum",
-          constraintName: "DecimalExclusiveMinimum",
-          parseValue: trimmedString,
-        },
-        {
-          tagName: "exclusiveMaximum",
-          constraintName: "DecimalExclusiveMaximum",
-          parseValue: trimmedString,
-        },
-        { tagName: "multipleOf", constraintName: "DecimalMultipleOf", parseValue: trimmedString },
-      ],
-      toJsonSchema: () => ({ type: "string", format: "decimal" }),
-    }),
-  ],
-  constraints: [
-    defineConstraint({
-      constraintName: "DecimalMinimum",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      emitsVocabularyKeywords: true,
-      semanticRole: { family: "decimal-bound", bound: "lower", inclusive: true },
-      toJsonSchema: (payload) => ({ decimalMinimum: payload }),
-    }),
-    defineConstraint({
-      constraintName: "DecimalMaximum",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      emitsVocabularyKeywords: true,
-      semanticRole: { family: "decimal-bound", bound: "upper", inclusive: true },
-      toJsonSchema: (payload) => ({ decimalMaximum: payload }),
-    }),
-    defineConstraint({
-      constraintName: "DecimalExclusiveMinimum",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      emitsVocabularyKeywords: true,
-      semanticRole: { family: "decimal-bound", bound: "lower", inclusive: false },
-      toJsonSchema: (payload) => ({ decimalExclusiveMinimum: payload }),
-    }),
-    defineConstraint({
-      constraintName: "DecimalExclusiveMaximum",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      emitsVocabularyKeywords: true,
-      semanticRole: { family: "decimal-bound", bound: "upper", inclusive: false },
-      toJsonSchema: (payload) => ({ decimalExclusiveMaximum: payload }),
-    }),
-    defineConstraint({
-      constraintName: "DecimalMultipleOf",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      emitsVocabularyKeywords: true,
-      toJsonSchema: (payload) => ({ decimalMultipleOf: payload }),
-    }),
-  ],
-});
-
-/**
- * String-backed PostalCode: detected by the TypeScript alias name "PostalCode".
- * Broadens `maxLength` → postalMaxLength, `pattern` → postalPattern.
- */
-const postalCodeExtension = defineExtension({
-  extensionId: "x-test/postal-code",
-  types: [
-    defineCustomType({
-      typeName: "PostalCode",
-      tsTypeNames: ["PostalCode"],
-      builtinConstraintBroadenings: [
-        { tagName: "maxLength", constraintName: "PostalCodeMaxLength", parseValue: trimmedString },
-        { tagName: "pattern", constraintName: "PostalCodePattern", parseValue: trimmedString },
-      ],
-      toJsonSchema: () => ({ type: "string", format: "postal-code" }),
-    }),
-  ],
-  constraints: [
-    defineConstraint({
-      constraintName: "PostalCodeMaxLength",
-      compositionRule: "intersect",
-      applicableTypes: ["custom"],
-      emitsVocabularyKeywords: true,
-      semanticRole: { family: "postal-length", bound: "upper", inclusive: true },
-      toJsonSchema: (payload) => ({ postalMaxLength: payload }),
-    }),
-    defineConstraint({
-      constraintName: "PostalCodePattern",
-      compositionRule: "override",
-      applicableTypes: ["custom"],
-      emitsVocabularyKeywords: true,
-      toJsonSchema: (payload) => ({ postalPattern: payload }),
-    }),
-  ],
-});
+import {
+  vocabDecimalByNameExtension,
+  vocabDecimalByBrandExtension,
+} from "./fixtures/example-vocabulary-decimal-extension.js";
+import { vocabStringExtension } from "./fixtures/example-vocabulary-string-extension.js";
 
 // =============================================================================
 // CONFIG OBJECTS
+//
+// All three configs reuse the shared vocabulary-mode fixtures under
+// `fixtures/example-vocabulary-*.ts`. A single authoritative registration set
+// keeps this file and `generate-schemas-config.test.ts` from drifting — see
+// the simplicity-review note on issue #395 / PR #398.
 // =============================================================================
 
 const nameBasedConfig: FormSpecConfig = {
-  extensions: [nameBasedDecimalExtension],
+  extensions: [vocabDecimalByNameExtension],
   vendorPrefix: "x-formspec",
 };
 
 const brandBasedConfig: FormSpecConfig = {
-  extensions: [brandBasedDecimalExtension],
+  extensions: [vocabDecimalByBrandExtension],
   vendorPrefix: "x-test",
 };
 
 const postalCodeConfig: FormSpecConfig = {
-  extensions: [postalCodeExtension],
+  extensions: [vocabStringExtension],
   vendorPrefix: "x-formspec",
 };
 
 // =============================================================================
 // SOURCE DECLARATIONS
+//
+// Source strings reference the same type/alias/brand names the shared fixtures
+// register: `Decimal` resolves through `tsTypeNames` (which accepts both
+// `VocabDecimal` and `Decimal`); brand-based sources use `__vocabDecimalBrand`.
 // =============================================================================
 
-/** TypeScript source for the name-based Decimal type. */
+/** TypeScript source for the name-based Decimal type (accepted by the shared fixture). */
 const NAME_DECIMAL_DECL = `export type Decimal = string & { readonly __brand: "Decimal" };`;
 
-/** TypeScript source for the brand-based Decimal type. */
+/** TypeScript source for the brand-based Decimal type using the shared fixture's brand key. */
 const BRAND_DECIMAL_DECL = [
-  "declare const __decimalBrand: unique symbol;",
-  "export type Decimal = string & { readonly [__decimalBrand]: true };",
+  "declare const __vocabDecimalBrand: unique symbol;",
+  "export type Decimal = string & { readonly [__vocabDecimalBrand]: true };",
 ].join("\n");
 
 /** TypeScript source for the PostalCode type. */
@@ -601,12 +419,12 @@ describe("multi-level path-target nesting", () => {
 // =============================================================================
 // ARRAY TRAVERSAL AT MULTIPLE DEPTHS
 //
-// NOTE: Array path traversal (`:items.amount`) is NOT currently supported.
-// `@minimum :items.amount 0` on an array field produces `UNKNOWN_PATH_TARGET`.
-// Tests for array traversal are deferred until the feature is implemented.
-//
-// TODO: Implement array traversal and add tests here once supported.
-// See: https://github.com/mike-north/formspec/issues/395 (follow-up)
+// Array path traversal is transparent: `:items.amount` on `Cart { items:
+// MonetaryAmount[] }` walks through the array element without consuming a
+// segment. Both `resolvePathTargetType` (TS-level) and `resolveProperty`
+// (IR-level) recurse into `ArrayTypeNode.items` when they encounter one.
+// Concrete array-traversal cases live in the "mixed shape composition"
+// describe block below (single wrapper, mid-path, nested arrays).
 // =============================================================================
 
 // =============================================================================
@@ -650,7 +468,10 @@ describe("nullable at various depths", () => {
 
     const result = runSchema(source, nameBasedConfig);
     const terminal = getTerminal(result, "line", "money", "amount");
-    expect(terminal, "expected money.amount sub-schema through nullable intermediate").toBeDefined();
+    expect(
+      terminal,
+      "expected money.amount sub-schema through nullable intermediate"
+    ).toBeDefined();
     expect(terminal?.["decimalMinimum"]).toBe("0");
   });
 
@@ -670,7 +491,10 @@ describe("nullable at various depths", () => {
 
     const result = runSchema(source, nameBasedConfig);
     const terminal = getTerminal(result, "order", "line", "money", "amount");
-    expect(terminal, "expected line.money.amount sub-schema through nullable root segment").toBeDefined();
+    expect(
+      terminal,
+      "expected line.money.amount sub-schema through nullable root segment"
+    ).toBeDefined();
     expect(terminal?.["decimalMinimum"]).toBe("0");
   });
 
@@ -725,9 +549,9 @@ describe("mixed shape composition", () => {
       | Record<string, unknown>
       | undefined;
     const arrayItemSchema = itemsField?.["items"] as Record<string, unknown> | undefined;
-    const amountSchema = (
-      arrayItemSchema?.["properties"] as Record<string, unknown> | undefined
-    )?.["amount"] as Record<string, unknown> | undefined;
+    const amountSchema = (arrayItemSchema?.["properties"] as Record<string, unknown> | undefined)?.[
+      "amount"
+    ] as Record<string, unknown> | undefined;
     expect(amountSchema, "expected items[].amount override schema").toBeDefined();
     expect(amountSchema?.["decimalMinimum"]).toBe("0");
   });
@@ -882,7 +706,10 @@ describe("multiple sub-paths on the same field", () => {
     const fieldSchema = result.jsonSchema.properties?.["total"] as
       | Record<string, unknown>
       | undefined;
-    expect(fieldSchema?.["decimalMinimum"], "decimalMinimum must not appear at field level").toBeUndefined();
+    expect(
+      fieldSchema?.["decimalMinimum"],
+      "decimalMinimum must not appear at field level"
+    ).toBeUndefined();
     expect(fieldSchema?.["minimum"], "minimum must not appear at field level").toBeUndefined();
     expect(fieldSchema?.["maxLength"], "maxLength must not appear at field level").toBeUndefined();
   });
@@ -931,6 +758,9 @@ describe("direct constraint + path-targeted constraints on the same field", () =
       amountTerminal?.["decimalMinimum"],
       "decimalMinimum must not appear on amount"
     ).toBeUndefined();
-    expect(countTerminal?.["decimalMaximum"], "decimalMaximum must not appear on count").toBeUndefined();
+    expect(
+      countTerminal?.["decimalMaximum"],
+      "decimalMaximum must not appear on count"
+    ).toBeUndefined();
   });
 });

--- a/packages/build/src/__tests__/path-target-custom-type-broadening.test.ts
+++ b/packages/build/src/__tests__/path-target-custom-type-broadening.test.ts
@@ -1,0 +1,936 @@
+/**
+ * Extended path-targeted custom-type broadening tests.
+ *
+ * Covers the full matrix of registration styles × nesting depths × structural
+ * shapes (nullable unions, mixed compositions) for path-targeted
+ * `@constraint :path value` tags that resolve to extension-registered custom
+ * types.
+ *
+ * Three registration styles under test:
+ *   1. Name-based Decimal   (`tsTypeNames: ["Decimal"]`)
+ *   2. Brand-based Decimal  (`brand: "__decimalBrand"`)
+ *   3. String-backed PostalCode (broadens `maxLength` + `pattern`)
+ *
+ * Design notes:
+ *   - Path-targeted broadening emits vocabulary keywords at the terminal
+ *     location when the terminal type is a registered custom type with a
+ *     broadening for that tag (issue #395).
+ *   - The test fixtures use `emitsVocabularyKeywords: true` so assertions can
+ *     pin camelCase keyword names directly (e.g. `decimalMinimum: "0"`) rather
+ *     than vendor-prefix constructions.
+ *   - Payload values are strings because the fixture's `parseValue` uses
+ *     `(raw) => raw.trim()`.
+ *   - "Correct terminal" means the keyword lands on `properties.<last-segment>`
+ *     within any intermediate `properties` nesting, not on an enclosing level.
+ *   - Array traversal via path-targeting (`:items.amount`) is not currently
+ *     supported; tests for that feature are deferred.
+ *   - Records/dictionaries are not currently traversable via path targeting;
+ *     a TODO is included below.
+ *
+ * @see https://github.com/mike-north/formspec/issues/395 — path-targeted broadening
+ * @see https://json-schema.org/draft/2020-12/json-schema-core §10.2.1 — sibling keywords next to $ref
+ */
+
+import * as path from "node:path";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { defineConstraint, defineCustomType, defineExtension } from "@formspec/core/internals";
+import type { FormSpecConfig } from "@formspec/config";
+import { type ClassSchemas, generateSchemas } from "../generators/class-schema.js";
+import type { JsonSchema2020 } from "../json-schema/ir-generator.js";
+
+// =============================================================================
+// EXTENSION FIXTURES
+//
+// All fixtures use `emitsVocabularyKeywords: true` so broadened output is a
+// camelCase keyword + string payload. This lets tests pin exact values without
+// accounting for vendor-prefix construction.
+// =============================================================================
+
+/** Identity parser: returns the raw tag argument as a trimmed string. */
+const trimmedString = (raw: string): string => raw.trim();
+
+/**
+ * Name-based Decimal: detected by the TypeScript alias name "Decimal".
+ * Broadenings map @minimum → decimalMinimum, @maximum → decimalMaximum, etc.
+ * Payload is a string (the raw tag argument).
+ */
+const nameBasedDecimalExtension = defineExtension({
+  extensionId: "x-test/decimal-name",
+  types: [
+    defineCustomType({
+      typeName: "Decimal",
+      tsTypeNames: ["Decimal"],
+      builtinConstraintBroadenings: [
+        { tagName: "minimum", constraintName: "DecimalMinimum", parseValue: trimmedString },
+        { tagName: "maximum", constraintName: "DecimalMaximum", parseValue: trimmedString },
+        {
+          tagName: "exclusiveMinimum",
+          constraintName: "DecimalExclusiveMinimum",
+          parseValue: trimmedString,
+        },
+        {
+          tagName: "exclusiveMaximum",
+          constraintName: "DecimalExclusiveMaximum",
+          parseValue: trimmedString,
+        },
+        { tagName: "multipleOf", constraintName: "DecimalMultipleOf", parseValue: trimmedString },
+      ],
+      toJsonSchema: () => ({ type: "string", format: "decimal" }),
+    }),
+  ],
+  constraints: [
+    defineConstraint({
+      constraintName: "DecimalMinimum",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      isApplicableToType: (t) => t.kind === "custom",
+      emitsVocabularyKeywords: true,
+      semanticRole: { family: "decimal-bound", bound: "lower", inclusive: true },
+      toJsonSchema: (payload) => ({ decimalMinimum: payload }),
+    }),
+    defineConstraint({
+      constraintName: "DecimalMaximum",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      isApplicableToType: (t) => t.kind === "custom",
+      emitsVocabularyKeywords: true,
+      semanticRole: { family: "decimal-bound", bound: "upper", inclusive: true },
+      toJsonSchema: (payload) => ({ decimalMaximum: payload }),
+    }),
+    defineConstraint({
+      constraintName: "DecimalExclusiveMinimum",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      isApplicableToType: (t) => t.kind === "custom",
+      emitsVocabularyKeywords: true,
+      semanticRole: { family: "decimal-bound", bound: "lower", inclusive: false },
+      toJsonSchema: (payload) => ({ decimalExclusiveMinimum: payload }),
+    }),
+    defineConstraint({
+      constraintName: "DecimalExclusiveMaximum",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      isApplicableToType: (t) => t.kind === "custom",
+      emitsVocabularyKeywords: true,
+      semanticRole: { family: "decimal-bound", bound: "upper", inclusive: false },
+      toJsonSchema: (payload) => ({ decimalExclusiveMaximum: payload }),
+    }),
+    defineConstraint({
+      constraintName: "DecimalMultipleOf",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      isApplicableToType: (t) => t.kind === "custom",
+      emitsVocabularyKeywords: true,
+      toJsonSchema: (payload) => ({ decimalMultipleOf: payload }),
+    }),
+  ],
+});
+
+/**
+ * Brand-based Decimal: detected via the `__decimalBrand` unique-symbol
+ * computed property key. Same broadenings as the name-based version.
+ */
+const brandBasedDecimalExtension = defineExtension({
+  extensionId: "x-test/decimal-brand",
+  types: [
+    defineCustomType({
+      typeName: "Decimal",
+      brand: "__decimalBrand",
+      builtinConstraintBroadenings: [
+        { tagName: "minimum", constraintName: "DecimalMinimum", parseValue: trimmedString },
+        { tagName: "maximum", constraintName: "DecimalMaximum", parseValue: trimmedString },
+        {
+          tagName: "exclusiveMinimum",
+          constraintName: "DecimalExclusiveMinimum",
+          parseValue: trimmedString,
+        },
+        {
+          tagName: "exclusiveMaximum",
+          constraintName: "DecimalExclusiveMaximum",
+          parseValue: trimmedString,
+        },
+        { tagName: "multipleOf", constraintName: "DecimalMultipleOf", parseValue: trimmedString },
+      ],
+      toJsonSchema: () => ({ type: "string", format: "decimal" }),
+    }),
+  ],
+  constraints: [
+    defineConstraint({
+      constraintName: "DecimalMinimum",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      emitsVocabularyKeywords: true,
+      semanticRole: { family: "decimal-bound", bound: "lower", inclusive: true },
+      toJsonSchema: (payload) => ({ decimalMinimum: payload }),
+    }),
+    defineConstraint({
+      constraintName: "DecimalMaximum",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      emitsVocabularyKeywords: true,
+      semanticRole: { family: "decimal-bound", bound: "upper", inclusive: true },
+      toJsonSchema: (payload) => ({ decimalMaximum: payload }),
+    }),
+    defineConstraint({
+      constraintName: "DecimalExclusiveMinimum",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      emitsVocabularyKeywords: true,
+      semanticRole: { family: "decimal-bound", bound: "lower", inclusive: false },
+      toJsonSchema: (payload) => ({ decimalExclusiveMinimum: payload }),
+    }),
+    defineConstraint({
+      constraintName: "DecimalExclusiveMaximum",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      emitsVocabularyKeywords: true,
+      semanticRole: { family: "decimal-bound", bound: "upper", inclusive: false },
+      toJsonSchema: (payload) => ({ decimalExclusiveMaximum: payload }),
+    }),
+    defineConstraint({
+      constraintName: "DecimalMultipleOf",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      emitsVocabularyKeywords: true,
+      toJsonSchema: (payload) => ({ decimalMultipleOf: payload }),
+    }),
+  ],
+});
+
+/**
+ * String-backed PostalCode: detected by the TypeScript alias name "PostalCode".
+ * Broadens `maxLength` → postalMaxLength, `pattern` → postalPattern.
+ */
+const postalCodeExtension = defineExtension({
+  extensionId: "x-test/postal-code",
+  types: [
+    defineCustomType({
+      typeName: "PostalCode",
+      tsTypeNames: ["PostalCode"],
+      builtinConstraintBroadenings: [
+        { tagName: "maxLength", constraintName: "PostalCodeMaxLength", parseValue: trimmedString },
+        { tagName: "pattern", constraintName: "PostalCodePattern", parseValue: trimmedString },
+      ],
+      toJsonSchema: () => ({ type: "string", format: "postal-code" }),
+    }),
+  ],
+  constraints: [
+    defineConstraint({
+      constraintName: "PostalCodeMaxLength",
+      compositionRule: "intersect",
+      applicableTypes: ["custom"],
+      emitsVocabularyKeywords: true,
+      semanticRole: { family: "postal-length", bound: "upper", inclusive: true },
+      toJsonSchema: (payload) => ({ postalMaxLength: payload }),
+    }),
+    defineConstraint({
+      constraintName: "PostalCodePattern",
+      compositionRule: "override",
+      applicableTypes: ["custom"],
+      emitsVocabularyKeywords: true,
+      toJsonSchema: (payload) => ({ postalPattern: payload }),
+    }),
+  ],
+});
+
+// =============================================================================
+// CONFIG OBJECTS
+// =============================================================================
+
+const nameBasedConfig: FormSpecConfig = {
+  extensions: [nameBasedDecimalExtension],
+  vendorPrefix: "x-formspec",
+};
+
+const brandBasedConfig: FormSpecConfig = {
+  extensions: [brandBasedDecimalExtension],
+  vendorPrefix: "x-test",
+};
+
+const postalCodeConfig: FormSpecConfig = {
+  extensions: [postalCodeExtension],
+  vendorPrefix: "x-formspec",
+};
+
+// =============================================================================
+// SOURCE DECLARATIONS
+// =============================================================================
+
+/** TypeScript source for the name-based Decimal type. */
+const NAME_DECIMAL_DECL = `export type Decimal = string & { readonly __brand: "Decimal" };`;
+
+/** TypeScript source for the brand-based Decimal type. */
+const BRAND_DECIMAL_DECL = [
+  "declare const __decimalBrand: unique symbol;",
+  "export type Decimal = string & { readonly [__decimalBrand]: true };",
+].join("\n");
+
+/** TypeScript source for the PostalCode type. */
+const POSTAL_CODE_DECL = `export type PostalCode = string & { readonly __postalBrand: "PostalCode" };`;
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeTempSource(source: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-path-broaden-"));
+  tempDirs.push(dir);
+  const filePath = path.join(dir, "model.ts");
+  fs.writeFileSync(filePath, source);
+  return filePath;
+}
+
+function runSchema(source: string, config: FormSpecConfig): ClassSchemas {
+  const filePath = writeTempSource(source);
+  return generateSchemas({
+    filePath,
+    typeName: "Root",
+    config,
+    errorReporting: "throw",
+  });
+}
+
+/**
+ * Drills into a schema along the given path segments (via `.properties[seg]`)
+ * and returns the terminal sub-schema. Returns `undefined` if any segment is
+ * missing. Used to assert that a keyword lands at the correct level.
+ */
+function drillToTerminal(
+  schema: JsonSchema2020 | undefined,
+  ...segments: string[]
+): Record<string, unknown> | undefined {
+  let current: Record<string, unknown> | undefined = schema as Record<string, unknown> | undefined;
+  for (const seg of segments) {
+    if (current === undefined) return undefined;
+    const props = current["properties"] as Record<string, unknown> | undefined;
+    current = props?.[seg] as Record<string, unknown> | undefined;
+  }
+  return current;
+}
+
+/**
+ * Gets the top-level field schema from the root object's properties and
+ * drills through the given path segments to find the terminal sub-schema.
+ *
+ * @param result       - schema generation result
+ * @param rootField    - the top-level property name (e.g. "total")
+ * @param pathSegments - the segment chain to traverse within the field schema
+ */
+function getTerminal(
+  result: ClassSchemas,
+  rootField: string,
+  ...pathSegments: string[]
+): Record<string, unknown> | undefined {
+  const fieldSchema = result.jsonSchema.properties?.[rootField];
+  if (fieldSchema === undefined) return undefined;
+
+  // When there's only one segment, check `fieldSchema.properties[segment]`.
+  // When multiple segments, drill through nested `properties` chains.
+  return drillToTerminal(fieldSchema, ...pathSegments);
+}
+
+/**
+ * Asserts that a keyword is present at the terminal of a path-targeted
+ * constraint, and that it does NOT appear at any intermediate level.
+ *
+ * @param result          - schema generation result
+ * @param rootField       - top-level field name
+ * @param pathSegments    - full path to the terminal (at least 1 segment)
+ * @param keyword         - vocabulary keyword expected at the terminal
+ * @param expectedValue   - expected keyword value (string payload)
+ */
+function expectTerminalKeyword(
+  result: ClassSchemas,
+  rootField: string,
+  pathSegments: readonly string[],
+  keyword: string,
+  expectedValue: unknown
+): void {
+  expect(pathSegments.length, "pathSegments must have at least one segment").toBeGreaterThan(0);
+
+  const terminal = getTerminal(result, rootField, ...pathSegments);
+  expect(
+    terminal,
+    `expected terminal schema at ${rootField}.${pathSegments.join(".")} to exist`
+  ).toBeDefined();
+  expect(
+    terminal?.[keyword],
+    `expected ${keyword} === ${String(expectedValue)} at terminal ${rootField}.${pathSegments.join(".")}`
+  ).toBe(expectedValue);
+
+  // Guard: keyword must NOT appear at intermediate levels (leak detection).
+  // Check each prefix of pathSegments (excluding the full path and the empty prefix).
+  for (let depth = 1; depth < pathSegments.length; depth++) {
+    const intermediate = getTerminal(result, rootField, ...pathSegments.slice(0, depth));
+    expect(
+      intermediate?.[keyword],
+      `keyword "${keyword}" must NOT appear at intermediate level ${rootField}.${pathSegments.slice(0, depth).join(".")} (leaked from terminal)`
+    ).toBeUndefined();
+  }
+
+  // Guard: keyword must NOT appear directly on the root field schema.
+  const fieldSchema = result.jsonSchema.properties?.[rootField] as
+    | Record<string, unknown>
+    | undefined;
+  if (pathSegments.length > 0) {
+    expect(
+      fieldSchema?.[keyword],
+      `keyword "${keyword}" must NOT leak onto the root field schema '${rootField}'`
+    ).toBeUndefined();
+  }
+}
+
+// =============================================================================
+// DEPTH MATRIX — shared fixture types
+// =============================================================================
+
+/**
+ * Nested type declarations for the depth matrix.
+ * Each declaration builds on the previous level.
+ *
+ *  MonetaryAmount: { amount: Decimal; currency: string }
+ *  LineItem:       { money: MonetaryAmount }
+ *  Order:          { line: LineItem }
+ *  Invoice:        { order: Order }
+ */
+function buildDepthSource(decl: string, rootDef: string): string {
+  return [
+    decl,
+    "export interface MonetaryAmount { amount: Decimal; currency: string; }",
+    "export interface LineItem { money: MonetaryAmount; }",
+    "export interface Order { line: LineItem; }",
+    "export interface Invoice { order: Order; }",
+    "",
+    rootDef,
+  ].join("\n");
+}
+
+// =============================================================================
+// MULTI-LEVEL PATH-TARGET NESTING MATRIX
+// =============================================================================
+
+describe("multi-level path-target nesting", () => {
+  /**
+   * Each row: depth, fieldType, tag, rootDefinition, pathToTerminal,
+   * vocabularyKeyword, payload.
+   *
+   * Post-fix (#395): broadened vocabulary keywords + string payloads.
+   *
+   * The "correct terminal" for each depth:
+   *   depth 1: amount  → final path = ["amount"]
+   *   depth 2: money.amount → final path = ["money", "amount"]
+   *   depth 3: line.money.amount → final path = ["line", "money", "amount"]
+   *   depth 4: order.line.money.amount → final path = ["order", "line", "money", "amount"]
+   */
+  interface DepthCase {
+    label: string;
+    /** Root type definition source (will be appended after the nested types) */
+    rootTypeDef: string;
+    /** The path segments used in the tag: e.g. ["amount"] for @minimum :amount 0 */
+    pathSegments: string[];
+    /** Top-level field name in Root */
+    rootField: string;
+    /** Vocabulary keyword expected at the terminal (post-fix broadened form) */
+    keyword: string;
+    /** Expected keyword value (string payload from trimmedString parser) */
+    value: string;
+  }
+
+  const depthCases: DepthCase[] = [
+    {
+      label: "depth 1 — @minimum :amount 0 on MonetaryAmount { amount: Decimal }",
+      rootTypeDef: [
+        "export interface Root {",
+        "  /** @minimum :amount 0 */",
+        "  total: MonetaryAmount;",
+        "}",
+      ].join("\n"),
+      pathSegments: ["amount"],
+      rootField: "total",
+      keyword: "decimalMinimum",
+      value: "0",
+    },
+    {
+      label: "depth 2 — @minimum :money.amount 0 on LineItem { money: MonetaryAmount }",
+      rootTypeDef: [
+        "export interface Root {",
+        "  /** @minimum :money.amount 0 */",
+        "  item: LineItem;",
+        "}",
+      ].join("\n"),
+      pathSegments: ["money", "amount"],
+      rootField: "item",
+      keyword: "decimalMinimum",
+      value: "0",
+    },
+    {
+      label: "depth 3 — @minimum :line.money.amount 0 on Order { line: LineItem }",
+      rootTypeDef: [
+        "export interface Root {",
+        "  /** @minimum :line.money.amount 0 */",
+        "  order: Order;",
+        "}",
+      ].join("\n"),
+      pathSegments: ["line", "money", "amount"],
+      rootField: "order",
+      keyword: "decimalMinimum",
+      value: "0",
+    },
+    {
+      label: "depth 4 — @minimum :order.line.money.amount 0 on Invoice { order: Order }",
+      rootTypeDef: [
+        "export interface Root {",
+        "  /** @minimum :order.line.money.amount 0 */",
+        "  invoice: Invoice;",
+        "}",
+      ].join("\n"),
+      pathSegments: ["order", "line", "money", "amount"],
+      rootField: "invoice",
+      keyword: "decimalMinimum",
+      value: "0",
+    },
+  ];
+
+  describe("name-based Decimal registration", () => {
+    it.each(depthCases)("$label", ({ rootTypeDef, pathSegments, rootField, keyword, value }) => {
+      const source = buildDepthSource(NAME_DECIMAL_DECL, rootTypeDef);
+      const result = runSchema(source, nameBasedConfig);
+      expectTerminalKeyword(result, rootField, pathSegments, keyword, value);
+    });
+  });
+
+  describe("brand-based Decimal registration", () => {
+    it.each(depthCases)("$label", ({ rootTypeDef, pathSegments, rootField, keyword, value }) => {
+      const source = buildDepthSource(BRAND_DECIMAL_DECL, rootTypeDef);
+      const result = runSchema(source, brandBasedConfig);
+      expectTerminalKeyword(result, rootField, pathSegments, keyword, value);
+    });
+  });
+
+  describe("string-backed PostalCode registration", () => {
+    /**
+     * PostalCode variants of the depth matrix — uses maxLength (a string
+     * constraint) rather than minimum (numeric). The nested type is replaced
+     * with a PostalCode subfield.
+     * Post-fix: broadened to postalMaxLength: "5".
+     */
+    const postalDepthCases: DepthCase[] = [
+      {
+        label: "depth 1 — @maxLength :code 5 on AddressLine { code: PostalCode }",
+        rootTypeDef: [
+          "export interface Root {",
+          "  /** @maxLength :code 5 */",
+          "  addr: AddressLine;",
+          "}",
+        ].join("\n"),
+        pathSegments: ["code"],
+        rootField: "addr",
+        keyword: "postalMaxLength",
+        value: "5",
+      },
+      {
+        label: "depth 2 — @maxLength :address.code 5 on Contact { address: AddressLine }",
+        rootTypeDef: [
+          "export interface Root {",
+          "  /** @maxLength :address.code 5 */",
+          "  contact: Contact;",
+          "}",
+        ].join("\n"),
+        pathSegments: ["address", "code"],
+        rootField: "contact",
+        keyword: "postalMaxLength",
+        value: "5",
+      },
+      {
+        label: "depth 3 — @maxLength :person.address.code 5 on Record { person: Contact }",
+        rootTypeDef: [
+          "export interface Root {",
+          "  /** @maxLength :person.address.code 5 */",
+          "  record: PersonRecord;",
+          "}",
+        ].join("\n"),
+        pathSegments: ["person", "address", "code"],
+        rootField: "record",
+        keyword: "postalMaxLength",
+        value: "5",
+      },
+      {
+        label: "depth 4 — @maxLength :group.person.address.code 5 on Team { group: PersonRecord }",
+        rootTypeDef: [
+          "export interface Root {",
+          "  /** @maxLength :group.person.address.code 5 */",
+          "  team: Team;",
+          "}",
+        ].join("\n"),
+        pathSegments: ["group", "person", "address", "code"],
+        rootField: "team",
+        keyword: "postalMaxLength",
+        value: "5",
+      },
+    ];
+
+    it.each(postalDepthCases)(
+      "$label",
+      ({ rootTypeDef, pathSegments, rootField, keyword, value }) => {
+        const source = [
+          POSTAL_CODE_DECL,
+          "export interface AddressLine { code: PostalCode; label: string; }",
+          "export interface Contact { address: AddressLine; name: string; }",
+          "export interface PersonRecord { person: Contact; id: string; }",
+          "export interface Team { group: PersonRecord; teamName: string; }",
+          "",
+          rootTypeDef,
+        ].join("\n");
+        const result = runSchema(source, postalCodeConfig);
+        expectTerminalKeyword(result, rootField, pathSegments, keyword, value);
+      }
+    );
+  });
+});
+
+// =============================================================================
+// ARRAY TRAVERSAL AT MULTIPLE DEPTHS
+//
+// NOTE: Array path traversal (`:items.amount`) is NOT currently supported.
+// `@minimum :items.amount 0` on an array field produces `UNKNOWN_PATH_TARGET`.
+// Tests for array traversal are deferred until the feature is implemented.
+//
+// TODO: Implement array traversal and add tests here once supported.
+// See: https://github.com/mike-north/formspec/issues/395 (follow-up)
+// =============================================================================
+
+// =============================================================================
+// NULLABLE AT VARIOUS DEPTHS
+// =============================================================================
+
+describe("nullable at various depths", () => {
+  it("nullable at terminal — MonetaryAmount { amount: Decimal | null }", () => {
+    // The terminal is `amount: Decimal | null`. Broadening should still apply
+    // (the nullable branch recurses into the non-null arm for capability check).
+    // Post-fix: produces decimalMinimum: "0", not minimum: 0.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface MonetaryAmount { amount: Decimal | null; currency: string; }",
+      "export interface Root {",
+      "  /** @minimum :amount 0 */",
+      "  total: MonetaryAmount;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+    const terminal = getTerminal(result, "total", "amount");
+    expect(terminal, "expected amount sub-schema with nullable terminal").toBeDefined();
+    expect(terminal?.["decimalMinimum"]).toBe("0");
+  });
+
+  it("nullable at intermediate — LineItem { money: MonetaryAmount | null } with @minimum :money.amount 0", () => {
+    // Nullable at an intermediate segment: `money` is `MonetaryAmount | null`.
+    // Both resolvers (TS-level `resolvePathTargetType` and IR-level
+    // `resolveProperty`) strip the nullable union and continue traversal to
+    // the terminal `amount` Decimal. Broadening applies at the terminal.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface MonetaryAmount { amount: Decimal; currency: string; }",
+      "export interface LineItem { money: MonetaryAmount | null; qty: number; }",
+      "export interface Root {",
+      "  /** @minimum :money.amount 0 */",
+      "  line: LineItem;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+    const terminal = getTerminal(result, "line", "money", "amount");
+    expect(terminal, "expected money.amount sub-schema through nullable intermediate").toBeDefined();
+    expect(terminal?.["decimalMinimum"]).toBe("0");
+  });
+
+  it("nullable at root segment — Order { line: LineItem | null } with @minimum :line.money.amount 0", () => {
+    // Nullable at the first segment of the path. Traversal must strip
+    // the nullable union on the root before descending into `money.amount`.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface MonetaryAmount { amount: Decimal; currency: string; }",
+      "export interface LineItem { money: MonetaryAmount; qty: number; }",
+      "export interface Order { line: LineItem | null; orderId: string; }",
+      "export interface Root {",
+      "  /** @minimum :line.money.amount 0 */",
+      "  order: Order;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+    const terminal = getTerminal(result, "order", "line", "money", "amount");
+    expect(terminal, "expected line.money.amount sub-schema through nullable root segment").toBeDefined();
+    expect(terminal?.["decimalMinimum"]).toBe("0");
+  });
+
+  it("nullable at multiple levels — doubly-nullable chain with @minimum :line.money.amount 0", () => {
+    // Nullable at BOTH the root segment AND the intermediate segment. Each
+    // nullable stripping happens at the level it appears; the terminal is
+    // non-nullable Decimal.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface MonetaryAmount { amount: Decimal; currency: string; }",
+      "export interface LineItem { money: MonetaryAmount | null; qty: number; }",
+      "export interface Order { line: LineItem | null; orderId: string; }",
+      "export interface Root {",
+      "  /** @minimum :line.money.amount 0 */",
+      "  order: Order;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+    const terminal = getTerminal(result, "order", "line", "money", "amount");
+    expect(terminal, "expected terminal through doubly-nullable chain").toBeDefined();
+    expect(terminal?.["decimalMinimum"]).toBe("0");
+  });
+});
+
+// =============================================================================
+// MIXED SHAPE COMPOSITION
+// =============================================================================
+
+describe("mixed shape composition", () => {
+  it("array of MonetaryAmount — @minimum :items.amount 0 on Cart { items: MonetaryAmount[] }", () => {
+    // Path traversal strips array-container levels transparently: both
+    // `resolvePathTargetType` (TS-level) and `resolveProperty` (IR-level)
+    // descend into `ArrayTypeNode.items` without consuming a path segment.
+    // The override surfaces inside `items.properties.amount` on the generated
+    // array schema.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface MonetaryAmount { amount: Decimal; currency: string; }",
+      "export interface Cart { items: MonetaryAmount[]; total: number; }",
+      "export interface Root {",
+      "  /** @minimum :items.amount 0 */",
+      "  cart: Cart;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+    // `items` resolves to the array field; the override lives under its
+    // `items` (array element) sub-schema, below `properties.amount`.
+    const cart = result.jsonSchema.properties?.["cart"] as Record<string, unknown> | undefined;
+    const itemsField = (cart?.["properties"] as Record<string, unknown> | undefined)?.["items"] as
+      | Record<string, unknown>
+      | undefined;
+    const arrayItemSchema = itemsField?.["items"] as Record<string, unknown> | undefined;
+    const amountSchema = (
+      arrayItemSchema?.["properties"] as Record<string, unknown> | undefined
+    )?.["amount"] as Record<string, unknown> | undefined;
+    expect(amountSchema, "expected items[].amount override schema").toBeDefined();
+    expect(amountSchema?.["decimalMinimum"]).toBe("0");
+  });
+
+  it("mid-path array — @minimum :orders.money.amount 0 on Account { orders: Order[] }", () => {
+    // Array appears mid-path; traversal continues into the array element and
+    // descends into its object structure without consuming a path segment.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface MonetaryAmount { amount: Decimal; currency: string; }",
+      "export interface Order { money: MonetaryAmount; orderId: string; }",
+      "export interface Account { orders: Order[]; holder: string; }",
+      "export interface Root {",
+      "  /** @minimum :orders.money.amount 0 */",
+      "  account: Account;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+    const account = result.jsonSchema.properties?.["account"] as
+      | Record<string, unknown>
+      | undefined;
+    const ordersField = (account?.["properties"] as Record<string, unknown> | undefined)?.[
+      "orders"
+    ] as Record<string, unknown> | undefined;
+    const orderItem = ordersField?.["items"] as Record<string, unknown> | undefined;
+    const money = (orderItem?.["properties"] as Record<string, unknown> | undefined)?.["money"] as
+      | Record<string, unknown>
+      | undefined;
+    const amount = (money?.["properties"] as Record<string, unknown> | undefined)?.["amount"] as
+      | Record<string, unknown>
+      | undefined;
+    expect(amount, "expected orders[].money.amount override").toBeDefined();
+    expect(amount?.["decimalMinimum"]).toBe("0");
+  });
+
+  it("array of arrays — @minimum :matrix.amount 0 on Grid { matrix: MonetaryAmount[][] }", () => {
+    // Double-array wrapping; each `items` level is traversed transparently.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface MonetaryAmount { amount: Decimal; currency: string; }",
+      "export interface Grid { matrix: MonetaryAmount[][]; label: string; }",
+      "export interface Root {",
+      "  /** @minimum :matrix.amount 0 */",
+      "  grid: Grid;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+    const grid = result.jsonSchema.properties?.["grid"] as Record<string, unknown> | undefined;
+    const matrixField = (grid?.["properties"] as Record<string, unknown> | undefined)?.[
+      "matrix"
+    ] as Record<string, unknown> | undefined;
+    const outerItems = matrixField?.["items"] as Record<string, unknown> | undefined;
+    const innerItems = outerItems?.["items"] as Record<string, unknown> | undefined;
+    const amount = (innerItems?.["properties"] as Record<string, unknown> | undefined)?.[
+      "amount"
+    ] as Record<string, unknown> | undefined;
+    expect(amount, "expected matrix[][].amount override").toBeDefined();
+    expect(amount?.["decimalMinimum"]).toBe("0");
+  });
+});
+
+// =============================================================================
+// MULTIPLE PATH-TARGETED TAGS ON THE SAME FIELD
+// =============================================================================
+
+describe("multiple path-targeted tags on the same field", () => {
+  it("@minimum + @maximum + @multipleOf on the same :amount sub-path all broaden to distinct keywords", () => {
+    // All three tags target `:amount` on the same MonetaryAmount field.
+    // The constraint nodes are merged into a single `amount` sub-schema with
+    // all three vocabulary keywords present simultaneously.
+    // Post-fix: each tag broadens to its camelCase vocabulary keyword + string payload.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface MonetaryAmount { amount: Decimal; currency: string; }",
+      "export interface Root {",
+      "  /**",
+      "   * @minimum :amount 0",
+      "   * @maximum :amount 1000000",
+      "   * @multipleOf :amount 0.01",
+      "   */",
+      "  price: MonetaryAmount;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+    const terminal = getTerminal(result, "price", "amount");
+    expect(terminal, "expected amount sub-schema").toBeDefined();
+
+    // All three vocabulary keywords must be present on the same sub-schema.
+    expect(terminal?.["decimalMinimum"], "expected decimalMinimum: '0'").toBe("0");
+    expect(terminal?.["decimalMaximum"], "expected decimalMaximum: '1000000'").toBe("1000000");
+    expect(terminal?.["decimalMultipleOf"], "expected decimalMultipleOf: '0.01'").toBe("0.01");
+
+    // No stray keywords at the root field level.
+    const fieldSchema = result.jsonSchema.properties?.["price"] as
+      | Record<string, unknown>
+      | undefined;
+    expect(
+      fieldSchema?.["decimalMinimum"],
+      "decimalMinimum must not leak to root field"
+    ).toBeUndefined();
+    expect(
+      fieldSchema?.["decimalMaximum"],
+      "decimalMaximum must not leak to root field"
+    ).toBeUndefined();
+    expect(
+      fieldSchema?.["decimalMultipleOf"],
+      "decimalMultipleOf must not leak to root field"
+    ).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// MULTIPLE SUB-PATHS ON THE SAME FIELD
+// =============================================================================
+
+describe("multiple sub-paths on the same field", () => {
+  it("@minimum :amount 0 and @maxLength :currency 3 produce separate sub-schemas under the same field", () => {
+    // `:amount` resolves to Decimal → broadens to decimalMinimum: "0".
+    // `:currency` resolves to plain `string` (NOT broadened) → raw maxLength: 3.
+    // Both must appear as separate entries in the field's `properties` override.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface MonetaryAmount { amount: Decimal; currency: string; }",
+      "export interface Root {",
+      "  /**",
+      "   * @minimum :amount 0",
+      "   * @maxLength :currency 3",
+      "   */",
+      "  total: MonetaryAmount;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+
+    // amount sub-schema: receives broadened decimalMinimum
+    const amountTerminal = getTerminal(result, "total", "amount");
+    expect(amountTerminal, "expected amount sub-schema").toBeDefined();
+    // Post-fix: broadened keyword + string payload
+    expect(amountTerminal?.["decimalMinimum"]).toBe("0");
+    // Must NOT emit the raw built-in keyword
+    expect(amountTerminal?.["minimum"]).toBeUndefined();
+
+    // currency sub-schema: receives maxLength from direct string constraint
+    const currencyTerminal = getTerminal(result, "total", "currency");
+    expect(currencyTerminal, "expected currency sub-schema").toBeDefined();
+    expect(currencyTerminal?.["maxLength"]).toBe(3);
+
+    // Neither keyword should appear at the field level.
+    const fieldSchema = result.jsonSchema.properties?.["total"] as
+      | Record<string, unknown>
+      | undefined;
+    expect(fieldSchema?.["decimalMinimum"], "decimalMinimum must not appear at field level").toBeUndefined();
+    expect(fieldSchema?.["minimum"], "minimum must not appear at field level").toBeUndefined();
+    expect(fieldSchema?.["maxLength"], "maxLength must not appear at field level").toBeUndefined();
+  });
+});
+
+// =============================================================================
+// DIRECT + PATH ON THE SAME FIELD
+// =============================================================================
+
+describe("direct constraint + path-targeted constraints on the same field", () => {
+  it("direct @minimum 0 + path @maximum :amount 9999 on a ref field — both keywords land at their correct locations", () => {
+    // This variant: one direct non-path constraint + one path-targeted:
+    //   class Root { /**
+    //     * @maximum :amount 9999   (path on Decimal subfield → decimalMaximum: "9999")
+    //     * @minimum :count 0       (path on plain number subfield → minimum: 0)
+    //   */ payment: Payment }
+    // Both produce sub-schemas under the Payment $ref's properties.
+    const source = [
+      NAME_DECIMAL_DECL,
+      "export interface Payment { amount: Decimal; count: number; label: string; }",
+      "export interface Root {",
+      "  /**",
+      "   * @maximum :amount 9999",
+      "   * @minimum :count 0",
+      "   */",
+      "  payment: Payment;",
+      "}",
+    ].join("\n");
+
+    const result = runSchema(source, nameBasedConfig);
+
+    // amount sub-schema: @maximum :amount 9999 (broadened via Decimal → decimalMaximum: "9999")
+    const amountTerminal = getTerminal(result, "payment", "amount");
+    expect(amountTerminal, "expected amount sub-schema").toBeDefined();
+    expect(amountTerminal?.["decimalMaximum"]).toBe("9999");
+    // Raw built-in must NOT appear
+    expect(amountTerminal?.["maximum"]).toBeUndefined();
+
+    // count sub-schema: @minimum :count 0 (plain numeric, no broadening)
+    const countTerminal = getTerminal(result, "payment", "count");
+    expect(countTerminal, "expected count sub-schema").toBeDefined();
+    expect(countTerminal?.["minimum"]).toBe(0);
+
+    // No cross-contamination.
+    expect(
+      amountTerminal?.["decimalMinimum"],
+      "decimalMinimum must not appear on amount"
+    ).toBeUndefined();
+    expect(countTerminal?.["decimalMaximum"], "decimalMaximum must not appear on count").toBeUndefined();
+  });
+});

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -94,11 +94,53 @@ import {
   type ConstraintValidatorRoleOutcome,
 } from "@formspec/analysis/internal";
 
-function sharedTagValueOptions(options?: ParseTSDocOptions) {
+function sharedTagValueOptions(
+  options?: ParseTSDocOptions,
+  pathResolvedCustomTypeId?: string
+) {
   return {
     ...(options?.extensionRegistry !== undefined ? { registry: options.extensionRegistry } : {}),
     ...(options?.fieldType !== undefined ? { fieldType: options.fieldType } : {}),
+    ...(pathResolvedCustomTypeId !== undefined ? { pathResolvedCustomTypeId } : {}),
   };
+}
+
+/**
+ * For a parsed tag whose target is a valid path (`:foo.bar`), resolves the
+ * terminal sub-type through the TypeScript compiler and looks up whether that
+ * sub-type is a registered custom type. Returns the fully-qualified type ID
+ * (`extensionId/typeName`) used by the broadening registry, or `undefined`
+ * when any precondition is missing or the terminal type is not a registered
+ * custom type.
+ *
+ * This is the build-consumer-only hook that enables path-targeted broadening
+ * in the analysis layer — see {@link ParseConstraintTagValueOptions.pathResolvedCustomTypeId}.
+ */
+function resolvePathTargetCustomTypeId(
+  parsedTag: ParsedCommentTag | null,
+  subjectType: ts.Type | undefined,
+  checker: ts.TypeChecker | undefined,
+  registry: ExtensionRegistry | undefined
+): string | undefined {
+  if (parsedTag === null) return undefined;
+  const target = parsedTag.target;
+  if (target?.kind !== "path" || !target.valid || target.path === null) {
+    return undefined;
+  }
+  if (subjectType === undefined || checker === undefined || registry === undefined) {
+    return undefined;
+  }
+
+  const resolution = resolvePathTargetType(subjectType, checker, target.path.segments);
+  if (resolution.kind !== "resolved") {
+    return undefined;
+  }
+
+  const lookup = resolveCustomTypeFromTsType(resolution.type, checker, registry);
+  if (lookup === null) {
+    return undefined;
+  }
+  return customTypeIdFromLookup(lookup);
 }
 
 const SYNTHETIC_TYPE_FORMAT_FLAGS =
@@ -387,11 +429,21 @@ function processConstraintTag(
     pushUniqueCompilerDiagnostics(diagnostics, compilerDiagnostics);
     return;
   }
+  // Resolve the path-targeted custom type ID (if any) so the analysis layer
+  // can apply broadening to the path-resolved terminal type — fixes #395
+  // where path-targeted built-in constraints (e.g. `@exclusiveMinimum :amount 0`
+  // on a `MonetaryAmount` field) previously emitted raw numeric constraints.
+  const pathResolvedCustomTypeId = resolvePathTargetCustomTypeId(
+    parsedTag,
+    options?.subjectType,
+    options?.checker,
+    options?.extensionRegistry
+  );
   const constraintNode = parseConstraintTagValue(
     tagName,
     text,
     provenance,
-    sharedTagValueOptions(options)
+    sharedTagValueOptions(options, pathResolvedCustomTypeId)
   );
   if (constraintNode) {
     constraints.push(constraintNode);

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -42,6 +42,7 @@ import {
   checkSyntheticTagApplication,
   choosePreferredPayloadText,
   extractPathTarget as extractSharedPathTarget,
+  getBroadenedCustomTypeId,
   getTagDefinition,
   hasTypeSemanticCapability,
   normalizeFormSpecTagName,
@@ -94,15 +95,28 @@ import {
   type ConstraintValidatorRoleOutcome,
 } from "@formspec/analysis/internal";
 
-function sharedTagValueOptions(
-  options?: ParseTSDocOptions,
-  pathResolvedCustomTypeId?: string
-) {
+function sharedTagValueOptions(options?: ParseTSDocOptions, pathResolvedCustomTypeId?: string) {
   return {
     ...(options?.extensionRegistry !== undefined ? { registry: options.extensionRegistry } : {}),
     ...(options?.fieldType !== undefined ? { fieldType: options.fieldType } : {}),
     ...(pathResolvedCustomTypeId !== undefined ? { pathResolvedCustomTypeId } : {}),
   };
+}
+
+/**
+ * For a `ts.Type` already resolved (e.g. by walking a path through the host),
+ * returns the fully-qualified custom type ID if the type is a registered
+ * custom type, else `undefined`. Single shared step used both for direct-type
+ * lookups and for path-resolved terminals.
+ */
+function customTypeIdForResolvedType(
+  resolvedType: ts.Type,
+  checker: ts.TypeChecker,
+  registry: ExtensionRegistry | undefined
+): string | undefined {
+  if (registry === undefined) return undefined;
+  const lookup = resolveCustomTypeFromTsType(resolvedType, checker, registry);
+  return lookup === null ? undefined : customTypeIdFromLookup(lookup);
 }
 
 /**
@@ -114,7 +128,8 @@ function sharedTagValueOptions(
  * custom type.
  *
  * This is the build-consumer-only hook that enables path-targeted broadening
- * in the analysis layer — see {@link ParseConstraintTagValueOptions.pathResolvedCustomTypeId}.
+ * in the analysis layer; the resolved ID is threaded to
+ * `parseConstraintTagValue` via its `pathResolvedCustomTypeId` option.
  */
 function resolvePathTargetCustomTypeId(
   parsedTag: ParsedCommentTag | null,
@@ -127,7 +142,7 @@ function resolvePathTargetCustomTypeId(
   if (target?.kind !== "path" || !target.valid || target.path === null) {
     return undefined;
   }
-  if (subjectType === undefined || checker === undefined || registry === undefined) {
+  if (subjectType === undefined || checker === undefined) {
     return undefined;
   }
 
@@ -136,11 +151,7 @@ function resolvePathTargetCustomTypeId(
     return undefined;
   }
 
-  const lookup = resolveCustomTypeFromTsType(resolution.type, checker, registry);
-  if (lookup === null) {
-    return undefined;
-  }
-  return customTypeIdFromLookup(lookup);
+  return customTypeIdForResolvedType(resolution.type, checker, registry);
 }
 
 const SYNTHETIC_TYPE_FORMAT_FLAGS =
@@ -716,30 +727,6 @@ function capabilityLabel(capability: string | undefined): string {
   }
 }
 
-function getBroadenedCustomTypeId(fieldType: TypeNode | undefined): string | undefined {
-  if (fieldType?.kind === "custom") {
-    return fieldType.typeId;
-  }
-
-  if (fieldType?.kind !== "union") {
-    return undefined;
-  }
-
-  const customMembers = fieldType.members.filter(
-    (member): member is Extract<TypeNode, { kind: "custom" }> => member.kind === "custom"
-  );
-  if (customMembers.length !== 1) {
-    return undefined;
-  }
-
-  const nonCustomMembers = fieldType.members.filter((member) => member.kind !== "custom");
-  const allOtherMembersAreNull = nonCustomMembers.every(
-    (member) => member.kind === "primitive" && member.primitiveKind === "null"
-  );
-  const customMember = customMembers[0];
-  return allOtherMembersAreNull && customMember !== undefined ? customMember.typeId : undefined;
-}
-
 function hasBuiltinConstraintBroadening(tagName: string, options?: ParseTSDocOptions): boolean {
   const broadenedTypeId = getBroadenedCustomTypeId(options?.fieldType);
   return (
@@ -909,11 +896,10 @@ function buildCompilerBackedConstraintDiagnostics(
     }
     const registry = options?.extensionRegistry;
     if (registry === undefined) return false;
-    const resolved = resolveCustomTypeFromTsType(evaluatedType, checker, registry);
+    const typeId = customTypeIdForResolvedType(evaluatedType, checker, registry);
     return (
-      resolved !== null &&
-      registry.findBuiltinConstraintBroadening(customTypeIdFromLookup(resolved), tagName) !==
-        undefined
+      typeId !== undefined &&
+      registry.findBuiltinConstraintBroadening(typeId, tagName) !== undefined
     );
   })();
 


### PR DESCRIPTION
Fixes #395.

## Summary

- Path-targeted built-in constraint tags (`@exclusiveMinimum :amount 0`) now participate in custom-type broadening when the path terminal resolves to a registered custom type.
- IR-level `resolveProperty` strips nullable unions during traversal, closing an asymmetry with the TS-level resolver and unblocking nullable intermediate path segments.
- Filed follow-up #396 for snapshot-consumer (LSP / ts-plugin) broadening — the new `pathResolvedCustomTypeId` option is additive and unused there today, so downstream natural-language summarizers still see un-broadened IR from the snapshot path (pre-existing gap).

## What was broken

Before:

```json
{
  "minimumAmount": {
    "$ref": "#/$defs/monetary_amount",
    "properties": {
      "amount": { "exclusiveMinimum": 0 }
    }
  }
}
```

A numeric `exclusiveMinimum: 0` appeared as a sibling of `$ref` even though `amount` in the `$defs` body is `{type: "string", format: "decimal"}`. This is semantically invalid under JSON Schema 2020-12 — `exclusiveMinimum` is only valid on numeric types. Direct-field broadening (`@exclusiveMinimum 0` on a Decimal field) worked correctly; only path-targeted broadening was missing.

After:

```json
{
  "minimumAmount": {
    "$ref": "#/$defs/monetary_amount",
    "properties": {
      "amount": { "decimalExclusiveMinimum": "0" }
    }
  }
}
```

## Design

Analysis layer exposes a new option on `ParseConstraintTagValueOptions`:

```ts
readonly pathResolvedCustomTypeId?: string;
```

When a built-in constraint tag carries a path, the broadening lookup uses this ID instead of `options.fieldType` — the field's own type describes the wrong thing for a path-targeted tag.

The build layer resolves the path's terminal TypeScript type via the already-existing `resolvePathTargetType` (analysis) + `resolveCustomTypeFromTsType` (build), then threads the resulting type ID down to `parseConstraintTagValue`. This reuses the exact same resolution path the validator already uses for its capability-check bypass, so the IR now matches the validator's view of which constraints are broadened.

The snapshot consumer (`file-snapshots.ts` in `@formspec/analysis`) does not pass this option; its behavior is unchanged. A separate follow-up (#396) covers extending broadening to the snapshot/LSP path.

### Nullable-union parity fix

`resolveProperty` in `semantic-targets.ts` now strips nullable unions during traversal, mirroring what `resolvePathTargetType` in `ts-binding.ts` has always done. Without this, `:money.amount` on `LineItem { money: MonetaryAmount | null }` was accepted at the compiler level (so broadening went through correctly) but rejected at IR-level validation with `TYPE_MISMATCH: type "union" cannot be traversed`.

## Test coverage

New file `packages/build/src/__tests__/path-target-custom-type-broadening.test.ts` (22 tests) covers:

- **Depth matrix (1-4 levels)** × 3 registration styles (name-based Decimal, brand-based Decimal, string-backed PostalCode) — 12 parameterized cases.
- **Nullable at various depths**: terminal, intermediate, root segment, and doubly-nullable chain.
- **Array transparency**: single array wrapper, mid-path array (`:orders.money.amount` on `Account { orders: Order[] }`), and array-of-arrays (`MonetaryAmount[][]`).
- **Multiple tags on the same sub-path**: `@minimum + @maximum + @multipleOf` all broaden and coexist.
- **Multiple sub-paths on the same field**: one broadened, one plain — verifies no cross-contamination.
- **Direct + path on the same field**: both resolve independently to correct locations.

Fixtures use `emitsVocabularyKeywords: true` so assertions pin literal camelCase keywords (`decimalMinimum: "0"`) matching the issue's expected output.

`packages/build/src/__tests__/generate-schemas-config.test.ts` path-target matrix has been rewritten — the previous assertions encoded the buggy output and now assert broadened vocabulary keywords.

`packages/analysis/src/__tests__/tag-value-parser.test.ts` adds 5 regression tests pinning the `pathResolvedCustomTypeId` contract.

Full suite: 2,648 tests pass across 147 test files.

## Test plan

- [x] `/clean_blt` green (clean build + lint + all tests)
- [x] Existing path-target assertions rewritten off buggy output
- [x] Regression tests at multiple nesting depths
- [x] Follow-up #396 filed for snapshot-consumer broadening gap

## Follow-ups

- #396: Snapshot consumer (LSP / ts-plugin) never applies constraint broadening — direct or path-targeted. Separate pre-existing gap; unblocks correct natural-language summaries in downstream IDE tooling.