### PR TITLE
refactor(analysis): port host-checker capability guard to snapshot consumer (Phase 5 Slice A)

### DIFF
--- a/.changeset/phase-5-slice-a-snapshot-capability-guard.md
+++ b/.changeset/phase-5-slice-a-snapshot-capability-guard.md
@@ -1,0 +1,17 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Port host-checker capability guard + placement pre-check to snapshot consumer
+
+Closes 8 Role-B silent-acceptance bugs tracked in #326. The snapshot consumer
+now runs the same `_supportsConstraintCapability` and `getMatchingTagSignatures`
+checks the build consumer already used, emitting `TYPE_MISMATCH` and
+`INVALID_TAG_PLACEMENT` at the same correctness boundary. Prerequisite for
+Phase 5C deletion of the synthetic machinery.

--- a/packages/analysis/src/__tests__/constraint-applicability.test.ts
+++ b/packages/analysis/src/__tests__/constraint-applicability.test.ts
@@ -98,6 +98,20 @@ describe("_supportsConstraintCapability", () => {
     expect(_supportsConstraintCapability("string-like", type, checker)).toBe(false);
   });
 
+  // Regression: nullable string array (string[] | null) must satisfy string-like.
+  // Before the fix, getArrayElementType called checker.isArrayType on the raw
+  // union, which returned false, silently failing the Role-B capability check.
+  it("returns true for string[] | null type with string-like capability (nullable-array regression)", () => {
+    const { type, checker } = makeProgram("string[] | null");
+    expect(_supportsConstraintCapability("string-like", type, checker)).toBe(true);
+  });
+
+  // Regression companion: nullable number array (number[] | null) must NOT satisfy string-like.
+  it("returns false for number[] | null type with string-like capability", () => {
+    const { type, checker } = makeProgram("number[] | null");
+    expect(_supportsConstraintCapability("string-like", type, checker)).toBe(false);
+  });
+
   // string[] satisfies array-like for @uniqueItems
   it("returns true for string[] type with array-like capability", () => {
     const { type, checker } = makeProgram("string[]");

--- a/packages/analysis/src/__tests__/constraint-applicability.test.ts
+++ b/packages/analysis/src/__tests__/constraint-applicability.test.ts
@@ -170,8 +170,8 @@ describe("snapshot consumer Role-B integration", () => {
     const typeMismatch = diagnostics.filter((d) => d.code === "TYPE_MISMATCH");
     expect(typeMismatch).toHaveLength(1);
     expect(typeMismatch[0]?.range).toBeDefined();
-    expect(typeof typeMismatch[0]?.range.start).toBe("number");
-    expect(typeof typeMismatch[0]?.range.end).toBe("number");
+    expect(typeMismatch[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(typeMismatch[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 
   // Invariant 8: pattern on multiple field types — strings pass, numbers fail
@@ -230,8 +230,8 @@ describe("snapshot consumer placement pre-check integration", () => {
     const placementDiag = diagnostics.find((d) => d.code === "INVALID_TAG_PLACEMENT");
     expect(placementDiag, "Expected an INVALID_TAG_PLACEMENT diagnostic").toBeDefined();
     expect(placementDiag?.range).toBeDefined();
-    expect(typeof placementDiag?.range.start).toBe("number");
-    expect(typeof placementDiag?.range.end).toBe("number");
+    expect(placementDiag?.range.start).toBeGreaterThanOrEqual(0);
+    expect(placementDiag?.range.end).toBeGreaterThanOrEqual(0);
   });
 
   // A @minimum tag on a valid class field should NOT produce INVALID_TAG_PLACEMENT

--- a/packages/analysis/src/__tests__/constraint-applicability.test.ts
+++ b/packages/analysis/src/__tests__/constraint-applicability.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for the `_supportsConstraintCapability` helper and its integration
+ * with the snapshot consumer's Role-B capability guard.
+ *
+ * This module re-asserts the narrow-applicability invariants that were
+ * previously only tested via the synthetic-checker path in
+ * `compiler-signatures.test.ts:751-873`. Those tests verify the synthetic
+ * call produces diagnostics for mismatched types; these tests verify that:
+ *
+ * 1. `_supportsConstraintCapability` correctly models capability gating.
+ * 2. The snapshot consumer (`buildFormSpecAnalysisFileSnapshot`) emits
+ *    `TYPE_MISMATCH` for the same inputs via Role B (not via the synthetic
+ *    checker), and `INVALID_TAG_PLACEMENT` for structural misplacement.
+ *
+ * @see packages/analysis/src/constraint-applicability.ts
+ * @see packages/analysis/src/file-snapshots.ts buildTagDiagnostics (§5 Phase 5A)
+ * @see packages/build/src/analyzer/tsdoc-parser.ts supportsConstraintCapability
+ * @see docs/refactors/synthetic-checker-retirement.md §4 Phase 5A
+ */
+
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+import { _supportsConstraintCapability } from "../constraint-applicability.js";
+import { buildFormSpecAnalysisFileSnapshot } from "../internal.js";
+import { createProgram } from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Unit tests for _supportsConstraintCapability
+// ---------------------------------------------------------------------------
+
+describe("_supportsConstraintCapability", () => {
+  function makeProgram(fieldType: string) {
+    const source = `class F { field!: ${fieldType}; }`;
+    const { checker, sourceFile } = createProgram(source);
+    // Locate the 'field' property and extract its type
+    let fieldNode: ts.PropertyDeclaration | undefined;
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isPropertyDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === "field"
+      ) {
+        fieldNode = node;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    if (fieldNode === undefined) throw new Error("field not found");
+    const type = checker.getTypeAtLocation(fieldNode.name);
+    return { type, checker };
+  }
+
+  // Invariant 1: valid number target for @minimum → capability check passes
+  it("returns true for number type with numeric-comparable capability", () => {
+    const { type, checker } = makeProgram("number");
+    expect(_supportsConstraintCapability("numeric-comparable", type, checker)).toBe(true);
+  });
+
+  // Invariant 2: string target for @minimum → capability check fails
+  it("returns false for string type with numeric-comparable capability", () => {
+    const { type, checker } = makeProgram("string");
+    expect(_supportsConstraintCapability("numeric-comparable", type, checker)).toBe(false);
+  });
+
+  // Invariant 3: boolean target for @minimum → capability check fails
+  it("returns false for boolean type with numeric-comparable capability", () => {
+    const { type, checker } = makeProgram("boolean");
+    expect(_supportsConstraintCapability("numeric-comparable", type, checker)).toBe(false);
+  });
+
+  // Invariant 4: string target for @pattern → string-like capability passes
+  it("returns true for string type with string-like capability", () => {
+    const { type, checker } = makeProgram("string");
+    expect(_supportsConstraintCapability("string-like", type, checker)).toBe(true);
+  });
+
+  // Invariant 5: number target for @pattern → string-like capability fails
+  it("returns false for number type with string-like capability", () => {
+    const { type, checker } = makeProgram("number");
+    expect(_supportsConstraintCapability("string-like", type, checker)).toBe(false);
+  });
+
+  // Invariant 6: boolean target for @pattern → string-like capability fails
+  it("returns false for boolean type with string-like capability", () => {
+    const { type, checker } = makeProgram("boolean");
+    expect(_supportsConstraintCapability("string-like", type, checker)).toBe(false);
+  });
+
+  // string-like array-element unwrap: string[] satisfies string-like
+  it("returns true for string[] type with string-like capability (array-element unwrap)", () => {
+    const { type, checker } = makeProgram("string[]");
+    expect(_supportsConstraintCapability("string-like", type, checker)).toBe(true);
+  });
+
+  // number[] does NOT satisfy string-like — element type is number, not string-like
+  it("returns false for number[] type with string-like capability", () => {
+    const { type, checker } = makeProgram("number[]");
+    expect(_supportsConstraintCapability("string-like", type, checker)).toBe(false);
+  });
+
+  // string[] satisfies array-like for @uniqueItems
+  it("returns true for string[] type with array-like capability", () => {
+    const { type, checker } = makeProgram("string[]");
+    expect(_supportsConstraintCapability("array-like", type, checker)).toBe(true);
+  });
+
+  // string (plain, non-array) does NOT satisfy array-like for @uniqueItems
+  it("returns false for string type with array-like capability", () => {
+    const { type, checker } = makeProgram("string");
+    expect(_supportsConstraintCapability("array-like", type, checker)).toBe(false);
+  });
+
+  // number does NOT satisfy array-like for @uniqueItems
+  it("returns false for number type with array-like capability", () => {
+    const { type, checker } = makeProgram("number");
+    expect(_supportsConstraintCapability("array-like", type, checker)).toBe(false);
+  });
+
+  // string literal union satisfies enum-member-addressable for @enumOptions
+  it("returns true for string literal union type with enum-member-addressable capability", () => {
+    const { type, checker } = makeProgram('"a" | "b"');
+    expect(_supportsConstraintCapability("enum-member-addressable", type, checker)).toBe(true);
+  });
+
+  // plain string does NOT satisfy enum-member-addressable for @enumOptions
+  it("returns false for string type with enum-member-addressable capability", () => {
+    const { type, checker } = makeProgram("string");
+    expect(_supportsConstraintCapability("enum-member-addressable", type, checker)).toBe(false);
+  });
+
+  // number does NOT satisfy enum-member-addressable for @enumOptions
+  it("returns false for number type with enum-member-addressable capability", () => {
+    const { type, checker } = makeProgram("number");
+    expect(_supportsConstraintCapability("enum-member-addressable", type, checker)).toBe(false);
+  });
+
+  // undefined capability → always passes (no constraint)
+  it("returns true when capability is undefined (no capability required)", () => {
+    const { type, checker } = makeProgram("string");
+    expect(_supportsConstraintCapability(undefined, type, checker)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: snapshot consumer emits TYPE_MISMATCH via Role B
+// ---------------------------------------------------------------------------
+
+describe("snapshot consumer Role-B integration", () => {
+  function diagnosticsFor(source: string, label: string) {
+    const { checker, sourceFile } = createProgram(source, `/virtual/applicability-${label}.ts`);
+    const snapshot = buildFormSpecAnalysisFileSnapshot(sourceFile, { checker });
+    return snapshot.diagnostics;
+  }
+
+  // Invariant 7 (multi-field): multiple fields in one class — valid number
+  // fields pass Role B, invalid string fields emit TYPE_MISMATCH each
+  it("emits TYPE_MISMATCH only for mismatched fields in a multi-field class", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @minimum 0 */
+        valid!: number;
+        /** @minimum 0 */
+        invalid!: string;
+      }
+      `,
+      "multi-field-minimum"
+    );
+    // Only the string field should get TYPE_MISMATCH; the number field should pass
+    const typeMismatch = diagnostics.filter((d) => d.code === "TYPE_MISMATCH");
+    expect(typeMismatch).toHaveLength(1);
+    expect(typeMismatch[0]?.range).toBeDefined();
+    expect(typeof typeMismatch[0]?.range.start).toBe("number");
+    expect(typeof typeMismatch[0]?.range.end).toBe("number");
+  });
+
+  // Invariant 8: pattern on multiple field types — strings pass, numbers fail
+  it("emits TYPE_MISMATCH for @pattern on non-string fields in a multi-field class", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @pattern ^[a-z]+$ */
+        validStr!: string;
+        /** @pattern ^[a-z]+$ */
+        invalidNum!: number;
+        /** @pattern ^[a-z]+$ */
+        invalidBool!: boolean;
+      }
+      `,
+      "multi-field-pattern"
+    );
+    const typeMismatches = diagnostics.filter((d) => d.code === "TYPE_MISMATCH");
+    expect(typeMismatches).toHaveLength(2);
+    for (const diag of typeMismatches) {
+      expect(diag.range).toBeDefined();
+    }
+  });
+
+  // Note: argument-type tests (e.g. @minimum "hello" → INVALID_TAG_ARGUMENT) are
+  // covered by constraint-canaries.test.ts and tag-argument-parser.test.ts.
+  // Those exercise Role C (typed parser), not Role B (capability check).
+});
+
+// ---------------------------------------------------------------------------
+// Integration test: snapshot consumer emits INVALID_TAG_PLACEMENT via
+// explicit getMatchingTagSignatures pre-check (§5 Phase 5A)
+// ---------------------------------------------------------------------------
+
+describe("snapshot consumer placement pre-check integration", () => {
+  function diagnosticsFor(source: string, label: string) {
+    const { checker, sourceFile } = createProgram(source, `/virtual/placement-${label}.ts`);
+    const snapshot = buildFormSpecAnalysisFileSnapshot(sourceFile, { checker });
+    return snapshot.diagnostics;
+  }
+
+  // A @minimum tag on a `type-alias` placement (e.g. `type Foo = number`) has
+  // no valid signature for "type-alias" placement. The type itself (number) DOES
+  // satisfy the "numeric-comparable" capability, so Role B passes and the
+  // placement pre-check (getMatchingTagSignatures → []) is the first to reject.
+  //
+  // This is distinct from a field placement where the tag is structurally valid.
+  it("emits INVALID_TAG_PLACEMENT for @minimum on a type alias (placement: type-alias)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      /** @minimum 0 */
+      type NumberAlias = number;
+      `,
+      "minimum-on-type-alias"
+    );
+    const placementDiag = diagnostics.find((d) => d.code === "INVALID_TAG_PLACEMENT");
+    expect(placementDiag, "Expected an INVALID_TAG_PLACEMENT diagnostic").toBeDefined();
+    expect(placementDiag?.range).toBeDefined();
+    expect(typeof placementDiag?.range.start).toBe("number");
+    expect(typeof placementDiag?.range.end).toBe("number");
+  });
+
+  // A @minimum tag on a valid class field should NOT produce INVALID_TAG_PLACEMENT
+  it("does NOT emit INVALID_TAG_PLACEMENT for @minimum on a class field (valid placement)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @minimum 0 */
+        value!: number;
+      }
+      `,
+      "minimum-on-field"
+    );
+    const placementDiag = diagnostics.find((d) => d.code === "INVALID_TAG_PLACEMENT");
+    expect(placementDiag).toBeUndefined();
+  });
+});

--- a/packages/analysis/src/__tests__/constraint-canaries.test.ts
+++ b/packages/analysis/src/__tests__/constraint-canaries.test.ts
@@ -108,8 +108,8 @@ describe("@minimum silent-acceptance canaries", () => {
     expect(diagnostic, "Expected an INVALID_TAG_ARGUMENT diagnostic").toBeDefined();
     // range is always present; verify it points somewhere in the source
     expect(diagnostic?.range).toBeDefined();
-    expect(typeof diagnostic?.range.start).toBe("number");
-    expect(typeof diagnostic?.range.end).toBe("number");
+    expect(diagnostic?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostic?.range.end).toBeGreaterThanOrEqual(0);
   });
 
   // @minimum true -- boolean is not a valid numeric argument.
@@ -168,8 +168,8 @@ describe("@minimum silent-acceptance canaries", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(diagnostics[0]?.range).toBeDefined();
-    expect(typeof diagnostics[0]?.range.start).toBe("number");
-    expect(typeof diagnostics[0]?.range.end).toBe("number");
+    expect(diagnostics[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostics[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 
   // @minimum 0 on a boolean field -- boolean has no numeric-comparable capability.
@@ -188,8 +188,8 @@ describe("@minimum silent-acceptance canaries", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(diagnostics[0]?.range).toBeDefined();
-    expect(typeof diagnostics[0]?.range.start).toBe("number");
-    expect(typeof diagnostics[0]?.range.end).toBe("number");
+    expect(diagnostics[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostics[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -201,12 +201,15 @@ describe("@enumOptions silent-acceptance canaries", () => {
   // @enumOptions with no argument omits the required JSON array.
   // Phase 3: typed parser (Role C) emits MISSING_TAG_ARGUMENT for the empty argument.
   // (Previously: the synthetic checker emitted INVALID_TAG_ARGUMENT.)
+  //
+  // Note: field type is "a" | "b" (string literal union) so Role B passes
+  // (enum-member-addressable capability) and Role C runs.
   it("emits MISSING_TAG_ARGUMENT for @enumOptions with no argument", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
         /** @enumOptions */
-        value!: string;
+        value!: "a" | "b";
       }
       `,
       "enumOptions-empty"
@@ -219,12 +222,15 @@ describe("@enumOptions silent-acceptance canaries", () => {
 
   // @enumOptions [1, -- truncated / malformed JSON.
   // The synthetic checker emits INVALID_TAG_ARGUMENT.
+  //
+  // Note: field type is "a" | "b" (string literal union) so Role B passes
+  // (enum-member-addressable capability) and Role C runs.
   it("emits INVALID_TAG_ARGUMENT for @enumOptions [1, (malformed JSON)", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
         /** @enumOptions [1, */
-        value!: string;
+        value!: "a" | "b";
       }
       `,
       "enumOptions-malformed"
@@ -238,12 +244,15 @@ describe("@enumOptions silent-acceptance canaries", () => {
   // @enumOptions 5 -- scalar number, not a JSON array.
   // Phase 3 FLIP: typed parser (Role C) now rejects this with INVALID_TAG_ARGUMENT.
   // (Previously: silent acceptance — no diagnostic emitted.)
+  //
+  // Note: field type is "a" | "b" (string literal union) so Role B passes
+  // (enum-member-addressable capability) and Role C runs.
   it("emits INVALID_TAG_ARGUMENT for @enumOptions 5 (scalar, not array)", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
         /** @enumOptions 5 */
-        value!: string;
+        value!: "a" | "b";
       }
       `,
       "enumOptions-scalar"
@@ -256,12 +265,15 @@ describe("@enumOptions silent-acceptance canaries", () => {
   // @enumOptions {} -- plain object, not a JSON array.
   // Phase 3 FLIP: typed parser (Role C) now rejects this with INVALID_TAG_ARGUMENT.
   // (Previously: silent acceptance — no diagnostic emitted.)
+  //
+  // Note: field type is "a" | "b" (string literal union) so Role B passes
+  // (enum-member-addressable capability) and Role C runs.
   it("emits INVALID_TAG_ARGUMENT for @enumOptions {} (object, not array)", () => {
     const diagnostics = diagnosticsFor(
       `
       class F {
         /** @enumOptions {} */
-        value!: string;
+        value!: "a" | "b";
       }
       `,
       "enumOptions-object"
@@ -289,8 +301,8 @@ describe("@enumOptions silent-acceptance canaries", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(diagnostics[0]?.range).toBeDefined();
-    expect(typeof diagnostics[0]?.range.start).toBe("number");
-    expect(typeof diagnostics[0]?.range.end).toBe("number");
+    expect(diagnostics[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostics[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -360,8 +372,8 @@ describe("@pattern silent-acceptance canaries", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(diagnostics[0]?.range).toBeDefined();
-    expect(typeof diagnostics[0]?.range.start).toBe("number");
-    expect(typeof diagnostics[0]?.range.end).toBe("number");
+    expect(diagnostics[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostics[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 
   // @pattern on a boolean field -- booleans are not string-like.
@@ -380,8 +392,8 @@ describe("@pattern silent-acceptance canaries", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(diagnostics[0]?.range).toBeDefined();
-    expect(typeof diagnostics[0]?.range.start).toBe("number");
-    expect(typeof diagnostics[0]?.range.end).toBe("number");
+    expect(diagnostics[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostics[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 
   // @pattern on a string[] (array) field -- arrays are not string-like...or are they?
@@ -440,8 +452,8 @@ describe("@pattern silent-acceptance canaries", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(diagnostics[0]?.range).toBeDefined();
-    expect(typeof diagnostics[0]?.range.start).toBe("number");
-    expect(typeof diagnostics[0]?.range.end).toBe("number");
+    expect(diagnostics[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostics[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -524,8 +536,8 @@ describe("@uniqueItems silent-acceptance canaries", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(diagnostics[0]?.range).toBeDefined();
-    expect(typeof diagnostics[0]?.range.start).toBe("number");
-    expect(typeof diagnostics[0]?.range.end).toBe("number");
+    expect(diagnostics[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostics[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 
   // @uniqueItems on a number field -- numbers are not arrays.
@@ -544,8 +556,8 @@ describe("@uniqueItems silent-acceptance canaries", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(diagnostics[0]?.range).toBeDefined();
-    expect(typeof diagnostics[0]?.range.start).toBe("number");
-    expect(typeof diagnostics[0]?.range.end).toBe("number");
+    expect(diagnostics[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostics[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -598,8 +610,8 @@ describe("@const silent-acceptance canaries", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
     expect(diagnostics[0]?.range).toBeDefined();
-    expect(typeof diagnostics[0]?.range.start).toBe("number");
-    expect(typeof diagnostics[0]?.range.end).toBe("number");
+    expect(diagnostics[0]?.range.start).toBeGreaterThanOrEqual(0);
+    expect(diagnostics[0]?.range.end).toBeGreaterThanOrEqual(0);
   });
 
   // @const {"a":1} on a number field -- a JSON object constant is not

--- a/packages/analysis/src/__tests__/constraint-canaries.test.ts
+++ b/packages/analysis/src/__tests__/constraint-canaries.test.ts
@@ -59,9 +59,18 @@
 // - @enumOptions 5 (scalar not array) — typed parser catches at Role C
 // - @enumOptions {} (object not array) — typed parser catches at Role C
 //
+// Phase 5A flips (2026-04-21):
+// - 8 Category-1 canaries: snapshot consumer now runs _supportsConstraintCapability
+//   Role-B guard in buildTagDiagnostics, matching the build path's check.
+//   Closes the 8 Role-B silent-acceptance gaps tracked in #326.
+// - @const "USD" on object (bonus flip): the TypeScript `object` primitive type
+//   has TypeFlags.NonPrimitive and is NOT json-like, so the capability check
+//   emits TYPE_MISMATCH directly. This is correct behavior.
+//
 // @see docs/refactors/synthetic-checker-retirement.md S.9.3 #14
 // @see docs/refactors/synthetic-checker-retirement.md §4 (Phase 3 scope)
-// @see packages/build/src/analyzer/tsdoc-parser.ts supportsConstraintCapability (Role B — build path only)
+// @see docs/refactors/synthetic-checker-retirement.md §4 Phase 5A
+// @see packages/analysis/src/constraint-applicability.ts _supportsConstraintCapability (Role B — shared)
 import { describe, expect, it } from "vitest";
 import { buildFormSpecAnalysisFileSnapshot } from "../internal.js";
 import { createProgram } from "./helpers.js";
@@ -143,48 +152,45 @@ describe("@minimum silent-acceptance canaries", () => {
 
   // @minimum 0 on a string field -- string has no numeric-comparable capability.
   //
-  // Phase 4D audit: SNAPSHOT PATH ONLY — still silently accepted.
-  // Root cause: the synthetic prelude's direct-field tag_minimum overload has no
-  // capability constraint on Subject. The build path (tsdoc-parser.ts) catches
-  // this via supportsConstraintCapability() at Role B, but the snapshot consumer
-  // (buildFormSpecAnalysisFileSnapshot) does not have an equivalent Role-B guard.
-  // Phase 5 target: add host-checker Role-B capability check to snapshot consumer,
-  // or retire the synthetic prelude in favour of the build path's guard.
-  it.fails(
-    "emits TYPE_MISMATCH for @minimum 0 on a string field [Phase 5 target: snapshot Role-B capability check]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @minimum 0 */
-          value!: string;
-        }
-        `,
-        "minimum-on-string"
-      );
-      expect(diagnostics.some((d) => d.code === "TYPE_MISMATCH")).toBe(true);
-    }
-  );
+  // Phase 5A FLIP: snapshot consumer now runs the Role-B capability guard
+  // (_supportsConstraintCapability) in buildTagDiagnostics, matching the build
+  // path's supportsConstraintCapability() check in tsdoc-parser.ts.
+  it("emits TYPE_MISMATCH for @minimum 0 on a string field (snapshot Role-B capability check)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @minimum 0 */
+        value!: string;
+      }
+      `,
+      "minimum-on-string"
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(diagnostics[0]?.range).toBeDefined();
+    expect(typeof diagnostics[0]?.range.start).toBe("number");
+    expect(typeof diagnostics[0]?.range.end).toBe("number");
+  });
 
   // @minimum 0 on a boolean field -- boolean has no numeric-comparable capability.
   //
-  // Phase 4D audit: same root cause as @minimum on string above.
-  // Phase 5 target: snapshot Role-B capability check.
-  it.fails(
-    "emits TYPE_MISMATCH for @minimum 0 on a boolean field [Phase 5 target: snapshot Role-B capability check]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @minimum 0 */
-          value!: boolean;
-        }
-        `,
-        "minimum-on-boolean"
-      );
-      expect(diagnostics.some((d) => d.code === "TYPE_MISMATCH")).toBe(true);
-    }
-  );
+  // Phase 5A FLIP: same mechanism as @minimum on string above.
+  it("emits TYPE_MISMATCH for @minimum 0 on a boolean field (snapshot Role-B capability check)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @minimum 0 */
+        value!: boolean;
+      }
+      `,
+      "minimum-on-boolean"
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(diagnostics[0]?.range).toBeDefined();
+    expect(typeof diagnostics[0]?.range.start).toBe("number");
+    expect(typeof diagnostics[0]?.range.end).toBe("number");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -267,25 +273,25 @@ describe("@enumOptions silent-acceptance canaries", () => {
 
   // @enumOptions on a number field -- no enum-member-addressable capability.
   //
-  // Phase 4D audit: same root cause as @minimum on string — synthetic prelude
-  // direct-field tag_enumOptions has no capability constraint on Subject.
-  // The build path does emit TYPE_MISMATCH (supportsConstraintCapability returns
-  // false for number with "enum-member-addressable"). Phase 5 target.
-  it.fails(
-    "emits a diagnostic for @enumOptions on a number field (no enum capability) [Phase 5 target: snapshot Role-B capability check]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @enumOptions ["a","b"] */
-          value!: number;
-        }
-        `,
-        "enumOptions-on-number"
-      );
-      expect(diagnostics.length).toBeGreaterThan(0);
-    }
-  );
+  // Phase 5A FLIP: snapshot consumer now runs the Role-B capability guard,
+  // matching the build path's supportsConstraintCapability() check which returns
+  // false for number with "enum-member-addressable".
+  it("emits TYPE_MISMATCH for @enumOptions on a number field (no enum-member-addressable capability)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @enumOptions ["a","b"] */
+        value!: number;
+      }
+      `,
+      "enumOptions-on-number"
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(diagnostics[0]?.range).toBeDefined();
+    expect(typeof diagnostics[0]?.range.start).toBe("number");
+    expect(typeof diagnostics[0]?.range.end).toBe("number");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -340,43 +346,43 @@ describe("@pattern silent-acceptance canaries", () => {
 
   // @pattern on a number field -- numbers are not string-like.
   //
-  // Phase 4D audit: same root cause as @minimum on string — synthetic prelude
-  // direct-field tag_pattern has no capability constraint on Subject.
-  // Phase 5 target: snapshot Role-B capability check.
-  it.fails(
-    "emits TYPE_MISMATCH for @pattern on a number field [Phase 5 target: snapshot Role-B capability check]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @pattern ^[a-z]+$ */
-          value!: number;
-        }
-        `,
-        "pattern-on-number"
-      );
-      expect(diagnostics.some((d) => d.code === "TYPE_MISMATCH")).toBe(true);
-    }
-  );
+  // Phase 5A FLIP: snapshot consumer now runs the Role-B capability guard.
+  it("emits TYPE_MISMATCH for @pattern on a number field (snapshot Role-B capability check)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @pattern ^[a-z]+$ */
+        value!: number;
+      }
+      `,
+      "pattern-on-number"
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(diagnostics[0]?.range).toBeDefined();
+    expect(typeof diagnostics[0]?.range.start).toBe("number");
+    expect(typeof diagnostics[0]?.range.end).toBe("number");
+  });
 
   // @pattern on a boolean field -- booleans are not string-like.
   //
-  // Phase 4D audit: same root cause as @pattern on number. Phase 5 target.
-  it.fails(
-    "emits TYPE_MISMATCH for @pattern on a boolean field [Phase 5 target: snapshot Role-B capability check]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @pattern ^yes$ */
-          value!: boolean;
-        }
-        `,
-        "pattern-on-boolean"
-      );
-      expect(diagnostics.some((d) => d.code === "TYPE_MISMATCH")).toBe(true);
-    }
-  );
+  // Phase 5A FLIP: snapshot consumer now runs the Role-B capability guard.
+  it("emits TYPE_MISMATCH for @pattern on a boolean field (snapshot Role-B capability check)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @pattern ^yes$ */
+        value!: boolean;
+      }
+      `,
+      "pattern-on-boolean"
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(diagnostics[0]?.range).toBeDefined();
+    expect(typeof diagnostics[0]?.range.start).toBe("number");
+    expect(typeof diagnostics[0]?.range.end).toBe("number");
+  });
 
   // @pattern on a string[] (array) field -- arrays are not string-like...or are they?
   //
@@ -414,37 +420,29 @@ describe("@pattern silent-acceptance canaries", () => {
 
   // @pattern ^yes$ on a number[] (array) field -- number[] is NOT string-like.
   //
-  // [Phase 5 target: snapshot Role-B capability check]
+  // Unlike string[] (which satisfies "string-like" via _supportsConstraintCapability's
+  // array-element unwrap branch), number[] is NOT string-like — the element type
+  // (number) is not string-like, and neither is the array itself.
   //
-  // Unlike string[] (which satisfies "string-like" via supportsConstraintCapability's
-  // array-element unwrap branch), number[] is NOT string-like — neither the element
-  // type (number) nor the array itself passes the "string-like" capability check.
-  // Both consumers should emit TYPE_MISMATCH, but currently neither does:
-  //   - Build path: supportsConstraintCapability's "string-like" branch unwraps the
-  //     array element to `number`, which is not string-like, so the guard WOULD fire
-  //     if the capability check were wired at Role B in this path. Requires Phase 5
-  //     to fully thread the check for array-of-non-string types.
-  //   - Snapshot path: the synthetic prelude's tag_pattern<Host, Subject> direct-field
-  //     overload has NO capability constraint on Subject, so the synthetic TypeScript
-  //     checker accepts @pattern on number[] without error.
-  // This is a genuine Role-B gap, distinct from the intentional string[] behavior above.
-  // Phase 5 will flip this canary when host-checker Role-B is added to the snapshot
-  // consumer (or the synthetic checker is retired).
-  it.fails(
-    "emits TYPE_MISMATCH for @pattern ^yes$ on a number[] field [Phase 5 target: snapshot Role-B capability check]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @pattern ^yes$ */
-          value!: number[];
-        }
-        `,
-        "pattern-on-number-array"
-      );
-      expect(diagnostics.some((d) => d.code === "TYPE_MISMATCH")).toBe(true);
-    }
-  );
+  // Phase 5A FLIP: snapshot consumer now runs the Role-B capability guard.
+  // _supportsConstraintCapability unwraps the array element to `number`, which
+  // is not string-like, so the capability check fails and TYPE_MISMATCH is emitted.
+  it("emits TYPE_MISMATCH for @pattern ^yes$ on a number[] field (snapshot Role-B capability check)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @pattern ^yes$ */
+        value!: number[];
+      }
+      `,
+      "pattern-on-number-array"
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(diagnostics[0]?.range).toBeDefined();
+    expect(typeof diagnostics[0]?.range.start).toBe("number");
+    expect(typeof diagnostics[0]?.range.end).toBe("number");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -512,43 +510,43 @@ describe("@uniqueItems silent-acceptance canaries", () => {
 
   // @uniqueItems on a string field -- strings are not arrays.
   //
-  // Phase 4D audit: same root cause as @minimum on string — synthetic prelude
-  // direct-field tag_uniqueItems has no capability constraint on Subject.
-  // Phase 5 target: snapshot Role-B capability check.
-  it.fails(
-    "emits TYPE_MISMATCH for @uniqueItems on a string field [Phase 5 target: snapshot Role-B capability check]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @uniqueItems */
-          value!: string;
-        }
-        `,
-        "uniqueItems-on-string"
-      );
-      expect(diagnostics.some((d) => d.code === "TYPE_MISMATCH")).toBe(true);
-    }
-  );
+  // Phase 5A FLIP: snapshot consumer now runs the Role-B capability guard.
+  it("emits TYPE_MISMATCH for @uniqueItems on a string field (snapshot Role-B capability check)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @uniqueItems */
+        value!: string;
+      }
+      `,
+      "uniqueItems-on-string"
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(diagnostics[0]?.range).toBeDefined();
+    expect(typeof diagnostics[0]?.range.start).toBe("number");
+    expect(typeof diagnostics[0]?.range.end).toBe("number");
+  });
 
   // @uniqueItems on a number field -- numbers are not arrays.
   //
-  // Phase 4D audit: same root cause as @uniqueItems on string. Phase 5 target.
-  it.fails(
-    "emits TYPE_MISMATCH for @uniqueItems on a number field [Phase 5 target: snapshot Role-B capability check]",
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @uniqueItems */
-          value!: number;
-        }
-        `,
-        "uniqueItems-on-number"
-      );
-      expect(diagnostics.some((d) => d.code === "TYPE_MISMATCH")).toBe(true);
-    }
-  );
+  // Phase 5A FLIP: same mechanism as @uniqueItems on string above.
+  it("emits TYPE_MISMATCH for @uniqueItems on a number field (snapshot Role-B capability check)", () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @uniqueItems */
+        value!: number;
+      }
+      `,
+      "uniqueItems-on-number"
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(diagnostics[0]?.range).toBeDefined();
+    expect(typeof diagnostics[0]?.range.start).toBe("number");
+    expect(typeof diagnostics[0]?.range.end).toBe("number");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -578,29 +576,31 @@ describe("@const silent-acceptance canaries", () => {
   // @const "USD" on an object field -- a string literal constant is not
   // compatible with an object field.
   //
-  // Phase 4D audit: IR-level mismatch — not surfaced by snapshot consumer.
-  // Root cause: both synthetic checkers accept the raw tag call (before IR
-  // validation) because the prelude declares `type JsonValue = unknown` — any
-  // JSON value (including "USD") is assignable to the Subject type parameter of
-  // tag_const. The build path later catches the mismatch in validateIR
-  // (semantic-targets.ts), but the snapshot consumer never reaches that layer.
-  // Phase 5 target: retire the synthetic checker and/or add IR-validation pass
-  // to the snapshot consumer.
-  it.fails(
-    'emits a diagnostic for @const "USD" on an object field [Phase 5 target: IR-validation pass in snapshot consumer]',
-    () => {
-      const diagnostics = diagnosticsFor(
-        `
-        class F {
-          /** @const "USD" */
-          value!: object;
-        }
-        `,
-        "const-on-object"
-      );
-      expect(diagnostics.length).toBeGreaterThan(0);
-    }
-  );
+  // Phase 5A FLIP (bonus): the TypeScript `object` primitive type has
+  // TypeFlags.NonPrimitive and is NOT json-like (isJsonLike returns false).
+  // The Role-B capability guard (_supportsConstraintCapability) catches this
+  // at capability check time: @const requires "json-like", but the TypeScript
+  // `object` keyword does not satisfy that capability.
+  //
+  // Note: this is different from struct/record object types (e.g. `{ code: string }`)
+  // which ARE json-like. The TypeScript `object` primitive is a catch-all for
+  // non-primitive values and is specifically not json-like.
+  it('emits TYPE_MISMATCH for @const "USD" on an object field (Role-B capability check)', () => {
+    const diagnostics = diagnosticsFor(
+      `
+      class F {
+        /** @const "USD" */
+        value!: object;
+      }
+      `,
+      "const-on-object"
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("TYPE_MISMATCH");
+    expect(diagnostics[0]?.range).toBeDefined();
+    expect(typeof diagnostics[0]?.range.start).toBe("number");
+    expect(typeof diagnostics[0]?.range.end).toBe("number");
+  });
 
   // @const {"a":1} on a number field -- a JSON object constant is not
   // compatible with a number field.

--- a/packages/analysis/src/__tests__/parity-harness.test.ts
+++ b/packages/analysis/src/__tests__/parity-harness.test.ts
@@ -27,6 +27,7 @@ import {
   buildFormSpecAnalysisFileSnapshot,
   checkSyntheticTagApplication,
   describeTypeKind,
+  getMatchingTagSignatures,
   getSubjectType,
   getTagDefinition,
   resolveDeclarationPlacement,
@@ -621,12 +622,31 @@ function runBuildConsumer(fixture: ParityFixture): BuildConsumerResult {
   // applies via `supportsConstraintCapability()` in `tsdoc-parser.ts`.
   // The snapshot consumer now also applies this check, so the proxy must mirror
   // it for parity to be meaningful. Only applies to direct-field (no target).
-  if (subjectType !== undefined) {
-    const requiredCapability = definition?.capabilities[0];
-    if (!_supportsConstraintCapability(requiredCapability, subjectType, checker)) {
+  if (subjectType !== undefined && definition !== null) {
+    const requiredCapability = definition.capabilities[0];
+    if (
+      requiredCapability !== undefined &&
+      !_supportsConstraintCapability(requiredCapability, subjectType, checker)
+    ) {
       hasDiagnostic = true;
       diagnosticCode = "TYPE_MISMATCH";
       diagnosticMessage = `constraint "@${fixture.tagName}" capability check failed (Role B)`;
+    }
+  }
+
+  // §5 Phase 5A — apply the placement pre-check that the real snapshot path
+  // applies via `getMatchingTagSignatures()` in `file-snapshots.ts`. The real
+  // build path handles this via lowerTagApplicationToSyntheticCall throwing for
+  // invalid placements (try/catch below). Mirroring the snapshot's explicit
+  // pre-check here ensures parity for placement-rejection cases.
+  if (!hasDiagnostic && definition !== null) {
+    // Parity fixtures use direct-field targets only (no path/member targets),
+    // so targetKind is always null here.
+    const matchingSignatures = getMatchingTagSignatures(definition, resolvedPlacement, null);
+    if (matchingSignatures.length === 0) {
+      hasDiagnostic = true;
+      diagnosticCode = "INVALID_TAG_PLACEMENT";
+      diagnosticMessage = `No synthetic signature for @${definition.canonicalName} on placement "${resolvedPlacement}"`;
     }
   }
 

--- a/packages/analysis/src/__tests__/parity-harness.test.ts
+++ b/packages/analysis/src/__tests__/parity-harness.test.ts
@@ -23,6 +23,7 @@
 import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 import {
+  _supportsConstraintCapability,
   buildFormSpecAnalysisFileSnapshot,
   checkSyntheticTagApplication,
   describeTypeKind,
@@ -600,28 +601,43 @@ function runBuildConsumer(fixture: ParityFixture): BuildConsumerResult {
   let diagnosticCode: string | undefined;
   let diagnosticMessage: string | undefined;
 
-  try {
-    const result = checkSyntheticTagApplication({
-      tagName: fixture.tagName,
-      placement: resolvedPlacement,
-      hostType: subjectTypeText,
-      subjectType: subjectTypeText,
-      supportingDeclarations,
-      ...(argumentExpression !== null ? { argumentExpression } : {}),
-    });
-    hasDiagnostic = result.diagnostics.length > 0;
-    if (hasDiagnostic) {
-      const firstDiag = result.diagnostics[0];
-      if (firstDiag !== undefined) {
-        diagnosticCode = deriveBuildDiagnosticCode(firstDiag.message);
-        diagnosticMessage = firstDiag.message;
-      }
+  // §5 Phase 5A — apply the Role-B capability guard that the real build path
+  // applies via `supportsConstraintCapability()` in `tsdoc-parser.ts`.
+  // The snapshot consumer now also applies this check, so the proxy must mirror
+  // it for parity to be meaningful. Only applies to direct-field (no target).
+  if (subjectType !== undefined) {
+    const requiredCapability = definition?.capabilities[0];
+    if (!_supportsConstraintCapability(requiredCapability, subjectType, checker)) {
+      hasDiagnostic = true;
+      diagnosticCode = "TYPE_MISMATCH";
+      diagnosticMessage = `constraint "@${fixture.tagName}" capability check failed (Role B)`;
     }
-  } catch (error) {
-    // lowerTagApplicationToSyntheticCall throws for invalid placements (A-reject)
-    hasDiagnostic = true;
-    diagnosticCode = "INVALID_TAG_PLACEMENT";
-    diagnosticMessage = error instanceof Error ? error.message : String(error);
+  }
+
+  if (!hasDiagnostic) {
+    try {
+      const result = checkSyntheticTagApplication({
+        tagName: fixture.tagName,
+        placement: resolvedPlacement,
+        hostType: subjectTypeText,
+        subjectType: subjectTypeText,
+        supportingDeclarations,
+        ...(argumentExpression !== null ? { argumentExpression } : {}),
+      });
+      hasDiagnostic = result.diagnostics.length > 0;
+      if (hasDiagnostic) {
+        const firstDiag = result.diagnostics[0];
+        if (firstDiag !== undefined) {
+          diagnosticCode = deriveBuildDiagnosticCode(firstDiag.message);
+          diagnosticMessage = firstDiag.message;
+        }
+      }
+    } catch (error) {
+      // lowerTagApplicationToSyntheticCall throws for invalid placements (A-reject)
+      hasDiagnostic = true;
+      diagnosticCode = "INVALID_TAG_PLACEMENT";
+      diagnosticMessage = error instanceof Error ? error.message : String(error);
+    }
   }
 
   return {
@@ -654,6 +670,12 @@ function deriveBuildDiagnosticCode(message: string): string {
 /**
  * Derives a role outcome for the build consumer based on diagnostic presence
  * and code.
+ *
+ * Phase 5A: Role-B capability failures are mapped to "C-reject" in the parity
+ * model to match the snapshot consumer's mapping (both emit TYPE_MISMATCH;
+ * the exact role label — B vs C — is not semantically significant for parity
+ * detection). The important thing is that both consumers agree on whether a
+ * diagnostic is produced and what its code is.
  */
 function deriveBuildRoleOutcome(result: BuildConsumerResult): RoleOutcome {
   if (!result.hasDiagnostic) {

--- a/packages/analysis/src/__tests__/parity-harness.test.ts
+++ b/packages/analysis/src/__tests__/parity-harness.test.ts
@@ -379,6 +379,22 @@ const FIXTURES: readonly ParityFixture[] = [
     subjectType: "number",
     tagArgument: "NaN",
   },
+
+  // -------------------------------------------------------------------------
+  // Guard-order parity pin (Fix #1): @minimum "hello" on string
+  //
+  // Both consumers should emit TYPE_MISMATCH (Role B wins — string has no
+  // numeric-comparable capability) before the argument type is checked.
+  // If the snapshot consumer runs Role C (typed parser) before Role B, it
+  // emits INVALID_TAG_ARGUMENT instead of TYPE_MISMATCH, creating a
+  // diagnostic-code divergence. This fixture pins the correct order.
+  // -------------------------------------------------------------------------
+  {
+    label: '@minimum "hello" on string (guard-order parity: Role B before Role C)',
+    tagName: "minimum",
+    subjectType: "string",
+    tagArgument: '"hello"',
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
+++ b/packages/analysis/src/__tests__/typed-parser-snapshot-canaries.test.ts
@@ -149,7 +149,10 @@ describe("@enumOptions typed-parser Role-C canaries (snapshot consumer)", () => 
     // "Expected @enumOptions to be a JSON array, got number."
     // Before Phase 3 this was a `.fails` case (constraint-canaries.test.ts).
     // Phase 3 wires the typed parser into the snapshot path, converting it.
-    const diagnostics = snapshotDiagnosticsFor("enumOptions", "5", "string", "scalar");
+    //
+    // Note: field type is "a" | "b" (string literal union) so Role B passes
+    // (enum-member-addressable capability) and Role C runs.
+    const diagnostics = snapshotDiagnosticsFor("enumOptions", "5", '"a" | "b"', "scalar");
     const invalidArgDiags = diagnostics.filter((d) => d.code === "INVALID_TAG_ARGUMENT");
     expect(
       invalidArgDiags,
@@ -163,7 +166,10 @@ describe("@enumOptions typed-parser Role-C canaries (snapshot consumer)", () => 
     // "Expected @enumOptions to be a JSON array, got object."
     // Mirrors the build-consumer canary for @enumOptions {} (typed-parser-canaries.test.ts).
     // Phase 3 wires the typed parser into the snapshot path for this case.
-    const diagnostics = snapshotDiagnosticsFor("enumOptions", "{}", "string", "object");
+    //
+    // Note: field type is "a" | "b" (string literal union) so Role B passes
+    // (enum-member-addressable capability) and Role C runs.
+    const diagnostics = snapshotDiagnosticsFor("enumOptions", "{}", '"a" | "b"', "object");
     const invalidArgDiags = diagnostics.filter((d) => d.code === "INVALID_TAG_ARGUMENT");
     expect(
       invalidArgDiags,

--- a/packages/analysis/src/constraint-applicability.ts
+++ b/packages/analysis/src/constraint-applicability.ts
@@ -27,7 +27,7 @@
 
 import * as ts from "typescript";
 import { type SemanticCapability } from "./tag-registry.js";
-import { hasTypeSemanticCapability } from "./ts-binding.js";
+import { hasTypeSemanticCapability, stripNullishUnion } from "./ts-binding.js";
 
 /**
  * Maps a {@link SemanticCapability} to a human-readable type name for use in
@@ -69,13 +69,23 @@ export function _capabilityLabel(capability: SemanticCapability | undefined): st
 /**
  * Returns `true` when `type` satisfies the constraint `capability`.
  *
- * Mirrors `supportsConstraintCapability` in `tsdoc-parser.ts` with one
- * addition: the `string-like` array-element unwrap path. This allows
- * `string[]` to satisfy `string-like` constraints (e.g. `@pattern`) by
- * inspecting the element type, consistent with the build path's behaviour.
+ * Ported from `supportsConstraintCapability` in `tsdoc-parser.ts` (build
+ * package). Both the build consumer (`tsdoc-parser.ts`) and the snapshot
+ * consumer (`file-snapshots.ts`) call this function, so the capability
+ * logic is shared and the TYPE_MISMATCH decisions are consistent across
+ * both paths.
  *
- * When `capability` is `undefined` (no constraint on target type), returns
- * `true` unconditionally.
+ * Behaviour:
+ * - When `capability` is `undefined` (no constraint on target type), returns
+ *   `true` unconditionally.
+ * - For `string-like` capability, also accepts `string[]` (and nullable
+ *   variants like `string[] | null`) by unwrapping the array element type.
+ *   This mirrors the build path's treatment of `@pattern` on string-array
+ *   fields.
+ * - Integer-brand bypass is the caller's responsibility. Callers must check
+ *   for integer-branded types and skip this function when appropriate (see
+ *   ordering invariants in the module-level JSDoc). There is no options
+ *   parameter — the bypass happens at the call site, not here.
  *
  * @param capability - The semantic capability required by the constraint tag.
  * @param fieldType  - The TypeScript type of the field being annotated.
@@ -110,11 +120,17 @@ export function _supportsConstraintCapability(
 /**
  * Returns the element type of an array type, or `null` if the type is not an
  * array.
+ *
+ * Applies {@link stripNullishUnion} before the array check so that nullable
+ * array types (e.g. `string[] | null`) are correctly unwrapped. Without this,
+ * `checker.isArrayType` returns `false` for the union type, causing nullable
+ * array fields to silently fail Role-B capability checks.
  */
 function getArrayElementType(type: ts.Type, checker: ts.TypeChecker): ts.Type | null {
-  if (!checker.isArrayType(type)) {
+  const stripped = stripNullishUnion(type);
+  if (!checker.isArrayType(stripped)) {
     return null;
   }
   // checker.isArrayType guarantees TypeReference here.
-  return checker.getTypeArguments(type as ts.TypeReference)[0] ?? null;
+  return checker.getTypeArguments(stripped as ts.TypeReference)[0] ?? null;
 }

--- a/packages/analysis/src/constraint-applicability.ts
+++ b/packages/analysis/src/constraint-applicability.ts
@@ -30,6 +30,43 @@ import { type SemanticCapability } from "./tag-registry.js";
 import { hasTypeSemanticCapability } from "./ts-binding.js";
 
 /**
+ * Maps a {@link SemanticCapability} to a human-readable type name for use in
+ * diagnostic messages (e.g. `"numeric-comparable"` → `"number"`).
+ *
+ * Both the build consumer (`tsdoc-parser.ts`) and the snapshot consumer
+ * (`file-snapshots.ts`) use this helper so their TYPE_MISMATCH messages are
+ * identical.
+ *
+ * @internal
+ */
+export function _capabilityLabel(capability: SemanticCapability | undefined): string {
+  switch (capability) {
+    case "numeric-comparable":
+      return "number";
+    case "string-like":
+      return "string";
+    case "array-like":
+      return "array";
+    case "enum-member-addressable":
+      return "enum";
+    case "json-like":
+      return "JSON-compatible";
+    case "object-like":
+      return "object";
+    case "condition-like":
+      return "conditional";
+    case undefined:
+      return "compatible";
+    default: {
+      // Exhaustiveness guard: if a new SemanticCapability is added to the
+      // union, TypeScript will error here until this switch is updated.
+      const exhaustive: never = capability;
+      return String(exhaustive);
+    }
+  }
+}
+
+/**
  * Returns `true` when `type` satisfies the constraint `capability`.
  *
  * Mirrors `supportsConstraintCapability` in `tsdoc-parser.ts` with one

--- a/packages/analysis/src/constraint-applicability.ts
+++ b/packages/analysis/src/constraint-applicability.ts
@@ -109,13 +109,12 @@ export function _supportsConstraintCapability(
 
 /**
  * Returns the element type of an array type, or `null` if the type is not an
- * array. Strips nullish union members before checking.
- *
- * Mirrors the private `getArrayElementType` helper in `tsdoc-parser.ts`.
+ * array.
  */
 function getArrayElementType(type: ts.Type, checker: ts.TypeChecker): ts.Type | null {
   if (!checker.isArrayType(type)) {
     return null;
   }
+  // checker.isArrayType guarantees TypeReference here.
   return checker.getTypeArguments(type as ts.TypeReference)[0] ?? null;
 }

--- a/packages/analysis/src/constraint-applicability.ts
+++ b/packages/analysis/src/constraint-applicability.ts
@@ -17,10 +17,10 @@
  *      bypass is not applied first, `_supportsConstraintCapability` will still
  *      return `true` for numeric-comparable on integer types (correct), but the
  *      guard ordering must match the build path's ordering.
- *   2. This check runs BEFORE the typed-parser Role-C call in the build path.
- *      In the snapshot consumer it should run after the typed-parser Role-C call
- *      (since Role C already ran earlier in the loop) but before the synthetic
- *      call.
+ *   2. This check runs BEFORE the typed-parser Role-C call (matching the build
+ *      path's guard order). For a bad-arg AND wrong-type input (e.g. `@minimum
+ *      "hello" on string`), Role B emits TYPE_MISMATCH before Role C inspects
+ *      the argument — ensuring both consumers produce the same diagnostic code.
  *
  * @internal
  */
@@ -43,18 +43,13 @@ import { hasTypeSemanticCapability } from "./ts-binding.js";
  * @param capability - The semantic capability required by the constraint tag.
  * @param fieldType  - The TypeScript type of the field being annotated.
  * @param checker    - The TypeScript type checker for the host program.
- * @param options    - Optional behaviour flags.
- * @param options.allowIntegerBrandedAsNumeric - Unused in this implementation
- *   because integer-brand bypass is handled by the caller before this function
- *   is invoked. Kept for API symmetry with the build path.
  *
  * @internal
  */
 export function _supportsConstraintCapability(
   capability: SemanticCapability | undefined,
   fieldType: ts.Type,
-  checker: ts.TypeChecker,
-  _options?: { allowIntegerBrandedAsNumeric?: boolean }
+  checker: ts.TypeChecker
 ): boolean {
   if (capability === undefined) {
     return true;

--- a/packages/analysis/src/constraint-applicability.ts
+++ b/packages/analysis/src/constraint-applicability.ts
@@ -1,0 +1,89 @@
+/**
+ * Constraint applicability guard — host-checker Role-B equivalent for the
+ * snapshot consumer.
+ *
+ * The build consumer (`tsdoc-parser.ts`) calls `supportsConstraintCapability()`
+ * before the synthetic-checker call to emit `TYPE_MISMATCH` when a constraint's
+ * required semantic capability is absent from the field type (e.g. `@minimum 0`
+ * on a `string` field has no `numeric-comparable` capability).
+ *
+ * This module ports that guard into `@formspec/analysis` so the snapshot
+ * consumer can apply the same check without depending on the build package.
+ *
+ * Ordering invariants (for callers in `file-snapshots.ts:buildTagDiagnostics`):
+ *   1. Integer-brand bypass MUST run before this check. Integer-branded types
+ *      (`number & { [__integerBrand]: true }`) look like plain numbers for
+ *      capability purposes but should bypass entirely (Phase 4A). If the brand
+ *      bypass is not applied first, `_supportsConstraintCapability` will still
+ *      return `true` for numeric-comparable on integer types (correct), but the
+ *      guard ordering must match the build path's ordering.
+ *   2. This check runs BEFORE the typed-parser Role-C call in the build path.
+ *      In the snapshot consumer it should run after the typed-parser Role-C call
+ *      (since Role C already ran earlier in the loop) but before the synthetic
+ *      call.
+ *
+ * @internal
+ */
+
+import * as ts from "typescript";
+import { type SemanticCapability } from "./tag-registry.js";
+import { hasTypeSemanticCapability } from "./ts-binding.js";
+
+/**
+ * Returns `true` when `type` satisfies the constraint `capability`.
+ *
+ * Mirrors `supportsConstraintCapability` in `tsdoc-parser.ts` with one
+ * addition: the `string-like` array-element unwrap path. This allows
+ * `string[]` to satisfy `string-like` constraints (e.g. `@pattern`) by
+ * inspecting the element type, consistent with the build path's behaviour.
+ *
+ * When `capability` is `undefined` (no constraint on target type), returns
+ * `true` unconditionally.
+ *
+ * @param capability - The semantic capability required by the constraint tag.
+ * @param fieldType  - The TypeScript type of the field being annotated.
+ * @param checker    - The TypeScript type checker for the host program.
+ * @param options    - Optional behaviour flags.
+ * @param options.allowIntegerBrandedAsNumeric - Unused in this implementation
+ *   because integer-brand bypass is handled by the caller before this function
+ *   is invoked. Kept for API symmetry with the build path.
+ *
+ * @internal
+ */
+export function _supportsConstraintCapability(
+  capability: SemanticCapability | undefined,
+  fieldType: ts.Type,
+  checker: ts.TypeChecker,
+  _options?: { allowIntegerBrandedAsNumeric?: boolean }
+): boolean {
+  if (capability === undefined) {
+    return true;
+  }
+
+  if (hasTypeSemanticCapability(fieldType, checker, capability)) {
+    return true;
+  }
+
+  // Array-element unwrap for "string-like": `string[]` satisfies `string-like`
+  // because the element type (`string`) does. This mirrors the build path's
+  // `supportsConstraintCapability` in `tsdoc-parser.ts` (~line 464–468).
+  if (capability === "string-like") {
+    const itemType = getArrayElementType(fieldType, checker);
+    return itemType !== null && hasTypeSemanticCapability(itemType, checker, capability);
+  }
+
+  return false;
+}
+
+/**
+ * Returns the element type of an array type, or `null` if the type is not an
+ * array. Strips nullish union members before checking.
+ *
+ * Mirrors the private `getArrayElementType` helper in `tsdoc-parser.ts`.
+ */
+function getArrayElementType(type: ts.Type, checker: ts.TypeChecker): ts.Type | null {
+  if (!checker.isArrayType(type)) {
+    return null;
+  }
+  return checker.getTypeArguments(type as ts.TypeReference)[0] ?? null;
+}

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -4,9 +4,11 @@ import {
   _mapSetupDiagnosticCode,
   _validateExtensionSetup,
   checkSyntheticTagApplicationsDetailed,
+  getMatchingTagSignatures,
   lowerTagApplicationToSyntheticCall,
   type SyntheticCompilerDiagnostic,
 } from "./compiler-signatures.js";
+import { _supportsConstraintCapability } from "./constraint-applicability.js";
 import {
   extractCommentBlockTagTexts,
   extractCommentSummaryText,
@@ -1634,6 +1636,53 @@ function buildTagDiagnostics(
             valueKind: typedParseResult.value.kind,
           });
         }
+
+        // §5 Phase 5A — Role B capability guard (snapshot consumer).
+        //
+        // Mirrors the build path's `supportsConstraintCapability()` call in
+        // `tsdoc-parser.ts` (~lines 870-896). The build path runs this check
+        // BEFORE the synthetic call to emit TYPE_MISMATCH when the field type
+        // lacks the required capability (e.g. @minimum 0 on string).
+        //
+        // Ordering invariant: integer-brand bypass ALREADY ran earlier in this
+        // loop (isIntegerBypass check above). This guard only runs on the
+        // non-broadened, non-bypassed path, after typed-parser C-pass.
+        //
+        // Only direct-field tags (target === null) are checked here.
+        // Path-targeted fields use the resolved path type, not the declared
+        // subject type — that check requires a different anchor and is already
+        // handled via the existing synthetic checker path until Phase 5C.
+        if (target === null) {
+          const requiredCapability = semantic.tagDefinition.capabilities[0];
+          if (!_supportsConstraintCapability(requiredCapability, subjectType, checker)) {
+            const actualTypeText =
+              standaloneSubjectTypeText ?? typeToString(subjectType, checker) ?? "unknown";
+            const capabilityLabel = requiredCapability ?? "unknown";
+            diagnostics.push(
+              createAnalysisDiagnostic(
+                "TYPE_MISMATCH",
+                `constraint "@${tag.normalizedTagName}" is only valid on ${capabilityLabel} targets, but field type is "${actualTypeText}"`,
+                tag.fullSpan,
+                {
+                  tagName: tag.normalizedTagName,
+                  placement,
+                }
+              )
+            );
+            if (snapshotLogsEnabled) {
+              logTagApplication(snapshotLog, {
+                consumer: "snapshot",
+                tag: tag.normalizedTagName,
+                placement,
+                subjectTypeKind: subjectTypeKindForLog,
+                roleOutcome: "B-reject",
+                elapsedMicros: elapsedMicros(tagStartMicros),
+              });
+            }
+            // Skip synthetic call — Role B already rejected.
+            continue;
+          }
+        }
       } else {
         // Extension-broadened (D1/D2) — bypass the typed parser but still pass
         // to the synthetic checker, which understands extension-registered types
@@ -1647,6 +1696,51 @@ function buildTagDiagnostics(
             roleOutcome: "bypass",
           });
         }
+      }
+    }
+
+    // §5 Phase 5A — placement pre-check (snapshot consumer).
+    //
+    // Before calling lowerTagApplicationToSyntheticCall, call
+    // getMatchingTagSignatures to detect INVALID_TAG_PLACEMENT without relying
+    // on the throw-and-catch path below. The try/catch is kept for defense-in-
+    // depth (Phase 5C will delete the synthetic machinery; the catch stays until
+    // then). When the explicit check fires first, the try/catch is unreachable
+    // for this tag application.
+    //
+    // Applies to ALL tags (builtin constraint and extension), not just builtin.
+    // semantic.tagDefinition is always non-null here (the null case causes an
+    // early `continue` at the top of the loop, line 1453).
+    {
+      const definition = semantic.tagDefinition;
+      const targetKind = target?.kind ?? null;
+      const matchingSignatures = getMatchingTagSignatures(definition, placement, targetKind);
+      if (matchingSignatures.length === 0) {
+        if (snapshotLogsEnabled) {
+          logTagApplication(snapshotLog, {
+            consumer: "snapshot",
+            tag: tag.normalizedTagName,
+            placement,
+            subjectTypeKind: subjectTypeKindForLog,
+            roleOutcome: "A-reject",
+            elapsedMicros: elapsedMicros(tagStartMicros),
+          });
+        }
+        diagnostics.push(
+          createAnalysisDiagnostic(
+            "INVALID_TAG_PLACEMENT",
+            `No synthetic signature for @${definition.canonicalName} on placement "${placement}"` +
+              (targetKind === null ? "" : ` with target kind "${targetKind}"`),
+            tag.fullSpan,
+            {
+              tagName: tag.normalizedTagName,
+              placement,
+              ...(target === null ? {} : { targetKind: target.kind, targetText: target.text }),
+            }
+          )
+        );
+        // Skip synthetic call — placement already rejected.
+        continue;
       }
     }
 
@@ -1785,9 +1879,7 @@ function buildTagDiagnostics(
     diagnostics.push(
       ..._mapGlobalSyntheticTsDiagnostics(batchCheck.globalDiagnostics, globalAnchorSpan, {
         placement,
-        tagNames: syntheticApplications.map(
-          (application) => application.tag.normalizedTagName
-        ),
+        tagNames: syntheticApplications.map((application) => application.tag.normalizedTagName),
       })
     );
   }

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -1567,6 +1567,61 @@ function buildTagDiagnostics(
       );
 
       if (!hasExtBroadening) {
+        // §5 Phase 5A — Role B capability guard (snapshot consumer).
+        //
+        // ORDERING: Role B runs BEFORE Role C (typed parser) to match the build
+        // path's guard order in `tsdoc-parser.ts` (~lines 855-884). The build
+        // path checks supportsConstraintCapability() first, so for a bad-arg AND
+        // wrong-type input (e.g. `@minimum "hello" on string`), both consumers
+        // must emit TYPE_MISMATCH (Role B wins) — not INVALID_TAG_ARGUMENT (Role
+        // C wins). Running Role C first would produce a diagnostic-code divergence
+        // for that class of inputs.
+        //
+        // Ordering invariant: integer-brand bypass ALREADY ran earlier in this
+        // loop (isIntegerBypass check above). This guard only runs on the
+        // non-broadened, non-bypassed path.
+        //
+        // Only direct-field tags (target === null) are checked here.
+        // Path-targeted fields use the resolved path type, not the declared
+        // subject type — that check requires a different anchor and is already
+        // handled via the existing synthetic checker path until Phase 5C.
+        if (target === null) {
+          const requiredCapability = semantic.tagDefinition.capabilities[0];
+          // Under noUncheckedIndexedAccess, capabilities[0] is SemanticCapability | undefined.
+          // No capability constraint on this tag → always valid for any field type.
+          // requiredCapability is narrowed to SemanticCapability in the else-if branch.
+          if (
+            requiredCapability !== undefined &&
+            !_supportsConstraintCapability(requiredCapability, subjectType, checker)
+          ) {
+            const actualTypeText =
+              standaloneSubjectTypeText ?? typeToString(subjectType, checker) ?? "unknown";
+            diagnostics.push(
+              createAnalysisDiagnostic(
+                "TYPE_MISMATCH",
+                `constraint "@${tag.normalizedTagName}" is only valid on ${requiredCapability} targets, but field type is "${actualTypeText}"`,
+                tag.fullSpan,
+                {
+                  tagName: tag.normalizedTagName,
+                  placement,
+                }
+              )
+            );
+            if (snapshotLogsEnabled) {
+              logTagApplication(snapshotLog, {
+                consumer: "snapshot",
+                tag: tag.normalizedTagName,
+                placement,
+                subjectTypeKind: subjectTypeKindForLog,
+                roleOutcome: "B-reject",
+                elapsedMicros: elapsedMicros(tagStartMicros),
+              });
+            }
+            // Skip synthetic call — Role B already rejected.
+            continue;
+          }
+        }
+
         // §4 Phase 4B — use shared extractEffectiveArgumentText so both
         // consumers derive argument text identically. For the snapshot consumer,
         // tag.argumentText is already target-stripped (parseCommentBlock strips
@@ -1574,6 +1629,11 @@ function buildTagDiagnostics(
         // rawText produces the same result as parseTagSyntax(tagName,
         // tag.argumentText).argumentText. The helper unifies the code paths so
         // future changes affect both consumers symmetrically.
+        //
+        // ORDERING: Role C runs AFTER Role B (capability check). This matches the
+        // build path's order: bypass → Role B → Role C. For wrong-type AND
+        // bad-arg inputs, Role B wins and emits TYPE_MISMATCH before the
+        // typed parser inspects the argument.
         const effectiveArgumentText = extractEffectiveArgumentText(
           tag.normalizedTagName,
           tag.argumentText,
@@ -1635,53 +1695,6 @@ function buildTagDiagnostics(
             roleOutcome: "C-pass",
             valueKind: typedParseResult.value.kind,
           });
-        }
-
-        // §5 Phase 5A — Role B capability guard (snapshot consumer).
-        //
-        // Mirrors the build path's `supportsConstraintCapability()` call in
-        // `tsdoc-parser.ts` (~lines 870-896). The build path runs this check
-        // BEFORE the synthetic call to emit TYPE_MISMATCH when the field type
-        // lacks the required capability (e.g. @minimum 0 on string).
-        //
-        // Ordering invariant: integer-brand bypass ALREADY ran earlier in this
-        // loop (isIntegerBypass check above). This guard only runs on the
-        // non-broadened, non-bypassed path, after typed-parser C-pass.
-        //
-        // Only direct-field tags (target === null) are checked here.
-        // Path-targeted fields use the resolved path type, not the declared
-        // subject type — that check requires a different anchor and is already
-        // handled via the existing synthetic checker path until Phase 5C.
-        if (target === null) {
-          const requiredCapability = semantic.tagDefinition.capabilities[0];
-          if (!_supportsConstraintCapability(requiredCapability, subjectType, checker)) {
-            const actualTypeText =
-              standaloneSubjectTypeText ?? typeToString(subjectType, checker) ?? "unknown";
-            const capabilityLabel = requiredCapability ?? "unknown";
-            diagnostics.push(
-              createAnalysisDiagnostic(
-                "TYPE_MISMATCH",
-                `constraint "@${tag.normalizedTagName}" is only valid on ${capabilityLabel} targets, but field type is "${actualTypeText}"`,
-                tag.fullSpan,
-                {
-                  tagName: tag.normalizedTagName,
-                  placement,
-                }
-              )
-            );
-            if (snapshotLogsEnabled) {
-              logTagApplication(snapshotLog, {
-                consumer: "snapshot",
-                tag: tag.normalizedTagName,
-                placement,
-                subjectTypeKind: subjectTypeKindForLog,
-                roleOutcome: "B-reject",
-                elapsedMicros: elapsedMicros(tagStartMicros),
-              });
-            }
-            // Skip synthetic call — Role B already rejected.
-            continue;
-          }
         }
       } else {
         // Extension-broadened (D1/D2) — bypass the typed parser but still pass

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -8,7 +8,10 @@ import {
   lowerTagApplicationToSyntheticCall,
   type SyntheticCompilerDiagnostic,
 } from "./compiler-signatures.js";
-import { _supportsConstraintCapability } from "./constraint-applicability.js";
+import {
+  _capabilityLabel,
+  _supportsConstraintCapability,
+} from "./constraint-applicability.js";
 import {
   extractCommentBlockTagTexts,
   extractCommentSummaryText,
@@ -1540,7 +1543,7 @@ function buildTagDiagnostics(
       const isIntegerBypass =
         target === null &&
         _isIntegerBrandedType(stripNullishUnion(subjectType)) &&
-        semantic.tagDefinition.capabilities.includes("numeric-comparable");
+        semantic.tagDefinition.capabilities[0] === "numeric-comparable";
 
       if (isIntegerBypass) {
         // §8.3b — log "bypass" roleOutcome on the snapshot consumer channel,
@@ -1599,7 +1602,7 @@ function buildTagDiagnostics(
             diagnostics.push(
               createAnalysisDiagnostic(
                 "TYPE_MISMATCH",
-                `constraint "@${tag.normalizedTagName}" is only valid on ${requiredCapability} targets, but field type is "${actualTypeText}"`,
+                `constraint "@${tag.normalizedTagName}" is only valid on ${_capabilityLabel(requiredCapability)} targets, but field type is "${actualTypeText}"`,
                 tag.fullSpan,
                 {
                   tagName: tag.normalizedTagName,

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -185,6 +185,7 @@ export {
   type TagArgumentLowering,
 } from "./tag-argument-parser.js";
 export { _isIntegerBrandedType, _collectBrandIdentifiers } from "./integer-brand.js";
+export { _supportsConstraintCapability } from "./constraint-applicability.js";
 export {
   CONSTRAINT_VALIDATOR_NS,
   CONSTRAINT_VALIDATOR_BUILD_NS,

--- a/packages/analysis/src/internal.ts
+++ b/packages/analysis/src/internal.ts
@@ -185,7 +185,7 @@ export {
   type TagArgumentLowering,
 } from "./tag-argument-parser.js";
 export { _isIntegerBrandedType, _collectBrandIdentifiers } from "./integer-brand.js";
-export { _supportsConstraintCapability } from "./constraint-applicability.js";
+export { _capabilityLabel, _supportsConstraintCapability } from "./constraint-applicability.js";
 export {
   CONSTRAINT_VALIDATOR_NS,
   CONSTRAINT_VALIDATOR_BUILD_NS,

--- a/packages/analysis/src/tag-registry.ts
+++ b/packages/analysis/src/tag-registry.ts
@@ -72,7 +72,16 @@ export interface TagDefinition {
   readonly allowDuplicates: boolean;
   readonly category: FormSpecTagCategory;
   readonly placements: readonly FormSpecPlacement[];
-  readonly capabilities: readonly SemanticCapability[];
+  /**
+   * The semantic capabilities required of the field type for this tag to be
+   * applicable. At most one capability may be declared per tag.
+   *
+   * The "at most one" invariant is structural: all `capabilitiesForValueKind`
+   * return paths yield 0 or 1 elements, and no tag definition supplies 2+
+   * capabilities. The tuple type enforces this at the type level so future
+   * additions that accidentally provide two capabilities produce a type error.
+   */
+  readonly capabilities: readonly [SemanticCapability] | readonly [];
   readonly completionDetail: string;
   readonly hoverSummary: string;
   readonly hoverMarkdown: string;
@@ -382,21 +391,21 @@ function getBuiltinConstraintCapability(name: BuiltinConstraintName): SemanticCa
 
 function capabilitiesForValueKind(
   valueKind: FormSpecValueKind | null
-): readonly SemanticCapability[] {
+): readonly [SemanticCapability] | readonly [] {
   switch (valueKind) {
     case "number":
     case "integer":
     case "signedInteger":
-      return ["numeric-comparable"];
+      return ["numeric-comparable"] as const;
     case "string":
-      return ["string-like"];
+      return ["string-like"] as const;
     case "json":
-      return ["json-like"];
+      return ["json-like"] as const;
     case "condition":
-      return ["condition-like"];
+      return ["condition-like"] as const;
     case "boolean":
     case null:
-      return [];
+      return [] as const;
     default: {
       const exhaustive: never = valueKind;
       return exhaustive;
@@ -568,7 +577,7 @@ const BUILTIN_TAG_DEFINITIONS = Object.fromEntries(
         allowDuplicates: false,
         category: "constraint" as const,
         placements: FIELD_PLACEMENTS,
-        capabilities: [subjectCapability],
+        capabilities: [subjectCapability] as const,
         completionDetail: CONSTRAINT_COMPLETION_DETAIL[name] ?? `@${name}`,
         hoverSummary: CONSTRAINT_HOVER_SUMMARIES[name],
         hoverMarkdown: CONSTRAINT_HOVER_DOCS[name] ?? `**@${name}**`,
@@ -805,7 +814,7 @@ function buildExtraTagDefinition(canonicalName: string, spec: ExtraTagSpec): Tag
     // regardless of its type, so their value-kind must not leak into a field
     // constraint. `EXTRA_TAG_SPECS` currently has no constraint entries, but
     // we keep the `spec.category === "constraint"` check for future-proofing.
-    capabilities: spec.category === "constraint" ? capabilitiesForValueKind(valueKind) : [],
+    capabilities: spec.category === "constraint" ? capabilitiesForValueKind(valueKind) : ([] as const),
     completionDetail: spec.completionDetail,
     hoverSummary: spec.hoverSummary,
     hoverMarkdown: buildHoverMarkdown(canonicalName, spec.hoverSummary, signatures, valueLabel),
@@ -884,7 +893,7 @@ function buildExtensionMetadataTagDefinition(
     // Extension metadata tags are always annotations — they attach a typed
     // value to a declaration without constraining the declaration's type.
     // See `buildExtraTagDefinition` for the rationale.
-    capabilities: [],
+    capabilities: [] as const,
     completionDetail: `Extension metadata tag from ${extensionId}`,
     hoverSummary: `Extension-defined metadata tag from \`${extensionId}\`.`,
     hoverMarkdown: [
@@ -937,7 +946,7 @@ export function getTagDefinition(
       allowDuplicates: true,
       category: "constraint",
       placements: FIELD_PLACEMENTS,
-      capabilities: [],
+      capabilities: [] as const,
       completionDetail: `Extension constraint tag from ${extensionRegistration.extensionId}`,
       hoverSummary: `Extension-defined constraint tag from \`${extensionRegistration.extensionId}\`.`,
       hoverMarkdown: [

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -39,6 +39,7 @@
 
 import * as ts from "typescript";
 import {
+  _supportsConstraintCapability,
   checkSyntheticTagApplication,
   choosePreferredPayloadText,
   extractPathTarget as extractSharedPathTarget,
@@ -440,33 +441,19 @@ function renderSyntheticArgumentExpression(
   }
 }
 
-function getArrayElementType(type: ts.Type, checker: ts.TypeChecker): ts.Type | null {
-  if (!checker.isArrayType(type)) {
-    return null;
-  }
-
-  return checker.getTypeArguments(type as ts.TypeReference)[0] ?? null;
-}
-
+/**
+ * Re-export shim: the implementation has moved to
+ * `@formspec/analysis/internal:_supportsConstraintCapability`.
+ *
+ * The local signature `(type, checker, capability)` is preserved so existing
+ * callers in this file do not need to change argument order.
+ */
 function supportsConstraintCapability(
   type: ts.Type,
   checker: ts.TypeChecker,
   capability: SemanticCapability | undefined
 ): boolean {
-  if (capability === undefined) {
-    return true;
-  }
-
-  if (hasTypeSemanticCapability(type, checker, capability)) {
-    return true;
-  }
-
-  if (capability === "string-like") {
-    const itemType = getArrayElementType(type, checker);
-    return itemType !== null && hasTypeSemanticCapability(itemType, checker, capability);
-  }
-
-  return false;
+  return _supportsConstraintCapability(capability, type, checker);
 }
 
 const MAX_HINT_CANDIDATES = 5;

--- a/packages/build/src/analyzer/tsdoc-parser.ts
+++ b/packages/build/src/analyzer/tsdoc-parser.ts
@@ -39,6 +39,7 @@
 
 import * as ts from "typescript";
 import {
+  _capabilityLabel,
   _supportsConstraintCapability,
   checkSyntheticTagApplication,
   choosePreferredPayloadText,
@@ -628,28 +629,6 @@ function placementLabel(
   }
 }
 
-function capabilityLabel(capability: string | undefined): string {
-  switch (capability) {
-    case "numeric-comparable":
-      return "number";
-    case "string-like":
-      return "string";
-    case "array-like":
-      return "array";
-    case "enum-member-addressable":
-      return "enum";
-    case "json-like":
-      return "JSON-compatible";
-    case "object-like":
-      return "object";
-    case "condition-like":
-      return "conditional";
-    case undefined:
-      return "compatible";
-    default:
-      return capability;
-  }
-}
 
 function getBroadenedCustomTypeId(fieldType: TypeNode | undefined): string | undefined {
   if (fieldType?.kind === "custom") {
@@ -836,7 +815,7 @@ function buildCompilerBackedConstraintDiagnostics(
     if (target === null) {
       if (
         _isIntegerBrandedType(stripNullishUnion(subjectType)) &&
-        definition.capabilities.includes("numeric-comparable")
+        definition.capabilities[0] === "numeric-comparable"
       ) {
         return true;
       }
@@ -859,7 +838,7 @@ function buildCompilerBackedConstraintDiagnostics(
       !supportsConstraintCapability(evaluatedType, checker, requiredCapability)
     ) {
       const actualType = checker.typeToString(evaluatedType, node, SYNTHETIC_TYPE_FORMAT_FLAGS);
-      const baseMessage = `Target "${targetLabel}": constraint "${tagName}" is only valid on ${capabilityLabel(requiredCapability)} targets, but field type is "${actualType}"`;
+      const baseMessage = `Target "${targetLabel}": constraint "${tagName}" is only valid on ${_capabilityLabel(requiredCapability)} targets, but field type is "${actualType}"`;
       // Path-target hints only apply to direct-field mismatches — the hint
       // suggests "did you mean a sub-path?" which is nonsensical when the
       // user is already path-targeting.
@@ -1031,8 +1010,7 @@ function buildCompilerBackedConstraintDiagnostics(
     ]);
   }
 
-  const expectedLabel =
-    definition.valueKind === null ? "compatible argument" : capabilityLabel(definition.valueKind);
+  const expectedLabel = definition.valueKind ?? "compatible argument";
   return emit("C-reject", [
     makeDiagnostic(
       "TYPE_MISMATCH",


### PR DESCRIPTION
## Summary

- Ports `supportsConstraintCapability` from `tsdoc-parser.ts` (build path) into a new shared helper `_supportsConstraintCapability` in `packages/analysis/src/constraint-applicability.ts`
- Wires the Role-B capability guard and an explicit `getMatchingTagSignatures` placement pre-check into the snapshot consumer's `buildTagDiagnostics` (closing 9 silent-acceptance gaps in `#326`)
- Updates the parity-harness build-consumer proxy to apply the same capability check so the harness correctly models the real build path

## Canary flips: 9 (expected 8, +1 bonus)

All 8 Category-1 canaries (Role-B gaps) now pass as regular `it()` assertions with exact `TYPE_MISMATCH` code + `.toHaveLength(1)` + span checks.

**Bonus flip**: `@const "USD" on object` — the TypeScript `object` primitive has `TypeFlags.NonPrimitive` and is NOT json-like, so the capability guard correctly emits `TYPE_MISMATCH`. This is correct behavior (the build path would also catch it). The original canary comment identified this as an "IR-level" issue but the capability check is an earlier, equally correct detection path.

## Scope

- `_supportsConstraintCapability` extracted to `packages/analysis/src/constraint-applicability.ts` with `@internal` export via `internal.ts`
- Build path `supportsConstraintCapability` becomes a local shim delegating to the shared helper
- Snapshot `buildTagDiagnostics` gains Role-B check (after integer-brand bypass, after typed-parser C-pass) and placement pre-check (before synthetic call, for all tags)
- 19 new tests in `constraint-applicability.test.ts` (unit + integration)
- Parity-harness `runBuildConsumer` proxy updated with the same capability guard to prevent false divergence reports

## Non-goals (deferred to Slice 5B and 5C)

- `@const` IR-level mismatches (Category-2 canaries) — Phase 5B
- Deletion of `lowerTagApplicationToSyntheticCall` / synthetic machinery — Phase 5C
- Alias-chain type-resolution divergence (#363) — deferred pending decision