### PR TITLE
chore(deps): upgrade typescript baseline to ^5.9.3

### DIFF
--- a/.changeset/typescript-5-9.md
+++ b/.changeset/typescript-5-9.md
@@ -1,0 +1,22 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/config": patch
+"@formspec/dsl": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/runtime": patch
+"@formspec/ts-plugin": patch
+"@formspec/validator": patch
+"formspec": patch
+---
+
+Raise the `typescript` minimum from `^5.7.3` to `^5.9.3` across every workspace package (peer, runtime, and dev dependencies) so packages advertise the latest stable TypeScript 5.x as their supported baseline.
+
+Consumer-visible:
+
+- `@formspec/analysis`, `@formspec/build`, `@formspec/eslint-plugin`, `@formspec/ts-plugin`: `typescript` peer dependency raised to `^5.9.3`.
+- `@formspec/cli`: `typescript` runtime dependency raised to `^5.9.3`.
+
+Consumers already on TypeScript 5.9 are unaffected. Consumers on older ranges will see a peer-dependency warning and should upgrade.

--- a/.changeset/typescript-5-9.md
+++ b/.changeset/typescript-5-9.md
@@ -12,11 +12,12 @@
 "formspec": patch
 ---
 
-Raise the `typescript` minimum from `^5.7.3` to `^5.9.3` across every workspace package (peer, runtime, and dev dependencies) so packages advertise the latest stable TypeScript 5.x as their supported baseline.
+Raise the `typescript` minimum from `^5.7.3` to `^5.9.3` for the workspace packages that declare a `typescript` peer or runtime dependency, so those packages advertise TypeScript 5.9 as their supported baseline. The other packages listed in this changeset receive a patch bump because they are part of the repo's linked version group.
 
 Consumer-visible:
 
 - `@formspec/analysis`, `@formspec/build`, `@formspec/eslint-plugin`, `@formspec/ts-plugin`: `typescript` peer dependency raised to `^5.9.3`.
 - `@formspec/cli`: `typescript` runtime dependency raised to `^5.9.3`.
+- `@formspec/config`, `@formspec/dsl`, `@formspec/language-server`, `@formspec/runtime`, `@formspec/validator`, and `formspec`: patch bumps only, with no direct `typescript` dependency range change in this changeset.
 
-Consumers already on TypeScript 5.9 are unaffected. Consumers on older ranges will see a peer-dependency warning and should upgrade.
+Consumers already on TypeScript 5.9 are unaffected. Consumers on older ranges will see a peer-dependency warning and should upgrade where applicable.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -31,7 +31,7 @@
     "eslint": "^9.39.2",
     "stripe": "^22.0.2",
     "tsx": "^4.21.0",
-    "typescript": "^5.7.3",
+    "typescript": "^5.9.3",
     "vitest": "^3.2.4",
     "vscode-languageserver-textdocument": "^1.0.12"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prettier": "^3.5.0",
     "syncpack": "^14.3.0",
     "tsup": "^8.5.1",
-    "typescript": "^5.7.3",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.21.0"
   },
   "engines": {

--- a/packages/analysis/package.json
+++ b/packages/analysis/package.json
@@ -46,7 +46,7 @@
     "pino-pretty": "^11.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.3"
   },
   "devDependencies": {
     "pino": "^9.0.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -51,7 +51,7 @@
     "pino-pretty": "^11.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.3"
   },
   "devDependencies": {
     "@formspec/dsl": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
     "api-extractor:local": "api-extractor run --local && node ../../scripts/normalize-generated-markdown.mjs api-report"
   },
   "dependencies": {
-    "typescript": "^5.7.3",
+    "typescript": "^5.9.3",
     "@formspec/build": "workspace:*",
     "@formspec/config": "workspace:*",
     "pino": "^9.0.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "eslint": "^9.39.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.3"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^8.55.0",

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -33,7 +33,7 @@
     "@formspec/core": "workspace:*"
   },
   "peerDependencies": {
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.3"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.21.0
@@ -100,7 +100,7 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
@@ -118,7 +118,7 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.9.3
         version: 5.9.3
     devDependencies:
       vitest:
@@ -144,7 +144,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.9.3
         version: 5.9.3
       zod:
         specifier: ^3.25.0
@@ -179,7 +179,7 @@ importers:
         specifier: ^11.0.0
         version: 11.3.0
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.9.3
         version: 5.9.3
     devDependencies:
       '@formspec/core':
@@ -257,7 +257,7 @@ importers:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.9.3
         version: 5.9.3
     devDependencies:
       '@typescript-eslint/parser':
@@ -335,7 +335,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.9.3
         version: 5.9.3
     devDependencies:
       '@microsoft/api-extractor':


### PR DESCRIPTION
Raises the advertised TypeScript minimum from `^5.7.3` (landed in #404) to `^5.9.3` — the latest stable TypeScript 5.x — across every workspace package. The lockfile was already resolving `5.9.3` within the prior range, so this bump aligns advertised minimums with what the repo actually builds and tests against.

## Changes

| Package | Specifier | Kind |
|---|---|---|
| `@formspec/analysis` | `typescript ^5.9.3` | peer |
| `@formspec/build` | `typescript ^5.9.3` | peer |
| `@formspec/eslint-plugin` | `typescript ^5.9.3` | peer |
| `@formspec/ts-plugin` | `typescript ^5.9.3` | peer |
| `@formspec/cli` | `typescript ^5.9.3` | runtime |
| workspace root | `typescript ^5.9.3` | dev |
| `@formspec/e2e` | `typescript ^5.9.3` | dev |

`syncpack lint --dependencies typescript` reports `✓ No issues found` — every specifier in the workspace resolves to the same range.

## Why not 6.x?

`typescript@6.0.3` is available but is a major version with its own migration considerations; this PR intentionally stays on the latest **5.x** per scope.

## Verification

- `pnpm run clean && pnpm run build`: green (api-extractor now uses the bundled TS 5.9.3 matching our resolved version)
- `pnpm run lint`: green
- `pnpm run test`: 272 tests pass across 34 e2e files + all package suites
- `pnpm exec syncpack lint`: ✓