### PR TITLE
ci: run knip on every PR

### DIFF
--- a/.changeset/knip-ci-integration.md
+++ b/.changeset/knip-ci-integration.md
@@ -1,0 +1,5 @@
+---
+"@formspec/build": patch
+---
+
+Internal refactor: unexport `MethodParamsSchemas` from `@formspec/build/src/generators/method-schema.ts`. The type was never referenced outside its defining module, was not part of the package's public `exports`, and did not appear in any API Extractor report — it is now a module-local interface. No consumer-visible change.

--- a/.changeset/knip-ci-integration.md
+++ b/.changeset/knip-ci-integration.md
@@ -1,5 +1,8 @@
 ---
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
 ---
 
 Internal refactor: unexport `MethodParamsSchemas` from `@formspec/build/src/generators/method-schema.ts`. The type was never referenced outside its defining module, was not part of the package's public `exports`, and did not appear in any API Extractor report — it is now a module-local interface. No consumer-visible change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,25 @@ jobs:
 
       - name: Type check
         run: pnpm run typecheck
+
+  knip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run knip
+        run: pnpm run knip

--- a/knip.json
+++ b/knip.json
@@ -11,7 +11,8 @@
       "entry": [
         "src/__tests__/fixtures/**/*.ts",
         "src/__tests__/parity/fixtures/**/*.ts"
-      ]
+      ],
+      "ignore": ["src/__tests__/fixtures/method-signature-schemas.ts"]
     },
     "packages/cli": {
       "entry": ["src/__tests__/fixtures/**/*.ts"]

--- a/packages/build/src/generators/method-schema.ts
+++ b/packages/build/src/generators/method-schema.ts
@@ -44,7 +44,7 @@ export interface MethodSchemas {
 /**
  * Parameter schemas for a method.
  */
-export interface MethodParamsSchemas {
+interface MethodParamsSchemas {
   /** JSON Schema for parameters */
   jsonSchema: JsonSchema2020;
   /** UI Schema / FormSpec for parameters (if available) */


### PR DESCRIPTION
Wires [knip](https://knip.dev) into the CI workflow so dead code, unused dependencies, and undeclared-as-public exports get caught at review time rather than accumulating between manual sweeps.

## Workflow change

A new `knip` job runs alongside `build-and-test` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Standard setup — checkout, pnpm, node, `pnpm install --frozen-lockfile` — followed by `pnpm run knip`. It's a separate job (parallel to build-and-test) so knip signal doesn't block the existing pipeline's failure reporting and vice versa.

## Making `pnpm knip` exit 0

Two small changes were needed to get the current `main` to a green knip baseline:

**1. Ignore `packages/build/src/__tests__/fixtures/method-signature-schemas.ts`** in [`knip.json`](knip.json).

The fixture intentionally exposes its `PaymentService` class under both a named and a default export to exercise the default-export resolver path in [`static-build-context.test.ts:95`](packages/build/src/__tests__/static-build-context.test.ts:95). Knip (correctly) flags that pattern as a duplicate export. Rather than disabling the `duplicates` rule globally, the ignore is scoped to this single file — duplicate detection stays active everywhere else.

**2. Unexport `MethodParamsSchemas`** in [`packages/build/src/generators/method-schema.ts`](packages/build/src/generators/method-schema.ts).

With the fixture ignored, knip surfaced that this interface was only referenced within its own module — not part of the package's public `exports`, not in any API Extractor report, not imported by any other file. Converted to a module-local `interface` declaration.

## Verification

- `pnpm exec knip` → 0 findings, exit 0
- `pnpm run build` / `lint` / `test` / `typecheck` → all green (272 tests across 34 e2e files + all package suites)