### PR TITLE
feat(ts-plugin): expose full API surface on CJS entry point

### DIFF
--- a/.changeset/ts-plugin-cjs-hybrid-surface.md
+++ b/.changeset/ts-plugin-cjs-hybrid-surface.md
@@ -1,0 +1,5 @@
+---
+"@formspec/ts-plugin": patch
+---
+
+Expose all public exports on the CJS entry point alongside the plugin init function.

--- a/e2e/tests/ts-plugin-cjs-entry-point.test.ts
+++ b/e2e/tests/ts-plugin-cjs-entry-point.test.ts
@@ -1,0 +1,85 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+interface CjsEntryPointReport {
+  readonly type: string;
+  readonly name: string;
+  readonly initSame: boolean;
+  readonly types: Record<string, string>;
+}
+
+/**
+ * Verifies that the CJS entry point (`index.cjs`) exposes the full public API
+ * surface alongside the callable `init` function.
+ *
+ * `tsserver` loads the plugin via `require("@formspec/ts-plugin")` and calls
+ * the result directly as `init(modules)`. The hybrid `Object.assign(plugin, api)`
+ * pattern preserves that contract while also making named exports available for
+ * downstream CJS consumers that destructure the module.
+ */
+describe("@formspec/ts-plugin CJS entry point surface", () => {
+  const entryPath = path.join(repoRoot, "packages/ts-plugin/index.cjs");
+
+  const script = `
+    const m = require(${JSON.stringify(entryPath)});
+    console.log(JSON.stringify({
+      type: typeof m,
+      name: m.name,
+      initSame: m.init === m,
+      types: {
+        FormSpecPluginService: typeof m.FormSpecPluginService,
+        FormSpecSemanticService: typeof m.FormSpecSemanticService,
+        createLanguageServiceProxy: typeof m.createLanguageServiceProxy,
+        FORMSPEC_ANALYSIS_PROTOCOL_VERSION: typeof m.FORMSPEC_ANALYSIS_PROTOCOL_VERSION,
+        FORMSPEC_ANALYSIS_SCHEMA_VERSION: typeof m.FORMSPEC_ANALYSIS_SCHEMA_VERSION,
+      },
+    }));
+  `;
+
+  let report: CjsEntryPointReport;
+
+  it("loads without throwing", async () => {
+    const { stdout } = await execFileAsync(process.execPath, ["-e", script], {
+      cwd: repoRoot,
+    });
+    report = JSON.parse(stdout.trim()) as CjsEntryPointReport;
+  });
+
+  it("default export is a callable function (tsserver backwards compat)", () => {
+    expect(report.type).toBe("function");
+  });
+
+  it("preserves the init function name", () => {
+    expect(report.name).toBe("init");
+  });
+
+  it("init property is the same reference as the default export", () => {
+    expect(report.initSame).toBe(true);
+  });
+
+  it("exposes FormSpecPluginService class", () => {
+    expect(report.types.FormSpecPluginService).toBe("function");
+  });
+
+  it("exposes FormSpecSemanticService class", () => {
+    expect(report.types.FormSpecSemanticService).toBe("function");
+  });
+
+  it("exposes createLanguageServiceProxy function", () => {
+    expect(report.types.createLanguageServiceProxy).toBe("function");
+  });
+
+  it("exposes FORMSPEC_ANALYSIS_PROTOCOL_VERSION constant", () => {
+    expect(report.types.FORMSPEC_ANALYSIS_PROTOCOL_VERSION).toBe("number");
+  });
+
+  it("exposes FORMSPEC_ANALYSIS_SCHEMA_VERSION constant", () => {
+    expect(report.types.FORMSPEC_ANALYSIS_SCHEMA_VERSION).toBe("number");
+  });
+});

--- a/e2e/tests/ts-plugin-cjs-entry-point.test.ts
+++ b/e2e/tests/ts-plugin-cjs-entry-point.test.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -44,7 +44,7 @@ describe("@formspec/ts-plugin CJS entry point surface", () => {
 
   let report: CjsEntryPointReport;
 
-  it("loads without throwing", async () => {
+  beforeAll(async () => {
     const { stdout } = await execFileAsync(process.execPath, ["-e", script], {
       cwd: repoRoot,
     });

--- a/packages/ts-plugin/README.md
+++ b/packages/ts-plugin/README.md
@@ -4,7 +4,7 @@ TypeScript language service plugin for FormSpec semantic comment analysis.
 
 This package serves two roles:
 
-- a turnkey `tsserver` plugin via `init()`
+- a turnkey `tsserver` plugin via `@formspec/ts-plugin`
 - a composable in-process semantic API for downstream TypeScript hosts
 
 The shipped plugin is the reference implementation. Downstream tools that
@@ -27,6 +27,10 @@ pnpm add -D @formspec/ts-plugin
   }
 }
 ```
+
+The package root is intentionally a hybrid CommonJS surface: `tsserver` can
+load it directly as a plugin module, while downstream hosts can also import the
+same package as a library to access FormSpec composition primitives.
 
 ## Public Composition APIs
 

--- a/packages/ts-plugin/index.cjs
+++ b/packages/ts-plugin/index.cjs
@@ -1,1 +1,4 @@
-module.exports = require("./dist/index.cjs").init;
+const api = require("./dist/index.cjs");
+const plugin = api.init;
+
+module.exports = Object.assign(plugin, api);


### PR DESCRIPTION
## Summary

- Makes the CJS entry point (`index.cjs`) a hybrid surface: the default export remains the callable `init` function (tsserver backwards compat), but all other public exports (`FormSpecPluginService`, `FormSpecSemanticService`, `createLanguageServiceProxy`, protocol constants) are merged onto it via `Object.assign`
- Adds e2e test verifying the CJS surface contract (callable default, named exports, constant types)
- Documents the hybrid CJS design in the package README

### `index.cjs`: Entry point change

```diff
-module.exports = require("./dist/index.cjs").init;
+const api = require("./dist/index.cjs");
+const plugin = api.init;
+
+module.exports = Object.assign(plugin, api);
```

## Test plan

- [x] Existing ts-plugin unit tests pass (57 tests)
- [x] New e2e test `ts-plugin-cjs-entry-point.test.ts` passes (9 assertions)
- [x] `pnpm -w run lint` passes
- [x] `pnpm -w run typecheck` passes
- [x] Full build succeeds