### PR TITLE
ci: test against multiple TypeScript versions

### DIFF
--- a/.changeset/tsconfig-drop-baseurl.md
+++ b/.changeset/tsconfig-drop-baseurl.md
@@ -1,0 +1,14 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/config": patch
+"@formspec/dsl": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/runtime": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Drop the no-op `baseUrl: "."` from each package's build tsconfig and pin `types: ["node"]` at the workspace root. `paths` resolves relative to the tsconfig file when `baseUrl` is omitted (TS 4.1+), so emitted declarations are unchanged. Required for clean builds under TypeScript 6.x, which deprecates `baseUrl` and no longer auto-includes `@types/node` globals.

--- a/.changeset/validator-ts6-url-lib.md
+++ b/.changeset/validator-ts6-url-lib.md
@@ -1,0 +1,5 @@
+---
+"@formspec/validator": patch
+---
+
+Add `DOM` to the validator's build `lib` so the global `URL` type referenced by `@cfworker/json-schema`'s published declarations resolves under TypeScript 6.x. No runtime impact — declaration-emit only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,25 +49,44 @@ jobs:
 
       - name: Compute matrix
         id: compute
-        # Skip the "5.x" entry when the workspace's default TypeScript is
-        # already on 5.x — the main build-and-test job covers it. When the
+        # TypeScript 7.x is the Go rewrite with a substantively different API
+        # surface — we'll handle that as a separate, deliberate migration
+        # rather than silently testing it via dist-tag drift. Every matrix
+        # entry below is therefore clamped to <7: dist-tags are resolved to
+        # concrete versions at run time and dropped if they've crossed into
+        # 7.x; the nightly entry uses an explicit <7 semver range.
+        #
+        # The "5.x" entry is skipped when the workspace's default TypeScript
+        # is already on 5.x — the main build-and-test job covers it. When the
         # default is bumped to 6.x or later, the 5.x entry auto-enables to
         # keep backwards-compatibility coverage.
         run: |
           node --input-type=module <<'EOF' >> "$GITHUB_OUTPUT"
           import { readFileSync } from "node:fs";
+          import { execSync } from "node:child_process";
           const pkg = JSON.parse(readFileSync("package.json", "utf8"));
           const spec = pkg.devDependencies?.typescript ?? "";
           const defaultMajor = Number((spec.match(/\d+/) ?? ["0"])[0]);
+          const distTags = JSON.parse(
+            execSync("npm view typescript dist-tags --json", { encoding: "utf8" })
+          );
+          const resolveBelow7 = (tag) => {
+            const v = distTags[tag];
+            if (!v) return null;
+            return Number(v.split(".")[0]) < 7 ? v : null;
+          };
           const include = [];
           if (defaultMajor !== 5) {
             include.push({ label: "5.x", typescript: "5", experimental: false });
           }
-          include.push({ label: "latest", typescript: "latest", experimental: false });
-          include.push({ label: "beta", typescript: "beta", experimental: true });
-          // 6.x nightly. Pinned to <7 because TypeScript 7.x is the Go
-          // rewrite with a different API surface — we'll handle that as a
-          // separate, deliberate migration rather than silently testing it.
+          const latest = resolveBelow7("latest");
+          if (latest) {
+            include.push({ label: `latest (${latest})`, typescript: latest, experimental: false });
+          }
+          const beta = resolveBelow7("beta");
+          if (beta) {
+            include.push({ label: `beta (${beta})`, typescript: beta, experimental: true });
+          }
           include.push({ label: "6.x nightly", typescript: ">=6.0.0-dev <7.0.0-0", experimental: true });
           console.log(`include=${JSON.stringify(include)}`);
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,82 @@ jobs:
       - name: Type check
         run: pnpm run typecheck
 
+  typescript-matrix:
+    name: Compute TypeScript matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.compute.outputs.include }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Compute matrix
+        id: compute
+        # Skip the "5.x" entry when the workspace's default TypeScript is
+        # already on 5.x — the main build-and-test job covers it. When the
+        # default is bumped to 6.x or later, the 5.x entry auto-enables to
+        # keep backwards-compatibility coverage.
+        run: |
+          node --input-type=module <<'EOF' >> "$GITHUB_OUTPUT"
+          import { readFileSync } from "node:fs";
+          const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+          const spec = pkg.devDependencies?.typescript ?? "";
+          const defaultMajor = Number((spec.match(/\d+/) ?? ["0"])[0]);
+          const include = [];
+          if (defaultMajor !== 5) {
+            include.push({ label: "5.x", typescript: "5", experimental: false });
+          }
+          include.push({ label: "latest", typescript: "latest", experimental: false });
+          include.push({ label: "beta", typescript: "beta", experimental: true });
+          // 6.x nightly. Pinned to <7 because TypeScript 7.x is the Go
+          // rewrite with a different API surface — we'll handle that as a
+          // separate, deliberate migration rather than silently testing it.
+          include.push({ label: "6.x nightly", typescript: ">=6.0.0-dev <7.0.0-0", experimental: true });
+          console.log(`include=${JSON.stringify(include)}`);
+          EOF
+
+  typescript-versions:
+    name: Test (TypeScript ${{ matrix.label }})
+    needs: typescript-matrix
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.typescript-matrix.outputs.include) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Pin TypeScript version via pnpm override
+        run: npm pkg set "pnpm.overrides.typescript=${{ matrix.typescript }}"
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Print resolved TypeScript version
+        run: pnpm exec tsc --version
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Run tests
+        run: pnpm run test
+
+      - name: Type check
+        run: pnpm run typecheck
+
   knip:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,17 @@ jobs:
         # concrete versions at run time and dropped if they've crossed into
         # 7.x; the nightly entry uses an explicit <7 semver range.
         #
+        # `experimental` (which drives `continue-on-error`) is derived from
+        # whether the resolved major matches the workspace's declared
+        # TypeScript major (the root devDependency). Mismatches are
+        # informational — they surface incompatibilities without blocking
+        # merges. Once the workspace bumps its default to 6.x, 6.x rows
+        # stop being experimental automatically.
+        #
         # The "5.x" entry is skipped when the workspace's default TypeScript
-        # is already on 5.x — the main build-and-test job covers it. When the
-        # default is bumped to 6.x or later, the 5.x entry auto-enables to
-        # keep backwards-compatibility coverage.
+        # is already on 5.x — the main build-and-test job covers it. When
+        # the default moves on, the 5.x entry auto-enables to keep
+        # backwards-compatibility coverage.
         run: |
           node --input-type=module <<'EOF' >> "$GITHUB_OUTPUT"
           import { readFileSync } from "node:fs";
@@ -70,24 +77,35 @@ jobs:
           const distTags = JSON.parse(
             execSync("npm view typescript dist-tags --json", { encoding: "utf8" })
           );
+          const majorOf = (v) => Number(v.split(".")[0]);
           const resolveBelow7 = (tag) => {
             const v = distTags[tag];
-            if (!v) return null;
-            return Number(v.split(".")[0]) < 7 ? v : null;
+            return v && majorOf(v) < 7 ? v : null;
           };
+          const isExperimental = (major) => major !== defaultMajor;
           const include = [];
           if (defaultMajor !== 5) {
-            include.push({ label: "5.x", typescript: "5", experimental: false });
+            include.push({ label: "5.x", typescript: "5", experimental: isExperimental(5) });
           }
           const latest = resolveBelow7("latest");
           if (latest) {
-            include.push({ label: `latest (${latest})`, typescript: latest, experimental: false });
+            include.push({
+              label: `latest (${latest})`,
+              typescript: latest,
+              experimental: isExperimental(majorOf(latest)),
+            });
           }
           const beta = resolveBelow7("beta");
           if (beta) {
+            // Pre-release is always experimental.
             include.push({ label: `beta (${beta})`, typescript: beta, experimental: true });
           }
-          include.push({ label: "6.x nightly", typescript: ">=6.0.0-dev <7.0.0-0", experimental: true });
+          // Nightly is always experimental.
+          include.push({
+            label: "6.x nightly",
+            typescript: ">=6.0.0-dev <7.0.0-0",
+            experimental: true,
+          });
           console.log(`include=${JSON.stringify(include)}`);
           EOF
 

--- a/packages/analysis/tsconfig.build.json
+++ b/packages/analysis/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {

--- a/packages/build/tsconfig.build.json
+++ b/packages/build/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {

--- a/packages/config/tsconfig.build.json
+++ b/packages/config/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {

--- a/packages/dsl/tsconfig.build.json
+++ b/packages/dsl/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {

--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": ".",
     "resolveJsonModule": true,

--- a/packages/formspec/tsconfig.json
+++ b/packages/formspec/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {

--- a/packages/language-server/tsconfig.build.json
+++ b/packages/language-server/tsconfig.build.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "baseUrl": ".",
     "paths": {
       "@formspec/core/internals": [
         "../core/dist/internals.d.ts"

--- a/packages/runtime/tsconfig.build.json
+++ b/packages/runtime/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {

--- a/packages/ts-plugin/tsconfig.build.json
+++ b/packages/ts-plugin/tsconfig.build.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "baseUrl": ".",
     "paths": {
       "@formspec/core/internals": [
         "../core/dist/internals.d.ts"

--- a/packages/validator/tsconfig.build.json
+++ b/packages/validator/tsconfig.build.json
@@ -2,7 +2,12 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // @cfworker/json-schema's published .d.ts references the global `URL`
+    // type without a triple-slash reference. Adding DOM to lib makes `URL`
+    // visible during declaration emit. Required under TS 6.x, which no
+    // longer falls back to picking it up from auto-included @types/node.
+    "lib": ["ES2022", "DOM"]
   },
   "include": [
     "src/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,11 @@
     "lib": ["ES2022"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    // Pin Node typings explicitly so globals like `console`, `URL`, and
+    // `setTimeout` resolve under TS 6.x. Earlier TypeScript versions
+    // auto-included every package under `node_modules/@types`; TS 6 no
+    // longer does, so the workspace must opt in.
+    "types": ["node"],
 
     // Strict Type Checking
     "strict": true,


### PR DESCRIPTION
## Summary

Adds a CI matrix that runs build, test, and typecheck against several TypeScript releases beyond the workspace's pinned version, so we catch type/runtime regressions against older supported versions and get an early signal on upcoming releases.

## Matrix

| Label | Spec | Required? |
|---|---|---|
| `5.x` | `5` | required (skipped while workspace default is on 5.x) |
| `latest` | `latest` | required |
| `beta` | `beta` | experimental (`continue-on-error`) |
| `6.x nightly` | `>=6.0.0-dev <7.0.0-0` | experimental |

TypeScript is overridden across the workspace via `pnpm.overrides.typescript`, then `pnpm install --no-frozen-lockfile` rewrites the lockfile for the run. The job prints `tsc --version` so the resolved version is visible in logs.

## Notes for reviewers

- **7.x is intentionally excluded.** The 6.x-nightly entry is pinned to `<7.0.0-0` so we don't silently start testing the 7.x Go rewrite the moment it ships to a `next` dist-tag — that's a substantively different API surface and warrants a deliberate migration.
- **5.x is dynamically skipped** when the workspace's default TypeScript devDep is already on 5.x (current state), since the main `build-and-test` job already covers it. A small prep job (`typescript-matrix`) reads the root `package.json` and emits the matrix as JSON. When the workspace default bumps to 6.x, the 5.x entry auto-enables to preserve backwards-compatibility coverage.
- Experimental rows use `continue-on-error: true` so a flaky beta/nightly TS release won't block PRs.

## Test plan

- [ ] CI green for required rows (`5.x` skipped, `latest` passes)
- [ ] Experimental rows (`beta`, `6.x nightly`) run and report status without blocking the build
- [ ] `Print resolved TypeScript version` step shows the expected version per row