### PR TITLE
Fix type registry name collisions

### DIFF
--- a/.changeset/issue-387-type-registry-collision.md
+++ b/.changeset/issue-387-type-registry-collision.md
@@ -1,0 +1,8 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Fail fast when TSDoc schema generation encounters same-named type definitions from different source modules, preventing silent `$defs` collisions.

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -3504,10 +3504,14 @@ function assertTypeRegistryDeclarationSource(
   // The registry is keyed by unqualified type names, so cross-file collisions
   // would otherwise make one declaration silently stand in for another.
   throw new Error(
-    `Type registry collision: "${typeName}" was already registered from ${existing.provenance.file}; ` +
-      `cannot re-register from a different source file (${provenance.file}). ` +
+    `Type registry collision: "${typeName}" was already registered from ${formatProvenanceLocation(existing.provenance)}; ` +
+      `cannot re-register from a different declaration location (${formatProvenanceLocation(provenance)}). ` +
       "Rename one of the conflicting types."
   );
+}
+
+function formatProvenanceLocation(provenance: Provenance): string {
+  return `${provenance.file}:${String(provenance.line)}:${String(provenance.column)}`;
 }
 
 function isSameTypeRegistryDeclaration(left: Provenance, right: Provenance): boolean {

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -2237,6 +2237,8 @@ function tryResolveNamedPrimitiveAlias(
   }
 
   const aliasName = aliasDecl.name.text;
+  const aliasProvenance = provenanceForDeclaration(aliasDecl, file);
+  assertTypeRegistryDeclarationSource(typeRegistry, aliasName, aliasProvenance);
   if (!typeRegistry[aliasName]) {
     const aliasType = checker.getTypeFromTypeNode(aliasDecl.type);
     const constraints = [
@@ -2286,7 +2288,7 @@ function tryResolveNamedPrimitiveAlias(
       ),
       ...(constraints.length > 0 && { constraints }),
       ...(annotations.length > 0 && { annotations }),
-      provenance: provenanceForDeclaration(aliasDecl, file),
+      provenance: aliasProvenance,
     };
   }
 
@@ -2495,6 +2497,11 @@ function resolveUnionType(
   }
 
   if (typeName && typeName in typeRegistry) {
+    assertTypeRegistryDeclarationSource(
+      typeRegistry,
+      typeName,
+      provenanceForDeclaration(namedDecl ?? sourceNode, file)
+    );
     return { kind: "reference", name: typeName, typeArguments: [] };
   }
 
@@ -2533,6 +2540,8 @@ function resolveUnionType(
     // node we synthesized here — that would destroy the real `$defs` entry and leave
     // a dangling self-reference like `{ "Tree": { "$ref": "#/$defs/Tree" } }`.
     const existing = typeRegistry[typeName];
+    const typeProvenance = provenanceForDeclaration(namedDecl ?? sourceNode, file);
+    assertTypeRegistryDeclarationSource(typeRegistry, typeName, typeProvenance);
     if (existing !== undefined && existing.type !== RESOLVING_TYPE_PLACEHOLDER) {
       return { kind: "reference", name: typeName, typeArguments: [] };
     }
@@ -2560,7 +2569,7 @@ function resolveUnionType(
       ...(metadata !== undefined && { metadata }),
       type: result,
       ...(annotations !== undefined && annotations.length > 0 && { annotations }),
-      provenance: provenanceForDeclaration(namedDecl ?? sourceNode, file),
+      provenance: typeProvenance,
     };
     return { kind: "reference", name: typeName, typeArguments: [] };
   };
@@ -2937,12 +2946,24 @@ function resolveObjectType(
   if (
     registryTypeName !== undefined &&
     shouldRegisterNamedType &&
+    typeRegistry[registryTypeName] !== undefined
+  ) {
+    assertTypeRegistryDeclarationSource(
+      typeRegistry,
+      registryTypeName,
+      provenanceForDeclaration(effectiveNamedDecl, file)
+    );
+  }
+  if (
+    registryTypeName !== undefined &&
+    shouldRegisterNamedType &&
     !typeRegistry[registryTypeName]
   ) {
+    const typeProvenance = provenanceForDeclaration(effectiveNamedDecl, file);
     typeRegistry[registryTypeName] = {
       name: registryTypeName,
       type: RESOLVING_TYPE_PLACEHOLDER,
-      provenance: provenanceForDeclaration(effectiveNamedDecl, file),
+      provenance: typeProvenance,
     };
   }
 
@@ -3006,12 +3027,14 @@ function resolveObjectType(
               }
             )
           : undefined;
+      const typeProvenance = provenanceForDeclaration(effectiveNamedDecl, file);
+      assertTypeRegistryDeclarationSource(typeRegistry, registryTypeName, typeProvenance);
       typeRegistry[registryTypeName] = {
         name: registryTypeName,
         ...(metadata !== undefined && { metadata }),
         type: recordNode,
         ...(annotations !== undefined && annotations.length > 0 && { annotations }),
-        provenance: provenanceForDeclaration(effectiveNamedDecl, file),
+        provenance: typeProvenance,
       };
       return {
         kind: "reference",
@@ -3144,12 +3167,14 @@ function resolveObjectType(
             }
           )
         : undefined;
+    const typeProvenance = provenanceForDeclaration(effectiveNamedDecl, file);
+    assertTypeRegistryDeclarationSource(typeRegistry, registryTypeName, typeProvenance);
     typeRegistry[registryTypeName] = {
       name: registryTypeName,
       ...(metadata !== undefined && { metadata }),
       type: objectNode,
       ...(annotations !== undefined && annotations.length > 0 && { annotations }),
-      provenance: provenanceForDeclaration(effectiveNamedDecl, file),
+      provenance: typeProvenance,
     };
     return {
       kind: "reference",
@@ -3463,7 +3488,35 @@ function provenanceForDeclaration(node: ts.Node | undefined, file: string): Prov
   if (!node) {
     return provenanceForFile(file);
   }
-  return provenanceForNode(node, file);
+  return provenanceForNode(node, node.getSourceFile().fileName);
+}
+
+function assertTypeRegistryDeclarationSource(
+  typeRegistry: Record<string, TypeDefinition>,
+  typeName: string,
+  provenance: Provenance
+): void {
+  const existing = typeRegistry[typeName];
+  if (existing === undefined || isSameTypeRegistryDeclaration(existing.provenance, provenance)) {
+    return;
+  }
+
+  // The registry is keyed by unqualified type names, so cross-file collisions
+  // would otherwise make one declaration silently stand in for another.
+  throw new Error(
+    `Type registry collision: "${typeName}" was already registered from ${existing.provenance.file}; ` +
+      `cannot re-register from a different source file (${provenance.file}). ` +
+      "Rename one of the conflicting types."
+  );
+}
+
+function isSameTypeRegistryDeclaration(left: Provenance, right: Provenance): boolean {
+  return (
+    left.surface === right.surface &&
+    left.file === right.file &&
+    left.line === right.line &&
+    left.column === right.column
+  );
 }
 
 // =============================================================================

--- a/packages/build/tests/type-registry-collision.test.ts
+++ b/packages/build/tests/type-registry-collision.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Regression coverage for issue #387: the TSDoc analyzer must not let two
+ * declarations from different modules share the same unqualified `$defs` key.
+ *
+ * The intended behavior is fail-fast rather than silently choosing whichever
+ * declaration happened to populate the registry first.
+ *
+ * @see https://github.com/mike-north/formspec/issues/387
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { generateSchemas, type GenerateSchemasOptions } from "../src/generators/class-schema.js";
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({ ...options, errorReporting: "throw" });
+}
+
+interface MultiFileFixture {
+  readonly dir: string;
+  readonly entryPath: string;
+}
+
+const fixtureDirs: string[] = [];
+
+function writeFixture(files: Record<string, string>): MultiFileFixture {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-type-registry-collision-"));
+  fixtureDirs.push(dir);
+
+  fs.writeFileSync(
+    path.join(dir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          strict: true,
+          skipLibCheck: true,
+          noEmit: true,
+        },
+        include: ["**/*.ts"],
+      },
+      null,
+      2
+    )
+  );
+
+  for (const [relativePath, source] of Object.entries(files)) {
+    const absolutePath = path.join(dir, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, source);
+  }
+
+  return { dir, entryPath: path.join(dir, "form.ts") };
+}
+
+afterEach(() => {
+  for (const dir of fixtureDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("type registry declaration collisions", () => {
+  it("throws when same-named primitive aliases are imported from different modules", () => {
+    const fixture = writeFixture({
+      "file-a.ts": "export type Email = string;\n",
+      "file-b.ts": "export type Email = string;\n",
+      "form.ts": [
+        'import type { Email as SenderEmail } from "./file-a";',
+        'import type { Email as RecipientEmail } from "./file-b";',
+        "",
+        "export class ContactForm {",
+        "  sender!: SenderEmail;",
+        "  recipient!: RecipientEmail;",
+        "}",
+      ].join("\n"),
+    });
+
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath: fixture.entryPath,
+        typeName: "ContactForm",
+      })
+    ).toThrow(/Type registry collision: "Email".*file-a\.ts.*file-b\.ts/s);
+  });
+
+  it("throws for the mixed primitive-alias and object-alias reproduction", () => {
+    const fixture = writeFixture({
+      "file-a.ts": "export type Email = string;\n",
+      "file-b.ts": "export type Email = { local: string; domain: string };\n",
+      "form.ts": [
+        'import type { Email as SenderEmail } from "./file-a";',
+        'import type { Email as RecipientEmail } from "./file-b";',
+        "",
+        "export class ContactForm {",
+        "  sender!: SenderEmail;",
+        "  recipient!: RecipientEmail;",
+        "}",
+      ].join("\n"),
+    });
+
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath: fixture.entryPath,
+        typeName: "ContactForm",
+      })
+    ).toThrow(/Type registry collision: "Email".*file-a\.ts.*file-b\.ts/s);
+  });
+
+  it("throws when same-named object types are imported from different modules", () => {
+    const fixture = writeFixture({
+      "file-a.ts": "export interface Address { street: string; }\n",
+      "file-b.ts": "export interface Address { postalCode: string; }\n",
+      "form.ts": [
+        'import type { Address as BillingAddress } from "./file-a";',
+        'import type { Address as ShippingAddress } from "./file-b";',
+        "",
+        "export class CheckoutForm {",
+        "  billing!: BillingAddress;",
+        "  shipping!: ShippingAddress;",
+        "}",
+      ].join("\n"),
+    });
+
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath: fixture.entryPath,
+        typeName: "CheckoutForm",
+      })
+    ).toThrow(/Type registry collision: "Address".*file-a\.ts.*file-b\.ts/s);
+  });
+
+  it("throws when same-named union aliases are imported from different modules", () => {
+    const fixture = writeFixture({
+      "file-a.ts": 'export type Status = "draft" | "sent";\n',
+      "file-b.ts": 'export type Status = "active" | "disabled";\n',
+      "form.ts": [
+        'import type { Status as MessageStatus } from "./file-a";',
+        'import type { Status as AccountStatus } from "./file-b";',
+        "",
+        "export class StatusForm {",
+        "  message?: MessageStatus;",
+        "  account?: AccountStatus;",
+        "}",
+      ].join("\n"),
+    });
+
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath: fixture.entryPath,
+        typeName: "StatusForm",
+      })
+    ).toThrow(/Type registry collision: "Status".*file-a\.ts.*file-b\.ts/s);
+  });
+
+  it("throws when same-named recursive record aliases are imported from different modules", () => {
+    const fixture = writeFixture({
+      "file-a.ts": "export type TreeMap = { [key: string]: TreeMap };\n",
+      "file-b.ts": "export type TreeMap = { [key: string]: TreeMap };\n",
+      "form.ts": [
+        'import type { TreeMap as LeftTreeMap } from "./file-a";',
+        'import type { TreeMap as RightTreeMap } from "./file-b";',
+        "",
+        "export class TreeForm {",
+        "  left!: LeftTreeMap;",
+        "  right!: RightTreeMap;",
+        "}",
+      ].join("\n"),
+    });
+
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath: fixture.entryPath,
+        typeName: "TreeForm",
+      })
+    ).toThrow(/Type registry collision: "TreeMap".*file-a\.ts.*file-b\.ts/s);
+  });
+
+  it("throws when same-named declarations come from different namespaces in one file", () => {
+    const fixture = writeFixture({
+      "form.ts": [
+        "namespace Billing {",
+        "  export interface Address { street: string; }",
+        "}",
+        "",
+        "namespace Shipping {",
+        "  export interface Address { postalCode: string; }",
+        "}",
+        "",
+        "export class CheckoutForm {",
+        "  billing!: Billing.Address;",
+        "  shipping!: Shipping.Address;",
+        "}",
+      ].join("\n"),
+    });
+
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath: fixture.entryPath,
+        typeName: "CheckoutForm",
+      })
+    ).toThrow(/Type registry collision: "Address".*form\.ts.*form\.ts/s);
+  });
+
+  it("allows repeated references to the same declaration", () => {
+    const fixture = writeFixture({
+      "models.ts": "export interface Address { street: string; }\n",
+      "form.ts": [
+        'import type { Address } from "./models";',
+        "",
+        "export class CheckoutForm {",
+        "  billing!: Address;",
+        "  shipping!: Address;",
+        "}",
+      ].join("\n"),
+    });
+
+    const result = generateSchemasOrThrow({
+      filePath: fixture.entryPath,
+      typeName: "CheckoutForm",
+    });
+
+    expect(result.jsonSchema.properties).toMatchObject({
+      billing: { $ref: "#/$defs/Address" },
+      shipping: { $ref: "#/$defs/Address" },
+    });
+    expect(result.jsonSchema.$defs).toHaveProperty("Address");
+  });
+});

--- a/packages/build/tests/type-registry-collision.test.ts
+++ b/packages/build/tests/type-registry-collision.test.ts
@@ -36,7 +36,7 @@ function writeFixture(files: Record<string, string>): MultiFileFixture {
         compilerOptions: {
           target: "ES2022",
           module: "NodeNext",
-          moduleResolution: "NodeNext",
+          moduleResolution: "nodenext",
           strict: true,
           skipLibCheck: true,
           noEmit: true,


### PR DESCRIPTION
## Summary
- Fail fast when same-named type declarations would collide in the TSDoc analyzer type registry
- Preserve declaration-source provenance for primitive aliases, unions, records, and object registrations
- Add regression coverage for cross-module and same-file collision cases
- Add a patch changeset for `@formspec/build`

## Test plan
- `pnpm --filter @formspec/build exec vitest run tests/type-registry-collision.test.ts`
- `pnpm --filter @formspec/build run test`
- `git diff --check`
