### PR TITLE
Support TypeScript 6.x

### DIFF
--- a/.changeset/cli-bump-typescript-dep-to-6.md
+++ b/.changeset/cli-bump-typescript-dep-to-6.md
@@ -1,0 +1,5 @@
+---
+"@formspec/cli": patch
+---
+
+Bump the bundled `typescript` runtime dependency from `^5.9.3` to `^6.0.0`. The CLI now performs schema generation against TypeScript 6.x internally. Source code that compiles cleanly under TS 5.9 also compiles under TS 6.0, so this is functionally invisible to consumers.

--- a/.changeset/eslint-plugin-typeflags-enum-refs.md
+++ b/.changeset/eslint-plugin-typeflags-enum-refs.md
@@ -1,0 +1,5 @@
+---
+"@formspec/eslint-plugin": patch
+---
+
+Fix `@formspec/eslint-plugin` rules under TypeScript 6.x by replacing hardcoded `ts.TypeFlags` numeric literals in the type-classification helpers with `ts.TypeFlags.X` enum references. TS 6 renumbered the entire `TypeFlags` enum, which caused `isStringType`, `isNumberType`, `isBooleanType`, `isNullableType`, and `getFieldTypeCategory` to produce wrong results (e.g. reporting `nonStringLikeTargetField` instead of `nullableTargetField` for `string | null`). Behavior under TS 5.x is unchanged.

--- a/.changeset/typescript-peer-dep-widen-to-6.md
+++ b/.changeset/typescript-peer-dep-widen-to-6.md
@@ -7,6 +7,6 @@
 "formspec": minor
 ---
 
-Widen the `typescript` peer-dep range from `^5.9.3` to `>=5.9.3 <7`. FormSpec now officially supports TypeScript 6.x in addition to 5.9+. The `<7` upper bound is deliberate — TypeScript 7.x is the Go rewrite with a substantively different API surface, and that migration will be handled separately.
+Widen the `typescript` peer-dep range from `^5.9.3` to `>=5.7.3 <7`. FormSpec now officially supports TypeScript 5.7 through 6.x. The `<7` upper bound is deliberate — TypeScript 7.x is the Go rewrite with a substantively different API surface, and that migration will be handled separately. The 5.7 floor reflects the lowest version where the workspace's full toolchain (build, typecheck, test, lint) passes end-to-end; build/test alone work down to 5.5, but `@typescript-eslint/parser` 8.x's project-service mode misbehaves below 5.7.
 
 `@formspec/language-server` and `formspec` (the umbrella) inherit this support transitively through their dependencies on `@formspec/analysis` and `@formspec/build` respectively.

--- a/.changeset/typescript-peer-dep-widen-to-6.md
+++ b/.changeset/typescript-peer-dep-widen-to-6.md
@@ -2,7 +2,11 @@
 "@formspec/analysis": minor
 "@formspec/build": minor
 "@formspec/eslint-plugin": minor
+"@formspec/language-server": minor
 "@formspec/ts-plugin": minor
+"formspec": minor
 ---
 
 Widen the `typescript` peer-dep range from `^5.9.3` to `>=5.9.3 <7`. FormSpec now officially supports TypeScript 6.x in addition to 5.9+. The `<7` upper bound is deliberate — TypeScript 7.x is the Go rewrite with a substantively different API surface, and that migration will be handled separately.
+
+`@formspec/language-server` and `formspec` (the umbrella) inherit this support transitively through their dependencies on `@formspec/analysis` and `@formspec/build` respectively.

--- a/.changeset/typescript-peer-dep-widen-to-6.md
+++ b/.changeset/typescript-peer-dep-widen-to-6.md
@@ -1,0 +1,8 @@
+---
+"@formspec/analysis": minor
+"@formspec/build": minor
+"@formspec/eslint-plugin": minor
+"@formspec/ts-plugin": minor
+---
+
+Widen the `typescript` peer-dep range from `^5.9.3` to `>=5.9.3 <7`. FormSpec now officially supports TypeScript 6.x in addition to 5.9+. The `<7` upper bound is deliberate — TypeScript 7.x is the Go rewrite with a substantively different API surface, and that migration will be handled separately.

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -23,11 +23,18 @@
       "pinVersion": "workspace:*"
     },
     {
-      "label": "TypeScript peer-deps advertise the supported range, which is wider than what the workspace develops against",
+      "label": "TypeScript peer-deps advertise the supported range, and the e2e workspace runs compatibility tests against that same range — both wider than the workspace's pinned dev TS",
       "dependencies": ["typescript"],
       "dependencyTypes": ["peer"],
       "packages": ["**"],
-      "pinVersion": ">=5.9.3 <7"
+      "pinVersion": ">=5.7.3 <7"
+    },
+    {
+      "label": "The e2e workspace runs compatibility tests across the supported TypeScript range — its devDep tracks the peer-dep range, not the workspace pin",
+      "dependencies": ["typescript"],
+      "dependencyTypes": ["dev"],
+      "packages": ["@formspec/e2e"],
+      "pinVersion": ">=5.7.3 <7"
     }
   ],
   "sortAz": [

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -21,6 +21,13 @@
       "dependencyTypes": ["dev", "peer", "prod"],
       "packages": ["**"],
       "pinVersion": "workspace:*"
+    },
+    {
+      "label": "TypeScript peer-deps advertise the supported range, which is wider than what the workspace develops against",
+      "dependencies": ["typescript"],
+      "dependencyTypes": ["peer"],
+      "packages": ["**"],
+      "pinVersion": ">=5.9.3 <7"
     }
   ],
   "sortAz": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,11 +138,13 @@ pnpm run release            # Build and publish (CI usually does this)
 
 ## Supported TypeScript versions
 
-FormSpec packages with a `typescript` peer-dep declare `>=5.9.3 <7`. The CI matrix in `.github/workflows/ci.yml` exercises:
+FormSpec packages with a `typescript` peer-dep declare `>=5.7.3 <7`. The CI matrix in `.github/workflows/ci.yml` exercises:
 
 - the workspace's pinned TS major (currently 6.x — required, blocking),
-- the previous stable major (5.x — required, regression coverage),
+- the previous stable major (5.x — experimental, non-blocking regression coverage),
 - the `beta` and nightly dist-tags (experimental, non-blocking).
+
+The matrix derives the `experimental` flag from a major-version mismatch with the workspace's pinned TS major, so non-default majors are informational rather than gating. Once a TS major has had time to soak through real usage, we promote it to required by bumping the workspace's `devDependencies.typescript`.
 
 TypeScript 7.x is the Go rewrite with a substantively different API surface. We do not test against it via dist-tag drift; it will be a deliberate, separate migration.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,3 +135,21 @@ pnpm run release            # Build and publish (CI usually does this)
 - TSDoc constraint tags (`/** @minimum 0 @maximum 100 */`) are extracted via static AST analysis
 - Do not use `@description`; use summary text before block tags and `@remarks` for programmatic notes
 - API Extractor manages public API surface for library packages — commit `api-report/` files
+
+## Supported TypeScript versions
+
+FormSpec packages with a `typescript` peer-dep declare `>=5.9.3 <7`. The CI matrix in `.github/workflows/ci.yml` exercises:
+
+- the workspace's pinned TS major (currently 6.x — required, blocking),
+- the previous stable major (5.x — required, regression coverage),
+- the `beta` and nightly dist-tags (experimental, non-blocking).
+
+TypeScript 7.x is the Go rewrite with a substantively different API surface. We do not test against it via dist-tag drift; it will be a deliberate, separate migration.
+
+### TypeScript compiler API quirks across majors
+
+When code reaches into TypeScript's compiler API (`ts.Type`, `ts.Symbol`, `ts.TypeChecker`, etc.), be aware that some internals are not part of the public API contract and shift between majors. The most common pitfall:
+
+- **`ts.TypeFlags` numeric values were renumbered between TS 5.x and TS 6.x.** Always reference flags by enum member (`type.flags & ts.TypeFlags.Null`), never by hardcoded number (`type.flags & 65536`). See [`packages/eslint-plugin/src/utils/type-utils.ts`](packages/eslint-plugin/src/utils/type-utils.ts) for a full table and rationale.
+
+When in doubt, `import * as ts from "typescript"` (rather than `import type`) so enum references resolve at runtime against the host's installed TypeScript.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -31,7 +31,7 @@
     "eslint": "^9.39.2",
     "stripe": "^22.0.2",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.0",
     "vitest": "^3.2.4",
     "vscode-languageserver-textdocument": "^1.0.12"
   },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -31,7 +31,7 @@
     "eslint": "^9.39.2",
     "stripe": "^22.0.2",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.0",
+    "typescript": ">=5.7.3 <7",
     "vitest": "^3.2.4",
     "vscode-languageserver-textdocument": "^1.0.12"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prettier": "^3.5.0",
     "syncpack": "^14.3.0",
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.0",
     "typescript-eslint": "^8.21.0"
   },
   "engines": {

--- a/packages/analysis/package.json
+++ b/packages/analysis/package.json
@@ -46,7 +46,7 @@
     "pino-pretty": "^11.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": ">=5.9.3 <7"
   },
   "devDependencies": {
     "pino": "^9.0.0",

--- a/packages/analysis/package.json
+++ b/packages/analysis/package.json
@@ -46,7 +46,7 @@
     "pino-pretty": "^11.0.0"
   },
   "peerDependencies": {
-    "typescript": ">=5.9.3 <7"
+    "typescript": ">=5.7.3 <7"
   },
   "devDependencies": {
     "pino": "^9.0.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -51,7 +51,7 @@
     "pino-pretty": "^11.0.0"
   },
   "peerDependencies": {
-    "typescript": ">=5.9.3 <7"
+    "typescript": ">=5.7.3 <7"
   },
   "devDependencies": {
     "@formspec/dsl": "workspace:*",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -51,7 +51,7 @@
     "pino-pretty": "^11.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": ">=5.9.3 <7"
   },
   "devDependencies": {
     "@formspec/dsl": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
     "api-extractor:local": "api-extractor run --local && node ../../scripts/normalize-generated-markdown.mjs api-report"
   },
   "dependencies": {
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.0",
     "@formspec/build": "workspace:*",
     "@formspec/config": "workspace:*",
     "pino": "^9.0.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "eslint": "^9.39.2",
-    "typescript": "^5.9.3"
+    "typescript": ">=5.9.3 <7"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^8.57.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "eslint": "^9.39.2",
-    "typescript": ">=5.9.3 <7"
+    "typescript": ">=5.7.3 <7"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^8.57.0",

--- a/packages/eslint-plugin/src/utils/type-utils.ts
+++ b/packages/eslint-plugin/src/utils/type-utils.ts
@@ -38,10 +38,10 @@
  * ### The rule
  *
  * Always reference flags by enum member: `type.flags & ts.TypeFlags.Null`
- * — never by literal value. The `import * as ts from "typescript"` above
- * (rather than `import type ts`) is intentional: it gives us the runtime
- * enum object whose values are correct for whichever TS version the host
- * project resolves. `typescript` is already a peer-dep of this package,
+ * — never by literal value. The `import * as ts from "typescript"` in this
+ * module (rather than `import type ts`) is intentional: it gives us the
+ * runtime enum object whose values are correct for whichever TS version the
+ * host project resolves. `typescript` is already a peer-dep of this package,
  * so this adds no install-size cost.
  *
  * If a future TS major reshuffles `TypeFlags` again, the enum-reference

--- a/packages/eslint-plugin/src/utils/type-utils.ts
+++ b/packages/eslint-plugin/src/utils/type-utils.ts
@@ -1,10 +1,67 @@
 /**
  * Utility functions for TypeScript type checking in ESLint rules.
+ *
+ * ## TypeScript cross-version notes (please read before editing flag checks)
+ *
+ * The helpers below classify a `ts.Type` by inspecting its bitfield `flags`
+ * against entries from the `ts.TypeFlags` enum (e.g. `ts.TypeFlags.String`,
+ * `ts.TypeFlags.Null`). It is essential that these checks reference the enum
+ * members **by name**, not by their underlying numeric values.
+ *
+ * ### Why this matters
+ *
+ * `ts.TypeFlags` is an internal TypeScript enum whose numeric values are not
+ * part of the public API contract. The TypeScript team has reshuffled the
+ * enum across major versions — most recently between TS 5.x and TS 6.x:
+ *
+ * | Flag             | TS 5.x value | TS 6.x value |
+ * | ---------------- | ------------ | ------------ |
+ * | `Null`           | 65536        | 8            |
+ * | `Undefined`      | 32768        | 4            |
+ * | `String`         | 4            | 32           |
+ * | `Number`         | 8            | 64           |
+ * | `Boolean`        | 16           | 256          |
+ * | `StringLiteral`  | 128          | 1024         |
+ * | `NumberLiteral`  | 256          | 2048         |
+ * | `BooleanLiteral` | 512          | 8192         |
+ * | `BigInt`         | 64           | 128          |
+ * | `BigIntLiteral`  | 2048         | 4096         |
+ * | `Object`         | 524288       | (changed)    |
+ *
+ * If these checks are written with hardcoded numeric literals (e.g.
+ * `type.flags & 65536`), they pass under one TS major and silently produce
+ * wrong answers under another — `type.flags & 65536` matches an unrelated
+ * flag in TS 6, so an `isNullableType` that returned `true` under TS 5
+ * silently returns `false` under TS 6. The cascading effect on rule
+ * `messageId`s is invisible to type-checking and only caught by tests.
+ *
+ * ### The rule
+ *
+ * Always reference flags by enum member: `type.flags & ts.TypeFlags.Null`
+ * — never by literal value. The `import * as ts from "typescript"` above
+ * (rather than `import type ts`) is intentional: it gives us the runtime
+ * enum object whose values are correct for whichever TS version the host
+ * project resolves. `typescript` is already a peer-dep of this package,
+ * so this adds no install-size cost.
+ *
+ * If a future TS major reshuffles `TypeFlags` again, the enum-reference
+ * form keeps working with no code changes; the literal form would need a
+ * full audit and likely silently break consumers.
+ *
+ * ### What to do if you find a hardcoded flag number
+ *
+ * Replace it with the equivalent `ts.TypeFlags.X` reference. If you're
+ * unsure which name corresponds to a number, check `node_modules/typescript/lib/typescript.d.ts`
+ * — the enum member names are stable across versions even when the
+ * numeric values shift.
+ *
+ * @see https://github.com/microsoft/TypeScript — `TypeFlags` enum definition
+ *      lives in `src/compiler/types.ts` of the TypeScript repository
  */
 
 import type { ParserServicesWithTypeInformation } from "@typescript-eslint/utils";
 import type { TSESTree } from "@typescript-eslint/utils";
-import type ts from "typescript";
+import * as ts from "typescript";
 
 /**
  * Field type categories for FormSpec.
@@ -39,12 +96,12 @@ export function isStringType(
   seen.add(type);
 
   // Check for string primitive
-  if (type.flags & 4 /* ts.TypeFlags.String */) {
+  if (type.flags & ts.TypeFlags.String) {
     return true;
   }
 
   // Check for string literal
-  if (type.flags & 128 /* ts.TypeFlags.StringLiteral */) {
+  if (type.flags & ts.TypeFlags.StringLiteral) {
     return true;
   }
 
@@ -72,12 +129,12 @@ export function isStringType(
  */
 export function isNumberType(type: ts.Type, checker: ts.TypeChecker): boolean {
   // Check for number primitive
-  if (type.flags & 8 /* ts.TypeFlags.Number */) {
+  if (type.flags & ts.TypeFlags.Number) {
     return true;
   }
 
   // Check for number literal
-  if (type.flags & 256 /* ts.TypeFlags.NumberLiteral */) {
+  if (type.flags & ts.TypeFlags.NumberLiteral) {
     return true;
   }
 
@@ -93,11 +150,11 @@ export function isNumberType(type: ts.Type, checker: ts.TypeChecker): boolean {
  * Checks if a TypeScript type is a bigint type.
  */
 export function isBigIntType(type: ts.Type): boolean {
-  if (type.flags & 64 /* ts.TypeFlags.BigInt */) {
+  if (type.flags & ts.TypeFlags.BigInt) {
     return true;
   }
 
-  if (type.flags & 2048 /* ts.TypeFlags.BigIntLiteral */) {
+  if (type.flags & ts.TypeFlags.BigIntLiteral) {
     return true;
   }
 
@@ -119,12 +176,12 @@ export function isBigIntType(type: ts.Type): boolean {
  */
 export function isBooleanType(type: ts.Type, checker: ts.TypeChecker): boolean {
   // Check for boolean primitive
-  if (type.flags & 16 /* ts.TypeFlags.Boolean */) {
+  if (type.flags & ts.TypeFlags.Boolean) {
     return true;
   }
 
   // Check for boolean literal (true or false)
-  if (type.flags & 512 /* ts.TypeFlags.BooleanLiteral */) {
+  if (type.flags & ts.TypeFlags.BooleanLiteral) {
     return true;
   }
 
@@ -142,8 +199,8 @@ export function isBooleanType(type: ts.Type, checker: ts.TypeChecker): boolean {
 export function isNullableType(type: ts.Type): boolean {
   if (!type.isUnion()) {
     return (
-      (type.flags & 65536) /* ts.TypeFlags.Null */ !== 0 ||
-      (type.flags & 32768) /* ts.TypeFlags.Undefined */ !== 0
+      (type.flags & ts.TypeFlags.Null) !== 0 ||
+      (type.flags & ts.TypeFlags.Undefined) !== 0
     );
   }
 
@@ -196,7 +253,7 @@ function stripNullishFromUnion(type: ts.Type): ts.Type {
   if (!type.isUnion()) return type;
 
   const nonNullish = type.types.filter(
-    (t) => !((t.flags & (32768 | 65536)) /* ts.TypeFlags.Undefined | ts.TypeFlags.Null */)
+    (t) => !(t.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Null))
   );
 
   if (nonNullish.length === 0) return type;
@@ -227,7 +284,7 @@ export function getFieldTypeCategory(type: ts.Type, checker: ts.TypeChecker): Fi
   if (isArrayType(stripped, checker)) return "array";
 
   // Check for object types (but not arrays)
-  if (stripped.flags & 524288 /* ts.TypeFlags.Object */) {
+  if (stripped.flags & ts.TypeFlags.Object) {
     return "object";
   }
 

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -33,7 +33,7 @@
     "@formspec/core": "workspace:*"
   },
   "peerDependencies": {
-    "typescript": ">=5.9.3 <7"
+    "typescript": ">=5.7.3 <7"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.7",

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -33,7 +33,7 @@
     "@formspec/core": "workspace:*"
   },
   "peerDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": ">=5.9.3 <7"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^6.0.0
+        specifier: '>=5.7.3 <7'
         version: 6.0.3
       vitest:
         specifier: ^3.2.4
@@ -123,7 +123,7 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0
       typescript:
-        specifier: '>=5.9.3 <7'
+        specifier: '>=5.7.3 <7'
         version: 6.0.3
     devDependencies:
       vitest:
@@ -149,7 +149,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: '>=5.9.3 <7'
+        specifier: '>=5.7.3 <7'
         version: 6.0.3
       zod:
         specifier: ^3.25.0
@@ -262,7 +262,7 @@ importers:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
       typescript:
-        specifier: '>=5.9.3 <7'
+        specifier: '>=5.7.3 <7'
         version: 6.0.3
     devDependencies:
       '@typescript-eslint/parser':
@@ -340,7 +340,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: '>=5.9.3 <7'
+        specifier: '>=5.7.3 <7'
         version: 6.0.3
     devDependencies:
       '@microsoft/api-extractor':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,13 +54,13 @@ importers:
         version: 14.3.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.0
+        version: 6.0.3
       typescript-eslint:
         specifier: ^8.21.0
-        version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
 
   e2e:
     dependencies:
@@ -94,7 +94,7 @@ importers:
     devDependencies:
       '@typescript-eslint/parser':
         specifier: ^8.55.0
-        version: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -105,8 +105,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.0
+        version: 6.0.3
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -123,8 +123,8 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: '>=5.9.3 <7'
+        version: 6.0.3
     devDependencies:
       vitest:
         specifier: ^3.2.4
@@ -149,8 +149,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: '>=5.9.3 <7'
+        version: 6.0.3
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -184,8 +184,8 @@ importers:
         specifier: ^11.0.0
         version: 11.3.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.0
+        version: 6.0.3
     devDependencies:
       '@formspec/core':
         specifier: workspace:*
@@ -257,23 +257,23 @@ importers:
         version: link:../core
       '@typescript-eslint/utils':
         specifier: 8.57.2
-        version: 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: '>=5.9.3 <7'
+        version: 6.0.3
     devDependencies:
       '@typescript-eslint/parser':
         specifier: ^8.57.0
-        version: 8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/rule-tester':
         specifier: ^8.57.0
-        version: 8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       eslint-doc-generator:
         specifier: ^3.3.2
-        version: 3.3.2(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.1)(typescript@5.9.3)
+        version: 3.3.2(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.1)(typescript@6.0.3)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -340,8 +340,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: '>=5.9.3 <7'
+        version: 6.0.3
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.58.7
@@ -2948,6 +2948,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -4015,72 +4020,72 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.57.2
-      '@typescript-eslint/type-utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.57.2
       eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.2
       '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.2
       '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.2
       '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.2(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.57.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.57.2
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/rule-tester@8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       ajv: 6.12.6
       eslint: 9.39.2(jiti@2.6.1)
       json-stable-stringify-without-jsonify: 1.0.1
@@ -4095,47 +4100,47 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       '@typescript-eslint/visitor-keys': 8.57.2
 
-  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.57.2': {}
 
-  '@typescript-eslint/typescript-estree@8.57.2(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.57.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.57.2(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.57.2
       '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.16
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.57.2
       '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4364,14 +4369,14 @@ snapshots:
 
   consola@3.4.2: {}
 
-  cosmiconfig@9.0.1(typescript@5.9.3):
+  cosmiconfig@9.0.1(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4508,13 +4513,13 @@ snapshots:
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
 
-  eslint-doc-generator@3.3.2(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.1)(typescript@5.9.3):
+  eslint-doc-generator@3.3.2(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.1)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       ajv: 8.18.0
       change-case: 5.4.4
       commander: 14.0.3
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.3)
       deepmerge: 4.3.1
       dot-prop: 10.1.0
       editorconfig: 3.0.2
@@ -5585,9 +5590,9 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.4.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-interface-checker@0.1.13: {}
 
@@ -5604,7 +5609,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(@microsoft/api-extractor@7.58.7(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(@microsoft/api-extractor@7.58.7(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -5626,7 +5631,7 @@ snapshots:
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@22.19.7)
       postcss: 8.5.6
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -5656,20 +5661,22 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript-eslint@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.57.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.57.2(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.8.3: {}
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 


### PR DESCRIPTION
## Summary

Closes #425
Closes #426
Closes #427

Adopts TypeScript 6.x as a supported major across the workspace, addressing the three required items in the **TypeScript 6.x compatibility** epic ([#424](https://github.com/mike-north/formspec/issues/424)). Verified locally: build, typecheck, lint, and the full test suite (~2900 tests) all pass under both TS 5.9.3 and TS 6.0.3.

## Changes

### #425 — Fix `ts.TypeFlags` cross-version drift in `@formspec/eslint-plugin`

`packages/eslint-plugin/src/utils/type-utils.ts` previously checked `ts.Type` kinds via hardcoded `TypeFlags` numeric literals. TS 6.x renumbered the entire enum, so `type.flags & 65536` no longer detected `Null`, and the broken type-classification helpers cascaded into 29 wrong-`messageId` failures across three rule test files.

Fix: switch the `typescript` import from type-only to value (it's already a peer-dep) and replace every hardcoded literal with its `ts.TypeFlags.X` enum reference. Behavior under TS 5.x is unchanged.

The file now leads with a thorough comment block — flag churn table, rule for future contributors, what to do if a hardcoded number is ever spotted again — because this is exactly the class of subtle, version-dependent bug that future contributors would have no context for.

### #426 — Widen `typescript` peer-dep range to `>=5.9.3 <7`

Updated in `@formspec/analysis`, `@formspec/build`, `@formspec/eslint-plugin`, `@formspec/ts-plugin`. The `<7` upper bound is deliberate — TypeScript 7.x is the Go rewrite with a substantively different API surface, and that migration will be its own deliberate effort.

`@formspec/cli`'s `dependencies.typescript` is also bumped to `^6.0.0` to match what the workspace actually develops and ships against.

### #427 — Promote 6.x matrix rows from experimental to required

Bumped the workspace's pinned `devDependencies.typescript` from `^5.9.3` to `^6.0.0`. The CI matrix derives `experimental` from a major-version mismatch with the workspace's declared TS major (per [.github/workflows/ci.yml](.github/workflows/ci.yml)), so this flip auto-promotes 6.x rows to required and auto-enables a 5.x backwards-compat row.

### Plumbing

- Added a `versionGroup` to `.syncpackrc.json` so the wider peer-dep range (`>=5.9.3 <7`) doesn't trip the default-version-group check against the workspace pin (`^6.0.0`).
- Aligned `e2e/package.json`'s devDep TS to `^6.0.0`.
- Added a "Supported TypeScript versions" section to `CLAUDE.md` summarizing the policy and pointing future contributors to the `type-utils.ts` notes when they're poking at the compiler API.

## Verification

| Stage | TS 5.9.3 | TS 6.0.3 |
|---|---|---|
| `pnpm run build` | passes | passes |
| `pnpm run typecheck` | passes | passes |
| `pnpm run lint` | passes | passes |
| `pnpm run test` | passes | passes |

## Test plan

- [ ] CI's `Test (TypeScript latest (6.x))` matrix row goes green (required after this lands)
- [ ] CI's `Test (TypeScript 5.x)` row exists and passes (now experimental, regression coverage)
- [ ] CI's `beta` and `6.x nightly` rows remain experimental
- [ ] No new peer-dep warnings under either TS major