### PR TITLE
Add TypeFlags classification regression tests

### DIFF
--- a/.changeset/typeflags-classification-tests.md
+++ b/.changeset/typeflags-classification-tests.md
@@ -1,0 +1,5 @@
+---
+"@formspec/eslint-plugin": patch
+---
+
+Add focused regression coverage for TypeScript-backed field type classification helpers.

--- a/packages/eslint-plugin/tests/utils/type-utils.test.ts
+++ b/packages/eslint-plugin/tests/utils/type-utils.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for TypeScript-backed field type classification helpers.
+ */
+
+import * as ts from "typescript";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  getFieldTypeCategory,
+  isBigIntType,
+  isBooleanType,
+  isNullableType,
+  isNumberType,
+  isStringType,
+} from "../../src/utils/type-utils.js";
+
+const fixtureFileName = "/type-utils-fixture.ts";
+
+const fixtureSource = `
+interface Fixture {
+  text: string;
+  textLiteral: "draft";
+  count: number;
+  countLiteral: 42;
+  big: bigint;
+  bigLiteral: 42n;
+  enabled: boolean;
+  enabledLiteral: true;
+  maybeText: string | null;
+  maybeCount: number | undefined;
+  nested: { id: string };
+  mixed: string | number;
+}
+`;
+
+interface FixtureProgram {
+  checker: ts.TypeChecker;
+  typeOf: (propertyName: string) => ts.Type;
+}
+
+function createFixtureProgram(): FixtureProgram {
+  const compilerOptions: ts.CompilerOptions = {
+    module: ts.ModuleKind.ESNext,
+    noEmit: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+    types: [],
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const originalFileExists = host.fileExists.bind(host);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  const originalReadFile = host.readFile.bind(host);
+
+  host.fileExists = (fileName) => fileName === fixtureFileName || originalFileExists(fileName);
+  host.readFile = (fileName) =>
+    fileName === fixtureFileName ? fixtureSource : originalReadFile(fileName);
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+    if (fileName === fixtureFileName) {
+      return ts.createSourceFile(fileName, fixtureSource, languageVersion, true);
+    }
+    return originalGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+  };
+
+  const program = ts.createProgram([fixtureFileName], compilerOptions, host);
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  expect(
+    diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+  ).toEqual([]);
+
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(fixtureFileName);
+  if (!sourceFile) {
+    throw new Error("Expected fixture source file to be present in test program.");
+  }
+
+  const fixture = sourceFile.statements.find(ts.isInterfaceDeclaration);
+  if (!fixture) {
+    throw new Error("Expected Fixture interface declaration in test program.");
+  }
+
+  const properties = new Map(
+    fixture.members
+      .filter(ts.isPropertySignature)
+      .map((member) => [member.name.getText(sourceFile), member] as const)
+  );
+
+  return {
+    checker,
+    typeOf(propertyName) {
+      const property = properties.get(propertyName);
+      if (!property?.type) {
+        throw new Error(`Expected property "${propertyName}" to have an explicit type.`);
+      }
+      return checker.getTypeAtLocation(property.type);
+    },
+  };
+}
+
+describe("type-utils", () => {
+  let fixture: FixtureProgram | null = null;
+
+  beforeAll(() => {
+    fixture = createFixtureProgram();
+  });
+
+  function getFixture(): FixtureProgram {
+    if (fixture === null) {
+      throw new Error("Expected type-utils fixture to be initialized before tests run.");
+    }
+    return fixture;
+  }
+
+  it("recognizes primitive and literal scalar types", () => {
+    const fixture = getFixture();
+
+    expect(isStringType(fixture.typeOf("text"), fixture.checker)).toBe(true);
+    expect(isStringType(fixture.typeOf("textLiteral"), fixture.checker)).toBe(true);
+
+    expect(isNumberType(fixture.typeOf("count"), fixture.checker)).toBe(true);
+    expect(isNumberType(fixture.typeOf("countLiteral"), fixture.checker)).toBe(true);
+
+    expect(isBigIntType(fixture.typeOf("big"))).toBe(true);
+    expect(isBigIntType(fixture.typeOf("bigLiteral"))).toBe(true);
+
+    expect(isBooleanType(fixture.typeOf("enabled"), fixture.checker)).toBe(true);
+    expect(isBooleanType(fixture.typeOf("enabledLiteral"), fixture.checker)).toBe(true);
+  });
+
+  it("rejects neighboring scalar types", () => {
+    const fixture = getFixture();
+
+    expect(isStringType(fixture.typeOf("count"), fixture.checker)).toBe(false);
+    expect(isNumberType(fixture.typeOf("enabled"), fixture.checker)).toBe(false);
+    expect(isBigIntType(fixture.typeOf("count"))).toBe(false);
+    expect(isBooleanType(fixture.typeOf("text"), fixture.checker)).toBe(false);
+  });
+
+  it("recognizes nullish union members", () => {
+    const fixture = getFixture();
+
+    expect(isNullableType(fixture.typeOf("maybeText"))).toBe(true);
+    expect(isNullableType(fixture.typeOf("maybeCount"))).toBe(true);
+    expect(isNullableType(fixture.typeOf("text"))).toBe(false);
+  });
+
+  it("categorizes fields after removing nullish union members", () => {
+    const fixture = getFixture();
+
+    expect(getFieldTypeCategory(fixture.typeOf("maybeText"), fixture.checker)).toBe("string");
+    expect(getFieldTypeCategory(fixture.typeOf("maybeCount"), fixture.checker)).toBe("number");
+    expect(getFieldTypeCategory(fixture.typeOf("nested"), fixture.checker)).toBe("object");
+    expect(getFieldTypeCategory(fixture.typeOf("mixed"), fixture.checker)).toBe("union");
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused compiler-API regression coverage for `@formspec/eslint-plugin` scalar, nullable, object, and union type classification helpers.
- Keep the PR scoped to test coverage now that #431 has landed the production TypeFlags enum-reference fix and TypeScript 6 peer-range updates.

Refs #425.

## Test plan
- `pnpm --filter @formspec/eslint-plugin exec vitest run tests/utils/type-utils.test.ts`
- `pnpm --filter @formspec/eslint-plugin run test`
- `pnpm --filter @formspec/eslint-plugin run typecheck`
- `pnpm exec prettier --check packages/eslint-plugin/tests/utils/type-utils.test.ts`
