### PR TITLE
Sort generated JSON Schema required arrays

### DIFF
--- a/.changeset/stable-required-ordering.md
+++ b/.changeset/stable-required-ordering.md
@@ -1,5 +1,8 @@
 ---
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
 ---
 
 Sort generated JSON Schema `required` arrays alphabetically for deterministic output.

--- a/.changeset/stable-required-ordering.md
+++ b/.changeset/stable-required-ordering.md
@@ -1,0 +1,5 @@
+---
+"@formspec/build": patch
+---
+
+Sort generated JSON Schema `required` arrays alphabetically for deterministic output.

--- a/e2e/tests/const-constraints.test.ts
+++ b/e2e/tests/const-constraints.test.ts
@@ -54,6 +54,6 @@ describe("Const Constraints", () => {
 
   it("all fields are required", () => {
     const required = schema["required"] as string[];
-    expect(required).toEqual(["currency", "statusCode", "enabled"]);
+    expect(required).toEqual(["currency", "enabled", "statusCode"]);
   });
 });

--- a/e2e/tests/type-mappings-comprehensive.test.ts
+++ b/e2e/tests/type-mappings-comprehensive.test.ts
@@ -109,7 +109,7 @@ describe("Type Mappings — comprehensive", () => {
         city: { type: "string" },
         country: { type: "string" },
       },
-      required: ["street", "city", "country"],
+      required: ["city", "country", "street"],
     });
   });
 

--- a/packages/build/src/generators/method-schema.ts
+++ b/packages/build/src/generators/method-schema.ts
@@ -222,7 +222,7 @@ function generateParamsSchemas(
     jsonSchema: {
       type: "object",
       properties,
-      ...(required.length > 0 ? { required } : {}),
+      ...(required.length > 0 ? { required: required.sort() } : {}),
     },
     uiSchema: null,
     formSpecExport: null,

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -282,8 +282,8 @@ export function generateJsonSchemaFromIR(
 
   collectFields(ir.elements, properties, required, ctx);
 
-  // Deduplicate required (same field can appear across conditional branches).
-  const uniqueRequired = [...new Set(required)];
+  // Deduplicate and sort required names so output stays stable across IR traversal changes.
+  const uniqueRequired = [...new Set(required)].sort();
 
   const result: JsonSchema2020 = {
     $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -733,7 +733,7 @@ function generateObjectType(type: ObjectTypeNode, ctx: GeneratorContext): JsonSc
   const schema: JsonSchema2020 = { type: "object", properties };
 
   if (required.length > 0) {
-    schema.required = required;
+    schema.required = required.sort();
   }
 
   if (!type.additionalProperties) {

--- a/packages/build/tests/fixtures/method-signature-schemas.ts
+++ b/packages/build/tests/fixtures/method-signature-schemas.ts
@@ -145,6 +145,12 @@ export class PaymentService {
     };
   }
 
+  multiParameter(type: string, id: string, label?: string): SubmitResult {
+    return {
+      approved: type.length > 0 && id.length > 0 && label !== "",
+    };
+  }
+
   status(): PaymentStatus {
     return "ok";
   }

--- a/packages/build/tests/generate-schemas.test.ts
+++ b/packages/build/tests/generate-schemas.test.ts
@@ -132,7 +132,7 @@ describe("generateSchemas", () => {
       "total",
       "address",
     ]);
-    expect(result.jsonSchema.required).toEqual(["first_name", "total", "address"]);
+    expect(result.jsonSchema.required).toEqual(["address", "first_name", "total"]);
     expect(result.jsonSchema.$defs).toMatchObject({
       PostalAddress: {
         type: "object",

--- a/packages/build/tests/generator.test.ts
+++ b/packages/build/tests/generator.test.ts
@@ -376,7 +376,7 @@ describe("generateJsonSchema - object fields", () => {
         city: { type: "string" },
         zip: { type: "string" },
       },
-      required: ["street", "city"],
+      required: ["city", "street"],
     });
   });
 });

--- a/packages/build/tests/integration.test.ts
+++ b/packages/build/tests/integration.test.ts
@@ -65,7 +65,7 @@ describe("Integration: Complete form workflow", () => {
         state: { type: "string" },
         zip: { type: "string" },
       },
-      required: ["street", "city"],
+      required: ["city", "street"],
     });
 
     // Verify array structure

--- a/packages/build/tests/ir-json-schema-generator.test.ts
+++ b/packages/build/tests/ir-json-schema-generator.test.ts
@@ -780,7 +780,7 @@ describe("generateJsonSchemaFromIR", () => {
       expect((prop["properties"] as Record<string, unknown>)["street"]).toEqual({ type: "string" });
       expect((prop["properties"] as Record<string, unknown>)["city"]).toEqual({ type: "string" });
       expect((prop["properties"] as Record<string, unknown>)["zip"]).toEqual({ type: "string" });
-      expect(prop["required"]).toEqual(["street", "city"]);
+      expect(prop["required"]).toEqual(["city", "street"]);
       expect(prop["required"]).not.toContain("zip");
     });
 
@@ -1646,6 +1646,17 @@ describe("generateJsonSchemaFromIR", () => {
       expect(schema.required).toEqual(["name"]);
     });
 
+    it("sorts root required field names alphabetically and excludes optional fields", () => {
+      const ir = makeIR([
+        makeField("type", { kind: "primitive", primitiveKind: "string" }, true),
+        makeField("label", { kind: "primitive", primitiveKind: "string" }, false),
+        makeField("id", { kind: "primitive", primitiveKind: "string" }, true),
+      ]);
+      const schema = generateJsonSchemaFromIR(ir);
+
+      expect(schema.required).toEqual(["id", "type"]);
+    });
+
     it("deduplicates required entries (e.g., fields repeated across branches)", () => {
       const ir: FormIR = {
         kind: "form-ir",
@@ -1986,7 +1997,7 @@ describe("generateJsonSchemaFromIR", () => {
       // Root-level assertions
       expect(schema.$schema).toBe("https://json-schema.org/draft/2020-12/schema");
       expect(schema.type).toBe("object");
-      expect(schema.required).toEqual(["customerName", "status", "billingAddress"]);
+      expect(schema.required).toEqual(["billingAddress", "customerName", "status"]);
 
       const props = schema.properties as Record<string, Record<string, unknown>>;
 
@@ -2033,7 +2044,7 @@ describe("generateJsonSchemaFromIR", () => {
             pattern: "^[A-Z]{2}$",
           },
         },
-        required: ["street", "city", "country"],
+        required: ["city", "country", "street"],
       });
     });
   });

--- a/packages/build/tests/mixed-authoring.test.ts
+++ b/packages/build/tests/mixed-authoring.test.ts
@@ -48,7 +48,7 @@ describe("buildMixedAuthoringSchemas", () => {
         },
         postalCode: { type: "string", title: "Postal Code" },
       },
-      required: ["country", "city"],
+      required: ["city", "country"],
     });
 
     expect(result.uiSchema).toEqual({
@@ -138,7 +138,7 @@ describe("buildMixedAuthoringSchemas", () => {
       overlays: requiredCountryShippingAddressOverlays,
     });
 
-    expect(result.jsonSchema.required).toEqual(["country", "city"]);
+    expect(result.jsonSchema.required).toEqual(["city", "country"]);
     expect(result.jsonSchema.properties?.["country"]).toEqual({
       type: "string",
       title: "Country",

--- a/packages/build/tests/signature-schema-generation.test.ts
+++ b/packages/build/tests/signature-schema-generation.test.ts
@@ -8,6 +8,8 @@ import {
   generateSchemasFromType,
   resolveModuleExportDeclaration,
 } from "../src/index.js";
+import type { MethodInfo } from "../src/analyzer/class-analyzer.js";
+import { generateMethodSchemas } from "../src/internals.js";
 
 const fixturePath = path.join(__dirname, "fixtures", "method-signature-schemas.ts");
 
@@ -27,6 +29,27 @@ function getMethod(
   }
 
   return method;
+}
+
+/** Builds the MethodInfo shape consumed by the internal method-schema generator. */
+function getMethodInfo(method: ts.MethodDeclaration, checker: ts.TypeChecker): MethodInfo {
+  const signature = checker.getSignatureFromDeclaration(method);
+  if (signature === undefined) {
+    throw new Error(`Method "${method.name.getText()}" signature not found`);
+  }
+
+  return {
+    name: method.name.getText(),
+    parameters: method.parameters.map((parameter) => ({
+      name: parameter.name.getText(),
+      typeNode: parameter.type,
+      type: checker.getTypeAtLocation(parameter),
+      formSpecExportName: null,
+      optional: parameter.questionToken !== undefined || parameter.initializer !== undefined,
+    })),
+    returnTypeNode: method.type,
+    returnType: checker.getReturnTypeOfSignature(signature),
+  };
 }
 
 describe("method-signature schema generation", () => {
@@ -160,7 +183,7 @@ describe("method-signature schema generation", () => {
       inline_amount_cents: { type: "number" },
       currency: { type: "string", title: "Inline Currency" },
     });
-    expect(schemas.jsonSchema.required).toEqual(["inline_amount_cents", "currency"]);
+    expect(schemas.jsonSchema.required).toEqual(["currency", "inline_amount_cents"]);
     expect(schemas.uiSchema).toMatchObject({
       type: "VerticalLayout",
       elements: [
@@ -191,6 +214,23 @@ describe("method-signature schema generation", () => {
       type: "VerticalLayout",
       elements: [{ type: "Control", scope: "#/properties/inline_ok" }],
     });
+  });
+
+  it("sorts required arrays for generated multi-parameter method schemas", () => {
+    const context = createStaticBuildContext(fixturePath);
+    const declaration = resolveModuleExportDeclaration(context, "PaymentService");
+    if (declaration === null || !ts.isClassDeclaration(declaration)) {
+      throw new Error("PaymentService class not found");
+    }
+
+    const method = getMethod(declaration, "multiParameter");
+    const schemas = generateMethodSchemas(
+      getMethodInfo(method, context.checker),
+      context.checker,
+      new Map()
+    );
+
+    expect(schemas.params?.jsonSchema.required).toEqual(["id", "type"]);
   });
 
   it("supports advanced generation from a resolved TypeScript type", () => {
@@ -406,7 +446,9 @@ describe("metadata policy that would rename the synthetic __result wrapper (regr
     },
   };
 
-  function getPaymentService(context: ReturnType<typeof createStaticBuildContext>): ts.ClassDeclaration {
+  function getPaymentService(
+    context: ReturnType<typeof createStaticBuildContext>
+  ): ts.ClassDeclaration {
     const declaration = resolveModuleExportDeclaration(context, "PaymentService");
     if (declaration === null || !ts.isClassDeclaration(declaration)) {
       throw new Error("PaymentService class not found");


### PR DESCRIPTION
## Summary
- Sort generated JSON Schema `required` arrays alphabetically for root, nested object, and multi-parameter method schemas
- Add focused coverage for root required sorting, method parameter required sorting, and updated schema expectations
- Add a patch changeset for `@formspec/build`

Closes #394.

## Test plan
- `pnpm --filter @formspec/build exec vitest run tests/ir-json-schema-generator.test.ts tests/signature-schema-generation.test.ts`
- `pnpm exec prettier --check packages/build/src/json-schema/ir-generator.ts packages/build/src/generators/method-schema.ts packages/build/tests/ir-json-schema-generator.test.ts packages/build/tests/fixtures/method-signature-schemas.ts packages/build/tests/signature-schema-generation.test.ts packages/build/tests/generate-schemas.test.ts packages/build/tests/generator.test.ts packages/build/tests/integration.test.ts packages/build/tests/mixed-authoring.test.ts`
- `pnpm --filter @formspec/build run test`
- `pnpm changeset status --since origin/main`
