### PR TITLE
Update circular reference spec docs

### DIFF
--- a/docs/001-canonical-ir.md
+++ b/docs/001-canonical-ir.md
@@ -198,9 +198,11 @@ interface ReferenceTypeNode {
 }
 ```
 
-The IR registry (section 9) maintains a `TypeDefinition` map from reference names to their resolved `TypeNode`. Generators walk this map to emit `$defs` in JSON Schema (PP7).
+The IR registry (section 10.3) maintains a `TypeDefinition` map from reference names to their resolved `TypeNode`. Generators walk this map to emit `$defs` in JSON Schema (PP7).
 
-**Current rule:** Circular type graphs are not supported in this revision. The analyzer should emit a clear source-located diagnostic rather than silently degrading to a fallback object schema. Future support for registry-backed recursive references is tracked in [issue #105](https://github.com/mike-north/formspec/issues/105).
+**Recursive named-type rule:** Named recursive type graphs are supported when the recursive shape is reachable through a named class, interface, or type alias. During analysis, the type registry seeds the named type before resolving its full body; recursive back-edges then become `ReferenceTypeNode` values whose `name` points at the seeded registry entry. This preserves the recursive structure without inlining indefinitely, and downstream JSON Schema generation emits a stable `$defs` entry with `$ref` back-edges.
+
+Anonymous recursive shapes are not part of this supported path because they have no stable registry identity to reference. They should be diagnosed as `ANONYMOUS_RECURSIVE_TYPE` rather than silently collapsing to an empty fallback object; that diagnostic work is tracked in [issue #422](https://github.com/mike-north/formspec/issues/422).
 
 ### 2.8 Dynamic Types
 

--- a/docs/003-json-schema-vocabulary.md
+++ b/docs/003-json-schema-vocabulary.md
@@ -448,9 +448,44 @@ Sibling keywords alongside `$ref` are standard JSON Schema 2020-12. Draft 2019-0
 
 ### 5.5 Circular Reference Handling
 
-Circular types are not supported in this revision. When the analyzer detects a recursive type graph (for example, `type TreeNode = { value: number; children?: TreeNode[] }`), it should emit a clear source-located diagnostic instead of attempting fallback generation.
+Named recursive type graphs are supported through the same `$defs` + `$ref` mechanism used for other named references. The canonical IR registry contains one entry for each named recursive type, and recursive back-edges inside that entry lower to `$ref` values that point back to the same `$defs` key.
 
-Future support for recursive `$defs` + `$ref` emission is tracked in [issue #105](https://github.com/mike-north/formspec/issues/105).
+For example, a named recursive type:
+
+```typescript
+export class CircularNode {
+  id!: string;
+  next?: CircularNode;
+}
+
+export class CircularForm {
+  node!: CircularNode;
+}
+```
+
+emits one reusable definition and references it from both the root field and the recursive property:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "node": { "$ref": "#/$defs/CircularNode" }
+  },
+  "required": ["node"],
+  "$defs": {
+    "CircularNode": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "next": { "$ref": "#/$defs/CircularNode" }
+      },
+      "required": ["id"]
+    }
+  }
+}
+```
+
+This supersedes the prior diagnostic-only circular-reference rule tracked by [issue #105](https://github.com/mike-north/formspec/issues/105), which was completed by recursive named-type support. Anonymous recursive shapes remain unsupported until they can produce a clear `ANONYMOUS_RECURSIVE_TYPE` diagnostic; that follow-up is tracked in [issue #422](https://github.com/mike-north/formspec/issues/422).
 
 ---
 

--- a/docs/003-json-schema-vocabulary.md
+++ b/docs/003-json-schema-vocabulary.md
@@ -467,6 +467,7 @@ emits one reusable definition and references it from both the root field and the
 
 ```json
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "node": { "$ref": "#/$defs/CircularNode" }

--- a/docs/006-parity-testing.md
+++ b/docs/006-parity-testing.md
@@ -236,6 +236,15 @@ Source: see 005 §6.2 for the TypeScript definition and JSON Schema output for `
 
 **Why this is a good fixture:** The `:value` and `:currency` path targets exercise the path-target grammar. The `total` field has four constraints targeting two different subfields, requiring the generator to emit an `allOf` with multiple property-level constraints (003 §5.4). This is the most structurally complex single-field case in the fixture suite.
 
+### 2.7 Coverage Note: Recursive Named Types
+
+This is not a strict TSDoc to ChainDSL parity fixture in this revision. The current ChainDSL fixture surface does not author recursive named type definitions directly, so a synthetic parity fixture would test registry plumbing rather than equivalent author intent. Existing tests cover recursive class handling, recursive type-alias handling, generic IR emission, and CLI generation:
+
+- `packages/build/tests/ir-analyzer.test.ts` verifies that recursive class properties resolve as named `ReferenceTypeNode` values and that the type registry contains the recursive named type.
+- `packages/build/tests/ir-json-schema-generator.test.ts` verifies that a self-referential named type emits a `$defs` entry whose recursive property points back to `#/$defs/<TypeName>`.
+- `packages/build/tests/defs-deduplication.test.ts` verifies a recursive `Tree` type alias whose `$defs.Tree` body remains a real object instead of a dangling self-reference.
+- `e2e/tests/cli-subprocess.test.ts` uses `e2e/fixtures/cli/circular-node.ts` to verify the CLI generates recursive schemas for circular references.
+
 ---
 
 ## 3. TSDoc ↔ Chain DSL Equivalence Test Patterns

--- a/docs/e2e-test-matrix.md
+++ b/docs/e2e-test-matrix.md
@@ -25,6 +25,7 @@
 - Field-level narrowing of alias constraints (inherited-constraints)
 - Path-target on `$ref` type — sibling keywords alongside `$ref` (path-target-constraints; see 003 §5.4)
 - Path-target on array item type — transparency (path-target-constraints)
+- Recursive named type → `$defs` with self-referential `$ref` (cli/circular-node; build analyzer/generator tests)
 - Chain DSL: groups, conditionals, labeled enums, dynamic enums, objects, arrays (chain-dsl fixtures)
 
 ### NOT yet covered (this matrix adds these)

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -8,6 +8,28 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
 - Group entries by the spec document being changed.
 - Link each entry back to the corresponding item in `scratch/spec-risk-log.md` when applicable.
 
+# 2026-04-26
+
+## 001-canonical-ir
+
+- Updated §2.7 to match the 2026-03-26 circular-reference supersession.
+  - Named recursive class/interface/type-alias graphs are supported through registry-backed `ReferenceTypeNode` back-edges.
+  - Anonymous recursive shapes remain deferred to the `ANONYMOUS_RECURSIVE_TYPE` diagnostic tracked in [#422](https://github.com/mike-north/formspec/issues/422).
+
+## 003-json-schema-vocabulary
+
+- Updated §5.5 to describe recursive `$defs` / `$ref` emission for named recursive types.
+  - The prior diagnostic-only language now points to completed tracker [#105](https://github.com/mike-north/formspec/issues/105), not future work.
+  - Anonymous recursive diagnostics remain a separate follow-up in [#422](https://github.com/mike-north/formspec/issues/422).
+
+## 006-parity-testing
+
+- Documented recursive named-type coverage as existing analyzer, generator, and CLI/e2e evidence rather than adding a strict TSDoc-to-ChainDSL parity fixture in this doc-only update.
+
+## e2e-test-matrix
+
+- Added recursive named-type coverage to the already-covered fixture list, backed by the existing `cli/circular-node` fixture and focused build tests.
+
 ## 000-principles.md
 
 - Added a naming principle for TSDoc tags.


### PR DESCRIPTION
## Summary
- Update canonical IR and JSON Schema specs to reflect supported named recursive type handling via registry-backed references and recursive `$defs` / `$ref` emission
- Add a self-contained `CircularForm` / `CircularNode` JSON Schema example and point anonymous recursive diagnostics to #422
- Document existing recursive coverage in the parity strategy, e2e matrix, and spec changelog without adding code or schema-generation changes

Closes #423.

## Test plan
- `pnpm --filter @formspec/build run test -- ir-analyzer.test.ts ir-json-schema-generator.test.ts`
- `pnpm --filter @formspec/e2e exec vitest run tests/cli-subprocess.test.ts`
- `pnpm exec prettier --check docs/001-canonical-ir.md docs/003-json-schema-vocabulary.md docs/006-parity-testing.md docs/e2e-test-matrix.md docs/spec-changelog.md`
- `git diff --check`

Notes: `pnpm run format:check` and `pnpm run lint` still report pre-existing unrelated issues outside the changed docs.
