### PR TITLE
Fix multi-line JSON tag arguments

### DIFF
--- a/.changeset/large-masks-sort.md
+++ b/.changeset/large-masks-sort.md
@@ -1,0 +1,11 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Support bracketed multi-line JSON tag arguments in comment parsing, including `@const` arrays and objects.

--- a/packages/analysis/src/comment-syntax.ts
+++ b/packages/analysis/src/comment-syntax.ts
@@ -1,4 +1,5 @@
 import type { PathTarget } from "@formspec/core/internals";
+import { createJsonLikeBalanceTracker } from "./json-like-balance.js";
 import { extractPathTarget } from "./path-target.js";
 import {
   getTagDefinition,
@@ -99,6 +100,18 @@ interface CommentLineProjection {
   readonly rawContentEnd: number;
 }
 
+interface MultiLineJsonArgument {
+  readonly argumentText: string;
+  readonly rawEnd: number;
+}
+
+const MULTI_LINE_JSON_ARGUMENT_TAGS: ReadonlySet<string> = new Set([
+  "const",
+  "defaultValue",
+  "enumOptions",
+  "example",
+]);
+
 function isWhitespace(char: string | undefined): boolean {
   return char === " " || char === "\t" || char === "\n" || char === "\r";
 }
@@ -143,6 +156,19 @@ function trimTrailingWhitespace(lineText: string, end: number): number {
   return cursor;
 }
 
+function startsWithJsonOpener(text: string): boolean {
+  const first = text.trimStart()[0];
+  return first === "[" || first === "{";
+}
+
+function startsWithFreshBlockTag(lineText: string): boolean {
+  let cursor = 0;
+  while (cursor < lineText.length && isWhitespace(lineText[cursor])) {
+    cursor += 1;
+  }
+  return isTagStart(lineText, cursor);
+}
+
 function spanFromLine(
   line: CommentLineProjection,
   start: number,
@@ -162,6 +188,80 @@ function spanFromLine(
   return {
     start: baseOffset + rawStart,
     end: baseOffset + rawEnd,
+  };
+}
+
+function findMultiLineJsonArgument(
+  lines: readonly CommentLineProjection[],
+  startLineIndex: number,
+  valueStart: number,
+  firstLineValueEnd: number
+): MultiLineJsonArgument | null {
+  const firstLine = lines[startLineIndex];
+  if (
+    firstLine === undefined ||
+    !startsWithJsonOpener(firstLine.text.slice(valueStart, firstLineValueEnd))
+  ) {
+    return null;
+  }
+
+  const balanceTracker = createJsonLikeBalanceTracker();
+  const pieces: string[] = [];
+  const rawOffsets: number[] = [];
+  let rawEnd = firstLine.rawContentEnd;
+
+  for (let lineIndex = startLineIndex; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    if (line === undefined) {
+      continue;
+    }
+
+    if (lineIndex > startLineIndex && startsWithFreshBlockTag(line.text)) {
+      return null;
+    }
+
+    const pieceStart = lineIndex === startLineIndex ? valueStart : 0;
+    if (lineIndex > startLineIndex) {
+      pieces.push("\n");
+      rawOffsets.push(-1);
+    }
+
+    const pieceEnd = lineIndex === startLineIndex ? firstLineValueEnd : line.text.length;
+    for (let index = pieceStart; index < pieceEnd; index += 1) {
+      rawOffsets.push(line.rawOffsets[index] ?? line.rawContentEnd);
+    }
+    const piece = line.text.slice(pieceStart, pieceEnd);
+    pieces.push(piece);
+    rawEnd =
+      pieceEnd >= line.text.length
+        ? line.rawContentEnd
+        : (line.rawOffsets[pieceEnd - 1] ?? line.rawContentEnd - 1) + 1;
+
+    const balancedEnd = balanceTracker.append(piece);
+    if (balancedEnd === null) {
+      continue;
+    }
+    const projectedArgumentText = pieces.join("");
+    const trailingText = projectedArgumentText.slice(balancedEnd);
+    if (trailingText.trim() === "") {
+      const closeRawOffset = rawOffsets[balancedEnd - 1];
+      if (closeRawOffset !== undefined && closeRawOffset >= 0) {
+        return {
+          argumentText: projectedArgumentText.slice(0, balancedEnd),
+          rawEnd: closeRawOffset + 1,
+        };
+      }
+    }
+
+    return {
+      argumentText: projectedArgumentText,
+      rawEnd,
+    };
+  }
+
+  return {
+    argumentText: pieces.join(""),
+    rawEnd,
   };
 }
 
@@ -305,13 +405,23 @@ export function parseCommentBlock(
 ): ParsedCommentBlock {
   const tags: ParsedCommentTag[] = [];
   const baseOffset = options?.offset ?? 0;
+  const lines = projectCommentLines(commentText);
+  let consumedRawUntil = -1;
 
-  for (const line of projectCommentLines(commentText)) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    if (line === undefined) {
+      continue;
+    }
     const tagStarts = collectTagStarts(line.text);
 
     for (let tagIndex = 0; tagIndex < tagStarts.length; tagIndex += 1) {
       const tagStart = tagStarts[tagIndex];
       if (tagStart === undefined) {
+        continue;
+      }
+      const tagStartRaw = line.rawOffsets[tagStart];
+      if (tagStartRaw === undefined || tagStartRaw < consumedRawUntil) {
         continue;
       }
 
@@ -343,14 +453,41 @@ export function parseCommentBlock(
         }
       }
 
-      const payloadSpan =
+      let payloadSpan =
         payloadStart < trimmedTagSegmentEnd
           ? spanFromLine(line, payloadStart, trimmedTagSegmentEnd, baseOffset)
           : null;
-      const valueSpan =
+      let valueSpan =
         valueStart < trimmedTagSegmentEnd
           ? spanFromLine(line, valueStart, trimmedTagSegmentEnd, baseOffset)
           : null;
+      let fullSpan = spanFromLine(line, tagStart, trimmedTagSegmentEnd, baseOffset);
+      let argumentText =
+        valueSpan === null
+          ? ""
+          : commentText.slice(valueSpan.start - baseOffset, valueSpan.end - baseOffset);
+
+      if (
+        valueSpan !== null &&
+        MULTI_LINE_JSON_ARGUMENT_TAGS.has(canonicalName) &&
+        startsWithJsonOpener(line.text.slice(valueStart, trimmedTagSegmentEnd))
+      ) {
+        const multiLineArgument = findMultiLineJsonArgument(
+          lines,
+          lineIndex,
+          valueStart,
+          trimmedTagSegmentEnd
+        );
+        if (multiLineArgument !== null && multiLineArgument.rawEnd >= valueSpan.end - baseOffset) {
+          const absoluteEnd = baseOffset + multiLineArgument.rawEnd;
+          valueSpan = { start: valueSpan.start, end: absoluteEnd };
+          payloadSpan =
+            payloadSpan === null ? null : { start: payloadSpan.start, end: absoluteEnd };
+          fullSpan = { start: fullSpan.start, end: absoluteEnd };
+          argumentText = multiLineArgument.argumentText;
+          consumedRawUntil = Math.max(consumedRawUntil, multiLineArgument.rawEnd);
+        }
+      }
 
       const parsedTarget =
         target === null
@@ -369,16 +506,13 @@ export function parseCommentBlock(
         rawTagName: rawName,
         normalizedTagName: canonicalName,
         recognized: getTagDefinition(canonicalName, options?.extensions) !== null,
-        fullSpan: spanFromLine(line, tagStart, trimmedTagSegmentEnd, baseOffset),
+        fullSpan,
         tagNameSpan: spanFromLine(line, tagStart, tagEnd, baseOffset),
         payloadSpan,
         colonSpan: parsedTarget?.colonSpan ?? null,
         target: parsedTarget,
         argumentSpan: valueSpan,
-        argumentText:
-          valueSpan === null
-            ? ""
-            : commentText.slice(valueSpan.start - baseOffset, valueSpan.end - baseOffset),
+        argumentText,
       });
     }
   }

--- a/packages/analysis/src/json-like-balance.ts
+++ b/packages/analysis/src/json-like-balance.ts
@@ -1,0 +1,128 @@
+/**
+ * Classifies whether a JSON-shaped tag argument has balanced bracket/brace
+ * delimiters before the JSON parser decides whether the value is valid JSON.
+ *
+ * This deliberately does not validate JSON syntax. Balanced-but-invalid JSON
+ * such as `[1,2,]` must still reach the existing raw-string fallback paths.
+ *
+ * @internal
+ */
+type JsonLikeBalanceStatus = "not-json-like" | "balanced" | "unbalanced";
+
+function expectedCloseFor(open: string): "]" | "}" | null {
+  if (open === "[") return "]";
+  if (open === "{") return "}";
+  return null;
+}
+
+/**
+ * Incrementally tracks bracket/brace balance for a JSON-shaped text stream.
+ *
+ * @internal
+ */
+export function createJsonLikeBalanceTracker(): { append(text: string): number | null } {
+  const expectedClosers: string[] = [];
+  let offset = 0;
+  let started = false;
+  let failed = false;
+  let inString = false;
+  let escaped = false;
+  let balancedEnd: number | null = null;
+
+  return {
+    append(text: string): number | null {
+      if (failed || balancedEnd !== null) {
+        offset += text.length;
+        return balancedEnd;
+      }
+
+      for (let localIndex = 0; localIndex < text.length; localIndex += 1) {
+        const char = text[localIndex];
+        const absoluteEnd = offset + localIndex + 1;
+
+        if (!started) {
+          if (char === " " || char === "\t" || char === "\n" || char === "\r") {
+            continue;
+          }
+
+          const firstExpectedClose = expectedCloseFor(char ?? "");
+          if (firstExpectedClose === null) {
+            failed = true;
+            continue;
+          }
+
+          expectedClosers.push(firstExpectedClose);
+          started = true;
+          continue;
+        }
+
+        if (inString) {
+          if (escaped) {
+            escaped = false;
+          } else if (char === "\\") {
+            escaped = true;
+          } else if (char === '"') {
+            inString = false;
+          }
+          continue;
+        }
+
+        if (char === '"') {
+          inString = true;
+          continue;
+        }
+
+        const openerExpectedClose = expectedCloseFor(char ?? "");
+        if (openerExpectedClose !== null) {
+          expectedClosers.push(openerExpectedClose);
+          continue;
+        }
+
+        if (char === "]" || char === "}") {
+          const expected = expectedClosers.pop();
+          if (expected !== char) {
+            failed = true;
+            continue;
+          }
+          if (expectedClosers.length === 0) {
+            balancedEnd = absoluteEnd;
+            break;
+          }
+        }
+      }
+
+      offset += text.length;
+      return balancedEnd;
+    },
+  };
+}
+
+/**
+ * Finds the one-past-the-end offset of the first balanced JSON-shaped bracket
+ * structure in text, starting at the first non-whitespace character.
+ *
+ * @internal
+ */
+function findJsonLikeBalancedEnd(rawArgumentText: string): number | null {
+  return createJsonLikeBalanceTracker().append(rawArgumentText);
+}
+
+/**
+ * Returns whether a raw argument begins with a bracketed JSON-shaped structure
+ * and, if so, whether that structure is balanced. "Unbalanced" covers both
+ * missing closing delimiters and mismatched delimiters.
+ *
+ * @internal
+ */
+export function getJsonLikeBalanceStatus(rawArgumentText: string): JsonLikeBalanceStatus {
+  const start = rawArgumentText.search(/\S/u);
+  if (start < 0) {
+    return "not-json-like";
+  }
+
+  if (expectedCloseFor(rawArgumentText[start] ?? "") === null) {
+    return "not-json-like";
+  }
+
+  return findJsonLikeBalancedEnd(rawArgumentText) === null ? "unbalanced" : "balanced";
+}

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -1,6 +1,7 @@
 import type { JsonValue } from "@formspec/core/internals";
 import { BUILTIN_CONSTRAINT_DEFINITIONS } from "@formspec/core/internals";
 import { parseTagSyntax, type ParsedCommentTag } from "./comment-syntax.js";
+import { getJsonLikeBalanceStatus } from "./json-like-balance.js";
 
 /**
  * Discriminates between "build" (compile-time via tsdoc-parser.ts) and
@@ -375,9 +376,9 @@ function parseEnumOptionsArgument(rawArgumentText: string): TagArgumentParseResu
  *   downstream IR compatibility check decides if the raw string matches the
  *   target type (semantic-targets.ts:~1255-1298).
  *
- * Note: parseTagSyntax truncates multi-line JSON at the first newline before
- * this parser runs (upstream issue #327 / PR #314 pin), so `@const [\n1,\n2\n]`
- * arrives as `"["` and hits the fallback path intentionally.
+ * JSON-shaped payloads with unbalanced brackets/braces are argument errors
+ * instead of raw-string fallbacks. Balanced-but-invalid JSON still falls back
+ * to a raw string to preserve existing `@const` semantics.
  */
 function parseConstArgument(rawArgumentText: string): TagArgumentParseResult {
   const trimmed = rawArgumentText.trim();
@@ -388,6 +389,16 @@ function parseConstArgument(rawArgumentText: string): TagArgumentParseResult {
       diagnostic: {
         code: TAG_ARGUMENT_DIAGNOSTIC_CODES.MISSING_TAG_ARGUMENT,
         message: "Expected a JSON value for @const.",
+      },
+    };
+  }
+
+  if (getJsonLikeBalanceStatus(rawArgumentText) === "unbalanced") {
+    return {
+      ok: false,
+      diagnostic: {
+        code: TAG_ARGUMENT_DIAGNOSTIC_CODES.INVALID_TAG_ARGUMENT,
+        message: "Expected a balanced JSON value for @const.",
       },
     };
   }

--- a/packages/analysis/src/tag-value-parser.ts
+++ b/packages/analysis/src/tag-value-parser.ts
@@ -15,6 +15,7 @@ import {
   type TypeNode,
 } from "@formspec/core/internals";
 import { parseTagSyntax } from "./comment-syntax.js";
+import { getJsonLikeBalanceStatus } from "./json-like-balance.js";
 
 const NUMERIC_CONSTRAINT_MAP: Record<string, NumericConstraintNode["constraintKind"]> = {
   minimum: "minimum",
@@ -163,6 +164,9 @@ export function parseConstraintTagValue(
     if (tagName === "const") {
       const trimmedText = effectiveText.trim();
       if (trimmedText === "") {
+        return null;
+      }
+      if (getJsonLikeBalanceStatus(effectiveText) === "unbalanced") {
         return null;
       }
 

--- a/packages/analysis/tests/comment-syntax.test.ts
+++ b/packages/analysis/tests/comment-syntax.test.ts
@@ -267,6 +267,140 @@ describe("parseCommentBlock", () => {
     expect(result.tags[0]?.argumentText).toBe('[{"value": "a"}]');
   });
 
+  it.each([
+    {
+      name: "arrays",
+      comment: "/**\n * @const [\n * 1,\n * 2\n * ]\n */",
+      expected: "[\n1,\n2\n]",
+    },
+    {
+      name: "objects",
+      comment: '/**\n * @const {\n * "a": 1,\n * "b": 2\n * }\n */',
+      expected: '{\n"a": 1,\n"b": 2\n}',
+    },
+    {
+      name: "nested values",
+      comment: '/**\n * @const {\n * "items": [\n * {"id": 1}\n * ]\n * }\n */',
+      expected: '{\n"items": [\n{"id": 1}\n]\n}',
+    },
+    {
+      name: "brackets inside strings",
+      comment: '/**\n * @const {\n * "text": "has [brackets] inside"\n * }\n */',
+      expected: '{\n"text": "has [brackets] inside"\n}',
+    },
+    {
+      name: "escaped quotes inside strings",
+      comment: '/**\n * @const {\n * "q": "contains \\"quote\\""\n * }\n */',
+      expected: '{\n"q": "contains \\"quote\\""\n}',
+    },
+  ])("preserves multi-line JSON $name as one bracketed argument", ({ comment, expected }) => {
+    const result = parseCommentBlock(comment);
+
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0]?.argumentText).toBe(expected);
+  });
+
+  it("continues parsing following block tags after a multi-line JSON argument", () => {
+    const comment = '/**\n * First summary line.\n * @const {\n * "a": 1\n * }\n * @minimum 0\n */';
+    const result = parseCommentBlock(comment);
+
+    expect(result.tags).toHaveLength(2);
+    expect(result.tags[0]?.normalizedTagName).toBe("const");
+    expect(result.tags[0]?.argumentText).toBe('{\n"a": 1\n}');
+    expect(result.tags[1]?.normalizedTagName).toBe("minimum");
+    expect(result.tags[1]?.argumentText).toBe("0");
+  });
+
+  it("continues parsing following same-line tags after JSON-shaped arguments", () => {
+    const comment = '/** @const {"a":1} @minimum 0 */';
+    const result = parseCommentBlock(comment);
+
+    expect(result.tags).toHaveLength(2);
+    expect(result.tags[0]?.normalizedTagName).toBe("const");
+    expect(result.tags[0]?.argumentText).toBe('{"a":1}');
+    expect(result.tags[1]?.normalizedTagName).toBe("minimum");
+    expect(result.tags[1]?.argumentText).toBe("0");
+  });
+
+  it("expands all source spans for multi-line JSON arguments", () => {
+    const offset = 50;
+    const comment = '/**\n * @const {\n * "a": 1\n * }\n * @minimum 0\n */';
+    const result = parseCommentBlock(comment, { offset });
+    const [constTag, minimumTag] = result.tags;
+    const sliceSpan = (span: { start: number; end: number } | null): string | null =>
+      span === null ? null : comment.slice(span.start - offset, span.end - offset);
+
+    expect(constTag?.argumentText).toBe('{\n"a": 1\n}');
+    expect(sliceSpan(constTag?.argumentSpan ?? null)).toBe('{\n * "a": 1\n * }');
+    expect(sliceSpan(constTag?.payloadSpan ?? null)).toBe('{\n * "a": 1\n * }');
+    expect(sliceSpan(constTag?.fullSpan ?? null)).toBe('@const {\n * "a": 1\n * }');
+    expect(minimumTag?.argumentText).toBe("0");
+  });
+
+  it("preserves multi-line @defaultValue JSON payloads", () => {
+    const comment = '/**\n * @defaultValue {\n * "enabled": true\n * }\n */';
+    const result = parseCommentBlock(comment);
+
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0]?.normalizedTagName).toBe("defaultValue");
+    expect(result.tags[0]?.argumentText).toBe('{\n"enabled": true\n}');
+  });
+
+  it("preserves multi-line @example JSON payloads", () => {
+    const comment = '/**\n * @example [\n * "draft",\n * "sent"\n * ]\n */';
+    const result = parseCommentBlock(comment);
+
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0]?.normalizedTagName).toBe("example");
+    expect(result.tags[0]?.argumentText).toBe('[\n"draft",\n"sent"\n]');
+  });
+
+  it("keeps trailing text after a multi-line JSON close in the argument", () => {
+    const comment = "/**\n * @const [\n * 1\n * ] trailing\n */";
+    const result = parseCommentBlock(comment);
+
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0]?.argumentText).toBe("[\n1\n] trailing");
+  });
+
+  it("leaves a new block tag visible when a JSON-shaped argument is unterminated", () => {
+    const comment = "/**\n * @const [\n * 1,\n * @minimum 0\n */";
+    const result = parseCommentBlock(comment);
+
+    expect(result.tags).toHaveLength(2);
+    expect(result.tags[0]?.normalizedTagName).toBe("const");
+    expect(result.tags[0]?.argumentText).toBe("[");
+    expect(result.tags[1]?.normalizedTagName).toBe("minimum");
+    expect(result.tags[1]?.argumentText).toBe("0");
+  });
+
+  it("does not sweep non-JSON multi-line tags into the first argument", () => {
+    const comment = "/**\n * @minimum 0\n * @maximum 10\n */";
+    const result = parseCommentBlock(comment);
+
+    expect(result.tags).toHaveLength(2);
+    expect(result.tags[0]?.argumentText).toBe("0");
+    expect(result.tags[1]?.argumentText).toBe("10");
+  });
+
+  it("does not truncate non-JSON text that starts with balanced brackets", () => {
+    const result = parseCommentBlock(
+      "/** @displayName :plural [Customer Names](https://example.com) */"
+    );
+
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0]?.argumentText).toBe("[Customer Names](https://example.com)");
+  });
+
+  it("does not sweep multi-line bracketed text for non-JSON-valued tags", () => {
+    const result = parseCommentBlock(
+      "/**\n * @displayName :plural [\n * Customer Names\n * ]\n */"
+    );
+
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0]?.argumentText).toBe("[");
+  });
+
   // ---------------------------------------------------------------------------
   // recognized field
   // ---------------------------------------------------------------------------

--- a/packages/analysis/tests/tag-argument-parser.test.ts
+++ b/packages/analysis/tests/tag-argument-parser.test.ts
@@ -674,9 +674,6 @@ describe("parseTagArgument", () => {
   });
 
   describe("json-value-with-fallback (@const)", () => {
-    // Upstream parseTagSyntax truncates multi-line tag arguments at the first
-    // newline (Issue #327 / PR #314 pin). See the truncation pinning test below.
-
     function expectJsonValue(text: string, expected: unknown): void {
       const result = parseTagArgument("const", text, "build");
       expect(result.ok, `expected ok=true for input: ${JSON.stringify(text)}`).toBe(true);
@@ -736,12 +733,30 @@ describe("parseTagArgument", () => {
     it("falls back to raw string for trailing-comma array (invalid JSON)", () => {
       expectRawFallback("[1,2,]", "[1,2,]");
     });
-    it('truncated-to-"[" (Issue #327): falls back to raw-string', () => {
-      // Upstream parseTagSyntax truncates multi-line JSON at the first newline.
-      // `@const [\n1,\n2\n]` arrives here as just "[" — an incomplete JSON
-      // token that fails to parse. Pin that behavior here so a fix to #327
-      // is immediately visible at this layer.
-      expectRawFallback("[", "[");
+    it("rejects unterminated JSON-shaped arrays", () => {
+      const result = parseTagArgument("const", "[\n1,\n2", "build");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+        expect(result.diagnostic.message).toContain("@const");
+      }
+    });
+    it("rejects unterminated JSON-shaped objects", () => {
+      const result = parseTagArgument("const", '{"a": 1', "build");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+      }
+    });
+    it.each(["[}", '{"a": ]'])("rejects mismatched JSON-shaped delimiters (%s)", (text) => {
+      const result = parseTagArgument("const", text, "build");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostic.code).toBe("INVALID_TAG_ARGUMENT");
+      }
     });
     it("returns MISSING_TAG_ARGUMENT for empty string", () => {
       const result = parseTagArgument("const", "", "build");

--- a/packages/analysis/tests/tag-value-parser.test.ts
+++ b/packages/analysis/tests/tag-value-parser.test.ts
@@ -126,23 +126,22 @@ describe("tag-value-parser", () => {
       });
     });
 
-    it("truncates multi-line JSON to first line and raw-string falls back (@const [\\n1,\\n2\\n])", () => {
-      // parseTagSyntax operates on the first line only — newlines are treated as
-      // tag-block terminators. The text reaching the JSON.parse try is "[" (just
-      // the opening bracket), which fails to parse, so the catch branch returns
-      // the trimmed first-line text verbatim as the const value.
-      // TODO: Phase 1 typed parser should decide whether to propagate this
-      // truncation or to accept multi-line spans. See
-      // docs/refactors/synthetic-checker-retirement.md §9.1 #5.
+    it("parses multi-line JSON arrays (@const [\\n1,\\n2\\n])", () => {
       const parsed = parseConstraintTagValue("const", "[\n1,\n2\n]", PROVENANCE);
 
       expect(parsed).not.toBeNull();
       expect(parsed).toEqual({
         kind: "constraint",
         constraintKind: "const",
-        value: "[",
+        value: [1, 2],
         provenance: PROVENANCE,
       });
+    });
+
+    it("rejects unterminated JSON-shaped @const payloads", () => {
+      const parsed = parseConstraintTagValue("const", "[\n1,\n2", PROVENANCE);
+
+      expect(parsed).toBeNull();
     });
 
     it("falls back to raw string for trailing-comma array (@const [1,2,])", () => {

--- a/packages/analysis/tests/typed-parser-snapshot-canaries.test.ts
+++ b/packages/analysis/tests/typed-parser-snapshot-canaries.test.ts
@@ -137,6 +137,33 @@ describe("@uniqueItems typed-parser Role-C canaries (snapshot consumer)", () => 
       "Expected no TYPE_MISMATCH — synthetic checker must not run after Role-C rejection"
     ).toBe(false);
   });
+
+  it("emits INVALID_TAG_ARGUMENT for unterminated multi-line @const JSON", () => {
+    const source = [
+      "class Form {",
+      "  /**",
+      "   * @const [",
+      "   * 1,",
+      "   * 2",
+      "   */",
+      "  value!: string;",
+      "}",
+    ].join("\n");
+
+    const { checker, sourceFile } = createProgram(
+      source,
+      "/virtual/snapshot-canary-const-multiline-unterminated.ts"
+    );
+    const snapshot = buildFormSpecAnalysisFileSnapshot(sourceFile, { checker });
+    const invalidArgDiags = snapshot.diagnostics.filter(
+      (diagnostic) => diagnostic.code === "INVALID_TAG_ARGUMENT"
+    );
+
+    expect(
+      invalidArgDiags,
+      "Expected unterminated multi-line @const JSON to reject through the source diagnostic path"
+    ).toHaveLength(1);
+  });
 });
 
 // =============================================================================

--- a/packages/build/tests/ir-jsdoc-constraints.test.ts
+++ b/packages/build/tests/ir-jsdoc-constraints.test.ts
@@ -279,6 +279,50 @@ describe("extractJSDocConstraintNodes", () => {
     });
   });
 
+  it("produces ConstConstraintNode for multi-line @const JSON arrays", () => {
+    const prop = getPropertyFromSource(`
+      class Foo {
+        /**
+         * @const [
+         * 1,
+         * 2
+         * ]
+         */
+        x!: unknown;
+      }
+    `);
+
+    const result = extractJSDocConstraintNodes(prop);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      kind: "constraint",
+      constraintKind: "const",
+      value: [1, 2],
+    });
+  });
+
+  it("produces ConstConstraintNode for multi-line @const JSON objects", () => {
+    const prop = getPropertyFromSource(`
+      class Foo {
+        /**
+         * @const {
+         *   "enabled": true,
+         *   "mode": "email"
+         * }
+         */
+        x!: unknown;
+      }
+    `);
+
+    const result = extractJSDocConstraintNodes(prop);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      kind: "constraint",
+      constraintKind: "const",
+      value: { enabled: true, mode: "email" },
+    });
+  });
+
   it("preserves falsy JSON values for @const", () => {
     const zeroProp = getPropertyFromSource(`
       class Foo {


### PR DESCRIPTION
## Summary
- support bracket-aware multi-line JSON tag arguments for `@const`, `@defaultValue`, `@example`, and `@enumOptions`
- reject unterminated JSON-shaped `@const` arguments through `INVALID_TAG_ARGUMENT` while preserving raw-string fallbacks for non-JSON and balanced invalid JSON
- add parser, typed-parser, build consumer, and source diagnostic coverage plus a patch changeset for affected published packages

Closes #327.

## Test plan
- `pnpm --filter @formspec/analysis exec vitest run tests/comment-syntax.test.ts tests/tag-argument-parser.test.ts tests/tag-value-parser.test.ts tests/typed-parser-snapshot-canaries.test.ts`
- `pnpm --filter @formspec/analysis run build && pnpm --filter @formspec/build exec vitest run tests/ir-jsdoc-constraints.test.ts`
- `pnpm run build`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run typecheck`
- `pnpm run knip`
- `CHANGED_FILES="$( (git diff --name-only origin/main...HEAD; git diff --name-only) | sort -u )" node .github/scripts/check-changesets.mjs`
- `pnpm exec prettier --check packages/analysis/src/comment-syntax.ts packages/analysis/src/json-like-balance.ts packages/analysis/src/tag-argument-parser.ts packages/analysis/src/tag-value-parser.ts packages/analysis/tests/comment-syntax.test.ts packages/analysis/tests/tag-argument-parser.test.ts packages/analysis/tests/tag-value-parser.test.ts packages/analysis/tests/typed-parser-snapshot-canaries.test.ts packages/build/tests/ir-jsdoc-constraints.test.ts .changeset/large-masks-sort.md`
- `git diff --check`
