### PR TITLE
Reconcile ESLint rule inventory

### DIFF
--- a/.changeset/issue-433-eslint-rule-inventory.md
+++ b/.changeset/issue-433-eslint-rule-inventory.md
@@ -1,0 +1,9 @@
+---
+"@formspec/eslint-plugin": minor
+---
+
+Reconcile the public ESLint rule inventory with the tooling spec.
+
+- Add canonical rule IDs `formspec/documentation/no-unsupported-description-tag`, `formspec/dsl-policy/allowed-field-types`, and `formspec/dsl-policy/allowed-layouts`.
+- Keep `formspec/constraint-validation/no-description-tag`, `formspec/constraints-allowed-field-types`, and `formspec/constraints-allowed-layouts` as deprecated aliases for existing ESLint configs.
+- Enable `formspec/tag-recognition/no-markdown-formatting` as a warning in `recommended` and an error in `strict`, and enable the DSL-policy rules in both presets.

--- a/docs/004-tooling.md
+++ b/docs/004-tooling.md
@@ -173,7 +173,7 @@ This phase validates constraint composition across the resolved IR nodes:
    - Array length: `@minItems` > `@maxItems`
    - Rule effects: `@showWhen` + `@hideWhen` on same field; `@enableWhen` + `@disableWhen`
 3. Checks for duplicate tags where only one instance is meaningful (producing `DUPLICATE_TAG`)
-4. Checks for missing summary text when `@remarks` is present (producing `REMARKS_WITHOUT_SUMMARY`)
+4. Reserves future documentation-hygiene diagnostics such as `REMARKS_WITHOUT_SUMMARY`
 5. Checks for unsupported `@description` tag usage (producing `UNSUPPORTED_DESCRIPTION_TAG`)
 6. Propagates constraints through the type inheritance chain when type context is available, detecting cross-type contradictions (producing `CONSTRAINT_CONTRADICTION` with both source locations per D2)
 
@@ -224,19 +224,21 @@ The pipeline is pure and stateless per invocation — no ambient configuration, 
 
 ## 3. ESLint Rule Architecture
 
-Per A7, ESLint owns all validation and auto-fix logic. The `@formspec/eslint-plugin` package provides a comprehensive rule set organized into categories that mirror the 002 §6 diagnostic code categories.
+Per A7, ESLint owns all validation and auto-fix logic. The `@formspec/eslint-plugin` package provides a comprehensive rule set organized into categories for TSDoc diagnostics, documentation hygiene, and DSL-policy enforcement.
 
 ### 3.1 Rule Categories
 
-Each rule category maps directly to a diagnostic category from 002 §6:
+Each rule category maps to either a diagnostic category from 002 §6 or an authoring-policy domain:
 
-| Rule category           | Diagnostic families                                                                                                  | Responsibility                                                               |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `tag-recognition`       | `UNKNOWN_TAG`, `MISSING_TAG_ARGUMENT`, `TAG_DISABLED`, `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE`, `SYNTHETIC_SETUP_FAILURE` | Unknown tags, missing arguments, disabled tags, and extension setup failures |
-| `value-parsing`         | `INVALID_NUMERIC_VALUE`, `INVALID_NON_NEGATIVE_INTEGER`, related                                                     | Malformed numeric, regex, JSON, and date values                              |
-| `type-compatibility`    | `TYPE_MISMATCH`                                                                                                      | Tags applied to incompatible field types                                     |
-| `target-resolution`     | `UNKNOWN_PATH_TARGET`, `UNKNOWN_MEMBER_TARGET`, related                                                              | Invalid path-target and member-target references                             |
-| `constraint-validation` | `CONSTRAINT_CONTRADICTION`, `DUPLICATE_TAG`, related                                                                 | Contradictions, duplicates, rule effect conflicts                            |
+| Rule category           | Diagnostic families                                                                                   | Responsibility                                                        |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `tag-recognition`       | `UNKNOWN_TAG`, `MISSING_TAG_ARGUMENT`, `TAG_DISABLED`, `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE`, related    | Unknown tags, missing arguments, disabled tags, and extension setup   |
+| `value-parsing`         | `INVALID_NUMERIC_VALUE`, `INVALID_NON_NEGATIVE_INTEGER`, related                                      | Malformed numeric, regex, JSON, and date values                       |
+| `type-compatibility`    | `TYPE_MISMATCH`                                                                                       | Tags applied to incompatible field types                              |
+| `target-resolution`     | `UNKNOWN_PATH_TARGET`, `UNKNOWN_MEMBER_TARGET`, related                                               | Invalid path-target and member-target references                      |
+| `constraint-validation` | `CONSTRAINT_CONTRADICTION`, `DUPLICATE_TAG`, discriminator diagnostics, related                       | Contradictions, duplicates, discriminator structure, rule conflicts   |
+| `documentation`         | `UNSUPPORTED_DESCRIPTION_TAG`, future documentation-hygiene diagnostics                               | Documentation-specific TSDoc usage                                    |
+| `dsl-policy`            | DSL-policy rule message IDs such as `disallowedFieldType`, `disallowedGroup`, `disallowedConditional` | Project policy over allowed Chain DSL field types and layout features |
 
 Rules within each category are named `formspec/<category>/<specific-rule>`, for example:
 
@@ -244,7 +246,7 @@ Rules within each category are named `formspec/<category>/<specific-rule>`, for 
 - `formspec/type-compatibility/tag-type-check`
 - `formspec/target-resolution/valid-path-target`
 
-Declaration-level tags such as `@discriminator` are validated by the same pipeline and surfaced through the same rule categories: placement and target issues are reported through target-resolution/type-compatibility checks, while duplicate occurrences continue to use `constraint-validation/no-duplicate-tags`.
+Declaration-level tags such as `@discriminator` are validated by the same pipeline. Discriminator placement, target, source operand, and target-field shape issues are surfaced through `constraint-validation/valid-discriminator`, while duplicate occurrences continue to use `constraint-validation/no-duplicate-tags`.
 
 ### 3.2 How Rules Consume the IR
 
@@ -300,31 +302,44 @@ const noContradictions: Rule.RuleModule = {
 
 ### 3.3 Built-In Rule Set
 
-The built-in rules cover all diagnostic codes defined in 002 §6. They are grouped into the recommended configuration (`formspec/recommended`) and a stricter configuration (`formspec/strict`) that upgrades configurable warnings to errors.
+The active built-in rules define the current public rule inventory for implemented tooling diagnostics and DSL-policy checks. They are grouped into the recommended configuration (`formspec/recommended`) and a stricter configuration (`formspec/strict`) that upgrades configurable warnings to errors.
 
 **`formspec/recommended` rule set:**
 
-| Rule                                           | Codes                                                                                                                                                                    | Default severity |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
-| `tag-recognition/no-unknown-tags`              | `UNKNOWN_TAG`                                                                                                                                                            | warn             |
-| `tag-recognition/require-tag-arguments`        | `MISSING_TAG_ARGUMENT`                                                                                                                                                   | error            |
-| `tag-recognition/no-disabled-tags`             | `TAG_DISABLED`                                                                                                                                                           | warn             |
-| `value-parsing/valid-numeric-value`            | `INVALID_NUMERIC_VALUE`                                                                                                                                                  | error            |
-| `value-parsing/valid-integer-value`            | `INVALID_NON_NEGATIVE_INTEGER`                                                                                                                                           | error            |
-| `value-parsing/valid-regex-pattern`            | `INVALID_REGEX_PATTERN`                                                                                                                                                  | error            |
-| `value-parsing/valid-json-value`               | `INVALID_JSON_VALUE`                                                                                                                                                     | error            |
-| `type-compatibility/tag-type-check`            | `TYPE_MISMATCH`                                                                                                                                                          | error            |
-| `target-resolution/valid-path-target`          | `UNKNOWN_PATH_TARGET`                                                                                                                                                    | error            |
-| `target-resolution/valid-member-target`        | `UNKNOWN_MEMBER_TARGET`                                                                                                                                                  | error            |
-| `target-resolution/no-unsupported-targeting`   | `UNSUPPORTED_TARGETING_SYNTAX`                                                                                                                                           | error            |
-| `target-resolution/no-member-target-on-object` | `MEMBER_TARGET_ON_NON_UNION`                                                                                                                                             | error            |
-| `target-resolution/discriminator-target`       | `INVALID_DISCRIMINATOR_TARGET`, `UNKNOWN_DISCRIMINATOR_TARGET`                                                                                                           | error            |
-| `type-compatibility/discriminator-source`      | `DISCRIMINATOR_SOURCE_NOT_TYPE_PARAMETER`, `DISCRIMINATOR_SOURCE_NOT_LOCAL_TYPE_PARAMETER`, `DISCRIMINATOR_SOURCE_UNSUPPORTED_SHAPE`, `DISCRIMINATOR_VALUE_UNRESOLVABLE` | error            |
-| `constraint-validation/no-contradictions`      | `CONSTRAINT_CONTRADICTION`                                                                                                                                               | error            |
-| `constraint-validation/no-duplicate-tags`      | `DUPLICATE_TAG`                                                                                                                                                          | warn             |
-| `documentation/remarks-without-summary`        | `REMARKS_WITHOUT_SUMMARY`                                                                                                                                                | info             |
-| `documentation/no-unsupported-description-tag` | `UNSUPPORTED_DESCRIPTION_TAG`                                                                                                                                            | error            |
-| `constraint-validation/no-contradictory-rules` | `CONTRADICTORY_RULE_EFFECTS`                                                                                                                                             | error            |
+| Rule                                                | Codes / message IDs                                                                                                                  | Default severity |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `tag-recognition/no-unknown-tags`                   | `UNKNOWN_TAG`                                                                                                                        | warn             |
+| `tag-recognition/require-tag-arguments`             | `MISSING_TAG_ARGUMENT`                                                                                                               | error            |
+| `tag-recognition/no-disabled-tags`                  | `TAG_DISABLED`                                                                                                                       | warn             |
+| `tag-recognition/no-markdown-formatting`            | `markdownFormattingForbidden`                                                                                                        | warn             |
+| `tag-recognition/tsdoc-comment-syntax`              | `tsdocSyntax`                                                                                                                        | error            |
+| `value-parsing/valid-numeric-value`                 | `INVALID_NUMERIC_VALUE`                                                                                                              | error            |
+| `value-parsing/valid-integer-value`                 | `INVALID_NON_NEGATIVE_INTEGER`                                                                                                       | error            |
+| `value-parsing/valid-regex-pattern`                 | `INVALID_REGEX_PATTERN`                                                                                                              | error            |
+| `value-parsing/valid-json-value`                    | `INVALID_JSON_VALUE`                                                                                                                 | error            |
+| `type-compatibility/tag-type-check`                 | `TYPE_MISMATCH`                                                                                                                      | error            |
+| `target-resolution/valid-path-target`               | `UNKNOWN_PATH_TARGET`                                                                                                                | error            |
+| `target-resolution/valid-member-target`             | `UNKNOWN_MEMBER_TARGET`                                                                                                              | error            |
+| `target-resolution/no-unsupported-targeting`        | `UNSUPPORTED_TARGETING_SYNTAX`                                                                                                       | error            |
+| `target-resolution/no-member-target-on-object`      | `MEMBER_TARGET_ON_NON_UNION`                                                                                                         | error            |
+| `constraint-validation/no-contradictions`           | `CONSTRAINT_CONTRADICTION`                                                                                                           | error            |
+| `constraint-validation/no-duplicate-tags`           | `DUPLICATE_TAG`                                                                                                                      | warn             |
+| `constraint-validation/no-contradictory-rules`      | `CONTRADICTORY_RULE_EFFECTS`                                                                                                         | error            |
+| `constraint-validation/valid-discriminator`         | `invalidPlacement`, `missingTarget`, `nestedTarget`, `invalidSourceOperand`, `nonLocalTypeParameter`, target-field shape diagnostics | error            |
+| `constraint-validation/no-double-underscore-fields` | `phantomField`                                                                                                                       | warn             |
+| `documentation/no-unsupported-description-tag`      | `UNSUPPORTED_DESCRIPTION_TAG`                                                                                                        | error            |
+| `dsl-policy/allowed-field-types`                    | `disallowedFieldType`                                                                                                                | error            |
+| `dsl-policy/allowed-layouts`                        | `disallowedGroup`, `disallowedConditional`                                                                                           | error            |
+
+Deprecated aliases remain registered for existing ESLint configurations, but they are not included in `formspec/recommended` or `formspec/strict`:
+
+| Deprecated rule ID                         | Replacement                                    |
+| ------------------------------------------ | ---------------------------------------------- |
+| `constraint-validation/no-description-tag` | `documentation/no-unsupported-description-tag` |
+| `constraints-allowed-field-types`          | `dsl-policy/allowed-field-types`               |
+| `constraints-allowed-layouts`              | `dsl-policy/allowed-layouts`                   |
+
+`documentation/remarks-without-summary` is specified for future documentation-hygiene work but is not part of this rule inventory.
 
 ### 3.4 Rule Configuration Interface
 
@@ -820,13 +835,13 @@ This enables the Outcome 8 scenario from 003 §6.1 without requiring the extensi
 
 ## Appendix A: Diagnostic Category Quick Reference
 
-| Category              | Representative symbolic codes                                                                                        | Responsibility                                                               |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Tag recognition       | `UNKNOWN_TAG`, `MISSING_TAG_ARGUMENT`, `TAG_DISABLED`, `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE`, `SYNTHETIC_SETUP_FAILURE` | Unknown tags, missing arguments, disabled tags, and extension setup failures |
-| Value parsing         | `INVALID_NUMERIC_VALUE`, `INVALID_REGEX_PATTERN`, related                                                            | Malformed numeric, regex, JSON, and date values                              |
-| Type compatibility    | `TYPE_MISMATCH`                                                                                                      | Tags applied to incompatible field types                                     |
-| Target resolution     | `UNKNOWN_PATH_TARGET`, `UNKNOWN_MEMBER_TARGET`, related                                                              | Invalid path-target and member-target references                             |
-| Constraint validation | `CONSTRAINT_CONTRADICTION`, `DUPLICATE_TAG`, related                                                                 | Contradictions, duplicates, rule effect conflicts                            |
+| Category              | Representative symbolic codes                                                                      | Responsibility                                                               |
+| --------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Tag recognition       | `UNKNOWN_TAG`, `MISSING_TAG_ARGUMENT`, `TAG_DISABLED`, `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE`, related | Unknown tags, missing arguments, disabled tags, and extension setup failures |
+| Value parsing         | `INVALID_NUMERIC_VALUE`, `INVALID_REGEX_PATTERN`, related                                          | Malformed numeric, regex, JSON, and date values                              |
+| Type compatibility    | `TYPE_MISMATCH`                                                                                    | Tags applied to incompatible field types                                     |
+| Target resolution     | `UNKNOWN_PATH_TARGET`, `UNKNOWN_MEMBER_TARGET`, related                                            | Invalid path-target and member-target references                             |
+| Constraint validation | `CONSTRAINT_CONTRADICTION`, `DUPLICATE_TAG`, related                                               | Contradictions, duplicates, rule effect conflicts                            |
 
 See 002 §6 for the individual diagnostic code definitions.
 

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -124,6 +124,10 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
 - Added declaration-level tooling coverage for `@discriminator`.
   - ESLint validation now includes declaration placement, duplicate detection, target-field validation, and local type-parameter validation for the discriminator surface.
   - The language server now needs tag completion, direct-property target completion, local type-parameter completion, and hover/signature help for the new tag.
+- Reconciled the ESLint rule inventory.
+  - `@description` validation now lives at `documentation/no-unsupported-description-tag`, while `constraint-validation/no-description-tag` remains a deprecated alias.
+  - Chain DSL policy rules now live under `dsl-policy/allowed-field-types` and `dsl-policy/allowed-layouts`; the previous `constraints-allowed-*` IDs remain deprecated aliases.
+  - The recommended preset includes the existing Markdown-formatting and DSL-policy rules, and stale `SYNTHETIC_SETUP_FAILURE` references were removed from 004's rule-category tables.
 
 ## 005-numeric-types.md
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -43,7 +43,7 @@ export default [
       "formspec/type-compatibility/tag-type-check": "error",
       "formspec/target-resolution/valid-path-target": "error",
       "formspec/constraint-validation/no-contradictions": "error",
-      "formspec/constraint-validation/no-description-tag": "error",
+      "formspec/documentation/no-unsupported-description-tag": "error",
     },
   },
 ];
@@ -88,14 +88,26 @@ pnpm --filter @formspec/eslint-plugin run check:eslint-docs
 
 - `constraint-validation/no-contradictions`
 - `constraint-validation/no-duplicate-tags`
-- `constraint-validation/no-description-tag`
 - `constraint-validation/no-contradictory-rules`
 - `constraint-validation/valid-discriminator`
+- `constraint-validation/no-double-underscore-fields`
 
-### `.formspec.yml` Capability Rules
+### Documentation
 
-- `constraints-allowed-field-types`
-- `constraints-allowed-layouts`
+- `documentation/no-unsupported-description-tag`
+
+### DSL Policy
+
+- `dsl-policy/allowed-field-types`
+- `dsl-policy/allowed-layouts`
+
+### Deprecated Rule IDs
+
+These legacy IDs remain registered for existing ESLint configs, but they are omitted from `recommended` and `strict`; update configs to the canonical IDs to avoid ESLint deprecation reporting.
+
+- `constraint-validation/no-description-tag` → `documentation/no-unsupported-description-tag`
+- `constraints-allowed-field-types` → `dsl-policy/allowed-field-types`
+- `constraints-allowed-layouts` → `dsl-policy/allowed-layouts`
 
 ## Base Entry Point
 
@@ -152,36 +164,42 @@ export default [...formspec.configs.recommended, { rules: { "tsdoc/syntax": "off
 
 ## Rules
 
+<!-- prettier-ignore-start -->
 <!-- begin auto-generated rules list -->
 
-🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
+❌ Deprecated.
 
-| Name                                                                                                                                                                                         | Description                                                                                        | 🔧  |
-| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- | :-- |
-| [constraint-validation/no-contradictions](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictions.md)                     | Reports contradictory FormSpec constraint combinations                                             |     |
-| [constraint-validation/no-contradictory-rules](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictory-rules.md)           | Reports contradictory FormSpec conditional rules on the same behavioral axis                       |     |
-| [constraint-validation/no-description-tag](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-description-tag.md)                   | Bans @description, which is not a standard TSDoc tag                                               |     |
-| [constraint-validation/no-double-underscore-fields](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-double-underscore-fields.md) | Warns when a property starts with "\_\_", indicating it will be excluded from the generated schema |     |
-| [constraint-validation/no-duplicate-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-duplicate-tags.md)                     | Reports duplicate FormSpec tags on the same field target                                           |     |
-| [constraint-validation/valid-discriminator](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/valid-discriminator.md)                 | Validates declaration placement, targeting, and source operands for @discriminator                 |     |
-| [constraints-allowed-field-types](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraints-allowed-field-types.md)                                     | Validates that field types are allowed by the project's constraints                                |     |
-| [constraints-allowed-layouts](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraints-allowed-layouts.md)                                             | Validates that layout constructs (group, conditionals) are allowed by the project's constraints    |     |
-| [tag-recognition/no-disabled-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-disabled-tags.md)                                   | Reports FormSpec tags disabled by project configuration                                            |     |
-| [tag-recognition/no-markdown-formatting](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-markdown-formatting.md)                       | Forbids Markdown formatting in configured FormSpec tag values                                      | 🔧  |
-| [tag-recognition/no-unknown-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-unknown-tags.md)                                     | Reports FormSpec tags that are not part of the specification                                       |     |
-| [tag-recognition/require-tag-arguments](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/require-tag-arguments.md)                         | Requires arguments for FormSpec tags that need values                                              |     |
-| [tag-recognition/tsdoc-comment-syntax](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/tsdoc-comment-syntax.md)                           | Validates TSDoc comment syntax, suppressing false positives on FormSpec raw-text tag payloads      |     |
-| [target-resolution/no-member-target-on-object](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/no-member-target-on-object.md)           | Disallows member-target syntax on non-string-literal-union fields                                  |     |
-| [target-resolution/no-unsupported-targeting](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/no-unsupported-targeting.md)               | Disallows path or member target syntax on tags that do not support it                              |     |
-| [target-resolution/valid-member-target](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/valid-member-target.md)                         | Validates member-target references against string literal union fields                             |     |
-| [target-resolution/valid-path-target](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/valid-path-target.md)                             | Validates path-target references against the resolved field type                                   |     |
-| [type-compatibility/tag-type-check](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/type-compatibility/tag-type-check.md)                                 | Ensures FormSpec tags are applied to compatible field types                                        |     |
-| [value-parsing/valid-integer-value](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-integer-value.md)                                 | Validates integer-valued FormSpec tags                                                             |     |
-| [value-parsing/valid-json-value](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-json-value.md)                                       | Validates JSON-valued FormSpec tags                                                                |     |
-| [value-parsing/valid-numeric-value](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-numeric-value.md)                                 | Validates numeric-valued FormSpec tags                                                             |     |
-| [value-parsing/valid-regex-pattern](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-regex-pattern.md)                                 | Validates @pattern tag values as regular expressions                                               |     |
+| Name                                                                                                                                                                                         | Description                                                                                      | 🔧 | ❌  |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- | :- | :- |
+| [constraint-validation/no-contradictions](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictions.md)                     | Reports contradictory FormSpec constraint combinations                                           |    |    |
+| [constraint-validation/no-contradictory-rules](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-contradictory-rules.md)           | Reports contradictory FormSpec conditional rules on the same behavioral axis                     |    |    |
+| [constraint-validation/no-description-tag](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-description-tag.md)                   | Bans @description, which is not a standard TSDoc tag                                             |    | ❌  |
+| [constraint-validation/no-double-underscore-fields](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-double-underscore-fields.md) | Warns when a property starts with "__", indicating it will be excluded from the generated schema |    |    |
+| [constraint-validation/no-duplicate-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/no-duplicate-tags.md)                     | Reports duplicate FormSpec tags on the same field target                                         |    |    |
+| [constraint-validation/valid-discriminator](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraint-validation/valid-discriminator.md)                 | Validates declaration placement, targeting, and source operands for @discriminator               |    |    |
+| [constraints-allowed-field-types](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraints-allowed-field-types.md)                                     | Validates that field types are allowed by the project's DSL policy                               |    | ❌  |
+| [constraints-allowed-layouts](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/constraints-allowed-layouts.md)                                             | Validates that layout constructs (group, conditionals) are allowed by the project's DSL policy   |    | ❌  |
+| [documentation/no-unsupported-description-tag](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/documentation/no-unsupported-description-tag.md)           | Bans @description, which is not a standard TSDoc tag                                             |    |    |
+| [dsl-policy/allowed-field-types](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/dsl-policy/allowed-field-types.md)                                       | Validates that field types are allowed by the project's DSL policy                               |    |    |
+| [dsl-policy/allowed-layouts](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/dsl-policy/allowed-layouts.md)                                               | Validates that layout constructs (group, conditionals) are allowed by the project's DSL policy   |    |    |
+| [tag-recognition/no-disabled-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-disabled-tags.md)                                   | Reports FormSpec tags disabled by project configuration                                          |    |    |
+| [tag-recognition/no-markdown-formatting](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-markdown-formatting.md)                       | Forbids Markdown formatting in configured FormSpec tag values                                    | 🔧 |    |
+| [tag-recognition/no-unknown-tags](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/no-unknown-tags.md)                                     | Reports FormSpec tags that are not part of the specification                                     |    |    |
+| [tag-recognition/require-tag-arguments](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/require-tag-arguments.md)                         | Requires arguments for FormSpec tags that need values                                            |    |    |
+| [tag-recognition/tsdoc-comment-syntax](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/tag-recognition/tsdoc-comment-syntax.md)                           | Validates TSDoc comment syntax, suppressing false positives on FormSpec raw-text tag payloads    |    |    |
+| [target-resolution/no-member-target-on-object](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/no-member-target-on-object.md)           | Disallows member-target syntax on non-string-literal-union fields                                |    |    |
+| [target-resolution/no-unsupported-targeting](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/no-unsupported-targeting.md)               | Disallows path or member target syntax on tags that do not support it                            |    |    |
+| [target-resolution/valid-member-target](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/valid-member-target.md)                         | Validates member-target references against string literal union fields                           |    |    |
+| [target-resolution/valid-path-target](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/target-resolution/valid-path-target.md)                             | Validates path-target references against the resolved field type                                 |    |    |
+| [type-compatibility/tag-type-check](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/type-compatibility/tag-type-check.md)                                 | Ensures FormSpec tags are applied to compatible field types                                      |    |    |
+| [value-parsing/valid-integer-value](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-integer-value.md)                                 | Validates integer-valued FormSpec tags                                                           |    |    |
+| [value-parsing/valid-json-value](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-json-value.md)                                       | Validates JSON-valued FormSpec tags                                                              |    |    |
+| [value-parsing/valid-numeric-value](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-numeric-value.md)                                 | Validates numeric-valued FormSpec tags                                                           |    |    |
+| [value-parsing/valid-regex-pattern](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/value-parsing/valid-regex-pattern.md)                                 | Validates @pattern tag values as regular expressions                                             |    |    |
 
 <!-- end auto-generated rules list -->
+<!-- prettier-ignore-end -->
 
 ## Example
 

--- a/packages/eslint-plugin/api-report/eslint-plugin.alpha.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.alpha.api.md
@@ -98,10 +98,8 @@ export const noContradictoryRules: ESLintUtils.RuleModule<"contradictoryRuleEffe
     name: string;
 };
 
-// @public
-export const noDescriptionTag: ESLintUtils.RuleModule<"descriptionTagForbidden", [], unknown, ESLintUtils.RuleListener> & {
-    name: string;
-};
+// @public @deprecated
+export const noDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []>;
 
 // @public
 export const noDisabledTags: NamedRuleModule<NoDisabledTagsMessageIds, NoDisabledTagsOptions>;
@@ -144,6 +142,9 @@ export const noMemberTargetOnObject: ESLintUtils.RuleModule<"memberTargetOnNonUn
 export const noUnknownTags: ESLintUtils.RuleModule<"unknownTag", [], unknown, ESLintUtils.RuleListener> & {
     name: string;
 };
+
+// @public
+export const noUnsupportedDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []>;
 
 // @public
 export const noUnsupportedTargeting: ESLintUtils.RuleModule<"unsupportedTargetingSyntax", [], unknown, ESLintUtils.RuleListener> & {
@@ -197,9 +198,6 @@ const plugin: {
         readonly "constraint-validation/no-duplicate-tags": TSESLint.RuleModule<"duplicateTag" | "duplicateDiscriminatorTag", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
-        readonly "constraint-validation/no-description-tag": TSESLint.RuleModule<"descriptionTagForbidden", [], unknown, TSESLint.RuleListener> & {
-            name: string;
-        };
         readonly "constraint-validation/no-contradictory-rules": TSESLint.RuleModule<"contradictoryRuleEffects", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
@@ -209,6 +207,10 @@ const plugin: {
         readonly "constraint-validation/no-double-underscore-fields": TSESLint.RuleModule<"phantomField", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
+        readonly "documentation/no-unsupported-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
+        readonly "dsl-policy/allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
+        readonly "dsl-policy/allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
+        readonly "constraint-validation/no-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
         readonly "constraints-allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
         readonly "constraints-allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
     };
@@ -267,9 +269,6 @@ export const rules: {
     readonly "constraint-validation/no-duplicate-tags": TSESLint.RuleModule<"duplicateTag" | "duplicateDiscriminatorTag", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
-    readonly "constraint-validation/no-description-tag": TSESLint.RuleModule<"descriptionTagForbidden", [], unknown, TSESLint.RuleListener> & {
-        name: string;
-    };
     readonly "constraint-validation/no-contradictory-rules": TSESLint.RuleModule<"contradictoryRuleEffects", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
@@ -279,6 +278,10 @@ export const rules: {
     readonly "constraint-validation/no-double-underscore-fields": TSESLint.RuleModule<"phantomField", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
+    readonly "documentation/no-unsupported-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
+    readonly "dsl-policy/allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
+    readonly "dsl-policy/allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
+    readonly "constraint-validation/no-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
     readonly "constraints-allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
     readonly "constraints-allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
 };

--- a/packages/eslint-plugin/api-report/eslint-plugin.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.api.md
@@ -102,10 +102,8 @@ export const noContradictoryRules: ESLintUtils.RuleModule<"contradictoryRuleEffe
     name: string;
 };
 
-// @public
-export const noDescriptionTag: ESLintUtils.RuleModule<"descriptionTagForbidden", [], unknown, ESLintUtils.RuleListener> & {
-    name: string;
-};
+// @public @deprecated
+export const noDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []>;
 
 // @public
 export const noDisabledTags: NamedRuleModule<NoDisabledTagsMessageIds, NoDisabledTagsOptions>;
@@ -148,6 +146,9 @@ export const noMemberTargetOnObject: ESLintUtils.RuleModule<"memberTargetOnNonUn
 export const noUnknownTags: ESLintUtils.RuleModule<"unknownTag", [], unknown, ESLintUtils.RuleListener> & {
     name: string;
 };
+
+// @public
+export const noUnsupportedDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []>;
 
 // @public
 export const noUnsupportedTargeting: ESLintUtils.RuleModule<"unsupportedTargetingSyntax", [], unknown, ESLintUtils.RuleListener> & {
@@ -201,9 +202,6 @@ const plugin: {
         readonly "constraint-validation/no-duplicate-tags": TSESLint.RuleModule<"duplicateTag" | "duplicateDiscriminatorTag", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
-        readonly "constraint-validation/no-description-tag": TSESLint.RuleModule<"descriptionTagForbidden", [], unknown, TSESLint.RuleListener> & {
-            name: string;
-        };
         readonly "constraint-validation/no-contradictory-rules": TSESLint.RuleModule<"contradictoryRuleEffects", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
@@ -213,6 +211,10 @@ const plugin: {
         readonly "constraint-validation/no-double-underscore-fields": TSESLint.RuleModule<"phantomField", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
+        readonly "documentation/no-unsupported-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
+        readonly "dsl-policy/allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
+        readonly "dsl-policy/allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
+        readonly "constraint-validation/no-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
         readonly "constraints-allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
         readonly "constraints-allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
     };
@@ -271,9 +273,6 @@ export const rules: {
     readonly "constraint-validation/no-duplicate-tags": TSESLint.RuleModule<"duplicateTag" | "duplicateDiscriminatorTag", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
-    readonly "constraint-validation/no-description-tag": TSESLint.RuleModule<"descriptionTagForbidden", [], unknown, TSESLint.RuleListener> & {
-        name: string;
-    };
     readonly "constraint-validation/no-contradictory-rules": TSESLint.RuleModule<"contradictoryRuleEffects", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
@@ -283,6 +282,10 @@ export const rules: {
     readonly "constraint-validation/no-double-underscore-fields": TSESLint.RuleModule<"phantomField", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
+    readonly "documentation/no-unsupported-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
+    readonly "dsl-policy/allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
+    readonly "dsl-policy/allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
+    readonly "constraint-validation/no-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
     readonly "constraints-allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
     readonly "constraints-allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
 };

--- a/packages/eslint-plugin/api-report/eslint-plugin.beta.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.beta.api.md
@@ -98,10 +98,8 @@ export const noContradictoryRules: ESLintUtils.RuleModule<"contradictoryRuleEffe
     name: string;
 };
 
-// @public
-export const noDescriptionTag: ESLintUtils.RuleModule<"descriptionTagForbidden", [], unknown, ESLintUtils.RuleListener> & {
-    name: string;
-};
+// @public @deprecated
+export const noDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []>;
 
 // @public
 export const noDisabledTags: NamedRuleModule<NoDisabledTagsMessageIds, NoDisabledTagsOptions>;
@@ -144,6 +142,9 @@ export const noMemberTargetOnObject: ESLintUtils.RuleModule<"memberTargetOnNonUn
 export const noUnknownTags: ESLintUtils.RuleModule<"unknownTag", [], unknown, ESLintUtils.RuleListener> & {
     name: string;
 };
+
+// @public
+export const noUnsupportedDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []>;
 
 // @public
 export const noUnsupportedTargeting: ESLintUtils.RuleModule<"unsupportedTargetingSyntax", [], unknown, ESLintUtils.RuleListener> & {
@@ -197,9 +198,6 @@ const plugin: {
         readonly "constraint-validation/no-duplicate-tags": TSESLint.RuleModule<"duplicateTag" | "duplicateDiscriminatorTag", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
-        readonly "constraint-validation/no-description-tag": TSESLint.RuleModule<"descriptionTagForbidden", [], unknown, TSESLint.RuleListener> & {
-            name: string;
-        };
         readonly "constraint-validation/no-contradictory-rules": TSESLint.RuleModule<"contradictoryRuleEffects", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
@@ -209,6 +207,10 @@ const plugin: {
         readonly "constraint-validation/no-double-underscore-fields": TSESLint.RuleModule<"phantomField", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
+        readonly "documentation/no-unsupported-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
+        readonly "dsl-policy/allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
+        readonly "dsl-policy/allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
+        readonly "constraint-validation/no-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
         readonly "constraints-allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
         readonly "constraints-allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
     };
@@ -267,9 +269,6 @@ export const rules: {
     readonly "constraint-validation/no-duplicate-tags": TSESLint.RuleModule<"duplicateTag" | "duplicateDiscriminatorTag", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
-    readonly "constraint-validation/no-description-tag": TSESLint.RuleModule<"descriptionTagForbidden", [], unknown, TSESLint.RuleListener> & {
-        name: string;
-    };
     readonly "constraint-validation/no-contradictory-rules": TSESLint.RuleModule<"contradictoryRuleEffects", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
@@ -279,6 +278,10 @@ export const rules: {
     readonly "constraint-validation/no-double-underscore-fields": TSESLint.RuleModule<"phantomField", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
+    readonly "documentation/no-unsupported-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
+    readonly "dsl-policy/allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
+    readonly "dsl-policy/allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
+    readonly "constraint-validation/no-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
     readonly "constraints-allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
     readonly "constraints-allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
 };

--- a/packages/eslint-plugin/api-report/eslint-plugin.public.api.md
+++ b/packages/eslint-plugin/api-report/eslint-plugin.public.api.md
@@ -98,10 +98,8 @@ export const noContradictoryRules: ESLintUtils.RuleModule<"contradictoryRuleEffe
     name: string;
 };
 
-// @public
-export const noDescriptionTag: ESLintUtils.RuleModule<"descriptionTagForbidden", [], unknown, ESLintUtils.RuleListener> & {
-    name: string;
-};
+// @public @deprecated
+export const noDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []>;
 
 // @public
 export const noDisabledTags: NamedRuleModule<NoDisabledTagsMessageIds, NoDisabledTagsOptions>;
@@ -144,6 +142,9 @@ export const noMemberTargetOnObject: ESLintUtils.RuleModule<"memberTargetOnNonUn
 export const noUnknownTags: ESLintUtils.RuleModule<"unknownTag", [], unknown, ESLintUtils.RuleListener> & {
     name: string;
 };
+
+// @public
+export const noUnsupportedDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []>;
 
 // @public
 export const noUnsupportedTargeting: ESLintUtils.RuleModule<"unsupportedTargetingSyntax", [], unknown, ESLintUtils.RuleListener> & {
@@ -197,9 +198,6 @@ const plugin: {
         readonly "constraint-validation/no-duplicate-tags": TSESLint.RuleModule<"duplicateTag" | "duplicateDiscriminatorTag", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
-        readonly "constraint-validation/no-description-tag": TSESLint.RuleModule<"descriptionTagForbidden", [], unknown, TSESLint.RuleListener> & {
-            name: string;
-        };
         readonly "constraint-validation/no-contradictory-rules": TSESLint.RuleModule<"contradictoryRuleEffects", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
@@ -209,6 +207,10 @@ const plugin: {
         readonly "constraint-validation/no-double-underscore-fields": TSESLint.RuleModule<"phantomField", [], unknown, TSESLint.RuleListener> & {
             name: string;
         };
+        readonly "documentation/no-unsupported-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
+        readonly "dsl-policy/allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
+        readonly "dsl-policy/allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
+        readonly "constraint-validation/no-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
         readonly "constraints-allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
         readonly "constraints-allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
     };
@@ -267,9 +269,6 @@ export const rules: {
     readonly "constraint-validation/no-duplicate-tags": TSESLint.RuleModule<"duplicateTag" | "duplicateDiscriminatorTag", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
-    readonly "constraint-validation/no-description-tag": TSESLint.RuleModule<"descriptionTagForbidden", [], unknown, TSESLint.RuleListener> & {
-        name: string;
-    };
     readonly "constraint-validation/no-contradictory-rules": TSESLint.RuleModule<"contradictoryRuleEffects", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
@@ -279,6 +278,10 @@ export const rules: {
     readonly "constraint-validation/no-double-underscore-fields": TSESLint.RuleModule<"phantomField", [], unknown, TSESLint.RuleListener> & {
         name: string;
     };
+    readonly "documentation/no-unsupported-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
+    readonly "dsl-policy/allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
+    readonly "dsl-policy/allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
+    readonly "constraint-validation/no-description-tag": NamedRuleModule<"descriptionTagForbidden", []>;
     readonly "constraints-allowed-field-types": NamedRuleModule<"disallowedFieldType", AllowedFieldTypesOptions>;
     readonly "constraints-allowed-layouts": NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions>;
 };

--- a/packages/eslint-plugin/docs/rules/constraint-validation/no-description-tag.md
+++ b/packages/eslint-plugin/docs/rules/constraint-validation/no-description-tag.md
@@ -2,4 +2,6 @@
 
 📝 Bans @description, which is not a standard TSDoc tag.
 
+❌ This rule is deprecated. It was replaced by [`@formspec/documentation/no-unsupported-description-tag`](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/documentation/no-unsupported-description-tag.md).
+
 <!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/documentation/no-unsupported-description-tag.md
+++ b/packages/eslint-plugin/docs/rules/documentation/no-unsupported-description-tag.md
@@ -1,0 +1,5 @@
+# @formspec/documentation/no-unsupported-description-tag
+
+📝 Bans @description, which is not a standard TSDoc tag.
+
+<!-- end auto-generated rule header -->

--- a/packages/eslint-plugin/docs/rules/dsl-policy/allowed-field-types.md
+++ b/packages/eslint-plugin/docs/rules/dsl-policy/allowed-field-types.md
@@ -1,8 +1,6 @@
-# @formspec/constraints-allowed-field-types
+# @formspec/dsl-policy/allowed-field-types
 
 📝 Validates that field types are allowed by the project's DSL policy.
-
-❌ This rule is deprecated. It was replaced by [`@formspec/dsl-policy/allowed-field-types`](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/dsl-policy/allowed-field-types.md).
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin/docs/rules/dsl-policy/allowed-layouts.md
+++ b/packages/eslint-plugin/docs/rules/dsl-policy/allowed-layouts.md
@@ -1,8 +1,6 @@
-# @formspec/constraints-allowed-layouts
+# @formspec/dsl-policy/allowed-layouts
 
 📝 Validates that layout constructs (group, conditionals) are allowed by the project's DSL policy.
-
-❌ This rule is deprecated. It was replaced by [`@formspec/dsl-policy/allowed-layouts`](https://github.com/mike-north/formspec/blob/main/packages/eslint-plugin/docs/rules/dsl-policy/allowed-layouts.md).
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -39,26 +39,26 @@ import {
   noUnsupportedTargeting,
   noMemberTargetOnObject,
   noDuplicateTags,
-  noDescriptionTag,
+  noUnsupportedDescriptionTag as noUnsupportedDescriptionTagRule,
   noContradictoryRules,
   validDiscriminator,
   noDoubleUnderscoreFields,
+  allowedFieldTypes as allowedFieldTypesRule,
+  allowedLayouts as allowedLayoutsRule,
   tsdocCommentSyntax as tsdocCommentSyntaxRule,
 } from "./rules/index.js";
 import {
   noContradictions as noContradictionsRule,
   type MessageIds as NoContradictionsMessageIds,
 } from "./rules/constraint-validation/no-contradictions.js";
-import {
-  allowedFieldTypes as allowedFieldTypesRule,
-  type MessageIds as AllowedFieldTypesMessageIds,
-  type Options as AllowedFieldTypesOptions,
-} from "./rules/constraints/allowed-field-types.js";
-import {
-  allowedLayouts as allowedLayoutsRule,
-  type MessageIds as AllowedLayoutsMessageIds,
-  type Options as AllowedLayoutsOptions,
-} from "./rules/constraints/allowed-layouts.js";
+import type {
+  MessageIds as AllowedFieldTypesMessageIds,
+  Options as AllowedFieldTypesOptions,
+} from "./rules/dsl-policy/allowed-field-types.js";
+import type {
+  MessageIds as AllowedLayoutsMessageIds,
+  Options as AllowedLayoutsOptions,
+} from "./rules/dsl-policy/allowed-layouts.js";
 import {
   noDisabledTags as noDisabledTagsRule,
   type MessageIds as NoDisabledTagsMessageIds,
@@ -79,6 +79,25 @@ export type NamedRuleModule<
   MessageIds extends string,
   Options extends readonly unknown[],
 > = TSESLint.RuleModule<MessageIds, Options> & { name: string };
+
+/**
+ * Creates an ESLint-visible alias without mutating the canonical rule module.
+ */
+function createDeprecatedRuleAlias<MessageIds extends string, Options extends readonly unknown[]>(
+  rule: NamedRuleModule<MessageIds, Options>,
+  name: string,
+  replacedBy: string
+): NamedRuleModule<MessageIds, Options> {
+  return {
+    ...rule,
+    name,
+    meta: {
+      ...rule.meta,
+      deprecated: true,
+      replacedBy: [replacedBy],
+    },
+  };
+}
 
 export type {
   AllowedFieldTypesMessageIds,
@@ -130,7 +149,30 @@ export const noMarkdownFormatting: NamedRuleModule<
 export const tsdocCommentSyntax: NamedRuleModule<"tsdocSyntax", []> = tsdocCommentSyntaxRule;
 
 /**
- * Validates allowed field types against project constraints.
+ * Bans `@description`, which is not a supported FormSpec documentation tag.
+ *
+ * @public
+ */
+export const noUnsupportedDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []> =
+  noUnsupportedDescriptionTagRule;
+
+const deprecatedNoDescriptionTag = createDeprecatedRuleAlias(
+  noUnsupportedDescriptionTag,
+  "constraint-validation/no-description-tag",
+  "documentation/no-unsupported-description-tag"
+);
+
+/**
+ * Deprecated alias for `documentation/no-unsupported-description-tag`.
+ *
+ * @deprecated Use `noUnsupportedDescriptionTag`.
+ * @public
+ */
+export const noDescriptionTag: NamedRuleModule<"descriptionTagForbidden", []> =
+  deprecatedNoDescriptionTag;
+
+/**
+ * Validates allowed field types against project DSL policy.
  *
  * @public
  */
@@ -140,12 +182,24 @@ export const allowedFieldTypes: NamedRuleModule<
 > = allowedFieldTypesRule;
 
 /**
- * Validates allowed layout constructs against project constraints.
+ * Validates allowed layout constructs against project DSL policy.
  *
  * @public
  */
 export const allowedLayouts: NamedRuleModule<AllowedLayoutsMessageIds, AllowedLayoutsOptions> =
   allowedLayoutsRule;
+
+const deprecatedAllowedFieldTypes = createDeprecatedRuleAlias(
+  allowedFieldTypes,
+  "constraints-allowed-field-types",
+  "dsl-policy/allowed-field-types"
+);
+
+const deprecatedAllowedLayouts = createDeprecatedRuleAlias(
+  allowedLayouts,
+  "constraints-allowed-layouts",
+  "dsl-policy/allowed-layouts"
+);
 
 /**
  * All rules provided by this plugin.
@@ -170,14 +224,17 @@ export const rules = {
   "target-resolution/no-member-target-on-object": noMemberTargetOnObject,
   "constraint-validation/no-contradictions": noContradictions,
   "constraint-validation/no-duplicate-tags": noDuplicateTags,
-  "constraint-validation/no-description-tag": noDescriptionTag,
   "constraint-validation/no-contradictory-rules": noContradictoryRules,
   "constraint-validation/valid-discriminator": validDiscriminator,
   "constraint-validation/no-double-underscore-fields": noDoubleUnderscoreFields,
+  "documentation/no-unsupported-description-tag": noUnsupportedDescriptionTag,
+  "dsl-policy/allowed-field-types": allowedFieldTypes,
+  "dsl-policy/allowed-layouts": allowedLayouts,
 
-  // Constraint rules for Chain DSL
-  "constraints-allowed-field-types": allowedFieldTypes,
-  "constraints-allowed-layouts": allowedLayouts,
+  // Deprecated aliases retained for existing ESLint configs.
+  "constraint-validation/no-description-tag": deprecatedNoDescriptionTag,
+  "constraints-allowed-field-types": deprecatedAllowedFieldTypes,
+  "constraints-allowed-layouts": deprecatedAllowedLayouts,
 } as const;
 
 /**
@@ -216,6 +273,7 @@ const recommendedConfig: TSESLint.FlatConfig.ConfigArray = [
       "formspec/tag-recognition/no-unknown-tags": "warn",
       "formspec/tag-recognition/require-tag-arguments": "error",
       "formspec/tag-recognition/no-disabled-tags": "warn",
+      "formspec/tag-recognition/no-markdown-formatting": "warn",
       "formspec/tag-recognition/tsdoc-comment-syntax": "error",
       "formspec/value-parsing/valid-numeric-value": "error",
       "formspec/value-parsing/valid-integer-value": "error",
@@ -228,10 +286,12 @@ const recommendedConfig: TSESLint.FlatConfig.ConfigArray = [
       "formspec/target-resolution/no-member-target-on-object": "error",
       "formspec/constraint-validation/no-contradictions": "error",
       "formspec/constraint-validation/no-duplicate-tags": "warn",
-      "formspec/constraint-validation/no-description-tag": "error",
       "formspec/constraint-validation/no-contradictory-rules": "error",
       "formspec/constraint-validation/valid-discriminator": "error",
       "formspec/constraint-validation/no-double-underscore-fields": "warn",
+      "formspec/documentation/no-unsupported-description-tag": "error",
+      "formspec/dsl-policy/allowed-field-types": "error",
+      "formspec/dsl-policy/allowed-layouts": "error",
     },
   },
 ];
@@ -253,6 +313,7 @@ const strictConfig: TSESLint.FlatConfig.ConfigArray = [
       "formspec/tag-recognition/no-unknown-tags": "error",
       "formspec/tag-recognition/require-tag-arguments": "error",
       "formspec/tag-recognition/no-disabled-tags": "error",
+      "formspec/tag-recognition/no-markdown-formatting": "error",
       "formspec/tag-recognition/tsdoc-comment-syntax": "error",
       "formspec/value-parsing/valid-numeric-value": "error",
       "formspec/value-parsing/valid-integer-value": "error",
@@ -265,10 +326,12 @@ const strictConfig: TSESLint.FlatConfig.ConfigArray = [
       "formspec/target-resolution/no-member-target-on-object": "error",
       "formspec/constraint-validation/no-contradictions": "error",
       "formspec/constraint-validation/no-duplicate-tags": "error",
-      "formspec/constraint-validation/no-description-tag": "error",
       "formspec/constraint-validation/no-contradictory-rules": "error",
       "formspec/constraint-validation/valid-discriminator": "error",
       "formspec/constraint-validation/no-double-underscore-fields": "error",
+      "formspec/documentation/no-unsupported-description-tag": "error",
+      "formspec/dsl-policy/allowed-field-types": "error",
+      "formspec/dsl-policy/allowed-layouts": "error",
     },
   },
 ];
@@ -358,7 +421,6 @@ export {
   noUnsupportedTargeting,
   noMemberTargetOnObject,
   noDuplicateTags,
-  noDescriptionTag,
   noContradictoryRules,
   noDoubleUnderscoreFields,
 };

--- a/packages/eslint-plugin/src/rules/constraint-validation/index.ts
+++ b/packages/eslint-plugin/src/rules/constraint-validation/index.ts
@@ -1,5 +1,4 @@
 export { noDuplicateTags } from "./no-duplicate-tags.js";
-export { noDescriptionTag } from "./no-description-tag.js";
 export { noContradictoryRules } from "./no-contradictory-rules.js";
 export { validDiscriminator } from "./valid-discriminator.js";
 export { noDoubleUnderscoreFields } from "./no-double-underscore-fields.js";

--- a/packages/eslint-plugin/src/rules/documentation/index.ts
+++ b/packages/eslint-plugin/src/rules/documentation/index.ts
@@ -1,0 +1,1 @@
+export { noUnsupportedDescriptionTag } from "./no-unsupported-description-tag.js";

--- a/packages/eslint-plugin/src/rules/documentation/no-unsupported-description-tag.ts
+++ b/packages/eslint-plugin/src/rules/documentation/no-unsupported-description-tag.ts
@@ -11,8 +11,8 @@ const createRule = ESLintUtils.RuleCreator(
  *
  * @public
  */
-export const noDescriptionTag = createRule<[], "descriptionTagForbidden">({
-  name: "constraint-validation/no-description-tag",
+export const noUnsupportedDescriptionTag = createRule<[], "descriptionTagForbidden">({
+  name: "documentation/no-unsupported-description-tag",
   meta: {
     type: "problem",
     docs: {

--- a/packages/eslint-plugin/src/rules/dsl-policy/allowed-field-types.ts
+++ b/packages/eslint-plugin/src/rules/dsl-policy/allowed-field-types.ts
@@ -1,8 +1,8 @@
 /**
- * Rule: constraints/allowed-field-types
+ * Rule: dsl-policy/allowed-field-types
  *
  * Validates that field types used in the Chain DSL are allowed by the
- * project's constraint configuration.
+ * project's DSL policy configuration.
  *
  * Works with: field.text(), field.number(), field.boolean(), field.enum(),
  * field.dynamicEnum(), field.dynamicSchema(), field.array(), field.object()
@@ -10,11 +10,7 @@
 
 import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
 import type { TSESTree } from "@typescript-eslint/utils";
-import {
-  getFieldTypeSeverity,
-  type FieldTypeConstraints,
-  type Severity as _Severity,
-} from "@formspec/config/browser";
+import { getFieldTypeSeverity, type FieldTypeConstraints } from "@formspec/config/browser";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) => `https://formspec.dev/eslint-plugin/rules/${name}`
@@ -70,11 +66,11 @@ export type Options = [FieldTypeConstraints];
  * @public
  */
 export const allowedFieldTypes = createRule<Options, MessageIds>({
-  name: "constraints-allowed-field-types",
+  name: "dsl-policy/allowed-field-types",
   meta: {
     type: "problem",
     docs: {
-      description: "Validates that field types are allowed by the project's constraints",
+      description: "Validates that field types are allowed by the project's DSL policy",
     },
     messages: {
       disallowedFieldType:

--- a/packages/eslint-plugin/src/rules/dsl-policy/allowed-layouts.ts
+++ b/packages/eslint-plugin/src/rules/dsl-policy/allowed-layouts.ts
@@ -1,8 +1,8 @@
 /**
- * Rule: constraints/allowed-layouts
+ * Rule: dsl-policy/allowed-layouts
  *
  * Validates that layout constructs (group, when/conditionals) used in the
- * Chain DSL are allowed by the project's constraint configuration.
+ * Chain DSL are allowed by the project's DSL policy configuration.
  *
  * Works with: group(), when()
  */
@@ -34,12 +34,12 @@ export type Options = [LayoutConstraints];
  * @public
  */
 export const allowedLayouts = createRule<Options, MessageIds>({
-  name: "constraints-allowed-layouts",
+  name: "dsl-policy/allowed-layouts",
   meta: {
     type: "problem",
     docs: {
       description:
-        "Validates that layout constructs (group, conditionals) are allowed by the project's constraints",
+        "Validates that layout constructs (group, conditionals) are allowed by the project's DSL policy",
     },
     messages: {
       disallowedGroup:

--- a/packages/eslint-plugin/src/rules/dsl-policy/index.ts
+++ b/packages/eslint-plugin/src/rules/dsl-policy/index.ts
@@ -1,0 +1,2 @@
+export { allowedFieldTypes } from "./allowed-field-types.js";
+export { allowedLayouts } from "./allowed-layouts.js";

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -3,3 +3,5 @@ export * from "./value-parsing/index.js";
 export * from "./type-compatibility/index.js";
 export * from "./target-resolution/index.js";
 export * from "./constraint-validation/index.js";
+export * from "./documentation/index.js";
+export * from "./dsl-policy/index.js";

--- a/packages/eslint-plugin/tests/plugin-exports.test.ts
+++ b/packages/eslint-plugin/tests/plugin-exports.test.ts
@@ -13,11 +13,63 @@ import plugin, {
   analyzeMetadataForSourceFile,
   configs,
   meta,
+  noDescriptionTag,
+  noUnsupportedDescriptionTag,
   rules,
 } from "../src/index.js";
 
 function getConfigRuleIds(config: TSESLint.FlatConfig.ConfigArray): string[] {
   return config.flatMap((entry) => Object.keys(entry.rules ?? {}));
+}
+
+const canonicalRuleIds = [
+  "tag-recognition/no-unknown-tags",
+  "tag-recognition/require-tag-arguments",
+  "tag-recognition/no-disabled-tags",
+  "tag-recognition/no-markdown-formatting",
+  "tag-recognition/tsdoc-comment-syntax",
+  "value-parsing/valid-numeric-value",
+  "value-parsing/valid-integer-value",
+  "value-parsing/valid-regex-pattern",
+  "value-parsing/valid-json-value",
+  "type-compatibility/tag-type-check",
+  "target-resolution/valid-path-target",
+  "target-resolution/valid-member-target",
+  "target-resolution/no-unsupported-targeting",
+  "target-resolution/no-member-target-on-object",
+  "constraint-validation/no-contradictions",
+  "constraint-validation/no-duplicate-tags",
+  "constraint-validation/no-contradictory-rules",
+  "constraint-validation/valid-discriminator",
+  "constraint-validation/no-double-underscore-fields",
+  "documentation/no-unsupported-description-tag",
+  "dsl-policy/allowed-field-types",
+  "dsl-policy/allowed-layouts",
+] as const;
+
+const deprecatedRuleAliases = [
+  "constraint-validation/no-description-tag",
+  "constraints-allowed-field-types",
+  "constraints-allowed-layouts",
+] as const;
+
+const deprecatedRuleReplacements = {
+  "constraint-validation/no-description-tag": "documentation/no-unsupported-description-tag",
+  "constraints-allowed-field-types": "dsl-policy/allowed-field-types",
+  "constraints-allowed-layouts": "dsl-policy/allowed-layouts",
+} as const;
+
+interface DeprecatedAliasBehaviorCase {
+  readonly aliasId: keyof typeof deprecatedRuleReplacements;
+  readonly fileName: string;
+  readonly ruleEntry: Linter.RuleEntry;
+  readonly code: string;
+  readonly messageId: string;
+}
+
+interface DeprecatedRuleMeta {
+  readonly deprecated?: unknown;
+  readonly replacedBy?: readonly string[];
 }
 
 describe("@formspec/eslint-plugin exports", () => {
@@ -33,14 +85,26 @@ describe("@formspec/eslint-plugin exports", () => {
       version: packageJson.version,
     });
 
-    expect(Object.keys(rules)).toEqual(
-      expect.arrayContaining([
-        "tag-recognition/no-unknown-tags",
-        "tag-recognition/no-markdown-formatting",
-        "constraint-validation/no-description-tag",
-        "constraints-allowed-field-types",
-      ])
+    expect(Object.keys(rules).sort()).toEqual(
+      [...canonicalRuleIds, ...deprecatedRuleAliases].sort()
     );
+
+    for (const ruleId of canonicalRuleIds) {
+      expect(rules[ruleId].meta.deprecated).toBeFalsy();
+    }
+
+    for (const aliasId of deprecatedRuleAliases) {
+      const aliasMeta = rules[aliasId].meta as DeprecatedRuleMeta;
+      expect(rules[aliasId].name).toBe(aliasId);
+      expect(aliasMeta.deprecated).toBe(true);
+      expect(aliasMeta.replacedBy).toEqual([deprecatedRuleReplacements[aliasId]]);
+    }
+
+    expect(noUnsupportedDescriptionTag.name).toBe("documentation/no-unsupported-description-tag");
+    /* eslint-disable @typescript-eslint/no-deprecated -- These assertions pin the compatibility export. */
+    expect(noDescriptionTag.name).toBe("constraint-validation/no-description-tag");
+    expect((noDescriptionTag.meta as DeprecatedRuleMeta).deprecated).toBe(true);
+    /* eslint-enable @typescript-eslint/no-deprecated */
 
     expect(configs.recommended).toBeInstanceOf(Array);
     expect(configs.strict).toBeInstanceOf(Array);
@@ -73,6 +137,33 @@ describe("@formspec/eslint-plugin exports", () => {
     }
   });
 
+  it("enables canonical rule IDs in presets without deprecated aliases", () => {
+    const recommendedRuleIds = getConfigRuleIds(configs.recommended).sort();
+    const strictRuleIds = getConfigRuleIds(configs.strict).sort();
+    const expectedPresetRuleIds = canonicalRuleIds.map((ruleId) => `formspec/${ruleId}`).sort();
+
+    expect(recommendedRuleIds).toEqual(expectedPresetRuleIds);
+    expect(strictRuleIds).toEqual(expectedPresetRuleIds);
+
+    for (const aliasId of deprecatedRuleAliases) {
+      expect(recommendedRuleIds).not.toContain(`formspec/${aliasId}`);
+      expect(strictRuleIds).not.toContain(`formspec/${aliasId}`);
+    }
+
+    expect(configs.recommended[0]?.rules).toMatchObject({
+      "formspec/tag-recognition/no-markdown-formatting": "warn",
+      "formspec/documentation/no-unsupported-description-tag": "error",
+      "formspec/dsl-policy/allowed-field-types": "error",
+      "formspec/dsl-policy/allowed-layouts": "error",
+    });
+    expect(configs.strict[0]?.rules).toMatchObject({
+      "formspec/tag-recognition/no-markdown-formatting": "error",
+      "formspec/documentation/no-unsupported-description-tag": "error",
+      "formspec/dsl-policy/allowed-field-types": "error",
+      "formspec/dsl-policy/allowed-layouts": "error",
+    });
+  });
+
   it("re-exports downstream metadata analysis helpers", () => {
     expect(typeof analyzeMetadataForNode).toBe("function");
     expect(typeof analyzeMetadataForSourceFile).toBe("function");
@@ -96,10 +187,11 @@ describe("@formspec/eslint-plugin exports", () => {
       }
     });
 
-    it("resolves and loads every rule against a real project", async () => {
-      const allRulesEnabled = Object.fromEntries(
-        Object.keys(rules).map((name) => [`formspec/${name}`, "warn"])
-      );
+    function createEslintForRules(ruleSettings: NonNullable<Linter.Config["rules"]>): ESLint {
+      if (tmpDir === undefined) {
+        throw new Error("Expected temporary directory");
+      }
+
       // The overrideConfig object is structurally compatible with ESLint 9 flat
       // config at runtime. The cast through unknown is required because
       // @typescript-eslint/utils's FlatConfig types and eslint's Linter.Config
@@ -112,19 +204,113 @@ describe("@formspec/eslint-plugin exports", () => {
           parserOptions: { projectService: true, tsconfigRootDir: tmpDir },
         },
         plugins: { formspec: { meta, rules } },
-        rules: allRulesEnabled,
+        rules: ruleSettings,
       };
 
-      const eslint = new ESLint({
+      return new ESLint({
         cwd: tmpDir,
         overrideConfigFile: true,
         overrideConfig: overrideConfig as unknown as Linter.Config,
       });
+    }
+
+    it("resolves and loads every rule against a real project", async () => {
+      const allRulesEnabled = Object.fromEntries(
+        Object.keys(rules).map((name) => [`formspec/${name}`, "warn"])
+      ) as NonNullable<Linter.Config["rules"]>;
+      const eslint = createEslintForRules(allRulesEnabled);
 
       const [result] = await eslint.lintFiles(["test.ts"]);
       if (result === undefined) throw new Error("Expected lint result");
       expect(result.messages).toEqual([]);
     });
+
+    it("reports deprecated aliases with their canonical replacements", async () => {
+      const aliasRulesEnabled = Object.fromEntries(
+        deprecatedRuleAliases.map((name) => [`formspec/${name}`, "warn"])
+      ) as NonNullable<Linter.Config["rules"]>;
+      const eslint = createEslintForRules(aliasRulesEnabled);
+
+      const [result] = await eslint.lintFiles(["test.ts"]);
+      if (result === undefined) throw new Error("Expected lint result");
+      expect(result.messages).toEqual([]);
+      expect(result.usedDeprecatedRules.map((rule) => rule.ruleId).sort()).toEqual(
+        deprecatedRuleAliases.map((ruleId) => `formspec/${ruleId}`).sort()
+      );
+
+      for (const [aliasId, replacementId] of Object.entries(deprecatedRuleReplacements)) {
+        const deprecatedRule = result.usedDeprecatedRules.find(
+          (rule) => rule.ruleId === `formspec/${aliasId}`
+        );
+        expect(deprecatedRule).toEqual({
+          ruleId: `formspec/${aliasId}`,
+          replacedBy: [replacementId],
+        });
+      }
+    });
+
+    const deprecatedAliasBehaviorCases: readonly DeprecatedAliasBehaviorCase[] = [
+      {
+        aliasId: "constraint-validation/no-description-tag",
+        fileName: "deprecated-description-alias.ts",
+        ruleEntry: "error",
+        code: `class Form { /** @description A name */ name!: string; }`,
+        messageId: "descriptionTagForbidden",
+      },
+      {
+        aliasId: "constraints-allowed-field-types",
+        fileName: "deprecated-field-policy-alias.ts",
+        ruleEntry: ["error", { dynamicEnum: "error" }],
+        code: `
+          const field = {
+            dynamicEnum: (name: string, source: string) => ({ name, source }),
+          };
+          field.dynamicEnum("country", "countries");
+        `,
+        messageId: "disallowedFieldType",
+      },
+      {
+        aliasId: "constraints-allowed-layouts",
+        fileName: "deprecated-layout-policy-alias.ts",
+        ruleEntry: ["error", { group: "error" }],
+        code: `
+          function group(label: string, ...elements: unknown[]) {
+            return { label, elements };
+          }
+          group("Contact", { name: "name" });
+        `,
+        messageId: "disallowedGroup",
+      },
+    ];
+
+    it.each(deprecatedAliasBehaviorCases)(
+      "runs deprecated alias $aliasId through its canonical rule implementation",
+      async ({ aliasId, fileName, ruleEntry, code, messageId }) => {
+        if (tmpDir === undefined) {
+          throw new Error("Expected temporary directory");
+        }
+
+        writeFileSync(join(tmpDir, fileName), code);
+        const eslint = createEslintForRules({
+          [`formspec/${aliasId}`]: ruleEntry,
+        });
+
+        const [result] = await eslint.lintFiles([fileName]);
+        if (result === undefined) throw new Error("Expected lint result");
+
+        expect(result.messages).toHaveLength(1);
+        expect(result.messages[0]).toMatchObject({
+          ruleId: `formspec/${aliasId}`,
+          messageId,
+        });
+        expect(result.usedDeprecatedRules).toEqual([
+          {
+            ruleId: `formspec/${aliasId}`,
+            replacedBy: [deprecatedRuleReplacements[aliasId]],
+          },
+        ]);
+      }
+    );
 
     it("supports downstream parser-services rules that reuse metadata analysis", async () => {
       if (tmpDir === undefined) {

--- a/packages/eslint-plugin/tests/rules/constraint-validation-extra.test.ts
+++ b/packages/eslint-plugin/tests/rules/constraint-validation-extra.test.ts
@@ -1,7 +1,7 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 import * as vitest from "vitest";
 import { noDuplicateTags } from "../../src/rules/constraint-validation/no-duplicate-tags.js";
-import { noDescriptionTag } from "../../src/rules/constraint-validation/no-description-tag.js";
+import { noUnsupportedDescriptionTag } from "../../src/rules/documentation/no-unsupported-description-tag.js";
 import { noContradictoryRules } from "../../src/rules/constraint-validation/no-contradictory-rules.js";
 import { validDiscriminator } from "../../src/rules/constraint-validation/valid-discriminator.js";
 import { noDoubleUnderscoreFields } from "../../src/rules/constraint-validation/no-double-underscore-fields.js";
@@ -16,6 +16,13 @@ const ruleTester = new RuleTester({
     parserOptions: {
       projectService: {
         allowDefaultProject: ["*.ts"],
+      },
+    },
+  },
+  plugins: {
+    "@rule-tester/documentation": {
+      rules: {
+        "no-unsupported-description-tag": noUnsupportedDescriptionTag,
       },
     },
   },
@@ -65,7 +72,7 @@ ruleTester.run("no-duplicate-tags", noDuplicateTags, {
   ],
 });
 
-ruleTester.run("no-description-tag", noDescriptionTag, {
+ruleTester.run("documentation/no-unsupported-description-tag", noUnsupportedDescriptionTag, {
   valid: [{ code: `class Form { /** A name */ name!: string; }` }],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/dsl-policy/allowed-field-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/dsl-policy/allowed-field-types.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for constraints/allowed-field-types rule.
+ * Tests for dsl-policy/allowed-field-types rule.
  */
 
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { allowedFieldTypes } from "../../../src/rules/constraints/allowed-field-types.js";
+import { allowedFieldTypes } from "../../../src/rules/dsl-policy/allowed-field-types.js";
 import * as vitest from "vitest";
 
 RuleTester.afterAll = vitest.afterAll;
@@ -19,9 +19,16 @@ const ruleTester = new RuleTester({
       },
     },
   },
+  plugins: {
+    "@rule-tester/dsl-policy": {
+      rules: {
+        "allowed-field-types": allowedFieldTypes,
+      },
+    },
+  },
 });
 
-ruleTester.run("constraints-allowed-field-types", allowedFieldTypes, {
+ruleTester.run("dsl-policy/allowed-field-types", allowedFieldTypes, {
   valid: [
     // All field types allowed by default (no constraints)
     {

--- a/packages/eslint-plugin/tests/rules/dsl-policy/allowed-layouts.test.ts
+++ b/packages/eslint-plugin/tests/rules/dsl-policy/allowed-layouts.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for constraints/allowed-layouts rule.
+ * Tests for dsl-policy/allowed-layouts rule.
  */
 
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { allowedLayouts } from "../../../src/rules/constraints/allowed-layouts.js";
+import { allowedLayouts } from "../../../src/rules/dsl-policy/allowed-layouts.js";
 import * as vitest from "vitest";
 
 RuleTester.afterAll = vitest.afterAll;
@@ -19,9 +19,16 @@ const ruleTester = new RuleTester({
       },
     },
   },
+  plugins: {
+    "@rule-tester/dsl-policy": {
+      rules: {
+        "allowed-layouts": allowedLayouts,
+      },
+    },
+  },
 });
 
-ruleTester.run("constraints-allowed-layouts", allowedLayouts, {
+ruleTester.run("dsl-policy/allowed-layouts", allowedLayouts, {
   valid: [
     // All layouts allowed by default (no constraints)
     {


### PR DESCRIPTION
## Summary

- Reorganizes the ESLint plugin rule inventory around canonical documentation and DSL-policy rule IDs while keeping published legacy IDs as deprecated aliases.
- Updates `recommended` and `strict` to use canonical IDs only, adds markdown-formatting to both presets, and enables the DSL-policy rules in both presets.
- Refreshes generated rule docs, API reports, tooling docs, spec changelog, and changeset copy.

| Deprecated ID | Canonical ID |
| --- | --- |
| `formspec/constraint-validation/no-description-tag` | `formspec/documentation/no-unsupported-description-tag` |
| `formspec/constraints-allowed-field-types` | `formspec/dsl-policy/allowed-field-types` |
| `formspec/constraints-allowed-layouts` | `formspec/dsl-policy/allowed-layouts` |

Closes #433

## Test plan

- `pnpm --filter @formspec/analysis run build`
- `pnpm --filter @formspec/eslint-plugin run test`
- `pnpm --filter @formspec/eslint-plugin run typecheck`
- `pnpm --filter @formspec/eslint-plugin run check:eslint-docs`
- `pnpm --filter @formspec/eslint-plugin run build`
- `pnpm exec prettier --check docs/004-tooling.md docs/spec-changelog.md packages/eslint-plugin/README.md packages/eslint-plugin/docs/rules/constraint-validation/no-description-tag.md packages/eslint-plugin/docs/rules/constraints-allowed-field-types.md packages/eslint-plugin/docs/rules/constraints-allowed-layouts.md packages/eslint-plugin/docs/rules/documentation/no-unsupported-description-tag.md packages/eslint-plugin/docs/rules/dsl-policy/allowed-field-types.md packages/eslint-plugin/docs/rules/dsl-policy/allowed-layouts.md .changeset/issue-433-eslint-rule-inventory.md packages/eslint-plugin/src/index.ts packages/eslint-plugin/src/rules/dsl-policy/allowed-field-types.ts packages/eslint-plugin/tests/plugin-exports.test.ts packages/eslint-plugin/tests/rules/dsl-policy/allowed-field-types.test.ts packages/eslint-plugin/tests/rules/dsl-policy/allowed-layouts.test.ts packages/eslint-plugin/tests/rules/constraint-validation-extra.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
