### PR TITLE
test(e2e): verify .d.ts consumer compatibility across the supported TypeScript range

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# FormSpec Review Guidance
+
+Authoritative artifacts: `formspec.cml`, `BOUNDED_CONTEXTS.md`, `GLOSSARY.md`, `docs/000-principles.md`.
+
+## Imports
+
+- Flag `@formspec/<x>/src/...` or `/dist/...` — bypasses the package barrel.
+- Flag relative imports that cross a package boundary.
+- Cross-package internal API is declared by `@internal`-tagged barrel exports (API Extractor strips them from public; siblings still import via the main entry). Non-barrel imports are allowed only inside a package's own tests. The only sanctioned subpath is `/browser` for env-conditioned bundles; legacy `/internals`, `/internal`, `/protocol`, `/base` are transitional — do not extend them.
+- Every cross-package edge must appear in `formspec.cml`. Each concept has one owning context — constraint extraction belongs in `@formspec/build`, tag parsing in `@formspec/analysis`, IR types in `@formspec/core`.
+
+## Vocabulary drifts to flag
+
+- `@formspec/constraints` → `@formspec/config`.
+- "JSDoc constraint" → "TSDoc tag".
+- `loadConfig` → `loadFormSpecConfig` (former deprecated).
+- `.formspec.yml` → `formspec.config.ts` (former legacy).
+
+## Principles on diffs
+
+- Generators read FormIR only — no chain DSL values, no TypeScript AST, no ambient state, no config loading inside generation. (A1/A3)
+- New IR constraint/annotation construction sites must carry `Provenance`. (S3)
+- A TSDoc tag misapplied to an incompatible type (e.g., `@minLength` on `number`) is a bug — analysis must reject it as a static error. (S4)
+- `Group` does not change schema shape; `when()` does not remove fields from JSON Schema. (C2/C3)
+- Extension JSON Schema keywords use the configurable vendor prefix; hardcoded `"x-formspec-…"` literals are wrong. (E3)
+- Schema generation is static — no `Reflect.metadata`, no `emitDecoratorMetadata`, no `eval`. All metadata flows through the TypeScript Compiler API at build time. (PP4)
+
+## Tests
+
+- Bug fixes need a regression test that fails pre-fix and names the bug.
+- Expected IR/schema values are hand-derived from the spec and cite the section (e.g., `// per design 003 §2.3`). See `packages/build/tests/parity/`. `toMatchSnapshot()` / `loadExpected()` as the sole correctness mechanism are tautological — flag.
+- Test layer matches the change: unit for pure logic; integration when crossing a CML package boundary; e2e for multi-context flows; UAT (CLI subprocess) for user-visible output.
+- `tsd` type tests need positive (`expectType`/`expectAssignable`) and negative (`expectError`) cases.
+- Fixed date constants or `vi.useFakeTimers()`. Never `new Date()`/`Date.now()` in fixtures.
+
+## Out of scope
+
+`@formspec/playground` references in older docs — separate cleanup PR.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["contextmapper.context-mapper-vscode-extension"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 Guidance for coding agents working in this repository.
 
+## Read these first
+
+Before making any change, read in this order:
+
+1. [`formspec.cml`](./formspec.cml) — the formal bounded-context model. Authoritative.
+2. [`BOUNDED_CONTEXTS.md`](./BOUNDED_CONTEXTS.md) — prose reader companion to the CML.
+3. [`GLOSSARY.md`](./GLOSSARY.md) — project vocabulary; pin the right term before writing code or commits.
+4. [`docs/000-principles.md`](./docs/000-principles.md) — the architectural invariants the system upholds.
+
+When in doubt about which package owns a concept, search `GLOSSARY.md` and `formspec.cml`. When in doubt about a cross-package change, the relationships in `formspec.cml` are the contract.
+
 ## Overview
 
 FormSpec is a TypeScript monorepo for defining type-safe forms that compile to JSON Schema 2020-12 and JSON Forms UI Schema.
@@ -14,7 +25,7 @@ Primary packages:
 - `@formspec/build` — schema generation and static TypeScript analysis
 - `@formspec/runtime` — resolver helpers for dynamic enum/schema sources
 - `@formspec/analysis` — shared semantic-analysis protocol types and helpers
-- `@formspec/constraints` — `.formspec.yml` parsing and DSL capability validation
+- `@formspec/config` — `formspec.config.ts` loading and DSL capability validation
 - `@formspec/eslint-plugin` — lint rules for tags and DSL usage
 - `@formspec/ts-plugin` — TypeScript language-service plugin and semantic service
 - `@formspec/language-server` — reference LSP implementation over shared helpers

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 FormSpec is a TypeScript monorepo for defining type-safe forms that compile to [JSON Schema](https://json-schema.org/) (for validation) and [JSON Forms UI Schema](https://jsonforms.io/) (for rendering).
 
+> **Companion documents.** This file describes the implementation: package responsibilities, build pipeline, and tooling. For the architectural _model_ — bounded contexts, subdomains, and inter-context relationships in formal Context Mapper Language — see [`formspec.cml`](./formspec.cml). The reader-friendly companion is [`BOUNDED_CONTEXTS.md`](./BOUNDED_CONTEXTS.md). The project's vocabulary lives in [`GLOSSARY.md`](./GLOSSARY.md). Architectural invariants are in [`docs/000-principles.md`](./docs/000-principles.md).
+
 ## Package Dependency Graph
 
 ```
@@ -14,7 +16,7 @@ formspec (umbrella — re-exports everything)
 @formspec/cli              (CLI tool)
 └── @formspec/build/internals
 
-@formspec/constraints      (constraint validation)
+@formspec/config           (constraint validation + formspec.config.ts loader)
 └── @formspec/core
 
 @formspec/analysis         (shared comment-tag analysis utilities)
@@ -22,7 +24,8 @@ formspec (umbrella — re-exports everything)
 
 @formspec/eslint-plugin    (lint rules for FormSpec)
 ├── @formspec/analysis
-├── @formspec/constraints
+├── @formspec/build
+├── @formspec/config
 └── @formspec/core
 
 @formspec/validator        (JSON Schema validator — @cfworker/json-schema)
@@ -43,10 +46,10 @@ formspec (umbrella — re-exports everything)
 Packages build in dependency order. `pnpm run build` at the root handles this automatically.
 
 1. `@formspec/core` — no dependencies
-2. `@formspec/dsl`, `@formspec/runtime`, `@formspec/constraints` — depend on core
+2. `@formspec/dsl`, `@formspec/runtime`, `@formspec/config` — depend on core
 3. `@formspec/analysis` — depends on core
-4. `@formspec/build` — depends on core
-5. `@formspec/cli`, `@formspec/eslint-plugin` — depend on build/constraints/analysis
+4. `@formspec/build` — depends on core, analysis, config
+5. `@formspec/cli`, `@formspec/eslint-plugin` — depend on build/config/analysis
 6. `@formspec/ts-plugin` — depends on analysis
 7. `@formspec/language-server` — depends on analysis, core
 8. `formspec` — umbrella, depends on all above
@@ -174,30 +177,39 @@ Combines static analysis with optional runtime loading:
 
 Options include `--emit-ir` (output Canonical IR as JSON) and `--validate-only` (validate without writing files).
 
-## Constraints (`@formspec/constraints`)
+## Constraints (`@formspec/config`)
 
-Restricts which FormSpec features are allowed, configured via `.formspec.yml`:
+Restricts which FormSpec features are allowed, configured in TypeScript via `formspec.config.ts` (or `.mts`/`.js`/`.mjs`). See [`docs/007-configuration.md`](./docs/007-configuration.md) for the full configuration spec.
 
-```yaml
-constraints:
-  fieldTypes:
-    dynamicEnum: error # Disallow dynamic enums
-    dynamicSchema: error # Disallow dynamic schemas
-  layout:
-    group: off # Allow groups
-    conditionals: warn # Warn on conditionals
-    maxNestingDepth: 3 # Limit nesting
-  fieldOptions:
-    placeholder: off # Allow placeholders
+```typescript
+// formspec.config.ts
+import { defineFormSpecConfig } from "@formspec/config";
+
+export default defineFormSpecConfig({
+  constraints: {
+    fieldTypes: {
+      dynamicEnum: "error", // Disallow dynamic enums
+      dynamicSchema: "error", // Disallow dynamic schemas
+    },
+    layout: {
+      group: "off", // Allow groups
+      conditionals: "warn", // Warn on conditionals
+      maxNestingDepth: 3, // Limit nesting
+    },
+    fieldOptions: {
+      placeholder: "off", // Allow placeholders
+    },
+  },
+});
 ```
 
 ### Enforcement Layers
 
-| Layer            | Tool                            | When                           |
-| ---------------- | ------------------------------- | ------------------------------ |
-| **Build-time**   | `@formspec/eslint-plugin`       | During linting / CI            |
-| **Programmatic** | `validateFormSpec()`            | At runtime or in build scripts |
-| **Browser**      | `@formspec/constraints/browser` | In the playground              |
+| Layer            | Tool                       | When                           |
+| ---------------- | -------------------------- | ------------------------------ |
+| **Build-time**   | `@formspec/eslint-plugin`  | During linting / CI            |
+| **Programmatic** | `validateFormSpec()`       | At runtime or in build scripts |
+| **Browser**      | `@formspec/config/browser` | In browser-embedded validation |
 
 ## ESLint Plugin (`@formspec/eslint-plugin`)
 
@@ -210,10 +222,10 @@ constraints:
 
 ### Chain DSL Rules
 
-| Rule                              | Purpose                                                                       |
-| --------------------------------- | ----------------------------------------------------------------------------- |
-| `constraints-allowed-field-types` | `field.text()`, `field.dynamicEnum()`, etc. validated against `.formspec.yml` |
-| `constraints-allowed-layouts`     | `group()`, `when()` validated against `.formspec.yml`                         |
+| Rule                              | Purpose                                                                            |
+| --------------------------------- | ---------------------------------------------------------------------------------- |
+| `constraints-allowed-field-types` | `field.text()`, `field.dynamicEnum()`, etc. validated against `formspec.config.ts` |
+| `constraints-allowed-layouts`     | `group()`, `when()` validated against `formspec.config.ts`                         |
 
 ## Tooling Architecture
 
@@ -304,14 +316,14 @@ DEBUG=formspec:analysis:constraint-validator:registry pnpm run build
 
 Each constraint-tag evaluation emits one structured record at `debug` level.
 
-| Field | Type | Description |
-|---|---|---|
-| `consumer` | `"build" \| "snapshot"` | Which pipeline emitted this entry |
-| `tag` | `string` | Normalized tag name, e.g. `"minimum"` |
-| `placement` | `string` | Declaration placement, e.g. `"class-field"` |
-| `subjectTypeKind` | `string` | Human-readable type description, e.g. `"primitive/string"`, `"object/Decimal"` |
-| `roleOutcome` | `string` | Final role in the validation pipeline (see below) |
-| `elapsedMicros` | `number` | Microseconds for this tag's full validation path |
+| Field             | Type                    | Description                                                                    |
+| ----------------- | ----------------------- | ------------------------------------------------------------------------------ |
+| `consumer`        | `"build" \| "snapshot"` | Which pipeline emitted this entry                                              |
+| `tag`             | `string`                | Normalized tag name, e.g. `"minimum"`                                          |
+| `placement`       | `string`                | Declaration placement, e.g. `"class-field"`                                    |
+| `subjectTypeKind` | `string`                | Human-readable type description, e.g. `"primitive/string"`, `"object/Decimal"` |
+| `roleOutcome`     | `string`                | Final role in the validation pipeline (see below)                              |
+| `elapsedMicros`   | `number`                | Microseconds for this tag's full validation path                               |
 
 #### Role outcome values
 
@@ -320,17 +332,17 @@ validation now flows through three roles in order: Role A (placement), Role B
 (capability guard, including path-target resolution), Role C (typed-parser
 argument validation). A `C-pass` outcome means all three roles accepted.
 
-| Value | Meaning |
-|---|---|
-| `A-pass` | Placement check passed; tag accepted without reaching role C |
-| `A-reject` | Placement check failed (`INVALID_TAG_PLACEMENT`) |
-| `B-pass` | Path/target check passed (for path-targeted constraints) |
-| `B-reject` | Capability or path-target check failed (`TYPE_MISMATCH`, `UNKNOWN_PATH_TARGET`, `UNSUPPORTED_TARGETING_SYNTAX`) |
-| `C-pass` | Typed-parser argument validation passed — terminal success outcome |
+| Value      | Meaning                                                                                                                          |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `A-pass`   | Placement check passed; tag accepted without reaching role C                                                                     |
+| `A-reject` | Placement check failed (`INVALID_TAG_PLACEMENT`)                                                                                 |
+| `B-pass`   | Path/target check passed (for path-targeted constraints)                                                                         |
+| `B-reject` | Capability or path-target check failed (`TYPE_MISMATCH`, `UNKNOWN_PATH_TARGET`, `UNSUPPORTED_TARGETING_SYNTAX`)                  |
+| `C-pass`   | Typed-parser argument validation passed — terminal success outcome                                                               |
 | `C-reject` | Typed-parser argument validation failed (`INVALID_TAG_ARGUMENT`, `MISSING_TAG_ARGUMENT`, `TYPE_MISMATCH` from `@const` IR check) |
-| `D1` | Direct-field custom-constraint dispatch (custom-type broadening) |
-| `D2` | Path-target built-in broadening dispatch |
-| `bypass` | Broadening registry short-circuit (tag accepted without role-C check) |
+| `D1`       | Direct-field custom-constraint dispatch (custom-type broadening)                                                                 |
+| `D2`       | Path-target built-in broadening dispatch                                                                                         |
+| `bypass`   | Broadening registry short-circuit (tag accepted without role-C check)                                                            |
 
 ### Sample log excerpt
 

--- a/BOUNDED_CONTEXTS.md
+++ b/BOUNDED_CONTEXTS.md
@@ -1,0 +1,156 @@
+# FormSpec Bounded Contexts
+
+Reader-friendly companion to [`formspec.cml`](./formspec.cml). The CML file is the source of truth — this document is the hand-maintained prose summary for readers who don't know Context Mapper Language.
+
+> **Keep in sync.** When you add or rename a bounded context, change a relationship, or change a context's responsibilities, update both `formspec.cml` and this document in the same PR.
+
+For project vocabulary, see [`GLOSSARY.md`](./GLOSSARY.md). For the architectural principles those contexts collectively satisfy, see [`docs/000-principles.md`](./docs/000-principles.md).
+
+---
+
+## Why bounded contexts?
+
+If you have a Domain-Driven Design background, skip to "Subdomains at a glance" below. Otherwise, the working definitions:
+
+- A **bounded context** is a part of the system inside which a particular domain language is internally consistent. In FormSpec, each production npm package sits inside exactly one bounded context.
+- A **subdomain** is a coarser grouping: several bounded contexts can realize the same subdomain when they collaborate on the same problem area.
+- The **context map** declares the relationships between bounded contexts. The notation (`OHS`, `PL`, `CF`, `ACL`) is explained in the "Context map at a glance" section below; you don't need to memorize it before reading the rest of this document.
+
+Naming the contexts explicitly does three things:
+
+1. **Helps contributors find where to make a change.** Every concept (Field, Constraint, Resolver, ...) has a single owning context — see [`GLOSSARY.md`](./GLOSSARY.md).
+2. **Makes inter-package contracts deliberate.** A change to a context's public surface is a contract change with downstream consequences; the context map names every such contract.
+3. **Enables CI guardrails.** A future check (planned for Phase 2 of the DDD-alignment campaign) parses `formspec.cml` and rejects any cross-package import not permitted by the context map.
+
+The campaign deliberately stops at the strategic level (BoundedContexts + ContextMap). Tactical DDD modeling (Aggregates, Entities, Value Objects) is not in scope today.
+
+---
+
+## Subdomains at a glance
+
+| Subdomain                | Type       | What it is                                                                                                     |
+| ------------------------ | ---------- | -------------------------------------------------------------------------------------------------------------- |
+| `FormSpecModelDomain`    | CORE       | The canonical FormIR vocabulary every other context shares                                                     |
+| `AuthoringDomain`        | CORE       | The two surfaces developers use to express form definitions                                                    |
+| `SemanticAnalysisDomain` | SUPPORTING | Static extraction of FormSpec semantics from TypeScript source — packaged for reuse by Compilation and tooling |
+| `CompilationDomain`      | CORE       | Canonicalization plus JSON Schema and UI Schema emission                                                       |
+| `ConfigurationDomain`    | SUPPORTING | `formspec.config.ts` loading and DSL capability restriction                                                    |
+| `RuntimeDomain`          | SUPPORTING | Resolver helpers for dynamic data at form-render time                                                          |
+| `DeveloperToolingDomain` | SUPPORTING | IDE, lint, and CLI integrations                                                                                |
+| `ValidationDomain`       | GENERIC    | Standard JSON Schema 2020-12 validation (conforms to an external standard, not to FormSpec specifics)          |
+
+CORE is where FormSpec's distinctive value lives. SUPPORTING domains are necessary but not what makes FormSpec FormSpec. GENERIC means an off-the-shelf solution works — for FormSpec, that's standard JSON Schema validation.
+
+---
+
+## Bounded contexts
+
+Each row below maps a CML `BoundedContext` to its npm package and primary responsibilities. Cell labels match the identifiers in [`formspec.cml`](./formspec.cml) — search there for the full vision statement.
+
+| Bounded context         | Package                     | Subdomain                | Role / responsibilities                                                                                                                               |
+| ----------------------- | --------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DomainModelContext`    | `@formspec/core`            | `FormSpecModelDomain`    | Defines and publishes the canonical FormIR. Discriminated FormElement union, IR node types, constraint/annotation registration APIs.                  |
+| `ChainDslContext`       | `@formspec/dsl`             | `AuthoringDomain`        | Fluent builder API: `field.*`, `group`, `when`, `formspec`. Full type inference of the resulting schema.                                              |
+| `StaticAnalysisContext` | `@formspec/analysis`        | `SemanticAnalysisDomain` | TSDoc tag parsing, constraint extraction, FileSnapshot protocol. The "TypeScript-AST work" every IDE/lint tool would otherwise re-implement.          |
+| `CompilationContext`    | `@formspec/build`           | `CompilationDomain`      | Canonicalize chain DSL and class-analysis output to FormIR; emit JSON Schema 2020-12 and JSON Forms UI Schema.                                        |
+| `ConfigurationContext`  | `@formspec/config`          | `ConfigurationDomain`    | Load `formspec.config.ts` (or `.mts`/`.js`/`.mjs`); register extensions and custom constraints; restrict the FormSpec capability surface per project. |
+| `RuntimeContext`        | `@formspec/runtime`         | `RuntimeDomain`          | `defineResolvers()` for dynamic enum and dynamic schema fields, with type-safe end-to-end binding.                                                    |
+| `ValidatorContext`      | `@formspec/validator`       | `ValidationDomain`       | Wraps `@cfworker/json-schema` to provide JSON Schema 2020-12 validation in edge-runtime environments. No FormSpec-specific dependencies.              |
+| `CliContext`            | `@formspec/cli`             | `DeveloperToolingDomain` | Drive schema and IR generation from the command line.                                                                                                 |
+| `EslintContext`         | `@formspec/eslint-plugin`   | `DeveloperToolingDomain` | ESLint rules: constraint type-mismatch, contradictions, capability restrictions, with auto-fixes where unambiguous.                                   |
+| `TsPluginContext`       | `@formspec/ts-plugin`       | `DeveloperToolingDomain` | TypeScript language-service plugin and reusable composable semantic service for IDE integrations.                                                     |
+| `LanguageServerContext` | `@formspec/language-server` | `DeveloperToolingDomain` | LSP reference implementation; thin presentation layer over composable analysis and TS-plugin helpers.                                                 |
+
+### Packages excluded from the formal model
+
+Three packages do not appear in `formspec.cml` because they are not bounded contexts in their own right:
+
+| Package                | Reason                                                                                                                                                           |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `formspec` (umbrella)  | Pure re-export of `@formspec/core`, `@formspec/dsl`, `@formspec/build`, `@formspec/runtime`. No domain language of its own. Modelled as a packaging convenience. |
+| `@formspec/playground` | Private playground app. Not currently present in the workspace; older docs may still reference it. A consumer of the production contexts, not a producer.        |
+| `e2e`                  | Test workspace. Exercises the production contexts end-to-end but adds no architecturally relevant behavior.                                                      |
+
+The `formspec` umbrella is still subject to dependency discipline: it must only re-export from the four upstream contexts listed above, and Phase 2's CI guardrail will enforce that.
+
+---
+
+## Context map at a glance
+
+Every relationship in `formspec.cml` corresponds to a real `package.json` dependency. Logical/data-flow couplings without code-level imports (e.g., `ValidatorContext` consumes JSON Schema produced by `CompilationContext`) are not modelled as edges; they live in the context's vision statement instead.
+
+CML notation, briefly:
+
+- **D, U** — Downstream / Upstream.
+- **OHS** — Open Host Service: the upstream provides a documented, stable protocol.
+- **PL** — Published Language: a shared, well-defined vocabulary used across the boundary.
+- **CF** — Conformist: the downstream accepts the upstream's model as-is, without translation. Used here for type-level consumption of `@formspec/core` and pure re-exports.
+- **ACL** — Anti-Corruption Layer: the downstream translates the upstream's model into a different vocabulary. Used here for tooling boundaries (compilation, lint, IDE, LSP) where FormSpec semantics are adapted into another vocabulary.
+
+### Who depends on whom (text rendering)
+
+```
+                       ┌──────────────────────┐
+                       │  DomainModelContext  │  (the published language: FormIR)
+                       │   @formspec/core     │
+                       └──────────┬───────────┘
+                                  │  OHS + PL  (CF — every internal context except Validator)
+       ┌──────────────────┬───────┼──────────┬────────────────┬─────────────────┐
+       │                  │       │          │                │                 │
+       ▼                  ▼       ▼          ▼                ▼                 ▼
+ChainDslContext   StaticAnalysis  Compilation Configuration  Runtime    (TsPlugin, LSP, ESLint)
+@formspec/dsl     @formspec/      @formspec/  @formspec/     @formspec/
+                  analysis        build       config         runtime
+                       │             ▲           │
+                       │  ACL+OHS+PL │           │  OHS
+                       └─────────────┤           │
+                                     │           │
+                                     │           │
+                          (CompilationContext consumes StaticAnalysis output
+                           via ACL: canonicalization translates parsed-tag
+                           info into FormIR per principle A4)
+
+Developer tooling — translate upstream semantics into their own vocabularies (ACL):
+  CliContext         (@formspec/cli)             ← Compilation (CF), Configuration
+  EslintContext      (@formspec/eslint-plugin)   ← Compilation (ACL), StaticAnalysis (ACL), Configuration
+  TsPluginContext    (@formspec/ts-plugin)       ← StaticAnalysis (ACL)
+  LanguageServer     (@formspec/language-server) ← StaticAnalysis (ACL), Configuration
+
+Standalone:
+  ValidatorContext   (@formspec/validator)       — no internal upstreams; conforms to JSON Schema 2020-12
+
+Re-export façade (not a bounded context — see "Packages excluded" above):
+  formspec (umbrella)                            ← DomainModel, ChainDsl, Compilation, Runtime
+```
+
+### Key edges to know
+
+| Downstream                                                                   | Upstream                | Pattern                 | What it means                                                                                                                                                        |
+| ---------------------------------------------------------------------------- | ----------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Everyone except Validator                                                    | `DomainModelContext`    | `D, CF` ← `U, OHS, PL`  | All FormSpec contexts conform to FormIR types as the published language. A change to `@formspec/core`'s public surface is a project-wide change.                     |
+| `CompilationContext`                                                         | `StaticAnalysisContext` | `D, ACL` ← `U, OHS, PL` | The build pipeline canonicalizes parsed comment-tag info into FormIR — that translation is an Anti-Corruption Layer per principle A4.                                |
+| `LanguageServerContext`                                                      | `StaticAnalysisContext` | `D, ACL` ← `U, OHS, PL` | LSP translates FormSpec analysis output into wire-format LSP types. Textbook ACL.                                                                                    |
+| `EslintContext`, `TsPluginContext`                                           | `StaticAnalysisContext` | `D, ACL` ← `U, OHS`     | Lint and TS-plugin translate analysis output into ESLint / tsserver vocabularies.                                                                                    |
+| `EslintContext`                                                              | `CompilationContext`    | `D, ACL` ← `U, OHS`     | Lint rules adapt build-pipeline outputs into ESLint diagnostics and fix descriptors.                                                                                 |
+| `CompilationContext`, `CliContext`, `EslintContext`, `LanguageServerContext` | `ConfigurationContext`  | `D, CF` ← `U, OHS`      | Capability restrictions and custom constraint registrations originate in `formspec.config.ts`. Downstreams consume `FormSpecConfig` as data, without translating it. |
+| `CliContext`                                                                 | `CompilationContext`    | `D, CF` ← `U, OHS`      | The CLI is a thin wrapper over the build APIs (principle A6); it consumes them verbatim rather than translating.                                                     |
+
+---
+
+## Practical consequences
+
+**Adding a new field type.** Define the type in `DomainModelContext` (`@formspec/core`). Add a builder in `ChainDslContext` (`@formspec/dsl`). Wire IR generation in `CompilationContext` (`@formspec/build`). If TSDoc tags can produce it, extend `StaticAnalysisContext` (`@formspec/analysis`). If the configuration system needs to be aware of it, update `ConfigurationContext` (`@formspec/config`). Lint rules live in `EslintContext` (`@formspec/eslint-plugin`).
+
+**Adding a new constraint.** Define the constraint type in `DomainModelContext`. Register it in `ConfigurationContext`. Implement extraction and application in `CompilationContext`. Add semantic diagnostics in `StaticAnalysisContext`. (Phase 4 of the DDD campaign will codify this split via an ADR — `docs/adr/0001-constraint-ownership.md` (planned, not yet authored) — and barrel files; until that lands, follow the same logical split.)
+
+**Adding a new tooling feature.** Decide whether it's a one-shot validation (lint) or a live editor capability (language server) per principle A7. Then place it in `EslintContext` or `LanguageServerContext` accordingly. Both consume `StaticAnalysisContext`.
+
+**When in doubt about ownership.** Read the vision statement in `formspec.cml` for the candidate contexts, and pick the one whose package would _break_ if the new concept were removed. That's the owning context.
+
+---
+
+## Future evolution
+
+The current model is `state = AS_IS`. When the architecture changes meaningfully, declare the new shape with a `state = TO_BE` ContextMap in `formspec.cml`, ship the implementation that brings reality in line, then flip to `AS_IS`.
+
+Tactical-level DDD modelling (Aggregates, Entities, Value Objects) is intentionally absent. If a future need arises (e.g., agent-driven changes need finer-grained ownership signals than "which package"), revisit then.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Architecture orientation
+
+Read these before making non-trivial changes:
+
+- [`formspec.cml`](./formspec.cml) — the formal bounded-context model (Context Mapper Language). Authoritative source for which package owns what role and which packages may depend on which.
+- [`BOUNDED_CONTEXTS.md`](./BOUNDED_CONTEXTS.md) — reader-friendly companion to the CML.
+- [`GLOSSARY.md`](./GLOSSARY.md) — project vocabulary. Use these terms verbatim.
+- [`docs/000-principles.md`](./docs/000-principles.md) — architectural principles every change must respect.
+
 ## Build & Development Commands
 
 ```bash
@@ -64,8 +73,8 @@ formspec (umbrella — re-exports everything)
 
 @formspec/analysis         (shared comment-tag analysis — depends on @formspec/core)
 @formspec/cli              (CLI tool — depends on @formspec/build/internals)
-@formspec/eslint-plugin    (ESLint rules — depends on @formspec/analysis, @formspec/constraints, @formspec/core)
-@formspec/constraints      (constraint validation — depends on @formspec/core)
+@formspec/eslint-plugin    (ESLint rules — depends on @formspec/analysis, @formspec/build, @formspec/config, @formspec/core)
+@formspec/config           (constraint validation + formspec.config.ts loader — depends on @formspec/core)
 @formspec/validator        (JSON Schema validation — @cfworker/json-schema)
 @formspec/ts-plugin        (TypeScript plugin + composable semantic service — reference implementation inside tsserver, depends on @formspec/analysis)
 @formspec/language-server  (reference LSP implementation — thin presentation layer over composable helpers, depends on @formspec/analysis and @formspec/core)
@@ -90,10 +99,10 @@ formspec (umbrella — re-exports everything)
 Packages must build in dependency order. The root `pnpm run build` handles this automatically. For manual builds:
 
 1. `@formspec/core` (no deps)
-2. `@formspec/dsl`, `@formspec/runtime`, `@formspec/constraints` (depend on core)
+2. `@formspec/dsl`, `@formspec/runtime`, `@formspec/config` (depend on core)
 3. `@formspec/analysis` (depends on core)
-4. `@formspec/build` (depends on core and analysis at runtime; peer dep on typescript)
-5. `@formspec/cli`, `@formspec/eslint-plugin` (depend on build/constraints/analysis)
+4. `@formspec/build` (depends on core, analysis, config at runtime; peer dep on typescript)
+5. `@formspec/cli`, `@formspec/eslint-plugin` (depend on build/config/analysis)
 6. `@formspec/ts-plugin` (depends on analysis)
 7. `@formspec/language-server` (depends on analysis, core)
 8. `formspec` (umbrella, depends on core, dsl, build, runtime)

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,227 @@
+# FormSpec Glossary
+
+The shared vocabulary of the FormSpec project. Use these terms verbatim in code, comments, commits, PR descriptions, and documentation.
+
+For the architectural roles of packages, see [`BOUNDED_CONTEXTS.md`](./BOUNDED_CONTEXTS.md) and the formal model in [`formspec.cml`](./formspec.cml). For the architectural principles those terms support, see [`docs/000-principles.md`](./docs/000-principles.md).
+
+---
+
+## Form-shaped concepts
+
+### FormSpec (project) vs `FormSpec` (type)
+
+- **FormSpec** (capitalized, prose): the project itself.
+- **`FormSpec`** (code identifier): the root TypeScript type produced by the chain DSL `formspec(...)` factory and the inferred shape of a class-based form.
+
+When ambiguity is possible, prefer "FormSpec project" or "the `FormSpec` type." Do not introduce new aliases.
+
+Owning bounded context: `DomainModelContext` (`@formspec/core`).
+
+### Form
+
+The user-facing artifact. A _form_ is what an end user fills in. In code, a form is represented either by a `FormSpec` value (chain DSL) or by a TypeScript class annotated with TSDoc (static-analysis surface). Both representations canonicalize to the same FormIR.
+
+### Form Element
+
+Any node that can appear inside a form: a Field, a Group, or a Conditional. Discriminated union exported from `@formspec/core`.
+
+Owning bounded context: `DomainModelContext`.
+
+### Field
+
+A leaf in a form definition that maps to a single value in the resulting data model. Examples: `TextField`, `NumberField`, `BooleanField`, `StaticEnumField`, `DynamicEnumField`, `ArrayField`, `ObjectField`. The discriminated union of all field types is exported as `AnyField`; there is no exported type literally named `Field`.
+
+Note: `ObjectField` creates schema nesting; `Group` does not. See **Group vs Object** below.
+
+Owning bounded context: `DomainModelContext`.
+
+### Group
+
+A UI-only organizational element (a labelled section). A group affects rendering only — fields inside a group appear at the same level in the JSON Schema as if the group were absent. See principle C2.
+
+Owning bounded context: `DomainModelContext`.
+
+### Conditional
+
+A `when(...)` wrapper that controls whether wrapped fields are _visible_ in the rendered UI. Wrapped fields remain present in the JSON Schema and become optional in the inferred TypeScript type. See principle C3.
+
+Owning bounded context: `DomainModelContext`.
+
+### Group vs Object
+
+These are deliberately different concepts:
+
+| Element        | Affects schema shape? | Affects UI?             | Use when                                      |
+| -------------- | --------------------- | ----------------------- | --------------------------------------------- |
+| `Group`        | No                    | Yes (visual grouping)   | Organize UI without changing data shape       |
+| `field.object` | Yes (creates nesting) | Yes (renders as nested) | Data model genuinely contains a nested object |
+
+---
+
+## Intermediate representation
+
+### Canonical IR (prose) / `FormIR` (type)
+
+The single intermediate representation that both authoring surfaces compile to. **"Canonical IR"** is the prose name used in docs and commit messages. **`FormIR`** is the TypeScript identifier used in code. They refer to the same thing.
+
+The IR is a plain serializable data structure (principle A2), captures semantics rather than syntax (principle A4), and is the only thing downstream generators read (principle A1).
+
+Owning bounded context: `DomainModelContext`.
+
+### `FieldNode`
+
+The IR-level representation of a Field. Distinct from the authoring-surface field types in `@formspec/core/types/elements.ts` (`AnyField` and its members): the authoring types describe what an author writes, and a `FieldNode` is the post-canonicalization IR shape with resolved type, constraints, and annotations attached.
+
+### `TypeNode`
+
+The IR-level representation of a TypeScript type. A discriminated union (`PrimitiveTypeNode`, `EnumTypeNode`, `ArrayTypeNode`, `ObjectTypeNode`, `RecordTypeNode`, `UnionTypeNode`, `ReferenceTypeNode`, `DynamicTypeNode`, `CustomTypeNode`).
+
+### `ConstraintNode`
+
+The IR representation of a constraint applied to a field. A discriminated union covering numeric, length, pattern, cardinality, const, and custom constraints. See **Constraint** below for the broader concept.
+
+### `AnnotationNode`
+
+The IR representation of a value-influencing annotation (`@displayName`, `@defaultValue`, `@deprecated`, etc.). Composes via override (closest-to-use wins) per principle C1.
+
+### Provenance
+
+Origin metadata attached to every IR-level constraint and annotation: the surface (chain DSL vs TSDoc), file, line, column, and the originating tag name. Diagnostics use Provenance to point at the author's source rather than at the IR (principle D2). See principle S3.
+
+Owning bounded context: `DomainModelContext`.
+
+### Path Target
+
+The IR concept for "this annotation/constraint targets a nested property at this path." Encoded as a `segments: string[]` array. Used by the `:value`, `:async`, etc. modifier syntax in TSDoc tags. See principle S5.
+
+---
+
+## Authoring concepts
+
+### Chain DSL
+
+The fluent builder authoring surface: `field.text(...)`, `field.number(...)`, `group(...)`, `when(...)`, `formspec(...)`. Lives in `@formspec/dsl`. Produces values typed by `@formspec/core`.
+
+Owning bounded context: `ChainDslContext`.
+
+### Static-Analysis Authoring Surface
+
+The TypeScript-class authoring surface. The author writes a TypeScript class or interface with TSDoc tags; FormSpec extracts the schema shape via the TypeScript Compiler API. No runtime reflection (principle PP4).
+
+Owning bounded context: `StaticAnalysisContext` (extraction) + `CompilationContext` (canonicalization).
+
+### Mixed Authoring
+
+A form definition that combines both authoring surfaces in one project — for example, a chain-DSL form whose object fields are typed by a TSDoc-annotated class. Compilation orchestrates the two paths via `buildMixedAuthoringSchemas` so that constraints from both surfaces flow into the same FormIR.
+
+Owning bounded context: `CompilationContext`.
+
+### `FormSpecAnalysisFileSnapshot` (FileSnapshot)
+
+The wire-safe, transport-shaped representation of a TypeScript file's FormSpec-relevant analysis output, exported from `@formspec/analysis/protocol`. Used to ship analysis results across process boundaries (for example, from a TS server plugin to the language server). The prose name "FileSnapshot" is fine for casual reference; the precise type identifier is `FormSpecAnalysisFileSnapshot`.
+
+Owning bounded context: `StaticAnalysisContext`.
+
+### TSDoc Tag / JSDoc Tag
+
+Tags written in code comments (`@minimum 0`, `@displayName "Age"`, etc.). FormSpec uses **TSDoc** as the spec FormSpec conforms to. **JSDoc** is the older, looser tradition; the names overlap in practice. When precision matters, write **TSDoc tag**. When referencing the older ecosystem (e.g., `@param`), JSDoc is fine.
+
+See principle S6 (Reuse ecosystem tags).
+
+### Canonicalization
+
+The transformation from an authoring-surface value (chain DSL output, or a class analysis result) into a `FormIR`. The IR is the input to all downstream generators (principle A1).
+
+Owning bounded context: `CompilationContext`.
+
+### Compilation
+
+The full pipeline from authoring input to JSON Schema 2020-12 + JSON Forms UI Schema. Comprises: parse → analyze → canonicalize → validate → generate (principle A5).
+
+Owning bounded context: `CompilationContext`.
+
+---
+
+## Constraint and annotation system
+
+### Constraint
+
+A **set-influencing** piece of metadata that narrows the set of allowed values for a field (principle C1). Examples: `@minimum`, `@maximum`, `@pattern`, `@minLength`. Constraints compose by intersection — adding a constraint can only narrow, never broaden (principle S1).
+
+Constraint logic is owned by:
+
+- `DomainModelContext` (`@formspec/core`) — the `Constraint` IR type and registration interfaces.
+- `ConfigurationContext` (`@formspec/config`) — user-facing registration via `defineConstraints`.
+- `CompilationContext` (`@formspec/build`) — extraction from source and application during IR construction.
+- `ValidatorContext` (`@formspec/validator`) — runtime enforcement against generated schemas.
+- `StaticAnalysisContext` (`@formspec/analysis`) — semantic diagnostics about constraint usage.
+
+This split is codified in the constraint-ownership ADR (`docs/adr/0001-constraint-ownership.md`, planned for Phase 4).
+
+### Annotation
+
+A **value-influencing** piece of metadata: identity metadata (display name, API name) plus single-scalar UI hints and documentation (description, default value, deprecation marker, format, placeholder). Annotations compose by override — closest-to-use wins (principle C1).
+
+Owning bounded context: `DomainModelContext`.
+
+### Extension
+
+A package distributed via npm that registers custom field types, constraints, or annotations with FormSpec (principle E5). Extensions use the same APIs as built-in types (principle E1).
+
+Owning bounded context: declared by `DomainModelContext`; orchestrated by `CompilationContext` and `ConfigurationContext`.
+
+---
+
+## Runtime and dynamic data
+
+### Resolver
+
+A function that supplies the runtime data for a Dynamic Field. Resolvers are bound to fields by name via `defineResolvers(...)`. The chain DSL knows about the resolver's input/output types end-to-end.
+
+Not to be confused with **Data Source** or **Dynamic Source** — see below.
+
+Owning bounded context: `RuntimeContext`.
+
+### Data Source
+
+The conceptual external system or in-process value store from which a Dynamic Field's options or schema are pulled (e.g., a remote API, an in-memory list). Distinct from **Resolver**, which is the _function_ the consumer supplies; the data source is what the resolver fetches _from_.
+
+### Dynamic Source / `x-formspec-source`
+
+The IR-level marker that names a runtime data source. The field carries an `x-formspec-source` JSON Schema vendor extension keyword identifying which resolver should populate it.
+
+When in doubt, prefer **Resolver** for the function and **data source** for the underlying system.
+
+---
+
+## Configuration
+
+### `formspec.config.ts`
+
+The project-level configuration file consumed by `@formspec/config`. Discovery searches for `formspec.config.ts`, `formspec.config.mts`, `formspec.config.js`, or `formspec.config.mjs` (in that order) starting from the working directory. Authors write the file as TypeScript using `defineFormSpecConfig({...})` and register extensions, custom constraints, vendor prefix, metadata policy, enum serialization, and per-package overrides.
+
+`.formspec.yml` is **legacy** and is no longer the default convention; YAML strings can still be parsed via `loadConfigFromString()` in the browser entry for embedded scenarios.
+
+Owning bounded context: `ConfigurationContext`. See [`docs/007-configuration.md`](./docs/007-configuration.md).
+
+### Capability
+
+A FormSpec feature that the configuration system can enable or disable per project (e.g., "dynamic enums," "conditional layout," "placeholder option"). Capability restrictions are enforced at three layers: ESLint plugin (build-time), `validateFormSpecElements()` (programmatic), and `@formspec/config/browser` (browser-embedded).
+
+### Capability Registry
+
+The internal data structure inside `@formspec/config` that holds the active set of allowed capabilities for a given resolved config. Consumed by `validateFormSpecElements()` and by the ESLint plugin's allowed-types and allowed-layouts rules. Distinct from a single **Capability** declaration — the registry is the aggregate enforcement state for a project or per-package override.
+
+Owning bounded context: `ConfigurationContext`.
+
+---
+
+## Where this glossary lives in the model
+
+Each entry above names an **owning bounded context** as defined in [`formspec.cml`](./formspec.cml). When code or docs introduce a new term, add it here and tie it to the context that owns it. When in doubt about which context owns a term, the rule is: the context whose package would _break_ if the term were removed owns it.
+
+## Where to go next
+
+- [`formspec.cml`](./formspec.cml) — the formal context map and bounded-context model.
+- [`BOUNDED_CONTEXTS.md`](./BOUNDED_CONTEXTS.md) — prose tour of the contexts and their relationships.
+- [`docs/000-principles.md`](./docs/000-principles.md) — the architectural principles every change must respect.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Type-safe form definitions that compile to JSON Schema 2020-12 and JSON Forms UI Schema.
 
+> **Architecture orientation.** New contributors and AI agents should read [`BOUNDED_CONTEXTS.md`](./BOUNDED_CONTEXTS.md) (a tour of the project's bounded contexts and how they relate) and [`GLOSSARY.md`](./GLOSSARY.md) (the project's vocabulary). The formal model lives in [`formspec.cml`](./formspec.cml).
+
 ## What It Covers
 
 FormSpec supports two authoring styles:
@@ -276,7 +278,7 @@ The default vendor prefix is `x-formspec`. `@formspec/build` also supports custo
 | `@formspec/build`           | JSON Schema / UI Schema generation and static TypeScript analysis                   |
 | `@formspec/runtime`         | Resolver helpers for dynamic data                                                   |
 | `@formspec/analysis`        | Shared semantic-analysis protocol types and comment-tag utilities                   |
-| `@formspec/constraints`     | `.formspec.yml` configuration and DSL capability validation                         |
+| `@formspec/config`          | `formspec.config.ts` loading and DSL capability validation                          |
 | `@formspec/validator`       | Runtime JSON Schema validation for secure environments                              |
 | `@formspec/eslint-plugin`   | ESLint rules for FormSpec tags and DSL usage                                        |
 | `@formspec/ts-plugin`       | TypeScript language-service plugin and reusable semantic service                    |

--- a/e2e/helpers/dts-consumer-harness.ts
+++ b/e2e/helpers/dts-consumer-harness.ts
@@ -1,0 +1,324 @@
+/**
+ * Test harness for verifying that consumers on supported TypeScript
+ * versions can parse the `.d.ts` rollups we publish.
+ *
+ * # Why this exists
+ *
+ * The TS-version CI matrix in `.github/workflows/ci.yml` exercises
+ * **producer-side** compatibility: each row pins one `typescript` version
+ * via `pnpm.overrides` and runs the workspace's own build, typecheck,
+ * test, and lint at that version. Producer and consumer always match.
+ *
+ * Real consumers don't see that combination. They install our published
+ * `@formspec/*` tarballs whose `dist/<package>.d.ts` rollup was emitted by
+ * **the workspace's pinned TypeScript** (currently 6.x), and then they
+ * type-check those rollups with **their own `tsc`** (e.g. 5.7).
+ *
+ * This harness reproduces that asymmetric path in a temp directory:
+ *
+ * 1. Pack each public `@formspec/*` (and `formspec`) package via
+ *    `pnpm pack`, using the workspace's pinned TypeScript.
+ * 2. Scaffold a synthetic consumer project that installs every tarball
+ *    via `file:` deps, plus realistic peer-dep companions (`@types/node`,
+ *    `eslint`).
+ * 3. Generate an `index.ts` that imports every public entry point and
+ *    forces the type checker to walk each module's full export surface
+ *    (`keyof typeof X`). This is what catches `.d.ts` syntax that the
+ *    consumer's `tsc` cannot parse.
+ * 4. Run `tsc --noEmit` with the configured target TypeScript version.
+ *
+ * # What this catches
+ *
+ * - `.d.ts` syntax newer than the consumer's `tsc` can parse (e.g. new
+ *   `infer` constraints, the `accessor` keyword, or any future emit
+ *   feature added in a TS major).
+ * - Missing/wrong types entries in `package.json#exports` that surface
+ *   only when `module: NodeNext` resolves the package from outside the
+ *   workspace.
+ * - Transitive type imports that leak into our rollup but require globals
+ *   (`URL`, NodeJS namespace, etc.) that consumers might not have.
+ *
+ * # What this does NOT catch
+ *
+ * - Runtime behaviour. This is a type-only check; we do not execute
+ *   anything from the published tarballs.
+ * - API design issues. The harness asserts "your `tsc` can parse our
+ *   `.d.ts`," not "the API is well-designed."
+ *
+ * # Cost
+ *
+ * Packing all packages is ~5s. `npm install` of the consumer is ~10–30s
+ * (one-time). `tsc --noEmit` per version is ~5–20s. End-to-end across
+ * four versions is roughly 1–3 minutes — comparable to other e2e suites.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * One public entry point exposed by an `@formspec/*` (or `formspec`)
+ * package. The harness imports each of these and exercises every export.
+ */
+export interface PublicEntryPoint {
+  /** Module specifier as a consumer would write it. */
+  specifier: string;
+  /** Identifier-safe name used in the generated `index.ts`. */
+  importName: string;
+  /** Optional reason if the entry is currently excluded. */
+  excludedReason?: string;
+}
+
+/**
+ * Inventory of every public entry point we want a consumer to be able to
+ * import. Keep this list synced with each package's `package.json#exports`.
+ *
+ * Excluded entries stay in the list — with `excludedReason` populated — so
+ * the absence is intentional and traceable, rather than silently dropped.
+ */
+export const PUBLIC_ENTRY_POINTS: readonly PublicEntryPoint[] = [
+  { specifier: "@formspec/analysis", importName: "analysis" },
+  { specifier: "@formspec/analysis/protocol", importName: "analysisProtocol" },
+  { specifier: "@formspec/analysis/internal", importName: "analysisInternal" },
+  { specifier: "@formspec/build", importName: "build" },
+  { specifier: "@formspec/build/browser", importName: "buildBrowser" },
+  { specifier: "@formspec/build/internals", importName: "buildInternals" },
+  { specifier: "@formspec/cli", importName: "cli" },
+  { specifier: "@formspec/config", importName: "config" },
+  { specifier: "@formspec/config/browser", importName: "configBrowser" },
+  { specifier: "@formspec/core", importName: "core" },
+  { specifier: "@formspec/core/internals", importName: "coreInternals" },
+  { specifier: "@formspec/dsl", importName: "dsl" },
+  { specifier: "@formspec/eslint-plugin", importName: "eslintPlugin" },
+  {
+    specifier: "@formspec/eslint-plugin/base",
+    importName: "eslintPluginBase",
+    excludedReason:
+      "tracked as a separate publish bug — `dist/base.d.ts` rollup is not emitted; see issue #454",
+  },
+  { specifier: "@formspec/language-server", importName: "languageServer" },
+  { specifier: "@formspec/runtime", importName: "runtime" },
+  { specifier: "@formspec/ts-plugin", importName: "tsPlugin" },
+  { specifier: "@formspec/validator", importName: "validator" },
+  { specifier: "formspec", importName: "formspec" },
+];
+
+/** Workspace package directories whose tarballs the consumer installs. */
+const PUBLISHABLE_PACKAGE_DIRS: readonly string[] = [
+  "packages/analysis",
+  "packages/build",
+  "packages/cli",
+  "packages/config",
+  "packages/core",
+  "packages/dsl",
+  "packages/eslint-plugin",
+  "packages/formspec",
+  "packages/language-server",
+  "packages/runtime",
+  "packages/ts-plugin",
+  "packages/validator",
+];
+
+interface PackedTarball {
+  packageName: string;
+  tarballPath: string;
+}
+
+export interface ConsumerHarnessOptions {
+  /** Repo root — used to locate the workspace packages and invoke `pnpm pack`. */
+  repoRoot: string;
+  /** Tarball staging dir — created if absent. Reused across TS versions. */
+  tarballDir: string;
+  /** Consumer scaffold dir — created if absent. */
+  consumerDir: string;
+  /** TypeScript version to install in the consumer. */
+  typescriptVersion: string;
+  /**
+   * Optional override for the `index.ts` body. The default body imports
+   * every non-excluded entry from {@link PUBLIC_ENTRY_POINTS} and forces
+   * the type checker to walk each module's exports.
+   *
+   * Tests can pass a custom body to verify negative cases — e.g. that the
+   * harness fails when a 6.x-only construct lands in a fixture.
+   */
+  indexTsOverride?: string;
+}
+
+/** Runs `pnpm pack` once per package; idempotent on the tarball dir. */
+export function packAllPackages(repoRoot: string, tarballDir: string): PackedTarball[] {
+  fs.mkdirSync(tarballDir, { recursive: true });
+  const packed: PackedTarball[] = [];
+  for (const relDir of PUBLISHABLE_PACKAGE_DIRS) {
+    const absDir = path.join(repoRoot, relDir);
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.join(absDir, "package.json"), "utf8")
+    ) as { name: string; version: string };
+    execFileSync("pnpm", ["pack", "--pack-destination", tarballDir], {
+      cwd: absDir,
+      stdio: ["ignore", "ignore", "inherit"],
+    });
+    // Tarball naming follows pnpm's convention:
+    //   `@formspec/foo` v1.2.3 → `formspec-foo-1.2.3.tgz`
+    //   `formspec` v1.2.3 → `formspec-1.2.3.tgz`
+    const flatName = pkgJson.name.startsWith("@")
+      ? pkgJson.name.slice(1).replace("/", "-")
+      : pkgJson.name;
+    const tarballPath = path.join(tarballDir, `${flatName}-${pkgJson.version}.tgz`);
+    if (!fs.existsSync(tarballPath)) {
+      throw new Error(
+        `Expected tarball at ${tarballPath} after \`pnpm pack\` of ${pkgJson.name}, ` +
+          `but it does not exist. Tarball naming may have drifted.`
+      );
+    }
+    packed.push({ packageName: pkgJson.name, tarballPath });
+  }
+  return packed;
+}
+
+function buildPackageJson(tarballs: PackedTarball[], tsVersion: string): string {
+  const dependencies: Record<string, string> = {};
+  for (const t of tarballs) {
+    dependencies[t.packageName] = `file:${t.tarballPath}`;
+  }
+  // Peer deps and host-side companions a real consumer would have. `eslint`
+  // is a peer of `@formspec/eslint-plugin`; `@types/node` ensures NodeJS
+  // globals resolve in transitive `vscode-jsonrpc` types pulled in by
+  // `@formspec/language-server`.
+  dependencies["@types/node"] = "^22.13.0";
+  dependencies["eslint"] = "^9.39.2";
+  dependencies["typescript"] = tsVersion;
+  return (
+    JSON.stringify(
+      {
+        name: "formspec-dts-consumer-test",
+        version: "0.0.0",
+        type: "module",
+        private: true,
+        dependencies,
+      },
+      null,
+      2
+    ) + "\n"
+  );
+}
+
+function buildTsconfig(): string {
+  // Realistic consumer defaults: strict, NodeNext resolution, ES2022. DOM
+  // is included because several FormSpec packages reach `URL` (a global
+  // available in browser, Workers, and Node — but only via DOM/types/node
+  // libs in TS). `skipLibCheck: true` matches the overwhelming consumer
+  // default and prevents transitive `node_modules` types from masking our
+  // own `.d.ts` parseability — those would surface as parse errors even
+  // with `skipLibCheck`, while consumer-side type-check failures from
+  // unrelated third-party dep regressions would not.
+  return (
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          lib: ["ES2022", "DOM"],
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          types: ["node"],
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+        },
+        include: ["index.ts"],
+      },
+      null,
+      2
+    ) + "\n"
+  );
+}
+
+function buildIndexTs(): string {
+  const active = PUBLIC_ENTRY_POINTS.filter((e) => !e.excludedReason);
+  const excluded = PUBLIC_ENTRY_POINTS.filter((e) => e.excludedReason);
+  const importLines = active
+    .map((e) => `import type * as ${e.importName} from "${e.specifier}";`)
+    .join("\n");
+  const exclusionLines = excluded
+    .map((e) => `// excluded: ${e.specifier} — ${e.excludedReason ?? "unknown"}`)
+    .join("\n");
+  // `keyof typeof X` forces the type checker to enumerate each namespace's
+  // export surface, which in turn forces full parsing of the corresponding
+  // `.d.ts`. A bare `import type * as X` alone is too weak — TS may resolve
+  // the module without deeply parsing it.
+  const surfaceUnion = active.map((e) => `  | keyof typeof ${e.importName}`).join("\n");
+  return `// Generated by e2e/helpers/dts-consumer-harness.ts. Edits will be lost.
+${exclusionLines}
+${importLines}
+
+type _PublicSurface =
+${surfaceUnion};
+
+declare const _check: _PublicSurface;
+void _check;
+`;
+}
+
+export interface RunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Scaffolds the consumer dir for a given TypeScript version, runs
+ * `npm install`, then `tsc --noEmit`. Throws on the install step (a
+ * setup failure shouldn't be reported as a `.d.ts` parse error). Returns
+ * the `tsc` result; tests assert `exitCode === 0`.
+ */
+export function runConsumerCheck(opts: ConsumerHarnessOptions): RunResult {
+  const tarballs = packAllPackages(opts.repoRoot, opts.tarballDir);
+
+  fs.mkdirSync(opts.consumerDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(opts.consumerDir, "package.json"),
+    buildPackageJson(tarballs, opts.typescriptVersion)
+  );
+  fs.writeFileSync(path.join(opts.consumerDir, "tsconfig.json"), buildTsconfig());
+  fs.writeFileSync(
+    path.join(opts.consumerDir, "index.ts"),
+    opts.indexTsOverride ?? buildIndexTs()
+  );
+
+  // Force a clean install so the requested `typescript@<version>` is what
+  // resolves. `npm install` is intentional here (not pnpm): a real consumer
+  // is most likely on npm/yarn, and this test exercises the published
+  // tarball path, not workspace symlinks.
+  fs.rmSync(path.join(opts.consumerDir, "node_modules"), {
+    recursive: true,
+    force: true,
+  });
+  fs.rmSync(path.join(opts.consumerDir, "package-lock.json"), { force: true });
+  execFileSync("npm", ["install", "--silent"], {
+    cwd: opts.consumerDir,
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+
+  // Capture stdout/stderr separately. `tsc --noEmit` writes diagnostics to
+  // stdout when it's a TTY-less subprocess; we still pipe stderr in case a
+  // future TS version changes that.
+  const tscBin = path.join(opts.consumerDir, "node_modules", ".bin", "tsc");
+  const result = spawnSyncCapturing(tscBin, ["--noEmit"], opts.consumerDir);
+  return result;
+}
+
+function spawnSyncCapturing(bin: string, args: string[], cwd: string): RunResult {
+  // We avoid `execFileSync` here because it throws on non-zero exit, and we
+  // want to assert on the exit code in tests rather than try/catch.
+  const r = spawnSync(bin, args, { cwd, encoding: "utf8" });
+  return {
+    exitCode: r.status ?? -1,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+  };
+}
+
+/** Convenience: a temp dir under the OS temp root, prefixed for findability. */
+export function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}

--- a/e2e/helpers/dts-consumer-harness.ts
+++ b/e2e/helpers/dts-consumer-harness.ts
@@ -104,8 +104,15 @@ export const PUBLIC_ENTRY_POINTS: readonly PublicEntryPoint[] = [
   { specifier: "formspec", importName: "formspec" },
 ];
 
-/** Workspace package directories whose tarballs the consumer installs. */
-const PUBLISHABLE_PACKAGE_DIRS: readonly string[] = [
+/**
+ * Workspace package directories whose tarballs the consumer installs.
+ *
+ * Exported so the test suite can verify this list matches the actual
+ * publishable packages on disk — adding a new public package without
+ * adding it here should fail the inventory test, not silently leave the
+ * harness un-coverage.
+ */
+export const PUBLISHABLE_PACKAGE_DIRS: readonly string[] = [
   "packages/analysis",
   "packages/build",
   "packages/cli",
@@ -145,7 +152,23 @@ export interface ConsumerHarnessOptions {
   indexTsOverride?: string;
 }
 
-/** Runs `pnpm pack` once per package; idempotent on the tarball dir. */
+/**
+ * Runs `pnpm pack` for each publishable package and returns the resulting
+ * tarball paths. Idempotent: if the expected tarball already exists in
+ * `tarballDir` (matched by package name + version), the pack step is
+ * skipped. The test suite invokes this once at suite startup; calling it
+ * again from `runConsumerCheck` is therefore essentially free.
+ *
+ * Skip semantics: tarball name encodes the version, and pnpm pack
+ * deterministically writes that filename. So an existing tarball with a
+ * matching filename means "we packed this exact version already." It does
+ * **not** check tarball mtime against source mtime — if a developer
+ * mutates package source between runs without bumping the version (or
+ * cleaning the tarball dir), the cached tarball will be reused. Since the
+ * suite always creates a fresh tarball dir under `os.tmpdir()`, this is
+ * not a concern in practice; the caveat exists for callers who pass a
+ * persistent tarball dir.
+ */
 export function packAllPackages(repoRoot: string, tarballDir: string): PackedTarball[] {
   fs.mkdirSync(tarballDir, { recursive: true });
   const packed: PackedTarball[] = [];
@@ -154,10 +177,6 @@ export function packAllPackages(repoRoot: string, tarballDir: string): PackedTar
     const pkgJson = JSON.parse(
       fs.readFileSync(path.join(absDir, "package.json"), "utf8")
     ) as { name: string; version: string };
-    execFileSync("pnpm", ["pack", "--pack-destination", tarballDir], {
-      cwd: absDir,
-      stdio: ["ignore", "ignore", "inherit"],
-    });
     // Tarball naming follows pnpm's convention:
     //   `@formspec/foo` v1.2.3 → `formspec-foo-1.2.3.tgz`
     //   `formspec` v1.2.3 → `formspec-1.2.3.tgz`
@@ -166,10 +185,16 @@ export function packAllPackages(repoRoot: string, tarballDir: string): PackedTar
       : pkgJson.name;
     const tarballPath = path.join(tarballDir, `${flatName}-${pkgJson.version}.tgz`);
     if (!fs.existsSync(tarballPath)) {
-      throw new Error(
-        `Expected tarball at ${tarballPath} after \`pnpm pack\` of ${pkgJson.name}, ` +
-          `but it does not exist. Tarball naming may have drifted.`
-      );
+      execFileSync("pnpm", ["pack", "--pack-destination", tarballDir], {
+        cwd: absDir,
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+      if (!fs.existsSync(tarballPath)) {
+        throw new Error(
+          `Expected tarball at ${tarballPath} after \`pnpm pack\` of ${pkgJson.name}, ` +
+            `but it does not exist. Tarball naming may have drifted.`
+        );
+      }
     }
     packed.push({ packageName: pkgJson.name, tarballPath });
   }
@@ -312,9 +337,11 @@ function spawnSyncCapturing(bin: string, args: string[], cwd: string): RunResult
   // want to assert on the exit code in tests rather than try/catch.
   const r = spawnSync(bin, args, { cwd, encoding: "utf8" });
   return {
+    // `r.status` is null when the process was killed by a signal — surface
+    // that as -1 so callers can distinguish from a clean zero exit.
     exitCode: r.status ?? -1,
-    stdout: r.stdout ?? "",
-    stderr: r.stderr ?? "",
+    stdout: r.stdout,
+    stderr: r.stderr,
   };
 }
 

--- a/e2e/tests/dts-consumer-compat.test.ts
+++ b/e2e/tests/dts-consumer-compat.test.ts
@@ -12,6 +12,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   PUBLIC_ENTRY_POINTS,
+  PUBLISHABLE_PACKAGE_DIRS,
   makeTempDir,
   packAllPackages,
   runConsumerCheck,
@@ -53,28 +54,44 @@ afterAll(() => {
 });
 
 describe(".d.ts consumer compatibility", () => {
-  it("declares an entry-point inventory that matches every published package", () => {
-    // Sanity: every publishable package's `.` export should be in the
-    // inventory. Subpath exports are listed individually. Excluded entries
-    // count as covered (they live in the inventory, just gated). This
-    // guards against silently dropping a new package from the harness.
-    const specifiers = new Set(PUBLIC_ENTRY_POINTS.map((e) => e.specifier));
-    const expectedRootSpecifiers = [
-      "@formspec/analysis",
-      "@formspec/build",
-      "@formspec/cli",
-      "@formspec/config",
-      "@formspec/core",
-      "@formspec/dsl",
-      "@formspec/eslint-plugin",
-      "@formspec/language-server",
-      "@formspec/runtime",
-      "@formspec/ts-plugin",
-      "@formspec/validator",
-      "formspec",
-    ];
-    for (const expected of expectedRootSpecifiers) {
-      expect(specifiers.has(expected), `missing entry-point for ${expected}`).toBe(true);
+  it("inventory covers every non-private workspace package", () => {
+    // Derive the truth from disk so adding a new public package without
+    // updating `PUBLISHABLE_PACKAGE_DIRS` or `PUBLIC_ENTRY_POINTS` fails
+    // this test instead of silently leaving the new package un-covered.
+    //
+    // - Walk every dir under packages/, drop private packages.
+    // - Assert each non-private package's directory appears in
+    //   PUBLISHABLE_PACKAGE_DIRS (so its tarball gets packed).
+    // - Assert each non-private package's `.` specifier appears in
+    //   PUBLIC_ENTRY_POINTS (so the consumer fixture imports it).
+    //   Subpath exports are not auto-validated here — they vary per
+    //   package and live in PUBLIC_ENTRY_POINTS as explicit entries.
+    const packagesDir = path.join(REPO_ROOT, "packages");
+    const onDisk: { dir: string; name: string }[] = [];
+    for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const pkgJsonPath = path.join(packagesDir, entry.name, "package.json");
+      if (!fs.existsSync(pkgJsonPath)) continue;
+      const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")) as {
+        name: string;
+        private?: boolean;
+      };
+      if (pkg.private) continue;
+      onDisk.push({ dir: `packages/${entry.name}`, name: pkg.name });
+    }
+
+    const inventorySpecifiers = new Set(PUBLIC_ENTRY_POINTS.map((e) => e.specifier));
+    const inventoryDirs = new Set(PUBLISHABLE_PACKAGE_DIRS);
+
+    for (const pkg of onDisk) {
+      expect(
+        inventoryDirs.has(pkg.dir),
+        `PUBLISHABLE_PACKAGE_DIRS is missing ${pkg.dir}; the harness will not pack this package.`
+      ).toBe(true);
+      expect(
+        inventorySpecifiers.has(pkg.name),
+        `PUBLIC_ENTRY_POINTS is missing the root specifier "${pkg.name}"; the consumer fixture will not import it.`
+      ).toBe(true);
     }
   });
 
@@ -104,7 +121,7 @@ describe(".d.ts consumer compatibility", () => {
           // Surface tsc's diagnostic output directly. Vitest will quote the
           // message, which keeps line/column information legible in CI logs.
           throw new Error(
-            `tsc --noEmit (typescript ${tsVersion}) failed with exit code ${result.exitCode}\n` +
+            `tsc --noEmit (typescript ${tsVersion}) failed with exit code ${String(result.exitCode)}\n` +
               `STDOUT:\n${result.stdout}\n` +
               `STDERR:\n${result.stderr}`
           );
@@ -155,7 +172,12 @@ describe(".d.ts consumer compatibility", () => {
           `,
         });
         expect(result.exitCode).not.toBe(0);
-        expect(result.stdout).toMatch(/error TS/);
+        // Check both streams: while `tsc --noEmit` emits diagnostics on
+        // stdout today, future TypeScript releases (or environments that
+        // detect TTY differently) could move them to stderr. Asserting on
+        // the combined output keeps the harness self-test resilient.
+        const combined = `${result.stdout}\n${result.stderr}`;
+        expect(combined).toMatch(/error TS/);
       },
       300_000
     );

--- a/e2e/tests/dts-consumer-compat.test.ts
+++ b/e2e/tests/dts-consumer-compat.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Verifies that consumers on each supported TypeScript version can parse
+ * the `.d.ts` rollups we publish.
+ *
+ * See `e2e/helpers/dts-consumer-harness.ts` for the rationale and the
+ * mechanics of how the consumer fixture is constructed and exercised.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  PUBLIC_ENTRY_POINTS,
+  makeTempDir,
+  packAllPackages,
+  runConsumerCheck,
+} from "../helpers/dts-consumer-harness.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+/**
+ * The TypeScript versions a published consumer might use. The floor must
+ * match the `typescript` peer-dep range advertised by the published
+ * packages (see each `packages/<name>/package.json#peerDependencies.typescript`),
+ * and the ceiling is the latest stable in the supported `<7` range.
+ *
+ * If you change this list, also update the peer-dep range and the
+ * "Supported TypeScript versions" section in CLAUDE.md.
+ */
+const TYPESCRIPT_VERSIONS_TO_TEST: readonly string[] = [
+  "5.7.3",
+  "5.8.3",
+  "5.9.3",
+  "6.0.3",
+];
+
+// Packing every workspace package and running `npm install` is expensive.
+// Pack once at suite startup; each TS-version case scaffolds its own
+// consumer dir but reuses the shared tarballs.
+let sharedTarballDir: string;
+
+beforeAll(() => {
+  sharedTarballDir = makeTempDir("formspec-dts-consumer-tarballs-");
+  packAllPackages(REPO_ROOT, sharedTarballDir);
+}, 120_000);
+
+afterAll(() => {
+  if (sharedTarballDir) {
+    fs.rmSync(sharedTarballDir, { recursive: true, force: true });
+  }
+});
+
+describe(".d.ts consumer compatibility", () => {
+  it("declares an entry-point inventory that matches every published package", () => {
+    // Sanity: every publishable package's `.` export should be in the
+    // inventory. Subpath exports are listed individually. Excluded entries
+    // count as covered (they live in the inventory, just gated). This
+    // guards against silently dropping a new package from the harness.
+    const specifiers = new Set(PUBLIC_ENTRY_POINTS.map((e) => e.specifier));
+    const expectedRootSpecifiers = [
+      "@formspec/analysis",
+      "@formspec/build",
+      "@formspec/cli",
+      "@formspec/config",
+      "@formspec/core",
+      "@formspec/dsl",
+      "@formspec/eslint-plugin",
+      "@formspec/language-server",
+      "@formspec/runtime",
+      "@formspec/ts-plugin",
+      "@formspec/validator",
+      "formspec",
+    ];
+    for (const expected of expectedRootSpecifiers) {
+      expect(specifiers.has(expected), `missing entry-point for ${expected}`).toBe(true);
+    }
+  });
+
+  describe.each(TYPESCRIPT_VERSIONS_TO_TEST)("typescript %s", (tsVersion) => {
+    let consumerDir: string;
+
+    beforeAll(() => {
+      consumerDir = makeTempDir(`formspec-dts-consumer-${tsVersion}-`);
+    });
+
+    afterAll(() => {
+      if (consumerDir) {
+        fs.rmSync(consumerDir, { recursive: true, force: true });
+      }
+    });
+
+    it(
+      "type-checks every public entry point",
+      () => {
+        const result = runConsumerCheck({
+          repoRoot: REPO_ROOT,
+          tarballDir: sharedTarballDir,
+          consumerDir,
+          typescriptVersion: tsVersion,
+        });
+        if (result.exitCode !== 0) {
+          // Surface tsc's diagnostic output directly. Vitest will quote the
+          // message, which keeps line/column information legible in CI logs.
+          throw new Error(
+            `tsc --noEmit (typescript ${tsVersion}) failed with exit code ${result.exitCode}\n` +
+              `STDOUT:\n${result.stdout}\n` +
+              `STDERR:\n${result.stderr}`
+          );
+        }
+        expect(result.stdout.trim()).toBe("");
+      },
+      // npm install + tsc on a fresh consumer dir is heavier than the
+      // default vitest test timeout. Set generously; first run dominates.
+      300_000
+    );
+  });
+
+  describe("self-test (negative case)", () => {
+    let consumerDir: string;
+
+    beforeAll(() => {
+      consumerDir = makeTempDir("formspec-dts-consumer-negative-");
+    });
+
+    afterAll(() => {
+      if (consumerDir) {
+        fs.rmSync(consumerDir, { recursive: true, force: true });
+      }
+    });
+
+    it(
+      "fails on a deliberate type error in the consumer fixture",
+      () => {
+        // Inject a clearly-wrong assignment into the consumer's index.ts
+        // so we can verify the harness actually surfaces consumer
+        // diagnostics rather than swallowing them. If this case ever
+        // starts passing, the harness has stopped doing its job.
+        const result = runConsumerCheck({
+          repoRoot: REPO_ROOT,
+          tarballDir: sharedTarballDir,
+          consumerDir,
+          typescriptVersion: "6.0.3",
+          indexTsOverride: `
+            // Imports a real entry point so the inventory still gets
+            // exercised, then commits a plainly-wrong assignment so we
+            // can verify the harness actually surfaces tsc diagnostics.
+            import type * as core from "@formspec/core";
+            type _Surface = keyof typeof core;
+            declare const _check: _Surface;
+            void _check;
+            const _intentionalTypeError: number = "this should fail";
+            void _intentionalTypeError;
+          `,
+        });
+        expect(result.exitCode).not.toBe(0);
+        expect(result.stdout).toMatch(/error TS/);
+      },
+      300_000
+    );
+  });
+});

--- a/formspec.cml
+++ b/formspec.cml
@@ -1,0 +1,437 @@
+/**
+ * FormSpec — Strategic DDD Model
+ *
+ * This file is the formal architectural model of the FormSpec project,
+ * written in Context Mapper Language (CML).
+ *
+ *   - https://contextmapper.org/docs/language-reference/
+ *
+ * It is the source of truth for:
+ *   - which bounded contexts exist
+ *   - which domain each context realizes
+ *   - which contexts may depend on which (the ContextMap)
+ *
+ * Reader-friendly companion: BOUNDED_CONTEXTS.md
+ * Vocabulary companion:      GLOSSARY.md
+ * Architectural principles:  docs/000-principles.md
+ *
+ * The strategic level (BoundedContext, Subdomain, ContextMap) is modelled here.
+ * Tactical-level modelling (Aggregate, Entity, ValueObject) is intentionally
+ * out of scope at this stage; it may be added in a later campaign if the
+ * payoff becomes clear.
+ *
+ * Install the Context Mapper VS Code extension for syntax highlighting and
+ * validation: contextmapper.context-mapper-vscode-extension
+ */
+
+// =============================================================================
+// Domains and Subdomains
+// =============================================================================
+
+Domain FormSpec {
+	domainVisionStatement
+		= "Define type-safe forms in TypeScript that compile to standard JSON Schema 2020-12 and JSON Forms UI Schema, with consistent semantics across two authoring surfaces (chain DSL and TSDoc-annotated classes)."
+
+	Subdomain FormSpecModelDomain {
+		type = CORE
+		domainVisionStatement
+			= "The canonical FormIR vocabulary that every other context shares. The published language of FormSpec."
+	}
+
+	Subdomain AuthoringDomain {
+		type = CORE
+		domainVisionStatement
+			= "How developers express form definitions in TypeScript. Two surfaces: the chain DSL builder API and the TSDoc-annotated class surface."
+	}
+
+	Subdomain SemanticAnalysisDomain {
+		type = SUPPORTING
+		domainVisionStatement
+			= "Static extraction of FormSpec semantics from TypeScript source — TSDoc tag parsing, constraint metadata, FileSnapshot protocol — packaged so downstream tooling (Compilation, ESLint, TS plugin, language server) does not re-implement TypeScript-AST traversal."
+	}
+
+	Subdomain CompilationDomain {
+		type = CORE
+		domainVisionStatement
+			= "Canonicalization of authoring outputs into FormIR, followed by emission of JSON Schema 2020-12 and JSON Forms UI Schema. The pipeline that turns code into standard schemas."
+	}
+
+	Subdomain ConfigurationDomain {
+		type = SUPPORTING
+		domainVisionStatement
+			= "User-facing extension and constraint registration plus DSL capability restriction. Authored as TypeScript via formspec.config.ts (.mts/.js/.mjs variants accepted); legacy YAML strings are still parseable via the browser entry."
+	}
+
+	Subdomain RuntimeDomain {
+		type = SUPPORTING
+		domainVisionStatement
+			= "Resolver helpers that bind dynamic enum and dynamic schema fields to runtime data sources at form-rendering time."
+	}
+
+	Subdomain DeveloperToolingDomain {
+		type = SUPPORTING
+		domainVisionStatement
+			= "IDE, lint, and CLI integrations that surface FormSpec semantics to developers as they author forms."
+	}
+
+	Subdomain ValidationDomain {
+		type = GENERIC
+		domainVisionStatement
+			= "Standard JSON Schema 2020-12 validation. Generic because it conforms to an external standard rather than to a FormSpec-specific model."
+	}
+}
+
+// =============================================================================
+// Bounded Contexts
+// =============================================================================
+
+BoundedContext DomainModelContext implements FormSpecModelDomain {
+	type = APPLICATION
+	domainVisionStatement
+		= "Define and publish the canonical FormIR vocabulary, FormElement types, constraint registration interfaces, and metadata policy primitives. The single source of truth for the shape of a form."
+	implementationTechnology = "TypeScript — npm package @formspec/core"
+	responsibilities
+		= "FormElement discriminated union (TextField, NumberField, ObjectField, etc.)",
+		  "FormIR nodes (FieldNode, FormIRElement, ConstraintNode, AnnotationNode, Provenance)",
+		  "Constraint and annotation registration interfaces",
+		  "Metadata policy primitives"
+	// Published types (the surface this context exports for downstream contexts):
+	//   public (.):           AnyField, FormElement, FormSpec, TextField, NumberField,
+	//                         BooleanField, StaticEnumField, DynamicEnumField,
+	//                         DynamicSchemaField, ArrayField, ObjectField, Group,
+	//                         Conditional, EnumOption, plus constraint and annotation
+	//                         registration interfaces, MetadataPolicy primitives,
+	//                         LoggerLike contract.
+	//   /internals:           FieldNode, FormIR, FormIRElement, AnnotationNode,
+	//                         ConstraintNode, TypeNode, Provenance, IR_VERSION,
+	//                         PathTarget, JsonValue, BUILTIN_CONSTRAINT_DEFINITIONS,
+	//                         normalizeConstraintTagName, _attachFormSpecMetadataPolicy.
+}
+
+BoundedContext ChainDslContext implements AuthoringDomain {
+	type = FEATURE
+	domainVisionStatement
+		= "Provide a fluent, type-safe builder API (field.*, group, when, formspec) for authoring forms in TypeScript with full inference of the resulting schema type."
+	implementationTechnology = "TypeScript — npm package @formspec/dsl"
+	responsibilities
+		= "Field builder functions",
+		  "Group and conditional layout helpers",
+		  "Root formspec() factory",
+		  "InferFormSchema type inference helpers"
+	// Published types (.):
+	//   formspec(), field, group, when, is, InferFormSchema.
+}
+
+BoundedContext StaticAnalysisContext implements SemanticAnalysisDomain {
+	type = FEATURE
+	domainVisionStatement
+		= "Extract semantic information from TypeScript source — TSDoc tag parsing, constraint extraction, FileSnapshot protocol — so that downstream tooling does not re-implement TypeScript-AST traversal."
+	implementationTechnology = "TypeScript + @microsoft/tsdoc — npm package @formspec/analysis"
+	responsibilities
+		= "Comment-tag parsing (unified parser, applicability rules)",
+		  "Constraint and annotation extraction with provenance",
+		  "FileSnapshot protocol for transport-safe analysis input",
+		  "Constraint-validator semantics for diagnostic generation"
+	// Published types:
+	//   public (.):    analyzeMetadataForNode, analyzeMetadataForSourceFile, plus
+	//                  re-export of all /protocol types.
+	//   /protocol:     FormSpecAnalysisFileSnapshot, FormSpecAnalysisDiagnostic,
+	//                  FormSpecAnalysisManifest, FormSpecSemanticQuery,
+	//                  FormSpecSemanticResponse, FORMSPEC_ANALYSIS_PROTOCOL_VERSION,
+	//                  FORMSPEC_ANALYSIS_SCHEMA_VERSION, computeFormSpecTextHash,
+	//                  isFormSpecAnalysisManifest, plus serialized-* type families.
+	//   /internal:     ParsedCommentTag, ParsedCommentBlock, parseCommentBlock,
+	//                  parseTagSyntax, parseConstraintTagValue, parseDefaultValueTagValue,
+	//                  ConstraintTagParseRegistryLike, semantic completion helpers.
+}
+
+BoundedContext CompilationContext implements CompilationDomain {
+	type = APPLICATION
+	domainVisionStatement
+		= "Canonicalize chain-DSL values and TSDoc-class analysis results into FormIR, then emit JSON Schema 2020-12 and JSON Forms UI Schema. The pipeline runs as a pure function of its inputs (principle A3)."
+	implementationTechnology = "TypeScript + zod + typescript (peer) — npm package @formspec/build"
+	responsibilities
+		= "Chain DSL canonicalization",
+		  "TSDoc class canonicalization (analyzer → IR)",
+		  "JSON Schema 2020-12 emission",
+		  "JSON Forms UI Schema emission",
+		  "Mixed-authoring orchestration"
+	// Published types:
+	//   public (.):    buildFormSchemas, generateSchemas, generateSchemasFromClass,
+	//                  generateSchemasFromProgram, buildMixedAuthoringSchemas,
+	//                  writeSchemas, JsonSchema2020.
+	//   /browser:      Schema generators without Node fs/path imports.
+	//   /internals:    createProgramContext, analyzeClass, ClassSchemas,
+	//                  MethodSchemas, LoadedFormSpecSchemas, ValidationResult.
+}
+
+BoundedContext ConfigurationContext implements ConfigurationDomain {
+	type = APPLICATION
+	domainVisionStatement
+		= "Load formspec.config.ts (or .mts/.js/.mjs) configuration; let consumers register extensions and custom constraints via defineFormSpecConfig; restrict the FormSpec capability surface (allowed field types, layout features, field options) per project."
+	implementationTechnology = "TypeScript + jiti — npm package @formspec/config"
+	responsibilities
+		= "loadFormSpecConfig() — discover and parse formspec.config.{ts,mts,js,mjs}",
+		  "defineFormSpecConfig() and defineConstraints() — typed configuration authoring",
+		  "validateFormSpecElements() / validateFormSpec() — DSL capability validation",
+		  "Browser-safe subset (loadConfigFromString) for embedded YAML-string parsing"
+	// Published types:
+	//   public (.):    loadFormSpecConfig, loadConfig (deprecated),
+	//                  defineFormSpecConfig, defineConstraints,
+	//                  validateFormSpecElements, validateFormSpec,
+	//                  resolveConfigForFile, FormSpecConfig, ConstraintConfig,
+	//                  ResolvedConstraintConfig, ValidationIssue, ValidationResult,
+	//                  DEFAULT_CONFIG, DEFAULT_CONSTRAINTS, mergeWithDefaults.
+	//   /browser:      loadConfigFromString and validation surface without
+	//                  Node fs/path or jiti.
+}
+
+BoundedContext RuntimeContext implements RuntimeDomain {
+	type = APPLICATION
+	domainVisionStatement
+		= "Provide defineResolvers() so applications can supply async data for dynamic enum and dynamic schema fields with type safety end-to-end."
+	implementationTechnology = "TypeScript — npm package @formspec/runtime"
+	responsibilities
+		= "defineResolvers() builder",
+		  "Resolver composition for dynamic enums",
+		  "Type-safe binding between resolver function signatures and form definitions"
+	// Published types (.):
+	//   defineResolvers, ResolverRegistry, resolver helper types.
+}
+
+BoundedContext ValidatorContext implements ValidationDomain {
+	type = APPLICATION
+	domainVisionStatement
+		= "Wrap @cfworker/json-schema to provide JSON Schema 2020-12 validation in environments (including Cloudflare Workers) where standard validators are unavailable. Conforms to JSON Schema, not to FormSpec specifics."
+	implementationTechnology = "TypeScript + @cfworker/json-schema — npm package @formspec/validator"
+	responsibilities
+		= "Runtime JSON Schema 2020-12 validation",
+		  "Edge-runtime compatibility (no Node-specific imports)"
+	// Published types (.):
+	//   Validator constructor, validation result types — no FormSpec-specific surface.
+}
+
+BoundedContext CliContext implements DeveloperToolingDomain {
+	type = APPLICATION
+	domainVisionStatement
+		= "Drive schema and IR generation from the command line: discover TypeScript source, delegate to Compilation, and write outputs."
+	implementationTechnology = "TypeScript + pino + typescript — npm package @formspec/cli"
+	responsibilities
+		= "Argument parsing for `formspec generate`",
+		  "Source-file discovery and program construction",
+		  "Delegation to Compilation",
+		  "Output writing (schemas, optional --emit-ir, --validate-only)"
+}
+
+BoundedContext EslintContext implements DeveloperToolingDomain {
+	type = APPLICATION
+	domainVisionStatement
+		= "Provide ESLint rules that surface FormSpec semantics to authors at lint time: constraint type-mismatches, contradictions, and config-driven capability restrictions."
+	implementationTechnology = "TypeScript + ESLint RuleTester — npm package @formspec/eslint-plugin"
+	responsibilities
+		= "Constraint-type-mismatch rule",
+		  "Consistent-constraints rule (e.g., @minimum ≤ @maximum)",
+		  "Constraints-allowed-field-types and constraints-allowed-layouts rules",
+		  "Auto-fix delivery for unambiguous corrections"
+}
+
+BoundedContext TsPluginContext implements DeveloperToolingDomain {
+	type = APPLICATION
+	domainVisionStatement
+		= "TypeScript language-service plugin and a reusable composable semantic service for IDE integrations."
+	implementationTechnology = "TypeScript language-service API — npm package @formspec/ts-plugin"
+	responsibilities
+		= "tsserver plugin entry point",
+		  "FormSpecSemanticService composable API exposed for higher-level tools",
+		  "IDE diagnostic and completion contributions"
+	// Published types (.):
+	//   FormSpecSemanticService, plugin factory entry. CJS-only consumers
+	//   (tsserver) load this package via require.
+}
+
+BoundedContext LanguageServerContext implements DeveloperToolingDomain {
+	type = APPLICATION
+	domainVisionStatement
+		= "LSP reference implementation. Thin presentation layer over the composable analysis and TS-plugin helpers; provides completion, hover, and diagnostics for FormSpec tags."
+	implementationTechnology = "TypeScript + vscode-languageserver — npm package @formspec/language-server"
+	responsibilities
+		= "LSP protocol handling",
+		  "Hover, completion, and diagnostic dispatch",
+		  "Translation between LSP types and FormSpec semantic helpers"
+}
+
+// NOTE: The `formspec` umbrella package is intentionally NOT modelled as a
+// BoundedContext. It re-exports `@formspec/core`, `@formspec/dsl`,
+// `@formspec/build`, and `@formspec/runtime` verbatim — it has no domain
+// language of its own and is purely a packaging convenience. See
+// BOUNDED_CONTEXTS.md for the rationale and how its dependencies are still
+// enforced (it must only re-export from the four upstream contexts).
+
+// =============================================================================
+// Context Map
+// =============================================================================
+//
+// Relationship notation (only patterns actually used in this map):
+//   [D]   = Downstream
+//   [U]   = Upstream
+//   [OHS] = Open Host Service (upstream provides a documented protocol)
+//   [PL]  = Published Language (a shared, well-defined vocabulary)
+//   [CF]  = Conformist (downstream accepts upstream's model as-is)
+//   [ACL] = Anti-Corruption Layer (downstream translates upstream into a
+//           different vocabulary)
+// (CML supports other patterns — Shared Kernel, Customer-Supplier,
+// Partnership — that are not currently used in FormSpec.)
+//
+// Every cross-context coupling in this map corresponds to a real
+// dependency declared in package.json — and conversely, every real
+// dependency between FormSpec packages is declared as an edge here.
+// (The CI guardrail planned for Phase 2 enforces both directions:
+// no edge in the map without a package.json dep, no package.json dep
+// without an edge in the map.) Logical / data-flow couplings that
+// are not code-level dependencies (for example: ValidatorContext consumes
+// JSON Schema produced by CompilationContext) are noted in domainVisionStatement
+// rather than as ContextMap edges, because no code import flows between them.
+// =============================================================================
+
+ContextMap FormSpecContextMap {
+	type = SYSTEM_LANDSCAPE
+	state = AS_IS
+
+	contains DomainModelContext
+	contains ChainDslContext
+	contains StaticAnalysisContext
+	contains CompilationContext
+	contains ConfigurationContext
+	contains RuntimeContext
+	contains ValidatorContext
+	contains CliContext
+	contains EslintContext
+	contains TsPluginContext
+	contains LanguageServerContext
+
+	// -------------------------------------------------------------------------
+	// DomainModelContext is the published language of FormSpec.
+	// Every other internal context that imports types from @formspec/core is
+	// downstream of it via OHS+PL.
+	// -------------------------------------------------------------------------
+
+	ChainDslContext [D, CF]<-[U, OHS, PL] DomainModelContext {
+		implementationTechnology = "TypeScript types via @formspec/core public exports"
+		exposedAggregates = "FormSpec, FieldTypes, ConstraintRegistry"
+	}
+
+	StaticAnalysisContext [D, CF]<-[U, OHS, PL] DomainModelContext {
+		implementationTechnology = "TypeScript types via @formspec/core public + /internals exports"
+		exposedAggregates = "PathTarget, JsonValue, BUILTIN_CONSTRAINT_DEFINITIONS, normalizeConstraintTagName"
+	}
+
+	CompilationContext [D, CF]<-[U, OHS, PL] DomainModelContext {
+		implementationTechnology = "TypeScript types via @formspec/core public + /internals exports"
+		exposedAggregates = "FieldNode, FormIR, FormIRElement, AnnotationNode, ConstraintNode, IR_VERSION"
+	}
+
+	ConfigurationContext [D, CF]<-[U, OHS, PL] DomainModelContext {
+		implementationTechnology = "TypeScript types via @formspec/core"
+		exposedAggregates = "Constraint registration interfaces, FieldType discriminants"
+	}
+
+	RuntimeContext [D, CF]<-[U, OHS, PL] DomainModelContext {
+		implementationTechnology = "TypeScript types via @formspec/core"
+		exposedAggregates = "DataSourceRegistry, DynamicEnumField, DynamicSchemaField"
+	}
+
+	EslintContext [D, CF]<-[U, OHS, PL] DomainModelContext {
+		implementationTechnology = "TypeScript types via @formspec/core"
+		exposedAggregates = "Constraint and annotation registration types"
+	}
+
+	TsPluginContext [D, CF]<-[U, OHS, PL] DomainModelContext {
+		implementationTechnology = "TypeScript types via @formspec/core"
+		exposedAggregates = "FormElement, FieldNode, Provenance"
+	}
+
+	LanguageServerContext [D, CF]<-[U, OHS, PL] DomainModelContext {
+		implementationTechnology = "TypeScript types via @formspec/core"
+		exposedAggregates = "FormElement, Provenance, diagnostic types"
+	}
+
+	// -------------------------------------------------------------------------
+	// StaticAnalysisContext exposes parsed comment-tag info as an OHS.
+	// Downstreams translate that information into different vocabularies
+	// (canonicalized IR, ESLint diagnostics, LSP responses) — these are
+	// Anti-Corruption Layer relationships, not Conformist consumption.
+	// -------------------------------------------------------------------------
+
+	CompilationContext [D, ACL]<-[U, OHS, PL] StaticAnalysisContext {
+		implementationTechnology = "TypeScript types via @formspec/analysis public + /internal exports"
+		exposedAggregates = "FormSpecAnalysisFileSnapshot, ParsedCommentTag (via /internal), parseConstraintTagValue (via /internal), analyzeMetadataForSourceFile"
+		// ACL: canonicalization translates parsed-tag info into FormIR (principle A4).
+	}
+
+	EslintContext [D, ACL]<-[U, OHS] StaticAnalysisContext {
+		implementationTechnology = "TypeScript types via @formspec/analysis"
+		exposedAggregates = "Constraint extraction helpers, applicability rules"
+		// ACL: lint rules translate constraint info into ESLint RuleContext / fix descriptors.
+	}
+
+	TsPluginContext [D, ACL]<-[U, OHS] StaticAnalysisContext {
+		implementationTechnology = "TypeScript types via @formspec/analysis"
+		exposedAggregates = "Comment parser, semantic analysis helpers"
+		// ACL: plugin translates parsed-tag info into ts-server diagnostic / completion shapes.
+	}
+
+	LanguageServerContext [D, ACL]<-[U, OHS, PL] StaticAnalysisContext {
+		implementationTechnology = "TypeScript types via @formspec/analysis (including /protocol for transport)"
+		exposedAggregates = "FormSpecAnalysisFileSnapshot, FormSpecAnalysisDiagnostic, FormSpecAnalysisManifest"
+		// ACL: textbook — translates analysis output into LSP wire types.
+	}
+
+	// -------------------------------------------------------------------------
+	// ConfigurationContext is upstream of any context that needs to know
+	// which capabilities the user has restricted.
+	// -------------------------------------------------------------------------
+
+	CompilationContext [D, CF]<-[U, OHS] ConfigurationContext {
+		implementationTechnology = "TypeScript via @formspec/config"
+		exposedAggregates = "FormSpecConfig, defineConstraints"
+	}
+
+	CliContext [D, CF]<-[U, OHS] ConfigurationContext {
+		implementationTechnology = "TypeScript via @formspec/config"
+		exposedAggregates = "loadConfig, FormSpecConfig"
+	}
+
+	EslintContext [D, CF]<-[U, OHS] ConfigurationContext {
+		implementationTechnology = "TypeScript via @formspec/config (including /browser for env-conditioned use)"
+		exposedAggregates = "validateFormSpecElements, capability registry"
+	}
+
+	LanguageServerContext [D, CF]<-[U, OHS] ConfigurationContext {
+		implementationTechnology = "TypeScript via @formspec/config"
+		exposedAggregates = "loadConfig, capability registry"
+	}
+
+	// -------------------------------------------------------------------------
+	// CompilationContext is upstream of consumers that need its build APIs
+	// (CLI, ESLint constraint enforcement, the umbrella package).
+	// -------------------------------------------------------------------------
+
+	CliContext [D, CF]<-[U, OHS] CompilationContext {
+		implementationTechnology = "TypeScript via @formspec/build public + /internals exports"
+		exposedAggregates = "buildFormSchemas, generateSchemas, ClassSchemas, MethodSchemas"
+	}
+
+	EslintContext [D, ACL]<-[U, OHS] CompilationContext {
+		implementationTechnology = "TypeScript via @formspec/build"
+		exposedAggregates = "Compilation helpers used by constraint rules"
+		// ACL: lint rules adapt build outputs into ESLint diagnostics.
+	}
+
+	// -------------------------------------------------------------------------
+	// ValidatorContext intentionally has no internal upstream relationships.
+	// It is a thin wrapper around @cfworker/json-schema and conforms to the
+	// JSON Schema 2020-12 standard. Any FormSpec context that needs runtime
+	// validation imports it directly without negotiation — see its
+	// domainVisionStatement.
+	// -------------------------------------------------------------------------
+}


### PR DESCRIPTION
## Summary

Closes #451

Adds a consumer-compatibility harness (in `e2e/`) that packs every public `@formspec/*` (and `formspec`) package via `pnpm pack`, scaffolds a synthetic consumer in a temp directory, and runs `tsc --noEmit` against each TypeScript version in the supported peer-dep range. End-to-end runtime is ~20 seconds for all four TS versions.

## Why

The existing TS-version CI matrix exercises **producer-side** compatibility — each row pins a single `typescript` via `pnpm.overrides` so the workspace's own build/typecheck/test/lint run at that version. Producer and consumer always match.

Real consumers see the asymmetric path: they install our published `.d.ts` rollups (emitted by the workspace's pinned TS) and parse them with their own `tsc`. Without this harness, the day a TS 6 emit feature lands in our rollup that a TS 5.7 consumer can't parse, we'd find out from a downstream bug report rather than CI.

## What it catches

- `.d.ts` syntax newer than the consumer's `tsc` can parse.
- Missing or wrong `package.json#exports.types` paths that surface only when `module: NodeNext` resolves the package from outside the workspace.
- Transitive type imports that leak into our rollup but require globals (`URL`, NodeJS namespace, etc.) the consumer doesn't have.

## What it does NOT catch

- Runtime behaviour. Type-only check; nothing from the published tarballs is executed.
- API design issues. The harness asserts "your `tsc` can parse our `.d.ts`," not "the API is well-designed."

## Side finding: surfaces a real publish bug

While building the inventory I noticed `@formspec/eslint-plugin/base`'s `package.json#exports./base.types` points at `./dist/base.d.ts`, but **that rollup is never emitted** — only `dist/src/base.d.ts` (per-source) exists. Consumers of `/base` get implicit-any.

Tracked separately as [#454](https://github.com/mike-north/formspec/issues/454). The harness explicitly excludes `/base` with an `excludedReason` field that surfaces the issue link, rather than silently dropping it. When #454 ships, removing the exclusion will be a one-line follow-up.

## Self-test (negative case)

The suite includes a self-test that injects a deliberate type error into the consumer fixture and asserts `tsc` exits non-zero with a `TS` diagnostic. Guards against the harness silently passing if its plumbing breaks.

## Test plan

- [x] Local: `pnpm run build && pnpm --filter @formspec/e2e exec vitest run tests/dts-consumer-compat.test.ts` — 6 tests pass (4 versions + inventory + negative), ~20s.
- [ ] CI: existing `build-and-test` job runs `pnpm run test`, which includes e2e. The new test will run once packages are built.
- [ ] Inventory test guards against silently dropping a future package — confirm by adding a temporary new package and watching the inventory test fail until it's added to `PUBLIC_ENTRY_POINTS`.
