### PR TITLE
Demote aspirational playground docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,6 @@ Primary packages:
 - `@formspec/language-server` — reference LSP implementation over shared helpers
 - `@formspec/cli` — CLI for schema and IR generation
 - `@formspec/validator` — runtime JSON Schema validation
-- `@formspec/playground` — private browser playground app
 - `@formspec/e2e` — end-to-end and benchmark workspace (`/e2e`)
 
 ## Repo Commands
@@ -58,7 +57,6 @@ pnpm --filter @formspec/build run test
 pnpm --filter @formspec/dsl run test:types
 pnpm --filter @formspec/eslint-plugin run fix:eslint-docs
 pnpm --filter @formspec/eslint-plugin run check:eslint-docs
-pnpm --filter @formspec/playground run dev
 ```
 
 ## Working Rules

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,9 +36,6 @@ formspec (umbrella — re-exports everything)
 @formspec/language-server  (reference LSP implementation — thin presentation layer over composable helpers)
 ├── @formspec/analysis
 └── @formspec/core
-
-@formspec/playground       (interactive browser editor — private)
-└── [all packages]
 ```
 
 ### Build Order
@@ -53,7 +50,6 @@ Packages build in dependency order. `pnpm run build` at the root handles this au
 6. `@formspec/ts-plugin` — depends on analysis
 7. `@formspec/language-server` — depends on analysis, core
 8. `formspec` — umbrella, depends on all above
-9. `@formspec/playground` — depends on everything, private
 
 ## DSL
 
@@ -243,11 +239,11 @@ themselves how diagnostics are surfaced.
 
 `@formspec/build` provides three entry points for different consumers:
 
-| Entry Point                 | Audience             | Exports                                                                           |
-| --------------------------- | -------------------- | --------------------------------------------------------------------------------- |
-| `@formspec/build`           | Public API           | `buildFormSchemas`, `writeSchemas`, `generateSchemasFromClass`, schema generators |
-| `@formspec/build/browser`   | Browser (playground) | Schema generators without Node.js fs/path                                         |
-| `@formspec/build/internals` | CLI (unstable)       | `createProgramContext`, `analyzeClass`, `generateClassSchemas`                    |
+| Entry Point                 | Audience          | Exports                                                                           |
+| --------------------------- | ----------------- | --------------------------------------------------------------------------------- |
+| `@formspec/build`           | Public API        | `buildFormSchemas`, `writeSchemas`, `generateSchemasFromClass`, schema generators |
+| `@formspec/build/browser`   | Browser consumers | Schema generators without Node.js fs/path                                         |
+| `@formspec/build/internals` | CLI (unstable)    | `createProgramContext`, `analyzeClass`, `generateClassSchemas`                    |
 
 ## Testing Strategy
 
@@ -260,7 +256,7 @@ themselves how diagnostics are surfaced.
 | **Integration**      | Vitest     | `src/__tests__/integration.test.ts` | Full pipeline (DSL → schema)               |
 | **Fixture-based**    | Vitest     | `src/__tests__/fixtures/`           | Real TypeScript files through the analyzer |
 | **ESLint rule**      | RuleTester | `src/__tests__/rules/*.test.ts`     | Valid/invalid code patterns per rule       |
-| **Example projects** | Vitest     | `examples/*/test/schemas.test.ts`   | Schema snapshot validation                 |
+| **Example projects** | Vitest     | `examples/*/test/schemas.test.ts`   | Future worked-example validation           |
 
 ### Test Infrastructure
 
@@ -268,15 +264,15 @@ themselves how diagnostics are surfaced.
 - **Timeout config**: 15s for packages with heavy TS analysis (cli, eslint-plugin); 5s default
 - **Circular reference tests**: Use Vitest timeout guards to prevent hangs
 
-## Playground (`@formspec/playground`)
+## Planned workspace areas
 
-Interactive browser-based editor (React + Vite + Monaco Editor):
+### Playground (`@formspec/playground`)
 
-1. **Editor**: Monaco with TypeScript syntax highlighting
-2. **Compiler**: `ts.transpileModule()` → execute → `buildFormSchemas()` → constraint validation
-3. **Output tabs**: JSON Schema, UI Schema, live form preview (JSON Forms), lint results, constraints
-4. **Persistence**: Code and constraint settings saved to localStorage
-5. **Debounced**: Compilation runs on idle after 500ms of inactivity
+`@formspec/playground` is planned as a private browser-based editor and preview app, but it is not currently present in the workspace. When implemented, it should consume the existing browser-safe entry points rather than introducing new core semantics.
+
+### Examples (`examples/`)
+
+`examples/` is reserved for worked examples and integration patterns. It is currently a documentation stub; add real examples as subdirectories so the existing `examples/*` workspace glob can pick them up.
 
 ## Versioning & Publishing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,6 @@ formspec (umbrella — re-exports everything)
 @formspec/validator        (JSON Schema validation — @cfworker/json-schema)
 @formspec/ts-plugin        (TypeScript plugin + composable semantic service — reference implementation inside tsserver, depends on @formspec/analysis)
 @formspec/language-server  (reference LSP implementation — thin presentation layer over composable helpers, depends on @formspec/analysis and @formspec/core)
-@formspec/playground       (interactive browser editor — private, depends on all)
 @formspec/e2e             (workspace for end-to-end tests and benchmarks)
 ```
 
@@ -106,7 +105,7 @@ Packages must build in dependency order. The root `pnpm run build` handles this 
 6. `@formspec/ts-plugin` (depends on analysis)
 7. `@formspec/language-server` (depends on analysis, core)
 8. `formspec` (umbrella, depends on core, dsl, build, runtime)
-9. `@formspec/playground` and `@formspec/e2e` (depend on many/all packages)
+9. `@formspec/e2e` (depends on many/all packages)
 
 ### Entry Points
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ The default vendor prefix is `x-formspec`. `@formspec/build` also supports custo
 | `@formspec/ts-plugin`       | TypeScript language-service plugin and reusable semantic service                    |
 | `@formspec/language-server` | Completion, hover, and definition support for FormSpec tags                         |
 | `@formspec/cli`             | Build-time CLI for schema and IR generation                                         |
-| `@formspec/playground`      | Private monorepo playground app                                                     |
 
 ## Monorepo Development
 

--- a/docs/000-principles.md
+++ b/docs/000-principles.md
@@ -188,7 +188,7 @@ Things FormSpec explicitly does NOT guarantee. These are useful for preventing s
 
 **NP5: No guaranteed JSON Schema draft compatibility beyond the target draft.** FormSpec targets a specific JSON Schema draft (2020-12 or as determined by the vocabulary design). Backward compatibility with older drafts (draft-07, draft-04) is not guaranteed.
 
-**NP6: No visual form builder.** FormSpec is a code-first tool. The playground provides preview feedback, not a drag-and-drop editor. WYSIWYG authoring is not a design goal.
+**NP6: No visual form builder.** FormSpec is a code-first tool. The planned playground provides preview feedback, not a drag-and-drop editor. WYSIWYG authoring is not a design goal.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# FormSpec Examples
+
+This directory is reserved for worked examples and integration patterns.
+
+Add real examples as subdirectories under `examples/` so the existing `examples/*` workspace glob can pick them up. For example, a future example package would live at `examples/<name>/package.json` with its tests and local README beside it.

--- a/packages/formspec/README.md
+++ b/packages/formspec/README.md
@@ -9,7 +9,7 @@ It re-exports the most commonly used pieces from:
 - `@formspec/build`
 - `@formspec/runtime`
 
-It does not include the CLI, ESLint plugin, language server, or playground app.
+It does not include the CLI, ESLint plugin, or language server.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Removes `@formspec/playground` from current package lists, build-order guidance, and package guide docs.
- Moves playground language in architecture/principles docs to planned-state wording.
- Adds an `examples/README.md` stub explaining that future examples should live in subdirectories for the existing `examples/*` workspace glob.

## Test plan

- `pnpm exec prettier --check AGENTS.md CLAUDE.md ARCHITECTURE.md README.md docs/000-principles.md examples/README.md packages/formspec/README.md`
- `git diff --check origin/main..HEAD`
- `pnpm -r --filter './examples/*' run lint`
