### PR TITLE
Add TypeFlags magic-number guard

### DIFF
--- a/.changeset/typeflags-magic-number-guard.md
+++ b/.changeset/typeflags-magic-number-guard.md
@@ -1,0 +1,5 @@
+---
+"@formspec/eslint-plugin": patch
+---
+
+Add a repository lint guard that rejects hardcoded numeric TypeScript compiler flag bitmasks in package source files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,5 +162,6 @@ TypeScript 7.x is the Go rewrite with a substantively different API surface. We 
 When code reaches into TypeScript's compiler API (`ts.Type`, `ts.Symbol`, `ts.TypeChecker`, etc.), be aware that some internals are not part of the public API contract and shift between majors. The most common pitfall:
 
 - **`ts.TypeFlags` numeric values were renumbered between TS 5.x and TS 6.x.** Always reference flags by enum member (`type.flags & ts.TypeFlags.Null`), never by hardcoded number (`type.flags & 65536`). See [`packages/eslint-plugin/src/utils/type-utils.ts`](packages/eslint-plugin/src/utils/type-utils.ts) for a full table and rationale.
+- `pnpm run lint` runs `scripts/check-typeflags-magic-numbers.mjs`, which fails on numeric literals in `.flags` bitmasks under `packages/**/src`. Replace any violation with the named `ts.TypeFlags.*` enum member.
 
 When in doubt, `import * as ts from "typescript"` (rather than `import type`) so enum references resolve at runtime against the host's installed TypeScript.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,11 @@ export default [
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["eslint.config.js", "scripts/normalize-generated-markdown.mjs"],
+          allowDefaultProject: [
+            "eslint.config.js",
+            "scripts/check-typeflags-magic-numbers.mjs",
+            "scripts/normalize-generated-markdown.mjs",
+          ],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "build": "pnpm -r run build",
     "clean": "pnpm -r run clean",
-    "lint": "eslint . && pnpm -r --filter './examples/*' run lint",
-    "lint:fix": "eslint . --fix && pnpm -r --filter './examples/*' run lint --fix",
+    "check:typeflags": "node scripts/check-typeflags-magic-numbers.mjs",
+    "lint": "eslint . && pnpm run check:typeflags && pnpm -r --filter './examples/*' run lint",
+    "lint:fix": "eslint . --fix && pnpm run check:typeflags && pnpm -r --filter './examples/*' run lint --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "pnpm -r run test",

--- a/packages/eslint-plugin/tests/typeflags-guard.test.ts
+++ b/packages/eslint-plugin/tests/typeflags-guard.test.ts
@@ -1,0 +1,136 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const guardScript = join(repoRoot, "scripts/check-typeflags-magic-numbers.mjs");
+
+function writeFixture(fileName: string, contents: string): string {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "formspec-typeflags-guard-"));
+  const filePath = join(fixtureRoot, fileName);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents);
+  return fixtureRoot;
+}
+
+function runGuard(fixtureRoot: string) {
+  return spawnSync(process.execPath, [guardScript, fixtureRoot], {
+    encoding: "utf8",
+  });
+}
+
+function parseReportedLiterals(stderr: string): string[] {
+  return stderr
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const match = /\(found (?<literal>\d+)\)\.$/.exec(line);
+      if (match?.groups?.["literal"] === undefined) {
+        throw new Error(`Unexpected diagnostic line: ${line}`);
+      }
+      return match.groups["literal"];
+    });
+}
+
+describe("TypeFlags magic-number guard", () => {
+  it("allows named TypeFlags enum masks and numeric zero comparisons", () => {
+    const fixtureRoot = writeFixture(
+      "packages/example/src/valid.ts",
+      `
+        import * as ts from "typescript";
+
+        export function isNullable(type: ts.Type): boolean {
+          return (type.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0;
+        }
+
+        export function usesComputedMask(type: ts.Type): boolean {
+          return (type.flags & lookupFlag(4)) !== 0;
+        }
+
+        // This comment documents a bad example: type.flags & 4
+        export const documentation = "Avoid code like type.flags & 8";
+      `
+    );
+
+    try {
+      const result = runGuard(fixtureRoot);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores package files outside src", () => {
+    const fixtureRoot = writeFixture(
+      "packages/example/tests/fixture.ts",
+      `
+        export function legacyTestFixture(type: { flags: number }): boolean {
+          return (type.flags & 4) !== 0;
+        }
+      `
+    );
+
+    try {
+      const result = runGuard(fixtureRoot);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects numeric literals in masks adjacent to .flags checks", () => {
+    const fixtureRoot = writeFixture(
+      "packages/example/src/invalid.ts",
+      `
+        import * as ts from "typescript";
+
+        export function isStringish(type: ts.Type): boolean {
+          return (
+            (type.flags & 4) !== 0 ||
+            (8 & type.flags) !== 0 ||
+            (type.flags & (16 | 32)) !== 0 ||
+            (type.flags & (64 | ts.TypeFlags.StringLiteral)) !== 0
+          );
+        }
+      `
+    );
+
+    try {
+      const result = runGuard(fixtureRoot);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(parseReportedLiterals(result.stderr)).toEqual(["4", "8", "16", "32", "64"]);
+      expect(result.stderr).toContain("invalid.ts");
+      expect(result.stderr).toContain("Use a named TypeScript compiler flag enum member");
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("reports missing scan targets without a stack trace", () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "formspec-typeflags-guard-"));
+    const missingTarget = join(fixtureRoot, "does-not-exist");
+
+    try {
+      const result = runGuard(missingTarget);
+
+      expect(result.status).toBe(2);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(`Error: Scan target does not exist: ${missingTarget}`);
+      expect(result.stderr).not.toContain("at ");
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/check-typeflags-magic-numbers.mjs
+++ b/scripts/check-typeflags-magic-numbers.mjs
@@ -1,0 +1,174 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import ts from "typescript";
+
+const DEFAULT_TARGETS = ["packages"];
+const IGNORED_DIRECTORY_NAMES = new Set(["coverage", "dist", "node_modules", "temp"]);
+const TYPE_SCRIPT_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
+
+/**
+ * @typedef {object} Finding
+ * @property {string} filePath
+ * @property {number} line
+ * @property {number} column
+ * @property {string} literal
+ */
+
+/**
+ * @param {string} entryPath
+ * @returns {Iterable<string>}
+ */
+function* walkSourceFiles(entryPath) {
+  const entryStat = statSync(entryPath);
+  if (entryStat.isDirectory()) {
+    if (IGNORED_DIRECTORY_NAMES.has(path.basename(entryPath))) {
+      return;
+    }
+
+    for (const child of readdirSync(entryPath).sort()) {
+      yield* walkSourceFiles(path.join(entryPath, child));
+    }
+    return;
+  }
+
+  if (isPackageSourceFile(entryPath)) {
+    yield entryPath;
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isPackageSourceFile(filePath) {
+  if (filePath.endsWith(".d.ts")) {
+    return false;
+  }
+
+  if (!TYPE_SCRIPT_EXTENSIONS.some((extension) => filePath.endsWith(extension))) {
+    return false;
+  }
+
+  const parts = path.resolve(filePath).split(path.sep);
+  const packagesIndex = parts.lastIndexOf("packages");
+  return packagesIndex >= 0 && parts[packagesIndex + 2] === "src";
+}
+
+/**
+ * @param {ts.Expression} expression
+ * @returns {ts.Expression}
+ */
+function stripExpressionWrappers(expression) {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/**
+ * @param {ts.Expression} expression
+ * @returns {boolean}
+ */
+function isFlagsAccessExpression(expression) {
+  const stripped = stripExpressionWrappers(expression);
+  return ts.isPropertyAccessExpression(stripped) && stripped.name.text === "flags";
+}
+
+/**
+ * The guard parses TypeScript instead of grepping so examples in comments and
+ * unrelated numeric comparisons such as `(type.flags & ts.TypeFlags.Null) !== 0`,
+ * `type.flags & lookup(4)`, or `object.flags & value` do not trigger false
+ * positives.
+ *
+ * @param {string} filePath
+ * @returns {Finding[]}
+ */
+function findMagicTypeFlagMasks(filePath) {
+  const sourceText = readFileSync(filePath, "utf8");
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
+  /** @type {Finding[]} */
+  const findings = [];
+  const seenPositions = new Set();
+
+  /**
+   * @param {ts.Expression} expression
+   * @returns {void}
+   */
+  function collectNumericMaskLiterals(expression) {
+    const stripped = stripExpressionWrappers(expression);
+
+    if (ts.isNumericLiteral(stripped)) {
+      const position = stripped.getStart(sourceFile);
+      if (!seenPositions.has(position)) {
+        const location = sourceFile.getLineAndCharacterOfPosition(position);
+        findings.push({
+          filePath,
+          line: location.line + 1,
+          column: location.character + 1,
+          literal: stripped.getText(sourceFile),
+        });
+        seenPositions.add(position);
+      }
+      return;
+    }
+
+    if (ts.isBinaryExpression(stripped) && stripped.operatorToken.kind === ts.SyntaxKind.BarToken) {
+      collectNumericMaskLiterals(stripped.left);
+      collectNumericMaskLiterals(stripped.right);
+    }
+  }
+
+  /**
+   * @param {ts.Node} node
+   * @returns {void}
+   */
+  function visit(node) {
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.AmpersandToken) {
+      if (isFlagsAccessExpression(node.left)) {
+        collectNumericMaskLiterals(node.right);
+      }
+      if (isFlagsAccessExpression(node.right)) {
+        collectNumericMaskLiterals(node.left);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return findings;
+}
+
+const targets = process.argv.slice(2);
+const scanTargets = targets.length === 0 ? DEFAULT_TARGETS : targets;
+/** @type {Finding[]} */
+const findings = [];
+
+for (const target of scanTargets) {
+  if (!existsSync(target)) {
+    globalThis.console.error(`Error: Scan target does not exist: ${target}`);
+    process.exit(2);
+  }
+
+  for (const filePath of walkSourceFiles(target)) {
+    findings.push(...findMagicTypeFlagMasks(filePath));
+  }
+}
+
+if (findings.length > 0) {
+  for (const finding of findings) {
+    const relativePath = path.relative(process.cwd(), finding.filePath);
+    const location = [relativePath, String(finding.line), String(finding.column)].join(":");
+    globalThis.console.error(
+      `${location} Use a named TypeScript compiler flag enum member, such as ts.TypeFlags.String, instead of hardcoded numeric bitmasks (found ${finding.literal}).`
+    );
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Add a TypeScript AST-based guard that fails on hardcoded numeric `.flags` bitmasks under `packages/**/src`
- Wire the guard into `pnpm run lint` and `pnpm run lint:fix`
- Document the TypeScript compiler flag guidance in `CLAUDE.md`
- Add regression tests for valid enum references, direct numeric masks, scoped package scanning, stderr diagnostics, and invalid scan targets

## Test plan
- `pnpm --filter @formspec/eslint-plugin run test`
- `pnpm --filter @formspec/eslint-plugin run typecheck`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm exec prettier --check CLAUDE.md eslint.config.js package.json scripts/check-typeflags-magic-numbers.mjs packages/eslint-plugin/tests/typeflags-guard.test.ts`
