### PR TITLE
docs: adopt deprecation-over-breaking-changes principle (PP14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,10 @@ pnpm run release            # Build and publish (CI usually does this)
 - Do not use `@description`; use summary text before block tags and `@remarks` for programmatic notes
 - API Extractor manages public API surface for library packages — commit `api-report/` files
 
+## Evolving the public API
+
+Per **PP14 — Deprecation over breaking changes** in [`docs/000-principles.md`](./docs/000-principles.md), prefer additive deprecation over outright removal when changing public APIs. When renaming, restructuring, or removing a public surface (TypeScript exports, ESLint rule IDs, configuration keys), add the new form, keep the old form as a deprecated alias that delegates to the new form, land the deprecation in a minor or patch release, and only remove the alias in a major release. Use `@deprecated` JSDoc tags on TypeScript exports, `meta.deprecated: true` plus `meta.replacedBy` on ESLint rules, and runtime warnings on configuration keys. Major releases should be mechanical — they remove deprecated aliases and dead deprecation-support code, not introduce new behavior. Exceptions (zero-user APIs, security/correctness fixes, `@alpha`/`@beta` churn) must be documented in the changeset. When proposing API changes — including in PR descriptions and design issues — explicitly state the chosen evolution strategy and, if breaking, justify the exception.
+
 ## Supported TypeScript versions
 
 FormSpec packages with a `typescript` peer-dep declare `>=5.7.3 <7`. The CI matrix in `.github/workflows/ci.yml` exercises:

--- a/docs/000-principles.md
+++ b/docs/000-principles.md
@@ -41,6 +41,34 @@ Good built-in examples:
 
 These names are good because the semantic role is visible in the tag itself. By contrast, generic names like `@data` are weak when they obscure the primary meaning at the point of use — for example, `@data countries` says almost nothing about whether the comment is describing selectable options, backing records, provenance, or some other unrelated notion of "data". This principle applies to both built-in tags and extension tags.
 
+**PP14: Deprecation over breaking changes.** Use deprecation as the primary tool for evolving the FormSpec API. Breaking changes should be avoided whenever an additive deprecation path is reasonable.
+
+When removing, renaming, or restructuring a public API element:
+
+1. **Add the new form.** Function, type, rule ID, export — whatever shape the replacement takes.
+2. **Retain the old form as a deprecated alias** that delegates to the new form.
+   - TypeScript exports: `@deprecated` JSDoc tag with a clear migration message.
+   - ESLint rules: `meta.deprecated: true` plus `meta.replacedBy`.
+   - Configuration keys: accepted at runtime; emit a deprecation warning to logs.
+3. **Land the deprecation in a minor or patch release.** Consumers see warnings; their code keeps working.
+4. **Remove the old form only in a major release.**
+
+Major releases are intentionally boring. A major release should consist of:
+
+- Removing previously deprecated exports and aliases.
+- Removing dead code paths that exist only to support deprecations.
+- No new behavior or functionality changes that were not already shipped under deprecation.
+
+Rationale: this discipline makes the upgrade path predictable. A consumer can stay on the latest minor of any major version indefinitely. Migration to the next major is mechanical (delete the deprecated calls the lints flagged) rather than investigative.
+
+Exceptions are acceptable when:
+
+- The element has demonstrably zero users (verified via search across known consumers and `npm` dependents).
+- A security or correctness issue makes maintaining the deprecation path unsafe.
+- The element is `@alpha` or `@beta` and the deprecation cost exceeds the value (cf. API Extractor release tags). This exception is currently load-bearing during pre-1.0 development (see PP12) and should narrow as APIs stabilize.
+
+When taking an exception, document the reason in the changeset.
+
 ---
 
 ## 2. Semantic Properties

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -33,6 +33,11 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
 
 ## 000-principles.md
 
+- Added PP14 — Deprecation over breaking changes ([#434](https://github.com/mike-north/formspec/issues/434)).
+  - Deprecation with an aliased replacement is the default mechanism for evolving public APIs (TypeScript exports, ESLint rule IDs, configuration keys).
+  - Removals land only in major releases; major releases are intentionally boring — they remove previously deprecated aliases and dead deprecation-support code, not introduce new behavior.
+  - Documented exceptions for zero-user APIs, security/correctness fixes, and `@alpha`/`@beta` churn — the alpha/beta exception is currently load-bearing during pre-1.0 development (PP12) and should narrow as APIs stabilize.
+  - CLAUDE.md gains a corresponding "Evolving the public API" section so contributors and AI agents internalize the principle when proposing API changes.
 - Added a naming principle for TSDoc tags.
   - FormSpec TSDoc tags should read as complete thoughts, even when they are not full sentences.
   - Generic names like `@data` are disfavored when they obscure the primary meaning being captured at the comment site.


### PR DESCRIPTION
## Summary

- Adds **PP14 — Deprecation over breaking changes** to [`docs/000-principles.md`](./docs/000-principles.md), establishing deprecation-with-alias as the default mechanism for evolving the FormSpec public API.
- Adds an **"Evolving the public API"** section to [`CLAUDE.md`](./CLAUDE.md) so contributors and AI agents internalize the principle when proposing API changes.
- Records the change under `000-principles.md` in [`docs/spec-changelog.md`](./docs/spec-changelog.md).

Closes #434.

## Principle text (PP14)

The numbered evolution path:

1. **Add the new form** (function, type, rule ID, export — whatever the replacement looks like).
2. **Retain the old form as a deprecated alias** that delegates to the new form.
   - TypeScript exports: `@deprecated` JSDoc with a clear migration message.
   - ESLint rules: `meta.deprecated: true` plus `meta.replacedBy`.
   - Configuration keys: accepted at runtime; emit a deprecation warning.
3. **Land the deprecation in a minor or patch release.**
4. **Remove the old form only in a major release.** Majors are intentionally boring — they remove deprecated aliases and dead deprecation-support code, not introduce new behavior.

**Exceptions** (must be documented in the changeset):
- The element has demonstrably zero users.
- A security or correctness issue makes maintaining the deprecation path unsafe.
- The element is `@alpha` or `@beta` and the deprecation cost exceeds the value. This exception is currently load-bearing during pre-1.0 development (PP12) and should narrow as APIs stabilize.

## Coordination notes

- **#419 (Theme 3) also adds a principle to `000-principles.md`.** Per #434's coordination note, this PR claims `PP14` (next available after `PP13`). If #419 lands first, this PR should rebase to `PP15`; if this lands first, #419 should rebase to `PP15`.
- **In-flight issue audit** (`#417`, `#420`, `#429`, `#433` review checklist in #434) is intentionally **not** included in this PR — those are notes/comments better left to the maintainer to apply on the relevant issues. The principle text is the durable artifact; the audit is a one-time triage that doesn't need to live in the same PR.

## Test plan

- [x] `pnpm run lint:docs` — stale-reference gate passes (the new text avoids `src/__tests__/`, `@formspec/constraints`, and `packages/constraints/`).
- [x] Format check confirms the three changed files (`CLAUDE.md`, `docs/000-principles.md`, `docs/spec-changelog.md`) are not flagged by Prettier.
- [ ] Visual review of the rendered Markdown on GitHub for the new PP14 block and the CLAUDE.md "Evolving the public API" section.
- [ ] Confirm PP14 numbering does not collide with #419 once both PRs converge.

https://claude.ai/code/session_01XFMQSdAdUyY7RfSL4793e1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFMQSdAdUyY7RfSL4793e1)_