### PR TITLE
docs: add data-vs-DSL constraint taxonomy principle (#419)

### DIFF
--- a/.changeset/constraint-kinds-principle.md
+++ b/.changeset/constraint-kinds-principle.md
@@ -1,7 +1,14 @@
 ---
 "@formspec/config": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"formspec": patch
 ---
 
 Reconcile `@formspec/config` documentation with its unified-configuration identity (resolves [#419](https://github.com/mike-north/formspec/issues/419) — documentation half).
 
 The package JSDoc on `packages/config/src/index.ts` now describes `@formspec/config` as the unified configuration package (schemas, extensions, serialization, metadata policy, pipeline settings) and acknowledges that DSL-policy validation lives here transitionally pending the factoring tracked in [#420](https://github.com/mike-north/formspec/issues/420). The `package.json` description is updated to mention DSL-policy validation explicitly. No source-code or runtime behavior changes.
+
+The transitive-dependent patch bumps (`@formspec/build`, `@formspec/cli`, `@formspec/eslint-plugin`, `@formspec/language-server`, `formspec`) are required by the monorepo's mechanical changeset gate; they carry no functional changes.

--- a/.changeset/constraint-kinds-principle.md
+++ b/.changeset/constraint-kinds-principle.md
@@ -1,0 +1,7 @@
+---
+"@formspec/config": patch
+---
+
+Reconcile `@formspec/config` documentation with its unified-configuration identity (resolves [#419](https://github.com/mike-north/formspec/issues/419) — documentation half).
+
+The package JSDoc on `packages/config/src/index.ts` now describes `@formspec/config` as the unified configuration package (schemas, extensions, serialization, metadata policy, pipeline settings) and acknowledges that DSL-policy validation lives here transitionally pending the factoring tracked in [#420](https://github.com/mike-north/formspec/issues/420). The `package.json` description is updated to mention DSL-policy validation explicitly. No source-code or runtime behavior changes.

--- a/docs/000-principles.md
+++ b/docs/000-principles.md
@@ -69,6 +69,13 @@ Exceptions are acceptable when:
 
 When taking an exception, document the reason in the changeset.
 
+**PP15: Constraint kinds.** FormSpec uses "constraint" as a generic term for narrowing rules. Two distinct kinds operate at different levels:
+
+- **Data constraints** narrow valid values of a field. They are authored as TSDoc tags, represented in the IR as `ConstraintNode`, and emitted as JSON Schema validation keywords.
+- **DSL policy** narrows which FormSpec features a project may author. It is composed of building-block constraints (field-type, layout, rule-effect, etc.) loaded from `FormSpecConfig` and enforced at authoring/lint time.
+
+Spec docs that introduce constraint-related concepts must specify which kind they mean.
+
 ---
 
 ## 2. Semantic Properties

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -8,6 +8,17 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
 - Group entries by the spec document being changed.
 - Link each entry back to the corresponding item in `scratch/spec-risk-log.md` when applicable.
 
+# 2026-04-27
+
+## 000-principles.md
+
+- Added PP15 — Constraint kinds.
+  - "Constraint" is the umbrella term for narrowing rules in FormSpec.
+  - **Data constraints** narrow valid values of a field; authored as TSDoc tags, represented in the IR as `ConstraintNode`, emitted as JSON Schema validation keywords.
+  - **DSL policy** narrows which FormSpec features a project may author; composed of building-block constraints (field-type, layout, rule-effect, etc.) loaded from `FormSpecConfig` and enforced at authoring/lint time.
+  - Spec docs that introduce constraint-related concepts must specify which kind they mean.
+  - Resolves the documentation half of [#419](https://github.com/mike-north/formspec/issues/419); the DSL-policy factoring follow-up is tracked in [#420](https://github.com/mike-north/formspec/issues/420).
+
 # 2026-04-26
 
 ## 002-tsdoc-grammar

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formspec/config",
   "version": "0.1.0-alpha.64",
-  "description": "Unified configuration for FormSpec - extensions, constraints, metadata, and pipeline settings",
+  "description": "Unified configuration for FormSpec - extensions, constraints, metadata, pipeline settings, and DSL-policy validation",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,21 +1,33 @@
 /**
  * \@formspec/config
  *
- * Constraint validation for FormSpec - restrict features based on target
- * environment capabilities.
+ * Unified configuration for FormSpec: schemas, extensions, serialization,
+ * metadata policy, and pipeline settings. This is the single entry point
+ * authors and downstream tools use to describe how a project consumes
+ * FormSpec.
  *
- * This package provides:
- * - Type definitions for constraint configuration
- * - YAML/TypeScript config file loading
- * - Core validation logic for FormSpec elements
- * - JSON Schema for .formspec.yml validation
+ * The package also currently hosts DSL-policy validation logic — the
+ * building-block constraints (field-type, layout, rule-effect, etc.) that
+ * narrow which authoring features a project may use. That responsibility
+ * lives here by historical accident from the `@formspec/constraints` era
+ * and is being factored into a private `@formspec/dsl-policy` package
+ * (tracked in [#420](https://github.com/mike-north/formspec/issues/420)).
+ *
+ * "Constraint" is overloaded in FormSpec; see the data-vs-DSL constraint
+ * taxonomy in `docs/000-principles.md` for the canonical distinction:
+ *
+ * - **Data constraints** narrow valid values of a field (TSDoc tags such
+ *   as `@minimum`, IR `ConstraintNode`, JSON Schema validation keywords).
+ * - **DSL policy** narrows which FormSpec features a project may author
+ *   (composed from `FieldTypeConstraints`, `LayoutConstraints`, etc.,
+ *   loaded from `FormSpecConfig` and enforced at lint/build time).
  *
  * @example
  * ```ts
  * import { loadConfig, validateFormSpecElements } from '@formspec/config';
  * import { formspec, field } from '@formspec/dsl';
  *
- * // Load constraints from .formspec.yml
+ * // Load configuration from formspec.config.ts
  * const { config } = await loadConfig();
  *
  * // Create a form
@@ -24,7 +36,7 @@
  *   field.dynamicEnum("country", "countries"),
  * );
  *
- * // Validate against constraints
+ * // Validate against the configured DSL policy
  * const result = validateFormSpecElements(form.elements, { constraints: config });
  *
  * if (!result.valid) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -24,11 +24,14 @@
  *
  * @example
  * ```ts
- * import { loadConfig, validateFormSpecElements } from '@formspec/config';
+ * import { loadFormSpecConfig, validateFormSpecElements } from '@formspec/config';
  * import { formspec, field } from '@formspec/dsl';
  *
  * // Load configuration from formspec.config.ts
- * const { config } = await loadConfig();
+ * const result = await loadFormSpecConfig();
+ * if (!result.found) {
+ *   throw new Error('No formspec.config.ts found');
+ * }
  *
  * // Create a form
  * const form = formspec(
@@ -37,10 +40,10 @@
  * );
  *
  * // Validate against the configured DSL policy
- * const result = validateFormSpecElements(form.elements, { constraints: config });
+ * const validation = validateFormSpecElements(form.elements, { constraints: result.config });
  *
- * if (!result.valid) {
- *   console.error('Validation failed:', result.issues);
+ * if (!validation.valid) {
+ *   console.error('Validation failed:', validation.issues);
  * }
  * ```
  *


### PR DESCRIPTION
Resolves the documentation half of #419. The mechanical CLAUDE.md / ARCHITECTURE.md / `docs/maintainer-migration-notes.md` / `docs/007-configuration.md` path fixes called out in the issue were already landed by the stale-reference docs gate in #461 — `grep` confirms no remaining `@formspec/constraints` or `packages/constraints/` references in current docs.

## Summary

- Add **PP14 — Constraint kinds** to `docs/000-principles.md`, naming "constraint" as the umbrella for narrowing rules and distinguishing data constraints (TSDoc tags / IR `ConstraintNode` / JSON Schema validation keywords) from DSL policy (`FormSpecConfig`-loaded feature gates enforced at lint time). Spec docs introducing constraint-related concepts must specify which kind they mean.
- Rewrite the `@formspec/config` package JSDoc (`packages/config/src/index.ts`) to describe the unified-configuration identity (schemas, extensions, serialization, metadata policy, pipeline settings) and acknowledge that DSL-policy validation lives there transitionally pending the factoring tracked in #420.
- Update `packages/config/package.json` description to mention DSL-policy validation explicitly.
- Record the principle addition in `docs/spec-changelog.md` under a new 2026-04-27 dated section.
- Patch changeset for `@formspec/config`.

No source-code or runtime behavior changes.

## Test plan

- [x] `node scripts/check-stale-doc-references.mjs` — clean
- [x] `node --test scripts/check-stale-doc-references.test.mjs` — 8/8 pass
- [x] `pnpm exec prettier --check` on all changed files
- [ ] Repo-wide `pnpm run lint` / `pnpm run test` / `pnpm run typecheck` (not run locally; changes are pure JSDoc/markdown text + a patch changeset)

https://claude.ai/code/session_01QxWWsxFSqQENMFPCHcaFyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxWWsxFSqQENMFPCHcaFyU)_