### PR TITLE
Document semantic service embedding API

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -235,6 +235,12 @@ This is intentionally white-labelable: downstream tools can reuse the same
 TypeScript `Program`, call `FormSpecSemanticService` directly, and decide for
 themselves how diagnostics are surfaced.
 
+Embedding hosts use the `@formspec/ts-plugin` package root as the public API:
+CommonJS/`require` resolves to `./index.cjs`, while ESM/`import` resolves to
+`./dist/index.js`. `docs/004-tooling.md` §2.7 is the normative reference for
+`FormSpecSemanticService`, its options and stats, and
+`createLanguageServiceProxy`.
+
 ## Entry Points
 
 `@formspec/build` provides three entry points for different consumers:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ formspec (umbrella — re-exports everything)
 5. **Dynamic Fields**: `field.dynamicEnum()` for runtime-fetched options; resolver functions defined via `defineResolvers()`
 6. **TSDoc Constraints**: Tags like `/** @minimum 0 */` produce constraint nodes in the Canonical IR; they propagate through nested class types
 7. **Canonical IR**: All form definitions pass through an intermediate representation before schema generation
-8. **Hybrid Tooling**: `@formspec/ts-plugin` exposes the reusable semantic service that works against a host TypeScript program; the shipped tsserver plugin and `@formspec/language-server` are reference implementations built on those lower-level APIs
+8. **Hybrid Tooling**: `@formspec/ts-plugin` exposes the reusable semantic service that works against a host TypeScript program; the shipped tsserver plugin and `@formspec/language-server` are reference implementations built on those lower-level APIs. Embedding hosts import the package root:
+   CommonJS/`require` resolves to `./index.cjs`, ESM/`import` resolves to `./dist/index.js`, and `docs/004-tooling.md` §2.7 is the normative embedding guide.
 9. **Description Semantics**: Summary text becomes JSON Schema `description`; `@description` is intentionally unsupported; `@remarks` is carried separately as metadata
 
 ### Build Order

--- a/docs/004-tooling.md
+++ b/docs/004-tooling.md
@@ -272,8 +272,10 @@ The service exposes these methods:
 | `dispose()`                              | Clears pending refresh timers and cached semantic snapshots.            |
 
 If `getProgram` returns `undefined` or the requested source file is unavailable,
-completion and hover queries return `null`. Diagnostics and file-snapshot
-queries return a snapshot with a `MISSING_SOURCE_FILE` infrastructure warning.
+completion and hover queries return `null`. Diagnostics queries return a
+diagnostics result with an empty `sourceHash` plus a `MISSING_SOURCE_FILE`
+infrastructure diagnostic, while file-snapshot queries return an empty snapshot
+with that diagnostic.
 
 `getStats()` returns `FormSpecSemanticServiceStats`. Hosts can use it for
 capacity planning and performance monitoring: `queryTotals` counts completion,

--- a/docs/004-tooling.md
+++ b/docs/004-tooling.md
@@ -111,17 +111,7 @@ The TypeScript compiler API is accessed via a shared `TypeResolutionContext`. ES
 #### 2.4.1 Reference Host Pattern
 
 Downstream TypeScript hosts that already control their own plugin/runtime can
-skip IPC entirely:
-
-1. Construct `FormSpecSemanticService` with the host's existing `getProgram`
-2. Call `getDiagnostics(filePath)`, `getCompletionContext(filePath, offset)`,
-   and `getHover(filePath, offset)` directly
-3. Render author feedback from canonical `code` + structured `data`
-4. Treat the shipped FormSpec `tsserver` plugin and LSP as reference
-   implementations of the same composition model
-
-The source repository includes a concrete reference example in the TypeScript
-plugin package and a test that exercises it against a real TypeScript program.
+skip IPC entirely; see §2.7 for the normative embedding contract.
 
 #### 2.4.2 Benchmark Harness
 
@@ -219,6 +209,158 @@ declare function analyzeDeclaration(
 ```
 
 The pipeline is pure and stateless per invocation — no ambient configuration, no cross-call state (per A3). ESLint calls it once per relevant AST node during a lint run; the TypeScript plugin calls it incrementally against the host editor's existing project state and caches/serializes the result for the lightweight language server.
+
+### 2.7 Embedding the Semantic Service
+
+`@formspec/ts-plugin` exposes its semantic service as a public embedding API for
+downstream TypeScript hosts. A host that already owns a TypeScript `Program`
+should pass that program through `getProgram`; the service must not create a
+second long-lived program for the same workspace. This keeps FormSpec analysis
+aligned with the host's compiler state and with the single-program model used
+by the shipped `tsserver` plugin; see Theme 7 tracker
+[#435](https://github.com/mike-north/formspec/issues/435).
+
+Consumers import from the package root:
+
+```typescript
+import { FormSpecSemanticService, createLanguageServiceProxy } from "@formspec/ts-plugin";
+```
+
+The package root is dual-mode. CommonJS `require("@formspec/ts-plugin")`
+resolves to `./index.cjs`, which is the entry point `tsserver` can load as a
+plugin module. ESM `import` resolves to `./dist/index.js`. Consumers should not
+deep-import files from `dist/` or `src/`; the package root is the supported
+public import surface, and deep imports are unsupported.
+
+Transport and IPC payload types are outside this embedding guide; use
+`packages/ts-plugin/api-report/ts-plugin.api.md` for the exact current
+package-root export inventory.
+
+#### 2.7.1 `FormSpecSemanticService`
+
+`FormSpecSemanticService` is the in-process semantic API. Its constructor accepts
+`FormSpecSemanticServiceOptions`.
+
+Required options:
+
+| Option              | Meaning                                                                  |
+| ------------------- | ------------------------------------------------------------------------ |
+| `workspaceRoot`     | Root directory used for runtime paths and contextual logging.            |
+| `typescriptVersion` | Version string reported by the host TypeScript runtime.                  |
+| `getProgram`        | Callback returning the current host `Program`, or `undefined` if absent. |
+
+Optional options:
+
+| Option                      | Meaning                                                           |
+| --------------------------- | ----------------------------------------------------------------- |
+| `logger`                    | Receives profiling and refresh-failure messages.                  |
+| `enablePerformanceLogging`  | Enables structured semantic-query hotspot logging.                |
+| `performanceLogThresholdMs` | Minimum query duration before a performance log entry is emitted. |
+| `snapshotDebounceMs`        | Debounce window for background snapshot refreshes.                |
+| `now`                       | Injectable clock for tests and deterministic snapshot timestamps. |
+
+The service exposes these methods:
+
+| Method                                   | Purpose                                                                 |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| `getCompletionContext(filePath, offset)` | Returns semantic completion context for a comment cursor position.      |
+| `getDiagnostics(filePath)`               | Returns canonical diagnostics for the file in the current host program. |
+| `getFileSnapshot(filePath)`              | Returns the full serialized semantic snapshot for a file.               |
+| `getHover(filePath, offset)`             | Returns semantic hover payload for a comment or declaration position.   |
+| `getStats()`                             | Returns query, path, and file-snapshot cache counters.                  |
+| `scheduleSnapshotRefresh(filePath)`      | Schedules a debounced background refresh for the file snapshot cache.   |
+| `dispose()`                              | Clears pending refresh timers and cached semantic snapshots.            |
+
+If `getProgram` returns `undefined` or the requested source file is unavailable,
+completion and hover queries return `null`. Diagnostics and file-snapshot
+queries return a snapshot with a `MISSING_SOURCE_FILE` infrastructure warning.
+
+`getStats()` returns `FormSpecSemanticServiceStats`. Hosts can use it for
+capacity planning and performance monitoring: `queryTotals` counts completion,
+hover, diagnostics, and file-snapshot calls; `queryPathTotals` splits
+diagnostics and file-snapshot calls into cold and warm snapshot-backed paths;
+`fileSnapshotCacheHits` and `fileSnapshotCacheMisses` expose cache behavior.
+The API report is the exact source for field-level details.
+
+#### 2.7.2 Standalone Host Example
+
+A standalone host that owns a TypeScript `Program` can call the service directly
+and render user-facing feedback from stable diagnostic `code` plus structured
+`data`:
+
+```typescript
+import * as ts from "typescript";
+import { FormSpecSemanticService } from "@formspec/ts-plugin";
+
+const semanticService = new FormSpecSemanticService({
+  workspaceRoot,
+  typescriptVersion: ts.version,
+  getProgram: () => program,
+});
+
+const diagnostics = semanticService.getDiagnostics(filePath).diagnostics;
+const hover = semanticService.getHover(filePath, offset);
+const completion = semanticService.getCompletionContext(filePath, offset);
+
+renderHostAuthoringState({ hover, completion });
+
+for (const diagnostic of diagnostics) {
+  renderHostDiagnostic({
+    code: diagnostic.code,
+    severity: diagnostic.severity,
+    facts: diagnostic.data,
+  });
+}
+
+semanticService.dispose();
+```
+
+In a real host, keep one service alive for the workspace or project so snapshot
+caches and debounced refreshes remain useful. Call `dispose()` when the host or
+plugin is torn down.
+
+`packages/ts-plugin/tests/downstream-authoring-host.test.ts` exercises direct
+service construction against a real `Program` and uses
+`packages/ts-plugin/src/reference-host-example.ts` as the diagnostic-rendering
+helper. `packages/ts-plugin/tests/semantic-service.test.ts` covers direct
+diagnostics, hover, and completion calls.
+
+#### 2.7.3 `tsserver` Plugin Host Example
+
+A host that is itself a `tsserver` plugin can keep FormSpec snapshots fresh by
+wrapping the existing TypeScript language service:
+
+```typescript
+import type * as tsServer from "typescript/lib/tsserverlibrary.js";
+import { FormSpecSemanticService, createLanguageServiceProxy } from "@formspec/ts-plugin";
+
+export function init(modules: {
+  readonly typescript: typeof tsServer;
+}): tsServer.server.PluginModule {
+  const typescriptVersion = modules.typescript.version;
+
+  return {
+    create(info) {
+      const semanticService = new FormSpecSemanticService({
+        workspaceRoot: info.project.getCurrentDirectory(),
+        typescriptVersion,
+        getProgram: () => info.languageService.getProgram(),
+        logger: info.project.projectService.logger,
+      });
+
+      return createLanguageServiceProxy(info.languageService, semanticService);
+    },
+  };
+}
+```
+
+`createLanguageServiceProxy(languageService, semanticService)` delegates normal
+TypeScript editor operations to the original language service and schedules
+snapshot refreshes for semantic diagnostics, completions, and quick-info calls.
+The packaged FormSpec `tsserver` plugin is a reference implementation of this
+composition model. The proxy does not publish FormSpec diagnostics by itself;
+hosts that want to surface FormSpec findings must call
+`semanticService.getDiagnostics(filePath)` or use the plugin transport.
 
 ---
 

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -18,6 +18,7 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
 
 ## 004-tooling
 
+- Added §2.7 for the public `@formspec/ts-plugin` embedding API and reduced §2.4.1 to a cross-reference.
 - Added `type-compatibility/no-anonymous-recursive-type` to the ESLint recommended and strict rule inventory.
   - The rule reports the build analyzer's `ANONYMOUS_RECURSIVE_TYPE` diagnostic at the recursive source edge.
 


### PR DESCRIPTION
## Summary

- Adds `docs/004-tooling.md` §2.7 for embedding `FormSpecSemanticService` from `@formspec/ts-plugin`
- Documents package-root CJS/ESM entry behavior, service options, methods, stats, lifecycle notes, and `createLanguageServiceProxy`
- Updates `CLAUDE.md`, `ARCHITECTURE.md`, and the spec changelog to point at the new normative section

Fixes #436

## Test plan

- `pnpm --filter @formspec/core --filter @formspec/analysis run build`
- `pnpm --filter @formspec/ts-plugin run test`
- `pnpm --filter @formspec/ts-plugin run typecheck`
- `pnpm exec prettier --check docs/004-tooling.md docs/spec-changelog.md CLAUDE.md ARCHITECTURE.md`
- `pnpm run lint:docs && pnpm run test:docs`
