### PR TITLE
Document single-program analysis

### DIFF
--- a/.changeset/document-single-program-analysis.md
+++ b/.changeset/document-single-program-analysis.md
@@ -1,0 +1,12 @@
+---
+"@formspec/analysis": patch
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"@formspec/e2e": patch
+"@formspec/language-server": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
+---
+
+Document the single-program analysis architecture and update stale post-synthetic-checker comments.

--- a/.changeset/document-single-program-analysis.md
+++ b/.changeset/document-single-program-analysis.md
@@ -9,4 +9,4 @@
 "formspec": patch
 ---
 
-Document the single-program analysis architecture and update stale post-synthetic-checker comments.
+Document the single-program analysis architecture, update stale post-synthetic-checker comments, and align snapshot broadening-bypass logging.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -231,6 +231,9 @@ FormSpec editor tooling uses a hybrid split:
 - `@formspec/ts-plugin` owns the reusable semantic service that works directly against a host `Program`/`TypeChecker`. Its shipped tsserver plugin and IPC server are reference implementations built on that same public service.
 - `@formspec/language-server` exports composable completion, hover, and diagnostics helpers. Its packaged LSP is a thin reference implementation that wires those helpers together.
 
+Per PP16, constraint validation reads that host program and does not create a
+second TypeScript `Program` during analysis.
+
 This is intentionally white-labelable: downstream tools can reuse the same
 TypeScript `Program`, call `FormSpecSemanticService` directly, and decide for
 themselves how diagnostics are surfaced.
@@ -323,10 +326,10 @@ Each constraint-tag evaluation emits one structured record at `debug` level.
 
 #### Role outcome values
 
-Phase 5C retired the synthetic TypeScript program batch. Constraint-tag
-validation now flows through three roles in order: Role A (placement), Role B
-(capability guard, including path-target resolution), Role C (typed-parser
-argument validation). A `C-pass` outcome means all three roles accepted.
+Constraint-tag validation flows through three roles in order: Role A
+(placement), Role B (capability guard, including path-target resolution), and
+Role C (typed-parser argument validation). A `C-pass` outcome means all three
+roles accepted.
 
 | Value      | Meaning                                                                                                                          |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/000-principles.md
+++ b/docs/000-principles.md
@@ -76,6 +76,8 @@ When taking an exception, document the reason in the changeset.
 
 Spec docs that introduce constraint-related concepts must specify which kind they mean.
 
+**PP16: Single-program analysis.** Constraint validation operates on the host TypeScript program. Tag arguments are parsed by a typed argument parser; their compatibility with the targeted type is checked by reading the host `ts.TypeChecker`. FormSpec analysis must not construct a second `ts.Program` at analysis time. This bounds memory and latency to the consumer's existing TypeScript work, and avoids the divergence problems that arose when two parallel checkers operated on the same source.
+
 ---
 
 ## 2. Semantic Properties
@@ -236,6 +238,6 @@ Subsequent design documents reference these principles by ID. For traceability:
 | PP2, PP3, PP7, A1, A4, A5, S1–S7, C1, D1, D2, D4, E1–E5, NP1       | 001 (Canonical IR)           |
 | PP1, PP2, PP9, PP10, S4–S7, D1–D6                                  | 002 (TSDoc Grammar)          |
 | PP2, PP6, PP7, PP9, PP10, S1, B3, B4, E3                           | 003 (JSON Schema Vocabulary) |
-| A7, PP9, PP10, PP11, D1–D6, E1                                     | 004 (Tooling)                |
+| A7, PP9, PP10, PP11, PP16, D1–D6, E1                               | 004 (Tooling)                |
 | PP2, PP3, S1, S2, S4, S7, B3, B4, C1, E1–E5                        | 005 (Numeric Types)          |
 | PP3, PP5, PP6, PP7, A1–A4, S1, S5, C1, D1, D3, D4, E1, E4, E5, NP1 | 006 (Parity Testing)         |

--- a/docs/004-tooling.md
+++ b/docs/004-tooling.md
@@ -26,6 +26,7 @@ The tooling layer sits between the authoring surface (TSDoc tags, chain DSL) and
 | **PP9** (configurable surface area)                 | Every FormSpec diagnostic severity is overridable via project configuration. Rules can be set to `off`, `warn`, or `error` per project                                                                                                                 |
 | **PP10** (white-labelable)                          | Canonical machine-readable diagnostic codes and structured raw facts stay stable, while downstream organizations own final presentation and branding                                                                                                   |
 | **PP11** (consumer-controlled messaging)            | Downstream tooling can ignore default messages and render from `code` + structured `data`. This phase does not require project-level message-template configuration                                                                                    |
+| **PP16** (single-program analysis)                  | Constraint validation reuses the host TypeScript `Program` and `TypeChecker`; FormSpec analysis does not construct a second `ts.Program`                                                                                                               |
 | **E1** (built-in types use the same extension API)  | The ESLint rule infrastructure described here is the same API used by built-in rules. Extensions get tag-on-type validation, contradiction detection, and path-target resolution for free                                                              |
 
 ### Relationship to Other Documents
@@ -144,8 +145,7 @@ The report prints:
 - `coldMs` for the first diagnostics/completion/hover query on a fresh instance
 - `warmMs` for the immediately repeated query
 - file-snapshot cache hit/miss totals
-- synthetic batch cache hit/miss totals
-- synthetic compiler program counts and application counts
+- per-operation summaries, such as diagnostic counts, completion counts, or hover text availability
 
 Use the benchmark to guide downstream integration choices:
 
@@ -178,6 +178,13 @@ This phase validates constraint composition across the resolved IR nodes:
 6. Propagates constraints through the type inheritance chain when type context is available, detecting cross-type contradictions (producing `CONSTRAINT_CONTRADICTION` with both source locations per D2)
 
 Extension-registered constraints participate in contradiction detection by declaring their contradiction predicate (see §4.2).
+
+PP16 governs this phase operationally. Role A validates placement first. Role B
+checks compatibility against the host `TypeChecker` and the registered semantic
+capabilities for the direct field or resolved path target. Role C validates tag
+arguments with the typed argument parser. Accepted constraints then flow into
+IR-level composition and contradiction checks. No analysis-time path constructs a
+second `ts.Program`.
 
 ### 2.6 Pipeline TypeScript Interface
 
@@ -458,7 +465,7 @@ Per A7, the language server owns the authoring experience: completions, hover, g
 
 FormSpec uses a hybrid architecture:
 
-- `@formspec/ts-plugin` is the semantic authority. It runs inside `tsserver`, reuses the host editor's existing `Program` and `TypeChecker`, and performs expensive semantic work such as path resolution, placement checks, compiler-backed synthetic signature validation, and effective constraint-state computation. Its shipped plugin wrapper is a reference implementation over the public in-process semantic service.
+- `@formspec/ts-plugin` is the semantic authority. It runs inside `tsserver`, reuses the host editor's existing `Program` and `TypeChecker`, and performs expensive semantic work such as path resolution, placement checks, host-checker-backed argument validation (PP16), and effective constraint-state computation. Its shipped plugin wrapper is a reference implementation over the public in-process semantic service.
 - `@formspec/language-server` is a lightweight standalone LSP surface. It keeps cheap syntax-local behavior in-process, then enriches hover/completion responses with semantic results produced by the TypeScript plugin. Its shipped server is a reference implementation over exported completion, hover, and diagnostics helpers.
 
 The two components communicate on the workspace host via:

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -19,6 +19,17 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
   - Spec docs that introduce constraint-related concepts must specify which kind they mean.
   - Resolves the documentation half of [#419](https://github.com/mike-north/formspec/issues/419); the DSL-policy factoring follow-up is tracked in [#420](https://github.com/mike-north/formspec/issues/420).
 
+- Added PP16 — Single-program analysis ([#435](https://github.com/mike-north/formspec/issues/435)).
+  - Constraint validation now normatively reads the host TypeScript `Program` and `TypeChecker`.
+  - Tag arguments are validated by the typed argument parser; analysis must not construct a second `ts.Program`.
+
+## 004-tooling.md
+
+- Updated the tooling architecture for the post-synthetic-checker analysis model ([#435](https://github.com/mike-north/formspec/issues/435)).
+  - Benchmark prose now documents the current hybrid-tooling report columns: startup/cold/warm timings, snapshot cache hit/miss counts, and per-operation summaries.
+  - Constraint-validation prose now describes host-checker capability checks, typed argument parsing, and IR-level validation under PP16.
+  - Language-server prose now refers to host-checker-backed argument validation rather than synthetic signature validation.
+
 # 2026-04-26
 
 ## 002-tsdoc-grammar

--- a/e2e/benchmarks/hybrid-tooling-benchmark-shared.ts
+++ b/e2e/benchmarks/hybrid-tooling-benchmark-shared.ts
@@ -174,7 +174,7 @@ export function renderHybridToolingBenchmarkReport(
     "- `startupMs` is the wrapper/service startup cost before the measured query path runs",
     "- `coldMs` is the first query against a fresh mode/scenario instance",
     "- `warmMs` repeats the same query immediately after to show cache reuse",
-    "- snapshot and synthetic cache counters come from the semantic service that actually performed the work",
+    "- snapshot cache counters come from the semantic service that actually performed the work",
     "",
   ];
 

--- a/packages/analysis/src/constraint-applicability.ts
+++ b/packages/analysis/src/constraint-applicability.ts
@@ -3,7 +3,7 @@
  * snapshot consumer.
  *
  * The build consumer (`tsdoc-parser.ts`) calls `supportsConstraintCapability()`
- * before the synthetic-checker call to emit `TYPE_MISMATCH` when a constraint's
+ * before argument validation to emit `TYPE_MISMATCH` when a constraint's
  * required semantic capability is absent from the field type (e.g. `@minimum 0`
  * on a `string` field has no `numeric-comparable` capability).
  *

--- a/packages/analysis/src/extension-setup-validation.ts
+++ b/packages/analysis/src/extension-setup-validation.ts
@@ -8,6 +8,9 @@
  * Produces two diagnostic codes:
  *   - `SYNTHETIC_SETUP_FAILURE` — invalid identifier, duplicate registration
  *   - `UNSUPPORTED_CUSTOM_TYPE_OVERRIDE` — unsupported TypeScript global-builtin override
+ *
+ * `SYNTHETIC_SETUP_FAILURE` predates the single-program analysis model and is
+ * retained as a stable internal diagnostic code.
  */
 
 import type { Provenance } from "@formspec/core/internals";

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -1696,7 +1696,16 @@ function buildTagDiagnostics(
       } else {
         // Extension-broadened (D1/D2) — bypass the typed parser; D1/D2
         // handling is performed by the downstream registry dispatch.
-        // Log at trace level if enabled.
+        if (snapshotLogsEnabled) {
+          logTagApplication(snapshotLog, {
+            consumer: "snapshot",
+            tag: tag.normalizedTagName,
+            placement,
+            subjectTypeKind: subjectTypeKindForLog,
+            roleOutcome: "bypass",
+            elapsedMicros: elapsedMicros(tagStartMicros),
+          });
+        }
         if (typedParserTraceEnabled) {
           typedParserLog.trace("typed-parser bypass", {
             consumer: "snapshot",
@@ -1706,6 +1715,7 @@ function buildTagDiagnostics(
             roleOutcome: "bypass",
           });
         }
+        continue;
       }
     }
 

--- a/packages/analysis/src/file-snapshots.ts
+++ b/packages/analysis/src/file-snapshots.ts
@@ -1321,8 +1321,8 @@ function buildTagDiagnostics(
     // semantic.tagDefinition is always non-null here (the null case causes an
     // early `continue` at the top of the loop).
     //
-    // §5 Phase 5C — this placement check is the only Role-A guard; the former
-    // synthetic-program fallback has been retired.
+    // This placement check is the only Role-A guard in the host-program
+    // analysis path.
     {
       const definition = semantic.tagDefinition;
       const targetKind = target?.kind ?? null;
@@ -1431,10 +1431,9 @@ function buildTagDiagnostics(
         // loop (isIntegerBypass check above). This guard only runs on the
         // non-broadened, non-bypassed path.
         //
-        // §5 Phase 5C — Role B now covers BOTH direct-field (target === null)
-        // and path-target (target.kind === "path") validation. Previously path
-        // targets were validated through the synthetic checker; Phase 5C retires
-        // that surface so Role B is the only remaining capability check.
+        // Role B covers BOTH direct-field (target === null) and path-target
+        // (target.kind === "path") validation. It is the host-checker-backed
+        // capability check for the resolved target type.
         //
         // For path targets we resolve the terminal type via resolvePathTargetType
         // and run the capability check against that resolved type. Path
@@ -1481,10 +1480,8 @@ function buildTagDiagnostics(
               if (pathTargetResolution === null) {
                 // tag.target.path is null — the path target text failed to
                 // parse (e.g. `@minimum :invalid-syntax 0` where the segment
-                // contains non-identifier characters). Before Phase 5C this
-                // fell through to the synthetic lowering which would reject it
-                // there; now that the synthetic checker is retired we must emit
-                // a diagnostic here instead of silently accepting it.
+                // contains non-identifier characters). The host-program path
+                // must emit a diagnostic here instead of silently accepting it.
                 pathRejection = {
                   code: "INVALID_PATH_TARGET",
                   message: `Tag "@${tag.normalizedTagName}" has an invalid path target.`,
@@ -1712,10 +1709,9 @@ function buildTagDiagnostics(
       }
     }
 
-    // §5 Phase 5C — all validation is now complete via Role A (placement
+    // All validation is now complete via Role A (placement
     // pre-check), Role B (capability guard, including path-target resolution),
-    // and Role C (typed-parser argument validation). The synthetic
-    // TypeScript program batch has been retired. Log C-pass for structured
+    // and Role C (typed-parser argument validation). Log C-pass for structured
     // tracing and move on.
     if (snapshotLogsEnabled) {
       logTagApplication(snapshotLog, {

--- a/packages/analysis/src/integer-brand.ts
+++ b/packages/analysis/src/integer-brand.ts
@@ -37,8 +37,8 @@ export function _collectBrandIdentifiers(type: ts.Type): readonly string[] {
  * includes a `number` base and a computed property keyed by `__integerBrand`.
  *
  * Used by both the build consumer (`tsdoc-parser.ts`) and the snapshot consumer
- * (`file-snapshots.ts`) to bypass the synthetic-checker constraint path for
- * imported types whose names the synthetic program cannot resolve.
+ * (`file-snapshots.ts`) so imported branded types are recognized consistently
+ * from the host checker.
  *
  * Call `stripNullishUnion` (re-exported from `@formspec/analysis/internal`)
  * before this function to handle nullable and optional fields

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -218,8 +218,8 @@ function parseNumericArgument(
   }
 
   // Pin current consumer behavior: Infinity, -Infinity, and NaN are accepted
-  // as valid numeric arguments. The synthetic snapshot path passes these
-  // identifiers through as-is. See §3 "Tie-break Infinity/NaN" and §9.3 #16.
+  // as valid numeric arguments. Snapshot analysis preserves these identifiers
+  // as numeric sentinels. See §3 "Tie-break Infinity/NaN" and §9.3 #16.
   if (text === "Infinity") {
     return { ok: true, value: { kind: "number", value: Infinity } };
   }
@@ -435,8 +435,8 @@ function parseConstArgument(rawArgumentText: string): TagArgumentParseResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Parses a single constraint-tag argument literal. Role C of the
- * synthetic-checker retirement plan §1.
+ * Parses a single constraint-tag argument literal for the Role C typed-parser
+ * validation step.
  *
  * @param tagName - normalized tag name (no leading "@")
  * @param rawArgumentText - argument text AFTER parseTagSyntax has stripped
@@ -560,7 +560,7 @@ export function mapTypedParserDiagnosticCode(
 
 /**
  * Derives the effective argument text that should be passed to
- * `parseTagArgument` (Role C of the synthetic-checker retirement plan).
+ * `parseTagArgument` for the Role C typed-parser validation step.
  *
  * Both the build consumer (`tsdoc-parser.ts`) and the snapshot consumer
  * (`file-snapshots.ts`) need to extract the same argument text from a tag

--- a/packages/analysis/src/tag-argument-parser.ts
+++ b/packages/analysis/src/tag-argument-parser.ts
@@ -217,9 +217,9 @@ function parseNumericArgument(
     };
   }
 
-  // Pin current consumer behavior: Infinity, -Infinity, and NaN are accepted
-  // as valid numeric arguments. Snapshot analysis preserves these identifiers
-  // as numeric sentinels. See §3 "Tie-break Infinity/NaN" and §9.3 #16.
+  // Pin shared parser behavior: Infinity, -Infinity, and NaN are accepted as
+  // valid numeric arguments and represented as numeric sentinels. See §3
+  // "Tie-break Infinity/NaN" and §9.3 #16.
   if (text === "Infinity") {
     return { ok: true, value: { kind: "number", value: Infinity } };
   }

--- a/packages/analysis/src/tag-registry.ts
+++ b/packages/analysis/src/tag-registry.ts
@@ -97,9 +97,9 @@ export interface ExtensionConstraintTagSource {
 }
 
 /**
- * Synthetic type declaration info for extension-registered custom types.
- * Used to emit type aliases in the synthetic program so declarations
- * referencing these types can be included in supportingDeclarations.
+ * Type declaration metadata for extension-registered custom types.
+ * Used by host-checker-aware consumers to recognize declarations that reference
+ * extension-provided type names.
  */
 export interface ExtensionCustomTypeSource {
   /** TypeScript surface names that resolve to this type (e.g., ['Decimal']) */

--- a/packages/build/src/analyzer/builtin-brands.ts
+++ b/packages/build/src/analyzer/builtin-brands.ts
@@ -2,10 +2,9 @@
  * Re-exports {@link _isIntegerBrandedType} from the shared
  * `@formspec/analysis` implementation.
  *
- * The detection logic was extracted to `@formspec/analysis` (Phase 4A of the
- * synthetic-checker retirement) so that both the build consumer
- * (`tsdoc-parser.ts`) and the snapshot consumer (`file-snapshots.ts`) can use
- * the same bypass check.
+ * The detection logic lives in `@formspec/analysis` so that both the build
+ * consumer (`tsdoc-parser.ts`) and the snapshot consumer (`file-snapshots.ts`)
+ * can use the same branded-type check.
  *
  * Callers inside `@formspec/build` continue to import from this module — no
  * import-site changes required in `class-analyzer.ts` or `tsdoc-parser.ts`.


### PR DESCRIPTION
## Summary

- Adds PP16 to make single-program analysis a normative FormSpec principle.
- Updates tooling and architecture docs to describe host-program constraint validation, current hybrid benchmark output, and the Role A/B/C validation order.
- Scrubs stale synthetic-checker comments while retaining the stable `SYNTHETIC_SETUP_FAILURE` diagnostic name.
- Aligns snapshot extension-broadening logs with the `bypass` role outcome and adds the required patch changeset.

Closes #435

## Test plan

- `rg -n "synthetic batch|synthetic compiler program|synthetic signature|synthetic snapshot path|synthetic-checker constraint path|synthetic-checker retirement plan|synthetic cache counters" docs/004-tooling.md ARCHITECTURE.md packages/analysis/src packages/build/src/analyzer/builtin-brands.ts e2e/benchmarks/hybrid-tooling-benchmark-shared.ts`
- `pnpm exec prettier --check docs/000-principles.md docs/004-tooling.md ARCHITECTURE.md docs/spec-changelog.md e2e/benchmarks/hybrid-tooling-benchmark-shared.ts packages/analysis/src/integer-brand.ts packages/build/src/analyzer/builtin-brands.ts packages/analysis/src/tag-argument-parser.ts packages/analysis/src/constraint-applicability.ts packages/analysis/src/tag-registry.ts packages/analysis/src/file-snapshots.ts packages/analysis/src/extension-setup-validation.ts .changeset/document-single-program-analysis.md`
- `pnpm run lint:docs`
- `git diff --check`
- `pnpm --filter @formspec/e2e exec vitest run tests/hybrid-tooling-benchmark.test.ts`
- `pnpm --filter @formspec/analysis exec vitest run tests/typed-parser-snapshot-canaries.test.ts`
- `pnpm changeset status --since origin/main`

Benchmark caveat: `pnpm --filter @formspec/e2e run benchmark:hybrid-tooling` currently fails before producing a report because `e2e/tsconfig.benchmarks.json` uses deprecated `baseUrl` under TypeScript 6.0 without `ignoreDeprecations: "6.0"`. After building missing workspace packages, `pnpm exec tsc --noEmit -p ./e2e/tsconfig.benchmarks.json --ignoreDeprecations 6.0` passes, but the direct runner still fails resolving `packages/ts-plugin/dist/service.js` from generated declarations.
