### PR TITLE
eslint-plugin: fix branded primitive tag checks via analysis capabilities

### DIFF
--- a/.changeset/branded-number-intersections-eslint.md
+++ b/.changeset/branded-number-intersections-eslint.md
@@ -2,4 +2,4 @@
 "@formspec/eslint-plugin": patch
 ---
 
-Fix `@formspec/eslint-plugin` type classification so built-in numeric constraint tags accept branded number intersections such as `Integer` and `PositiveInteger`. This prevents false-positive type-mismatch errors for `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, and `@multipleOf` when those tags are applied to number aliases defined as `number & { ...brand... }`.
+Align `@formspec/eslint-plugin` tag applicability checks with `@formspec/analysis` semantic capabilities, so built-in tags classify branded primitive intersections consistently. Numeric constraint tags such as `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, and `@multipleOf` now accept branded numeric aliases like `Integer`, `PositiveInteger`, and branded `bigint` types without false-positive type-mismatch errors, while incorrect cross-kind usages still report mismatches.

--- a/.changeset/branded-number-intersections-eslint.md
+++ b/.changeset/branded-number-intersections-eslint.md
@@ -1,0 +1,5 @@
+---
+"@formspec/eslint-plugin": patch
+---
+
+Fix `@formspec/eslint-plugin` type classification so built-in numeric constraint tags accept branded number intersections such as `Integer` and `PositiveInteger`. This prevents false-positive type-mismatch errors for `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, and `@multipleOf` when those tags are applied to number aliases defined as `number & { ...brand... }`.

--- a/packages/eslint-plugin/src/rules/type-compatibility/tag-type-check.ts
+++ b/packages/eslint-plugin/src/rules/type-compatibility/tag-type-check.ts
@@ -7,10 +7,11 @@ import {
   resolveTagTarget,
 } from "../../utils/rule-helpers.js";
 import { scanFormSpecTags } from "../../utils/tag-scanner.js";
-import { getFieldTypeCategory, type FieldTypeCategory } from "../../utils/type-utils.js";
 import { getTagMetadata } from "../../utils/tag-metadata.js";
 import {
+  _capabilityLabel,
   getTagDefinition,
+  hasTypeSemanticCapability,
   readExtensionRegistryFromSettings,
   type SemanticCapability,
 } from "@formspec/analysis/internal";
@@ -21,34 +22,19 @@ const createRule = ESLintUtils.RuleCreator(
 
 type MessageIds = "typeMismatch";
 
-const CAPABILITY_TO_FIELD_TYPES: Record<SemanticCapability, FieldTypeCategory[]> = {
-  "numeric-comparable": ["number", "bigint"],
-  "string-like": ["string"],
-  "array-like": ["array"],
-  "enum-member-addressable": ["string", "union"],
-  "json-like": [],
-  "condition-like": [],
-  "object-like": ["object"],
-};
-
-function getExpectedTypesForTag(tagName: string): FieldTypeCategory[] | null {
+function getRequiredCapabilityForTag(tagName: string): SemanticCapability | null {
   const definition = getTagDefinition(tagName);
   if (definition === null) return null;
-  const capabilities = definition.capabilities;
-  if (capabilities.length === 0) return null;
-  const types: FieldTypeCategory[] = [];
-  for (const cap of capabilities) {
-    // CAPABILITY_TO_FIELD_TYPES covers all SemanticCapability variants
-    const capTypes = CAPABILITY_TO_FIELD_TYPES[cap];
-    if (capTypes.length === 0) {
-      // json-like or condition-like: skip type check entirely
-      return null;
-    }
-    for (const t of capTypes) {
-      if (!types.includes(t)) types.push(t);
-    }
+  const capability = definition.capabilities[0];
+  if (capability === undefined) return null;
+
+  // Preserve the current ESLint rule behavior for capabilities that do not
+  // translate cleanly into a single field-kind diagnostic label.
+  if (capability === "json-like" || capability === "condition-like") {
+    return null;
   }
-  return types.length > 0 ? types : null;
+
+  return capability;
 }
 
 /**
@@ -81,8 +67,8 @@ export const tagTypeCheck = createRule<[], MessageIds>({
       if (!declarationType) return;
       const fieldName = getDeclarationName(node);
       for (const tag of scanFormSpecTags(node, context.sourceCode)) {
-        const expectedTypes = getExpectedTypesForTag(tag.normalizedName);
-        if (!expectedTypes) continue;
+        const requiredCapability = getRequiredCapabilityForTag(tag.normalizedName);
+        if (requiredCapability === null) continue;
         const metadata = getTagMetadata(tag.rawName);
         const supportsValueLessCheck =
           metadata?.valueKind === "boolean" || metadata?.requiresArgument === false;
@@ -111,8 +97,7 @@ export const tagTypeCheck = createRule<[], MessageIds>({
 
         const resolved = resolveTagTarget(tag, declarationType, services);
         if (!resolved.valid || !resolved.type) continue;
-        const actualCategory = getFieldTypeCategory(resolved.type, checker);
-        if (expectedTypes.includes(actualCategory)) continue;
+        if (hasTypeSemanticCapability(resolved.type, checker, requiredCapability)) continue;
 
         // Check for builtin constraint broadening via extension registry.
         // Use checker.typeToString for the name — it correctly resolves
@@ -135,7 +120,7 @@ export const tagTypeCheck = createRule<[], MessageIds>({
           messageId: "typeMismatch",
           data: {
             tag: tag.rawName,
-            expected: expectedTypes.join(" or "),
+            expected: _capabilityLabel(requiredCapability),
             field: fieldName,
             actualType: getResolvedTypeName(resolved.type, services),
           },

--- a/packages/eslint-plugin/src/utils/type-utils.ts
+++ b/packages/eslint-plugin/src/utils/type-utils.ts
@@ -78,6 +78,10 @@ export type FieldTypeCategory =
   | "union"
   | "unknown";
 
+function isIntersectionWithBase(type: ts.Type, predicate: (member: ts.Type) => boolean): boolean {
+  return type.isIntersection() && type.types.some((member) => predicate(member));
+}
+
 /**
  * Checks if a TypeScript type is a string type.
  *
@@ -94,29 +98,65 @@ export function isStringType(
   checker: ts.TypeChecker,
   seen = new Set<ts.Type>()
 ): boolean {
-  if (seen.has(type)) {
+  const stripped = stripNullishFromUnion(type);
+  if (seen.has(stripped)) {
     return false;
   }
-  seen.add(type);
+  seen.add(stripped);
 
   // Check for string primitive
-  if (type.flags & ts.TypeFlags.String) {
+  if (stripped.flags & ts.TypeFlags.String) {
     return true;
   }
 
   // Check for string literal
-  if (type.flags & ts.TypeFlags.StringLiteral) {
+  if (stripped.flags & ts.TypeFlags.StringLiteral) {
     return true;
   }
 
   // Check for union of string literals (e.g., "a" | "b")
-  if (type.isUnion()) {
-    return type.types.every((t) => isStringType(t, checker, seen));
+  if (stripped.isUnion()) {
+    return stripped.types.every((t) => isStringType(t, checker, seen));
   }
 
-  const baseConstraint = checker.getBaseConstraintOfType(type);
-  if (baseConstraint !== undefined && baseConstraint !== type) {
+  if (isIntersectionWithBase(stripped, (t) => isStringType(t, checker, seen))) {
+    return true;
+  }
+
+  const baseConstraint = checker.getBaseConstraintOfType(stripped);
+  if (baseConstraint !== undefined && baseConstraint !== stripped) {
     return isStringType(baseConstraint, checker, seen);
+  }
+
+  return false;
+}
+
+function isNumberTypeInner(type: ts.Type, checker: ts.TypeChecker, seen: Set<ts.Type>): boolean {
+  const stripped = stripNullishFromUnion(type);
+  if (seen.has(stripped)) {
+    return false;
+  }
+  seen.add(stripped);
+
+  if (stripped.flags & ts.TypeFlags.Number) {
+    return true;
+  }
+
+  if (stripped.flags & ts.TypeFlags.NumberLiteral) {
+    return true;
+  }
+
+  if (stripped.isUnion()) {
+    return stripped.types.every((t) => isNumberTypeInner(t, checker, seen));
+  }
+
+  if (isIntersectionWithBase(stripped, (t) => isNumberTypeInner(t, checker, seen))) {
+    return true;
+  }
+
+  const baseConstraint = checker.getBaseConstraintOfType(stripped);
+  if (baseConstraint !== undefined && baseConstraint !== stripped) {
+    return isNumberTypeInner(baseConstraint, checker, seen);
   }
 
   return false;
@@ -136,26 +176,29 @@ export function isStringType(
  * @public
  */
 export function isNumberType(type: ts.Type, checker: ts.TypeChecker): boolean {
-  // Check for number primitive
-  if (type.flags & ts.TypeFlags.Number) {
+  return isNumberTypeInner(type, checker, new Set<ts.Type>());
+}
+
+function isBigIntTypeInner(type: ts.Type, seen: Set<ts.Type>): boolean {
+  const stripped = stripNullishFromUnion(type);
+  if (seen.has(stripped)) {
+    return false;
+  }
+  seen.add(stripped);
+
+  if (stripped.flags & ts.TypeFlags.BigInt) {
     return true;
   }
 
-  // Check for number literal
-  if (type.flags & ts.TypeFlags.NumberLiteral) {
+  if (stripped.flags & ts.TypeFlags.BigIntLiteral) {
     return true;
   }
 
-  // Check for union of number literals
-  if (type.isUnion()) {
-    return type.types.every((t) => isNumberType(t, checker));
+  if (stripped.isUnion()) {
+    return stripped.types.every((t) => isBigIntTypeInner(t, seen));
   }
 
-  if (type.isIntersection()) {
-    return type.types.some((t) => isNumberType(t, checker));
-  }
-
-  return false;
+  return isIntersectionWithBase(stripped, (t) => isBigIntTypeInner(t, seen));
 }
 
 /**
@@ -164,16 +207,35 @@ export function isNumberType(type: ts.Type, checker: ts.TypeChecker): boolean {
  * @public
  */
 export function isBigIntType(type: ts.Type): boolean {
-  if (type.flags & ts.TypeFlags.BigInt) {
+  return isBigIntTypeInner(type, new Set<ts.Type>());
+}
+
+function isBooleanTypeInner(type: ts.Type, checker: ts.TypeChecker, seen: Set<ts.Type>): boolean {
+  const stripped = stripNullishFromUnion(type);
+  if (seen.has(stripped)) {
+    return false;
+  }
+  seen.add(stripped);
+
+  if (stripped.flags & ts.TypeFlags.Boolean) {
     return true;
   }
 
-  if (type.flags & ts.TypeFlags.BigIntLiteral) {
+  if (stripped.flags & ts.TypeFlags.BooleanLiteral) {
     return true;
   }
 
-  if (type.isUnion()) {
-    return type.types.every((t) => isBigIntType(t));
+  if (stripped.isUnion()) {
+    return stripped.types.every((t) => isBooleanTypeInner(t, checker, seen));
+  }
+
+  if (isIntersectionWithBase(stripped, (t) => isBooleanTypeInner(t, checker, seen))) {
+    return true;
+  }
+
+  const baseConstraint = checker.getBaseConstraintOfType(stripped);
+  if (baseConstraint !== undefined && baseConstraint !== stripped) {
+    return isBooleanTypeInner(baseConstraint, checker, seen);
   }
 
   return false;
@@ -191,22 +253,7 @@ export function isBigIntType(type: ts.Type): boolean {
  * @public
  */
 export function isBooleanType(type: ts.Type, checker: ts.TypeChecker): boolean {
-  // Check for boolean primitive
-  if (type.flags & ts.TypeFlags.Boolean) {
-    return true;
-  }
-
-  // Check for boolean literal (true or false)
-  if (type.flags & ts.TypeFlags.BooleanLiteral) {
-    return true;
-  }
-
-  // Check for union of true | false
-  if (type.isUnion()) {
-    return type.types.every((t) => isBooleanType(t, checker));
-  }
-
-  return false;
+  return isBooleanTypeInner(type, checker, new Set<ts.Type>());
 }
 
 /**
@@ -214,10 +261,7 @@ export function isBooleanType(type: ts.Type, checker: ts.TypeChecker): boolean {
  */
 export function isNullableType(type: ts.Type): boolean {
   if (!type.isUnion()) {
-    return (
-      (type.flags & ts.TypeFlags.Null) !== 0 ||
-      (type.flags & ts.TypeFlags.Undefined) !== 0
-    );
+    return (type.flags & ts.TypeFlags.Null) !== 0 || (type.flags & ts.TypeFlags.Undefined) !== 0;
   }
 
   return type.types.some((t) => isNullableType(t));

--- a/packages/eslint-plugin/src/utils/type-utils.ts
+++ b/packages/eslint-plugin/src/utils/type-utils.ts
@@ -125,11 +125,13 @@ export function isStringType(
 /**
  * Checks if a TypeScript type is a number type.
  *
- * Handles number primitives, number literals, and unions of number types.
+ * Handles number primitives, number literals, unions of number types, and
+ * branded intersections whose numeric member is a number type.
  *
  * @param type - The TypeScript type to check
  * @param checker - The TypeScript type checker instance
- * @returns True if the type is number, a number literal, or a union of number types
+ * @returns True if the type is number, a number literal, a union of number
+ * types, or an intersection containing a number type
  *
  * @public
  */
@@ -147,6 +149,10 @@ export function isNumberType(type: ts.Type, checker: ts.TypeChecker): boolean {
   // Check for union of number literals
   if (type.isUnion()) {
     return type.types.every((t) => isNumberType(t, checker));
+  }
+
+  if (type.isIntersection()) {
+    return type.types.some((t) => isNumberType(t, checker));
   }
 
   return false;

--- a/packages/eslint-plugin/tests/rules/constraint-type-mismatch.test.ts
+++ b/packages/eslint-plugin/tests/rules/constraint-type-mismatch.test.ts
@@ -170,6 +170,29 @@ ruleTester.run("tag-type-check", tagTypeCheck, {
         }
       `,
     },
+    {
+      code: `
+        export declare const __integerBrand: unique symbol;
+        export declare const __positiveIntegerBrand: unique symbol;
+
+        export type Integer = number & {
+          readonly [__integerBrand]: true;
+        };
+
+        export type PositiveInteger = number & {
+          readonly [__integerBrand]: true;
+          readonly [__positiveIntegerBrand]: true;
+        };
+
+        export interface MyFields {
+          /** @minimum 0 @maximum 100 */
+          count: Integer;
+
+          /** @exclusiveMinimum 0 @exclusiveMaximum 1000 @multipleOf 5 */
+          batchSize: PositiveInteger;
+        }
+      `,
+    },
 
     // -------------------------------------------------------------------------
     // @minLength on string fields

--- a/packages/eslint-plugin/tests/rules/constraint-type-mismatch.test.ts
+++ b/packages/eslint-plugin/tests/rules/constraint-type-mismatch.test.ts
@@ -193,6 +193,42 @@ ruleTester.run("tag-type-check", tagTypeCheck, {
         }
       `,
     },
+    {
+      code: `
+        export declare const __integerBrand: unique symbol;
+        export declare const __positiveIntegerBrand: unique symbol;
+
+        export type Integer = number & {
+          readonly [__integerBrand]: true;
+        };
+
+        export type PositiveInteger = number & {
+          readonly [__integerBrand]: true;
+          readonly [__positiveIntegerBrand]: true;
+        };
+
+        export type Count = Integer | PositiveInteger;
+
+        export interface MyFields {
+          /** @minimum 0 @maximum 1000 */
+          count: Count;
+        }
+      `,
+    },
+    {
+      code: `
+        export declare const __amountBrand: unique symbol;
+
+        export type Amount = bigint & {
+          readonly [__amountBrand]: true;
+        };
+
+        export interface MyFields {
+          /** @minimum 0 @maximum 1000 @multipleOf 5 */
+          amount: Amount;
+        }
+      `,
+    },
 
     // -------------------------------------------------------------------------
     // @minLength on string fields
@@ -212,6 +248,20 @@ ruleTester.run("tag-type-check", tagTypeCheck, {
         class Form {
           /** @minLength 1 */
           name!: string;
+        }
+      `,
+    },
+    {
+      code: `
+        export declare const __emailBrand: unique symbol;
+
+        export type Email = string & {
+          readonly [__emailBrand]: true;
+        };
+
+        export interface MyFields {
+          /** @minLength 3 @maxLength 255 @pattern .+@.+ */
+          email: Email;
         }
       `,
     },
@@ -601,6 +651,21 @@ ruleTester.run("tag-type-check", tagTypeCheck, {
       `,
       errors: [{ messageId: "typeMismatch" }],
     },
+    {
+      code: `
+        export declare const __emailBrand: unique symbol;
+
+        export type Email = string & {
+          readonly [__emailBrand]: true;
+        };
+
+        class Form {
+          /** @Minimum 0 */
+          email!: Email;
+        }
+      `,
+      errors: [{ messageId: "typeMismatch" }],
+    },
 
     // -------------------------------------------------------------------------
     // @maximum on non-number fields
@@ -761,6 +826,21 @@ ruleTester.run("tag-type-check", tagTypeCheck, {
         class Form {
           /** @MinLength 1 */
           tags!: string[];
+        }
+      `,
+      errors: [{ messageId: "typeMismatch" }],
+    },
+    {
+      code: `
+        export declare const __integerBrand: unique symbol;
+
+        export type Integer = number & {
+          readonly [__integerBrand]: true;
+        };
+
+        class Form {
+          /** @MinLength 1 */
+          count!: Integer;
         }
       `,
       errors: [{ messageId: "typeMismatch" }],

--- a/packages/eslint-plugin/tests/utils/type-utils.test.ts
+++ b/packages/eslint-plugin/tests/utils/type-utils.test.ts
@@ -16,17 +16,34 @@ import {
 const fixtureFileName = "/type-utils-fixture.ts";
 
 const fixtureSource = `
+declare const __integerBrand: unique symbol;
+declare const __emailBrand: unique symbol;
+declare const __amountBrand: unique symbol;
+declare const __flagBrand: unique symbol;
+
+type Integer = number & { readonly [__integerBrand]: true };
+type Email = string & { readonly [__emailBrand]: true };
+type Amount = bigint & { readonly [__amountBrand]: true };
+type Flag = boolean & { readonly [__flagBrand]: true };
+
 interface Fixture {
   text: string;
   textLiteral: "draft";
   count: number;
   countLiteral: 42;
+  brandedCount: Integer;
   big: bigint;
   bigLiteral: 42n;
+  brandedBig: Amount;
   enabled: boolean;
   enabledLiteral: true;
+  brandedEnabled: Flag;
+  brandedText: Email;
   maybeText: string | null;
   maybeCount: number | undefined;
+  maybeBrandedText: Email | null;
+  maybeBrandedCount: Integer | undefined;
+  maybeBrandedBig: Amount | null;
   nested: { id: string };
   mixed: string | number;
 }
@@ -114,15 +131,19 @@ describe("type-utils", () => {
 
     expect(isStringType(fixture.typeOf("text"), fixture.checker)).toBe(true);
     expect(isStringType(fixture.typeOf("textLiteral"), fixture.checker)).toBe(true);
+    expect(isStringType(fixture.typeOf("brandedText"), fixture.checker)).toBe(true);
 
     expect(isNumberType(fixture.typeOf("count"), fixture.checker)).toBe(true);
     expect(isNumberType(fixture.typeOf("countLiteral"), fixture.checker)).toBe(true);
+    expect(isNumberType(fixture.typeOf("brandedCount"), fixture.checker)).toBe(true);
 
     expect(isBigIntType(fixture.typeOf("big"))).toBe(true);
     expect(isBigIntType(fixture.typeOf("bigLiteral"))).toBe(true);
+    expect(isBigIntType(fixture.typeOf("brandedBig"))).toBe(true);
 
     expect(isBooleanType(fixture.typeOf("enabled"), fixture.checker)).toBe(true);
     expect(isBooleanType(fixture.typeOf("enabledLiteral"), fixture.checker)).toBe(true);
+    expect(isBooleanType(fixture.typeOf("brandedEnabled"), fixture.checker)).toBe(true);
   });
 
   it("rejects neighboring scalar types", () => {
@@ -147,6 +168,18 @@ describe("type-utils", () => {
 
     expect(getFieldTypeCategory(fixture.typeOf("maybeText"), fixture.checker)).toBe("string");
     expect(getFieldTypeCategory(fixture.typeOf("maybeCount"), fixture.checker)).toBe("number");
+    expect(getFieldTypeCategory(fixture.typeOf("maybeBrandedText"), fixture.checker)).toBe(
+      "string"
+    );
+    expect(getFieldTypeCategory(fixture.typeOf("maybeBrandedCount"), fixture.checker)).toBe(
+      "number"
+    );
+    expect(getFieldTypeCategory(fixture.typeOf("maybeBrandedBig"), fixture.checker)).toBe(
+      "bigint"
+    );
+    expect(getFieldTypeCategory(fixture.typeOf("brandedEnabled"), fixture.checker)).toBe(
+      "boolean"
+    );
     expect(getFieldTypeCategory(fixture.typeOf("nested"), fixture.checker)).toBe("object");
     expect(getFieldTypeCategory(fixture.typeOf("mixed"), fixture.checker)).toBe("union");
   });


### PR DESCRIPTION
## Motivation

`tag-type-check` had drifted from the canonical type-semantic logic in `@formspec/analysis`. The rule was translating tag capabilities back through local `FieldTypeCategory` helpers, while `@formspec/analysis` already handled nullish-union stripping and branded intersections uniformly. That divergence showed up as false-positive type-mismatch errors for built-in numeric tags on aliases like `Integer = number & { ... }`, and it left the eslint-plugin helper surface asymmetrical across branded primitive shapes.

## Summary

This branch brings `@formspec/eslint-plugin` back into line with the analysis bounded context and fixes the branded-primitive regressions as a cohesive change:

- `tag-type-check` now consults `@formspec/analysis` semantic capabilities directly instead of mapping them back through local `FieldTypeCategory` buckets.
- Built-in numeric tags such as `@minimum`, `@maximum`, `@exclusiveMinimum`, `@exclusiveMaximum`, and `@multipleOf` no longer raise false `typeMismatch` errors on branded numeric aliases.
- The fix covers branded `number`, branded `bigint`, and unions of branded numeric aliases such as `Integer | PositiveInteger`.
- The exported primitive-classification helpers in `@formspec/eslint-plugin` now treat intersections and nullish unions consistently across `string`, `number`, `bigint`, and `boolean`, so the public helper surface no longer has one-off branded-number behavior.
- Regression coverage now includes both positive and negative cases, proving the rule is correctly scoped rather than merely looser: branded strings still reject numeric tags, branded numbers still reject string-only tags, branded bigints are pinned as fixed, and branded numeric unions are covered.

## Test plan

Focused `@formspec/eslint-plugin` validation:

- `vitest` on `tests/rules/constraint-type-mismatch.test.ts`
- `vitest` on `tests/utils/type-utils.test.ts` and `tests/rules/constraint-type-mismatch.test.ts`
- `eslint` on `packages/eslint-plugin/src/utils/type-utils.ts` and `packages/eslint-plugin/tests/rules/constraint-type-mismatch.test.ts`
- `tsc --noEmit` in `packages/eslint-plugin`
- `prettier --check` on the touched eslint-plugin files

Manual validation also performed on a local project.