### PR TITLE
Add TS 7 tsgo CI row

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,14 @@ Authoritative artifacts: `formspec.cml`, `BOUNDED_CONTEXTS.md`, `GLOSSARY.md`, `
 - Extension JSON Schema keywords use the configurable vendor prefix; hardcoded `"x-formspec-…"` literals are wrong. (E3)
 - Schema generation is static — no `Reflect.metadata`, no `emitDecoratorMetadata`, no `eval`. All metadata flows through the TypeScript Compiler API at build time. (PP4)
 
+## TypeScript compatibility reviews
+
+For diffs that touch TypeScript compiler API imports, direct `typescript` dependencies, TypeScript-version workflows, or the TS 7 `tsgo` native-preview job, also review against `docs/typescript-compiler-compatibility.md`.
+
+- Flag new TypeScript-using workspaces that are not discoverable by `scripts/tsgo-ci.mts`.
+- Flag raw compiler API expansion that should become part of the longer-term facade tracked in #476.
+- Flag attempts to make TS 7 blocking, test it through `typescript` dist-tag drift, or bypass the `assert-alias` guard.
+
 ## Tests
 
 - Bug fixes need a regression test that fails pre-fix and names the bug.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,59 +190,10 @@ jobs:
         # tsc directly, and @formspec/ts-plugin imports tsserverlibrary.
         # These local CI-only bridges keep that TS 6 surface available while
         # package imports from "typescript" resolve through the JS API shim.
-        run: |
-          root_tsc6="$(pwd)/node_modules/.bin/tsc6"
-          for bin in node_modules/.bin packages/*/node_modules/.bin e2e/node_modules/.bin; do
-            if [ -d "$bin" ]; then
-              printf '#!/usr/bin/env sh\nexec "%s" "$@"\n' "$root_tsc6" > "$bin/tsc"
-              chmod +x "$bin/tsc"
-            fi
-          done
-          node <<'EOF'
-          const { existsSync, symlinkSync } = require("node:fs");
-          const { createRequire } = require("node:module");
-          const { dirname, join } = require("node:path");
-
-          const aliasPackageJson = require.resolve("typescript/package.json");
-          const requireFromAlias = createRequire(aliasPackageJson);
-          const aliasLib = join(dirname(aliasPackageJson), "lib");
-          const realTypescriptLib = dirname(requireFromAlias.resolve("typescript/lib/typescript.js"));
-
-          for (const fileName of ["tsserver.js", "tsserverlibrary.d.ts", "tsserverlibrary.js"]) {
-            const target = join(aliasLib, fileName);
-            if (!existsSync(target)) {
-              symlinkSync(join(realTypescriptLib, fileName), target);
-            }
-          }
-          EOF
+        run: pnpm exec tsx scripts/tsgo-ci.mts prepare-compat
 
       - name: Assert TypeScript API alias resolution
-        run: |
-          node <<'EOF'
-          const { createRequire } = require("node:module");
-          const { resolve } = require("node:path");
-
-          const workspaceRoots = [
-            ".",
-            "packages/analysis",
-            "packages/build",
-            "packages/cli",
-            "packages/eslint-plugin",
-            "packages/ts-plugin",
-            "e2e",
-          ];
-
-          for (const workspaceRoot of workspaceRoots) {
-            const requireFromWorkspace = createRequire(resolve(workspaceRoot, "package.json"));
-            const pkg = requireFromWorkspace("typescript/package.json");
-            if (pkg.name !== "@typescript/typescript6") {
-              throw new Error(
-                `${workspaceRoot} resolved ${pkg.name}@${pkg.version}, expected @typescript/typescript6`,
-              );
-            }
-            console.log(`${workspaceRoot}: ${pkg.name}@${pkg.version}`);
-          }
-          EOF
+        run: pnpm exec tsx scripts/tsgo-ci.mts assert-alias
 
       - name: Print resolved versions
         run: |
@@ -258,32 +209,7 @@ jobs:
         # Temporarily scope the root config to the package typecheck surface
         # for this direct tsgo invocation. e2e tsgo coverage remains tracked
         # in #471, and type-level negative tests continue to run through tsd.
-        run: |
-          backup="${RUNNER_TEMP:-$(pwd)}/formspec-tsconfig.json"
-          cp tsconfig.json "$backup"
-          restore_tsconfig() {
-            cp "$backup" tsconfig.json
-          }
-          trap restore_tsconfig EXIT
-          node <<'EOF'
-          const { readFileSync, writeFileSync } = require("node:fs");
-          const ts = require("typescript");
-
-          const fileName = "tsconfig.json";
-          const parsed = ts.parseConfigFileTextToJson(fileName, readFileSync(fileName, "utf8"));
-          if (parsed.error) {
-            throw new Error(ts.formatDiagnosticsWithColorAndContext([parsed.error], {
-              getCanonicalFileName: (name) => name,
-              getCurrentDirectory: () => process.cwd(),
-              getNewLine: () => "\n",
-            }));
-          }
-
-          parsed.config.include = ["packages/*/src/**/*", "packages/*/tests/**/*"];
-          parsed.config.exclude = ["packages/*/tests/**/*.test-d.ts"];
-          writeFileSync(fileName, `${JSON.stringify(parsed.config, null, 2)}\n`);
-          EOF
-          pnpm exec tsgo --noEmit --skipLibCheck
+        run: pnpm exec tsx scripts/tsgo-ci.mts typecheck
 
       - name: Run tests
         # Tests still execute through tsc/tsup-backed tooling. Running them here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -150,6 +153,142 @@ jobs:
 
       - name: Type check
         run: pnpm run typecheck
+
+  typescript-7-tsgo:
+    name: Test (TypeScript 7.0 native preview)
+    runs-on: ubuntu-latest
+    continue-on-error: true # experimental: TS 7 is the Go rewrite with a separate API surface
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Pin TypeScript via the typescript6 alias and native-preview
+        # Keep tools that import from "typescript" on the TS 6 JS API shim,
+        # while the native-preview package supplies the tsgo compiler binary.
+        # This follows Microsoft's TS 7 beta side-by-side guidance.
+        run: |
+          npm pkg set "pnpm.overrides.typescript=npm:@typescript/typescript6@^6.0.0"
+          npm pkg set "pnpm.overrides.@typescript/typescript6>typescript=^6.0.0"
+          npm pkg set "devDependencies.@typescript/native-preview=beta"
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Expose TypeScript 6 compatibility bins and server subpaths
+        # @typescript/typescript6 deliberately names its compiler tsc6 so it
+        # can coexist with a future TS 7 tsc. Existing package scripts invoke
+        # tsc directly, and @formspec/ts-plugin imports tsserverlibrary.
+        # These local CI-only bridges keep that TS 6 surface available while
+        # package imports from "typescript" resolve through the JS API shim.
+        run: |
+          root_tsc6="$(pwd)/node_modules/.bin/tsc6"
+          for bin in node_modules/.bin packages/*/node_modules/.bin e2e/node_modules/.bin; do
+            if [ -d "$bin" ]; then
+              printf '#!/usr/bin/env sh\nexec "%s" "$@"\n' "$root_tsc6" > "$bin/tsc"
+              chmod +x "$bin/tsc"
+            fi
+          done
+          node <<'EOF'
+          const { existsSync, symlinkSync } = require("node:fs");
+          const { createRequire } = require("node:module");
+          const { dirname, join } = require("node:path");
+
+          const aliasPackageJson = require.resolve("typescript/package.json");
+          const requireFromAlias = createRequire(aliasPackageJson);
+          const aliasLib = join(dirname(aliasPackageJson), "lib");
+          const realTypescriptLib = dirname(requireFromAlias.resolve("typescript/lib/typescript.js"));
+
+          for (const fileName of ["tsserver.js", "tsserverlibrary.d.ts", "tsserverlibrary.js"]) {
+            const target = join(aliasLib, fileName);
+            if (!existsSync(target)) {
+              symlinkSync(join(realTypescriptLib, fileName), target);
+            }
+          }
+          EOF
+
+      - name: Assert TypeScript API alias resolution
+        run: |
+          node <<'EOF'
+          const { createRequire } = require("node:module");
+          const { resolve } = require("node:path");
+
+          const workspaceRoots = [
+            ".",
+            "packages/analysis",
+            "packages/build",
+            "packages/cli",
+            "packages/eslint-plugin",
+            "packages/ts-plugin",
+            "e2e",
+          ];
+
+          for (const workspaceRoot of workspaceRoots) {
+            const requireFromWorkspace = createRequire(resolve(workspaceRoot, "package.json"));
+            const pkg = requireFromWorkspace("typescript/package.json");
+            if (pkg.name !== "@typescript/typescript6") {
+              throw new Error(
+                `${workspaceRoot} resolved ${pkg.name}@${pkg.version}, expected @typescript/typescript6`,
+              );
+            }
+            console.log(`${workspaceRoot}: ${pkg.name}@${pkg.version}`);
+          }
+          EOF
+
+      - name: Print resolved versions
+        run: |
+          pnpm exec tsc --version
+          pnpm exec tsgo --version
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Typecheck with tsgo
+        # FIXME(#469): scoped skipLibCheck workaround for the @types/chai
+        # "containSubset" duplicate-identifier error under tsgo.
+        # Temporarily scope the root config to the package typecheck surface
+        # for this direct tsgo invocation. e2e tsgo coverage remains tracked
+        # in #471, and type-level negative tests continue to run through tsd.
+        run: |
+          backup="${RUNNER_TEMP:-$(pwd)}/formspec-tsconfig.json"
+          cp tsconfig.json "$backup"
+          restore_tsconfig() {
+            cp "$backup" tsconfig.json
+          }
+          trap restore_tsconfig EXIT
+          node <<'EOF'
+          const { readFileSync, writeFileSync } = require("node:fs");
+          const ts = require("typescript");
+
+          const fileName = "tsconfig.json";
+          const parsed = ts.parseConfigFileTextToJson(fileName, readFileSync(fileName, "utf8"));
+          if (parsed.error) {
+            throw new Error(ts.formatDiagnosticsWithColorAndContext([parsed.error], {
+              getCanonicalFileName: (name) => name,
+              getCurrentDirectory: () => process.cwd(),
+              getNewLine: () => "\n",
+            }));
+          }
+
+          parsed.config.include = ["packages/*/src/**/*", "packages/*/tests/**/*"];
+          parsed.config.exclude = ["packages/*/tests/**/*.test-d.ts"];
+          writeFileSync(fileName, `${JSON.stringify(parsed.config, null, 2)}\n`);
+          EOF
+          pnpm exec tsgo --noEmit --skipLibCheck
+
+      - name: Run tests
+        # Tests still execute through tsc/tsup-backed tooling. Running them here
+        # validates that the TS 6 API alias remains compatible end-to-end.
+        run: pnpm run test
 
   knip:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,9 @@ pnpm --filter @formspec/eslint-plugin run check:eslint-docs
 - [README.md](./README.md)
 - [docs/002-tsdoc-grammar.md](./docs/002-tsdoc-grammar.md)
 - [docs/004-tooling.md](./docs/004-tooling.md)
+
+## Supplemental Resources
+
+Load these only when the change touches the named area:
+
+- [docs/typescript-compiler-compatibility.md](./docs/typescript-compiler-compatibility.md) — read before changing TypeScript compiler API imports, TypeScript package dependencies, TypeScript-version CI, or the TS 7 `tsgo` native-preview job.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,11 +164,11 @@ The matrix derives the `experimental` flag from a major-version mismatch with th
 - **Tier 1 (per-PR):** full pipeline against latest of each supported TypeScript major. `.github/workflows/ci.yml` computes these rows through `typescript-matrix` and runs them through `typescript-versions`; the workspace's pinned major is required, while other supported majors remain informational until promoted.
 - **Tier 2 (per-PR, experimental):** full pipeline against pre-release tracks such as `beta` and `6.x nightly`. These rows are intentionally non-blocking so upstream pre-release drift does not block regular FormSpec work.
 - **Tier 3 (weekly cron, informational):** typecheck-only smoke against the latest patch of every supported TypeScript minor. `.github/workflows/typescript-minor-smoke.yml` derives rows from `packages/analysis/package.json`, runs `pnpm run build && pnpm run typecheck`, and opens or comments on a `tier-3-ts-smoke-failure` tracking issue rather than blocking PRs.
-- **TS 7 (`tsgo`):** separate experimental coverage, tracked in [#449](https://github.com/mike-north/formspec/issues/449).
+- **TS 7 (`tsgo`):** separate experimental coverage, tracked in [#449](https://github.com/mike-north/formspec/issues/449). `.github/workflows/ci.yml` installs `@typescript/native-preview@beta` in the dedicated non-blocking `Test (TypeScript 7.0 native preview)` job.
 
 Patch-level matrix coverage is intentionally out of scope. TypeScript patches are bug-fix releases, and dist-tag drift on `latest` already exercises patch-level movement.
 
-TypeScript 7.x is the Go rewrite with a substantively different API surface. We do not test against it via dist-tag drift; it will be a deliberate, separate migration.
+TypeScript 7.x is the Go rewrite with a substantively different API surface. FormSpec is not opting into official TS 7 support until a future deliberate migration, and we do not test TS 7 through dist-tag drift. The `tsgo` job is native-preview coverage only; the workflow comments own the temporary compatibility details for existing TS 6 tooling.
 
 ### TypeScript compiler API quirks across majors
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,8 @@ Patch-level matrix coverage is intentionally out of scope. TypeScript patches ar
 
 TypeScript 7.x is the Go rewrite with a substantively different API surface. FormSpec is not opting into official TS 7 support until a future deliberate migration, and we do not test TS 7 through dist-tag drift. The `tsgo` job is native-preview coverage only; the workflow comments own the temporary compatibility details for existing TS 6 tooling.
 
+For changes that touch TypeScript compiler API imports, TypeScript package dependencies, TypeScript-version CI, or TS 7 `tsgo` failures, load the supplemental guide in [`docs/typescript-compiler-compatibility.md`](./docs/typescript-compiler-compatibility.md). Do not load it for ordinary feature work that does not affect those areas.
+
 ### TypeScript compiler API quirks across majors
 
 When code reaches into TypeScript's compiler API (`ts.Type`, `ts.Symbol`, `ts.TypeChecker`, etc.), be aware that some internals are not part of the public API contract and shift between majors. The most common pitfall:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Type-safe form definitions that compile to JSON Schema 2020-12 and JSON Forms UI Schema.
 
+[![CI + TS matrix](https://img.shields.io/github/actions/workflow/status/mike-north/formspec/ci.yml?branch=main&label=CI%20%2B%20TS%20matrix&style=flat-square)](https://github.com/mike-north/formspec/actions/workflows/ci.yml)
+[![TS minor smoke](https://img.shields.io/github/actions/workflow/status/mike-north/formspec/typescript-minor-smoke.yml?branch=main&label=TS%20minor%20smoke&style=flat-square)](https://github.com/mike-north/formspec/actions/workflows/typescript-minor-smoke.yml)
+
 > **Architecture orientation.** New contributors and AI agents should read [`BOUNDED_CONTEXTS.md`](./BOUNDED_CONTEXTS.md) (a tour of the project's bounded contexts and how they relate) and [`GLOSSARY.md`](./GLOSSARY.md) (the project's vocabulary). The formal model lives in [`formspec.cml`](./formspec.cml).
 
 ## What It Covers
@@ -20,6 +23,12 @@ pnpm add formspec
 ```
 
 Use the umbrella package when you want the common runtime-facing APIs in one import. Tooling packages such as the CLI, ESLint plugin, and language server are published separately.
+
+## TypeScript Support
+
+Packages that expose or consume the TypeScript compiler API currently support TypeScript `>=5.7.3 <7`. The per-PR CI workflow runs the main build, tests, lint, and typecheck against the workspace TypeScript version, plus non-blocking compatibility rows for other supported majors and pre-release tracks.
+
+TypeScript 7 is covered separately through a non-blocking `tsgo` native-preview CI row using `@typescript/native-preview@beta`. TS 7 is experimental coverage, not an official supported major yet.
 
 ## Quick Start
 
@@ -284,6 +293,21 @@ The default vendor prefix is `x-formspec`. `@formspec/build` also supports custo
 | `@formspec/ts-plugin`       | TypeScript language-service plugin and reusable semantic service                    |
 | `@formspec/language-server` | Completion, hover, and definition support for FormSpec tags                         |
 | `@formspec/cli`             | Build-time CLI for schema and IR generation                                         |
+
+## Published Packages
+
+[![NPM](https://nodei.co/npm/formspec.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/formspec/)
+[![NPM](https://nodei.co/npm/@formspec/core.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/core/)
+[![NPM](https://nodei.co/npm/@formspec/dsl.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/dsl/)
+[![NPM](https://nodei.co/npm/@formspec/build.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/build/)
+[![NPM](https://nodei.co/npm/@formspec/runtime.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/runtime/)
+[![NPM](https://nodei.co/npm/@formspec/analysis.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/analysis/)
+[![NPM](https://nodei.co/npm/@formspec/config.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/config/)
+[![NPM](https://nodei.co/npm/@formspec/validator.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/validator/)
+[![NPM](https://nodei.co/npm/@formspec/eslint-plugin.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/eslint-plugin/)
+[![NPM](https://nodei.co/npm/@formspec/ts-plugin.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/ts-plugin/)
+[![NPM](https://nodei.co/npm/@formspec/language-server.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/language-server/)
+[![NPM](https://nodei.co/npm/@formspec/cli.svg?style=flat-square&data=n,v,u,d&color=brightgreen)](https://nodei.co/npm/@formspec/cli/)
 
 ## Monorepo Development
 

--- a/docs/typescript-compiler-compatibility.md
+++ b/docs/typescript-compiler-compatibility.md
@@ -1,0 +1,77 @@
+# TypeScript Compiler Compatibility
+
+This supplemental guide is for changes that touch FormSpec's TypeScript compiler API usage or the TypeScript-version CI matrix. Do not load it for ordinary feature work that does not import `typescript`, change TypeScript package dependencies, or debug TypeScript-version CI.
+
+## Current Support Model
+
+FormSpec's official TypeScript peer range is `>=5.7.3 <7` for packages that expose or consume the compiler API. TypeScript 7 is not an official supported major yet. The dedicated `typescript-7-tsgo` CI job is a non-blocking native-preview probe for issue [#449](https://github.com/mike-north/formspec/issues/449).
+
+The TS 7 job deliberately uses two TypeScript surfaces:
+
+- `@typescript/native-preview@beta` supplies the `tsgo` binary.
+- `@typescript/typescript6` supplies the JavaScript compiler API currently used by FormSpec packages and tooling.
+
+Keep this distinction intact. `pnpm run build`, `pnpm run test`, `tsup`, lint, and API Extractor still run through the TS 6 JavaScript API in that job. The direct native-preview check is only `pnpm exec tsgo --noEmit --skipLibCheck`, wrapped by `scripts/tsgo-ci.mts`.
+
+## Key Files
+
+- `.github/workflows/ci.yml`: owns the per-PR TypeScript matrix and the non-blocking `typescript-7-tsgo` job.
+- `.github/workflows/typescript-minor-smoke.yml`: owns weekly minor-version smoke coverage for supported TS 5/6 minors.
+- `scripts/tsgo-ci.mts`: owns TS 7 job setup details that would otherwise become embedded workflow JavaScript.
+- `scripts/tsgo-ci.test.mts`: tests the TS 7 setup helpers and should grow with the helper.
+- `knip.json`: ignores the CI-only `tsgo` binary.
+- `CLAUDE.md` and `AGENTS.md`: point agents here only for TypeScript-compatibility work.
+
+## When Adding A Package That Uses TypeScript
+
+If a new workspace imports from `typescript` or shells out to `tsc`, decide whether it needs a direct `typescript` dependency:
+
+- Public package/runtime compiler API use generally belongs in `peerDependencies` with the supported range, currently `>=5.7.3 <7`.
+- Private test, benchmark, or fixture workspaces can use `devDependencies`.
+- Do not add a direct dependency just to inherit another package's compiler host. Prefer an existing FormSpec package API when one exists.
+
+The TS 7 alias guard in `scripts/tsgo-ci.mts` discovers workspaces under `packages/*`, `examples/*`, and `e2e` that declare a direct `typescript` dependency. If a new workspace lives somewhere else, update `discoverTypeScriptApiWorkspaceRoots()` and its tests. Do not replace the guard with a static list unless the workspace layout itself becomes static and tested.
+
+After adding or moving a TypeScript-using workspace, run:
+
+```bash
+pnpm run test:scripts
+pnpm run knip
+```
+
+Then run the TS 7 row in a temporary copy if the change can affect compiler resolution or workflow behavior.
+
+## When Adding Compiler API Usage
+
+Prefer a small helper in the existing owning package over scattering raw compiler checks across the repo. The longer-term target is tracked in issue [#476](https://github.com/mike-north/formspec/issues/476): a unified internal compiler API facade that insulates most of FormSpec from TS 5/6/7 nuance.
+
+Until that facade exists:
+
+- Import the runtime namespace with `import * as ts from "typescript"` when reading enum values or runtime compiler helpers.
+- Use named enum members such as `ts.TypeFlags.Null`; never hardcode numeric flag values.
+- Keep compiler objects out of Canonical IR and serialized protocols.
+- Treat new public APIs exposing `ts.*` types as API design work. Update API reports and document the public evolution strategy.
+- Add tests for intended FormSpec behavior, not snapshots of whatever the current compiler happens to return.
+
+If a change reaches for a new part of the compiler API, ask whether the behavior should be normalized behind a helper now. If the answer is "not in this PR," mention issue #476 in the PR or follow-up issue.
+
+## Debugging The TS 7 Job
+
+Map failures to the step that owns them:
+
+- `Pin TypeScript via the typescript6 alias and native-preview`: package mutation failed, or the `@typescript/native-preview` beta tag changed unexpectedly.
+- `Install dependencies`: pnpm override interaction failed. Inspect `package.json`, `pnpm-lock.yaml`, and `pnpm why typescript`.
+- `Expose TypeScript 6 compatibility bins and server subpaths`: the `@typescript/typescript6` package layout changed, `tsc6` is missing, or tsserver subpaths moved.
+- `Assert TypeScript API alias resolution`: a workspace with a direct `typescript` dependency did not resolve to `@typescript/typescript6`. This often means a new package was added outside the discovery rules, or an override no longer applies to that package.
+- `Build` or `Run tests`: the TS 6 JavaScript API alias is not behaving like the supported compiler API. This is not a `tsgo` native check failure.
+- `Typecheck with tsgo`: the native-preview compiler rejected the scoped package source/test surface. The current `skipLibCheck` workaround is tracked in [#469](https://github.com/mike-north/formspec/issues/469); e2e tsgo coverage is tracked in [#471](https://github.com/mike-north/formspec/issues/471).
+
+When reproducing locally, use a temporary copy so `npm pkg set` and `pnpm install --no-frozen-lockfile` do not dirty the PR worktree. Run the workflow commands in the same order as CI, including `pnpm exec tsx scripts/tsgo-ci.mts prepare-compat`, `assert-alias`, and `typecheck`.
+
+## What Not To Do
+
+- Do not make TS 7 blocking until the project explicitly promotes it to official support.
+- Do not test TS 7 through `typescript` dist-tag drift. Use `@typescript/native-preview@beta` for the native-preview row.
+- Do not add lint, `tsup`, or API Extractor to the direct `tsgo` path unless the project has adopted a stable TS 7 programmatic API.
+- Do not remove the `assert-alias` step to get a green build. Fix workspace discovery, package dependencies, or pnpm overrides instead.
+- Do not broaden public peer ranges for TS 7 until the public compiler API exposure and facade plan are resolved.

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignoreBinaries": ["tsgo"],
   "workspaces": {
     "packages/core": {
       "entry": ["tests/**/*.test-d.ts"]
@@ -8,10 +9,7 @@
       "entry": ["tests/**/*.test-d.ts"]
     },
     "packages/build": {
-      "entry": [
-        "tests/fixtures/**/*.ts",
-        "tests/parity/fixtures/**/*.ts"
-      ],
+      "entry": ["tests/fixtures/**/*.ts", "tests/parity/fixtures/**/*.ts"],
       "ignore": ["tests/fixtures/method-signature-schemas.ts"]
     },
     "packages/cli": {
@@ -21,11 +19,7 @@
       "ignoreDependencies": ["pino-pretty"]
     },
     "e2e": {
-      "entry": [
-        "benchmarks/**/*.{ts,cjs}",
-        "fixtures/**/*.ts",
-        "helpers/**/*.ts"
-      ],
+      "entry": ["benchmarks/**/*.{ts,cjs}", "fixtures/**/*.ts", "helpers/**/*.ts"],
       "project": ["**/*.{ts,cjs}"],
       "ignoreDependencies": ["@formspec/cli", "@formspec/core"]
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "pnpm run test:scripts && pnpm -r run test",
-    "test:scripts": "node --test scripts/*.test.mjs",
+    "test:scripts": "node --test scripts/*.test.mjs && tsx --test scripts/*.test.mts",
     "test:e2e": "pnpm run build && pnpm --filter @formspec/e2e run test",
     "typecheck": "pnpm -r run typecheck",
     "api-extractor": "pnpm -r run api-extractor",
@@ -47,6 +47,7 @@
     "prettier": "^3.5.0",
     "syncpack": "^14.3.0",
     "tsup": "^8.5.1",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.0",
     "typescript-eslint": "^8.21.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@22.19.7))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^6.0.0
         version: 6.0.3

--- a/scripts/tsgo-ci.mts
+++ b/scripts/tsgo-ci.mts
@@ -1,0 +1,297 @@
+#!/usr/bin/env tsx
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SCOPED_TSGO_INCLUDE = ["packages/*/src/**/*", "packages/*/tests/**/*"];
+const SCOPED_TSGO_EXCLUDE = ["packages/*/tests/**/*.test-d.ts"];
+const TYPE_SCRIPT_SERVER_SUBPATHS = ["tsserver.js", "tsserverlibrary.d.ts", "tsserverlibrary.js"];
+const TYPE_SCRIPT_DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+type TypeScriptModule = typeof import("typescript");
+
+export interface TypeScriptAliasResolution {
+  workspaceRoot: string;
+  packageName: string;
+  version: string;
+}
+
+export interface CommandResult {
+  status: number | null;
+  signal?: string | null;
+  error?: Error;
+}
+
+function resolveFromRepoRoot(repoRoot: string, ...segments: string[]): string {
+  return path.resolve(repoRoot, ...segments);
+}
+
+function createRequireFromRepoRoot(repoRoot: string): NodeJS.Require {
+  return createRequire(resolveFromRepoRoot(repoRoot, "package.json"));
+}
+
+function isStringKeyedRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readJsonRecord(filePath: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(readFileSync(filePath, "utf8"));
+  if (!isStringKeyedRecord(parsed)) {
+    throw new Error(`${filePath} must contain a JSON object`);
+  }
+
+  return parsed;
+}
+
+function discoverChildPackageRoots(repoRoot: string, directory: string): string[] {
+  const packagesRoot = resolveFromRepoRoot(repoRoot, directory);
+  if (!existsSync(packagesRoot)) {
+    return [];
+  }
+
+  return readdirSync(packagesRoot, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .filter((entry) => entry.isDirectory())
+    .filter((entry) =>
+      existsSync(resolveFromRepoRoot(repoRoot, directory, entry.name, "package.json"))
+    )
+    .map((entry) => path.posix.join(directory, entry.name));
+}
+
+function discoverWorkspacePackageRoots(repoRoot: string): string[] {
+  return [
+    ...discoverChildPackageRoots(repoRoot, "packages"),
+    ...discoverChildPackageRoots(repoRoot, "examples"),
+    ...(existsSync(resolveFromRepoRoot(repoRoot, "e2e/package.json")) ? ["e2e"] : []),
+  ];
+}
+
+function declaresTypeScriptDependency(packageJson: Record<string, unknown>): boolean {
+  return TYPE_SCRIPT_DEPENDENCY_SECTIONS.some((sectionName) => {
+    const section = packageJson[sectionName];
+    return isStringKeyedRecord(section) && typeof section["typescript"] === "string";
+  });
+}
+
+export function discoverTypeScriptApiWorkspaceRoots({
+  repoRoot = process.cwd(),
+}: {
+  repoRoot?: string;
+} = {}): string[] {
+  return [".", ...discoverWorkspacePackageRoots(repoRoot)].filter((workspaceRoot) => {
+    const packageJsonPath = resolveFromRepoRoot(repoRoot, workspaceRoot, "package.json");
+    return (
+      existsSync(packageJsonPath) && declaresTypeScriptDependency(readJsonRecord(packageJsonPath))
+    );
+  });
+}
+
+function discoverTypeScriptBinDirectories(repoRoot: string, packageRoots: string[]): string[] {
+  return [
+    resolveFromRepoRoot(repoRoot, "node_modules/.bin"),
+    ...packageRoots.map((packageRoot) =>
+      resolveFromRepoRoot(repoRoot, packageRoot, "node_modules/.bin")
+    ),
+    resolveFromRepoRoot(repoRoot, "e2e/node_modules/.bin"),
+  ].filter((binDirectory) => existsSync(binDirectory));
+}
+
+function loadTypeScriptFromRepoRoot(repoRoot: string): TypeScriptModule {
+  return createRequireFromRepoRoot(repoRoot)("typescript") as TypeScriptModule;
+}
+
+function formatDiagnosticsHost(): Parameters<
+  TypeScriptModule["formatDiagnosticsWithColorAndContext"]
+>[1] {
+  return {
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => process.cwd(),
+    getNewLine: () => "\n",
+  };
+}
+
+export function prepareTypeScript6Compatibility({
+  repoRoot = process.cwd(),
+  packageRoots = discoverWorkspacePackageRoots(repoRoot),
+}: {
+  repoRoot?: string;
+  packageRoots?: string[];
+} = {}): void {
+  const rootTsc6 = resolveFromRepoRoot(repoRoot, "node_modules/.bin/tsc6");
+  const launcher = `#!/usr/bin/env sh\nexec ${JSON.stringify(rootTsc6)} "$@"\n`;
+
+  for (const binDirectory of discoverTypeScriptBinDirectories(repoRoot, packageRoots)) {
+    const launcherPath = path.join(binDirectory, "tsc");
+    writeFileSync(launcherPath, launcher, { mode: 0o755 });
+    chmodSync(launcherPath, 0o755);
+  }
+
+  bridgeTypeScriptServerSubpaths(repoRoot);
+}
+
+function bridgeTypeScriptServerSubpaths(repoRoot: string): void {
+  const requireFromRepo = createRequireFromRepoRoot(repoRoot);
+  const aliasPackageJson = requireFromRepo.resolve("typescript/package.json");
+  const requireFromAlias = createRequire(aliasPackageJson);
+  const aliasLib = path.join(path.dirname(aliasPackageJson), "lib");
+  const realTypescriptLib = path.dirname(requireFromAlias.resolve("typescript/lib/typescript.js"));
+
+  mkdirSync(aliasLib, { recursive: true });
+
+  for (const fileName of TYPE_SCRIPT_SERVER_SUBPATHS) {
+    const target = path.join(aliasLib, fileName);
+    if (!existsSync(target)) {
+      symlinkSync(path.join(realTypescriptLib, fileName), target);
+    }
+  }
+}
+
+export function assertTypeScript6AliasResolution({
+  repoRoot = process.cwd(),
+  workspaceRoots = discoverTypeScriptApiWorkspaceRoots({ repoRoot }),
+}: {
+  repoRoot?: string;
+  workspaceRoots?: string[];
+} = {}): TypeScriptAliasResolution[] {
+  return workspaceRoots.map((workspaceRoot) => {
+    const requireFromWorkspace = createRequire(
+      resolveFromRepoRoot(repoRoot, workspaceRoot, "package.json")
+    );
+    const packageJson = requireFromWorkspace("typescript/package.json") as {
+      name?: unknown;
+      version?: unknown;
+    };
+    const packageName = String(packageJson.name);
+    const version = String(packageJson.version);
+
+    if (packageName !== "@typescript/typescript6") {
+      throw new Error(
+        `${workspaceRoot} resolved ${packageName}@${version}, expected @typescript/typescript6`
+      );
+    }
+
+    return { workspaceRoot, packageName, version };
+  });
+}
+
+export function writeScopedTsgoRootConfig({
+  repoRoot = process.cwd(),
+  typescript = loadTypeScriptFromRepoRoot(repoRoot),
+}: {
+  repoRoot?: string;
+  typescript?: TypeScriptModule;
+} = {}): void {
+  const fileName = resolveFromRepoRoot(repoRoot, "tsconfig.json");
+  const parsed = typescript.parseConfigFileTextToJson(fileName, readFileSync(fileName, "utf8"));
+
+  if (parsed.error !== undefined) {
+    throw new Error(
+      typescript.formatDiagnosticsWithColorAndContext([parsed.error], formatDiagnosticsHost())
+    );
+  }
+
+  if (typeof parsed.config !== "object" || parsed.config === null || Array.isArray(parsed.config)) {
+    throw new Error(`${fileName} must contain a JSON object`);
+  }
+
+  const config = parsed.config as Record<string, unknown>;
+  config.include = SCOPED_TSGO_INCLUDE;
+  config.exclude = SCOPED_TSGO_EXCLUDE;
+
+  writeFileSync(fileName, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+export function runScopedTsgoTypecheck({
+  repoRoot = process.cwd(),
+  typescript = loadTypeScriptFromRepoRoot(repoRoot),
+  runCommand = () =>
+    spawnSync("pnpm", ["exec", "tsgo", "--noEmit", "--skipLibCheck"], {
+      cwd: repoRoot,
+      stdio: "inherit",
+    }) as SpawnSyncReturns<Buffer>,
+}: {
+  repoRoot?: string;
+  typescript?: TypeScriptModule;
+  runCommand?: () => CommandResult;
+} = {}): CommandResult {
+  const fileName = resolveFromRepoRoot(repoRoot, "tsconfig.json");
+  const originalConfig = readFileSync(fileName, "utf8");
+
+  try {
+    writeScopedTsgoRootConfig({ repoRoot, typescript });
+    const result = runCommand();
+
+    if (result.error !== undefined) {
+      throw result.error;
+    }
+
+    if (result.signal !== undefined && result.signal !== null) {
+      throw new Error(`tsgo typecheck terminated by signal ${result.signal}`);
+    }
+
+    if (result.status !== 0) {
+      throw new Error(`tsgo typecheck failed with exit status ${String(result.status)}`);
+    }
+
+    return result;
+  } finally {
+    writeFileSync(fileName, originalConfig);
+  }
+}
+
+function printAliasResolution(): void {
+  for (const result of assertTypeScript6AliasResolution()) {
+    console.log(`${result.workspaceRoot}: ${result.packageName}@${result.version}`);
+  }
+}
+
+function printUsage(): void {
+  console.error("Usage: tsx scripts/tsgo-ci.mts <prepare-compat|assert-alias|typecheck>");
+}
+
+function main(): void {
+  const command = process.argv[2];
+
+  switch (command) {
+    case "prepare-compat":
+      prepareTypeScript6Compatibility();
+      break;
+    case "assert-alias":
+      printAliasResolution();
+      break;
+    case "typecheck":
+      runScopedTsgoTypecheck();
+      break;
+    default:
+      printUsage();
+      process.exitCode = 2;
+  }
+}
+
+if (
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/tsgo-ci.test.mts
+++ b/scripts/tsgo-ci.test.mts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import * as ts from "typescript";
+
+import {
+  assertTypeScript6AliasResolution,
+  discoverTypeScriptApiWorkspaceRoots,
+  prepareTypeScript6Compatibility,
+  runScopedTsgoTypecheck,
+  writeScopedTsgoRootConfig,
+} from "./tsgo-ci.mts";
+
+async function withFixture(
+  files: Record<string, string>,
+  testFn: (root: string) => void | Promise<void>
+): Promise<void> {
+  const root = await mkdtemp(path.join(tmpdir(), "formspec-tsgo-ci-"));
+  try {
+    for (const [filePath, contents] of Object.entries(files)) {
+      const absolutePath = path.join(root, filePath);
+      await mkdir(path.dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, contents, "utf8");
+    }
+
+    await testFn(root);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+function packageJson(packageJson: object): string {
+  return `${JSON.stringify(packageJson, null, 2)}\n`;
+}
+
+function parseJsonRecord(contents: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(contents);
+  assert.equal(typeof parsed, "object");
+  assert.notEqual(parsed, null);
+  assert.equal(Array.isArray(parsed), false);
+  return parsed as Record<string, unknown>;
+}
+
+void describe("prepareTypeScript6Compatibility", () => {
+  void it("adds tsc launchers and tsserver subpath bridges for the TS 6 alias package", async () => {
+    await withFixture(
+      {
+        "node_modules/.bin/tsc6": "#!/usr/bin/env sh\n",
+        "node_modules/typescript/package.json": packageJson({
+          name: "@typescript/typescript6",
+          version: "6.0.3",
+        }),
+        "node_modules/typescript/node_modules/typescript/package.json": packageJson({
+          name: "typescript",
+          version: "6.0.3",
+        }),
+        "node_modules/typescript/node_modules/typescript/lib/typescript.js": "",
+        "node_modules/typescript/node_modules/typescript/lib/tsserver.js": "",
+        "node_modules/typescript/node_modules/typescript/lib/tsserverlibrary.d.ts": "",
+        "node_modules/typescript/node_modules/typescript/lib/tsserverlibrary.js": "",
+      },
+      async (root) => {
+        await mkdir(path.join(root, "node_modules/.bin"), { recursive: true });
+        await mkdir(path.join(root, "packages/build/node_modules/.bin"), { recursive: true });
+        await mkdir(path.join(root, "e2e/node_modules/.bin"), { recursive: true });
+
+        prepareTypeScript6Compatibility({
+          repoRoot: root,
+          packageRoots: ["packages/build"],
+        });
+
+        const rootLauncher = await readFile(path.join(root, "node_modules/.bin/tsc"), "utf8");
+        const packageLauncher = await readFile(
+          path.join(root, "packages/build/node_modules/.bin/tsc"),
+          "utf8"
+        );
+        const e2eLauncher = await readFile(path.join(root, "e2e/node_modules/.bin/tsc"), "utf8");
+
+        assert.match(rootLauncher, /node_modules\/\.bin\/tsc6/);
+        assert.equal(packageLauncher, rootLauncher);
+        assert.equal(e2eLauncher, rootLauncher);
+
+        for (const fileName of ["tsserver.js", "tsserverlibrary.d.ts", "tsserverlibrary.js"]) {
+          const stat = await lstat(path.join(root, "node_modules/typescript/lib", fileName));
+          assert.equal(stat.isSymbolicLink(), true);
+        }
+      }
+    );
+  });
+});
+
+void describe("discoverTypeScriptApiWorkspaceRoots", () => {
+  void it("discovers workspace packages that declare a direct TypeScript dependency", async () => {
+    await withFixture(
+      {
+        "package.json": packageJson({ devDependencies: { typescript: "^6.0.0" } }),
+        "packages/build/package.json": packageJson({
+          name: "@formspec/build",
+          peerDependencies: { typescript: ">=5.7.3 <7" },
+        }),
+        "packages/core/package.json": packageJson({ name: "@formspec/core" }),
+        "examples/consumer/package.json": packageJson({
+          name: "consumer",
+          devDependencies: { typescript: "^6.0.0" },
+        }),
+        "e2e/package.json": packageJson({
+          name: "@formspec/e2e",
+          devDependencies: { typescript: ">=5.7.3 <7" },
+        }),
+      },
+      (root) => {
+        assert.deepEqual(discoverTypeScriptApiWorkspaceRoots({ repoRoot: root }), [
+          ".",
+          "packages/build",
+          "examples/consumer",
+          "e2e",
+        ]);
+      }
+    );
+  });
+});
+
+void describe("assertTypeScript6AliasResolution", () => {
+  void it("accepts workspaces that resolve the TypeScript 6 alias package", async () => {
+    await withFixture(
+      {
+        "package.json": packageJson({ private: true }),
+        "packages/build/package.json": packageJson({ name: "@formspec/build" }),
+        "node_modules/typescript/package.json": packageJson({
+          name: "@typescript/typescript6",
+          version: "6.0.3",
+        }),
+      },
+      (root) => {
+        assert.deepEqual(
+          assertTypeScript6AliasResolution({
+            repoRoot: root,
+            workspaceRoots: [".", "packages/build"],
+          }),
+          [
+            { workspaceRoot: ".", packageName: "@typescript/typescript6", version: "6.0.3" },
+            {
+              workspaceRoot: "packages/build",
+              packageName: "@typescript/typescript6",
+              version: "6.0.3",
+            },
+          ]
+        );
+      }
+    );
+  });
+
+  void it("rejects workspaces that resolve the regular TypeScript package", async () => {
+    await withFixture(
+      {
+        "package.json": packageJson({ private: true }),
+        "node_modules/typescript/package.json": packageJson({
+          name: "typescript",
+          version: "6.0.3",
+        }),
+      },
+      (root) => {
+        assert.throws(
+          () =>
+            assertTypeScript6AliasResolution({
+              repoRoot: root,
+              workspaceRoots: ["."],
+            }),
+          /resolved typescript@6\.0\.3, expected @typescript\/typescript6/
+        );
+      }
+    );
+  });
+});
+
+void describe("writeScopedTsgoRootConfig", () => {
+  void it("limits direct tsgo coverage to package src and test files", async () => {
+    await withFixture(
+      {
+        "package.json": packageJson({ private: true }),
+        "tsconfig.json": ["{", '  "compilerOptions": {', '    "strict": true', "  }", "}", ""].join(
+          "\n"
+        ),
+      },
+      async (root) => {
+        writeScopedTsgoRootConfig({ repoRoot: root, typescript: ts });
+
+        const parsed = parseJsonRecord(await readFile(path.join(root, "tsconfig.json"), "utf8"));
+        assert.deepEqual(parsed["include"], ["packages/*/src/**/*", "packages/*/tests/**/*"]);
+        assert.deepEqual(parsed["exclude"], ["packages/*/tests/**/*.test-d.ts"]);
+        assert.deepEqual(parsed["compilerOptions"], { strict: true });
+      }
+    );
+  });
+});
+
+void describe("runScopedTsgoTypecheck", () => {
+  void it("restores the root tsconfig after a passing tsgo command", async () => {
+    const originalConfig = '{ "compilerOptions": { "strict": true } }\n';
+
+    await withFixture(
+      {
+        "package.json": packageJson({ private: true }),
+        "tsconfig.json": originalConfig,
+      },
+      async (root) => {
+        let commandConfig: unknown;
+        const result = runScopedTsgoTypecheck({
+          repoRoot: root,
+          typescript: ts,
+          runCommand: () => {
+            // The command must see the scoped config before restoration.
+            commandConfig = JSON.parse(readFileSync(path.join(root, "tsconfig.json"), "utf8"));
+            return { status: 0 };
+          },
+        });
+
+        assert.deepEqual(commandConfig, {
+          compilerOptions: { strict: true },
+          include: ["packages/*/src/**/*", "packages/*/tests/**/*"],
+          exclude: ["packages/*/tests/**/*.test-d.ts"],
+        });
+        assert.equal(result.status, 0);
+        assert.equal(await readFile(path.join(root, "tsconfig.json"), "utf8"), originalConfig);
+      }
+    );
+  });
+
+  void it("restores the root tsconfig after a failing tsgo command", async () => {
+    const originalConfig = '{ "compilerOptions": { "strict": true } }\n';
+
+    await withFixture(
+      {
+        "package.json": packageJson({ private: true }),
+        "tsconfig.json": originalConfig,
+      },
+      async (root) => {
+        assert.throws(
+          () =>
+            runScopedTsgoTypecheck({
+              repoRoot: root,
+              typescript: ts,
+              runCommand: () => ({ status: 1 }),
+            }),
+          /tsgo typecheck failed with exit status 1/
+        );
+
+        assert.equal(await readFile(path.join(root, "tsconfig.json"), "utf8"), originalConfig);
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add a non-blocking `typescript-7-tsgo` CI job that installs `@typescript/native-preview@beta` alongside the TypeScript 6 JS API alias.
- Move the TS 7 workflow's compatibility bridge, alias assertion, and scoped tsgo typecheck logic into `scripts/tsgo-ci.mts`, exercised by script tests and invoked through root `tsx`.
- Add supplemental TS compiler compatibility guidance for future agents/reviewers, plus README TypeScript support notes, CI matrix health badges, and published-package npm badges.
- Document that TS 7 native-preview coverage is experimental and not an official supported TypeScript major yet.

Closes #449
Refs #469
Refs #471
Refs #476

## Test plan

- `pnpm run build`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run typecheck`
- `pnpm run knip`
- `pnpm run test:scripts`
- `pnpm exec eslint scripts/tsgo-ci.mts scripts/tsgo-ci.test.mts`
- `pnpm exec prettier --check README.md package.json pnpm-lock.yaml .github/workflows/ci.yml .github/copilot-instructions.md AGENTS.md CLAUDE.md docs/typescript-compiler-compatibility.md knip.json scripts/tsgo-ci.mts scripts/tsgo-ci.test.mts`
- `git diff --check`
- Temp CI-row simulation in `/private/tmp`: TS6 alias/native-preview install, `pnpm exec tsx scripts/tsgo-ci.mts prepare-compat`, alias assertion, `pnpm exec tsc --version`, `pnpm exec tsgo --version`, `pnpm run build`, `pnpm exec tsx scripts/tsgo-ci.mts typecheck`, `pnpm run test`

`actionlint` was not installed locally, so workflow semantic validation is left to CI.
