### PR TITLE
Clean stale benchmark counter wording

### DIFF
--- a/.changeset/some-canyons-act.md
+++ b/.changeset/some-canyons-act.md
@@ -1,0 +1,5 @@
+---
+"@formspec/e2e": patch
+---
+
+Update benchmark documentation to describe post-synthetic-checker cache metrics.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -25,7 +25,8 @@ pnpm --filter @formspec/e2e run benchmark:hybrid-tooling
 **Baseline:** `docs/refactors/phase-0-baseline.md`
 
 Measures `generateSchemasFromProgram` wall time and peak RSS, plus
-`FormSpecSemanticService.getDiagnostics` file-snapshot cache hit/miss totals.
+`FormSpecSemanticService.getDiagnostics` file-snapshot cache per-run hit/miss
+deltas (fresh-service).
 Used as the Phase 0-C baseline for the synthetic-checker retirement refactor.
 
 ```bash

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -24,8 +24,9 @@ pnpm --filter @formspec/e2e run benchmark:hybrid-tooling
 **Fixture:** `benchmarks/analysis-bench-fixture.ts` — 20-field `AnalysisBenchFixture` interface
 **Baseline:** `docs/refactors/phase-0-baseline.md`
 
-Measures `generateSchemasFromProgram` wall time, peak RSS, and synthetic `ts.createProgram`
-invocation count. Used as the Phase 0-C baseline for the synthetic-checker retirement refactor.
+Measures `generateSchemasFromProgram` wall time and peak RSS, plus
+`FormSpecSemanticService.getDiagnostics` file-snapshot cache hit/miss totals.
+Used as the Phase 0-C baseline for the synthetic-checker retirement refactor.
 
 ```bash
 pnpm --filter @formspec/e2e run bench:analysis
@@ -214,9 +215,10 @@ pnpm --filter @formspec/e2e run bench:stripe-realistic-tsserver
 | **eslint** | **519.1 MB** (warm median) | 420.2 ms | 2.8 ms | **false** |
 | **tsserver-plugin** | **567.4 MB** (session) | 373.8 ms | ~0 ms | **false** |
 
-Notes on tsserver-plugin: the bench creates one service and calls `getDiagnostics` 3× (open-file
-+ 2 keystrokes) on the same instance. Session RSS is measured across all three calls. Warm
-wall-time is near-zero because the service caches analysis results across calls.
+Notes on tsserver-plugin: the bench creates one service and calls `getDiagnostics` 3× (one
+open-file call plus two keystroke re-analyses) on the same instance. Session RSS is measured
+across all three calls. Warm wall-time is near-zero because the service caches analysis results
+across calls.
 
 All four surfaces came in under 1 GB — none OOMed on this machine (M-series arm64, Node v24.14.0).
 Build / snapshot are above 840 MB, within 180 MB of the 1 GB cap. A machine with less available

--- a/e2e/benchmarks/README.md
+++ b/e2e/benchmarks/README.md
@@ -8,8 +8,8 @@ developer tools — they are not part of the test suite run by `pnpm test`.
 ### `analysis-bench.ts` — Phase 0-C analysis pipeline baseline
 
 Measures `generateSchemasFromProgram` wall time + peak RSS and
-`FormSpecSemanticService.getDiagnostics` synthetic-program count against the
-20-field `AnalysisBenchFixture`.
+`FormSpecSemanticService.getDiagnostics` file-snapshot cache hit/miss totals
+against the 20-field `AnalysisBenchFixture`.
 
 **Run:**
 

--- a/e2e/benchmarks/README.md
+++ b/e2e/benchmarks/README.md
@@ -8,8 +8,8 @@ developer tools — they are not part of the test suite run by `pnpm test`.
 ### `analysis-bench.ts` — Phase 0-C analysis pipeline baseline
 
 Measures `generateSchemasFromProgram` wall time + peak RSS and
-`FormSpecSemanticService.getDiagnostics` file-snapshot cache hit/miss totals
-against the 20-field `AnalysisBenchFixture`.
+`FormSpecSemanticService.getDiagnostics` file-snapshot cache per-run
+hit/miss deltas (fresh-service) against the 20-field `AnalysisBenchFixture`.
 
 **Run:**
 

--- a/e2e/benchmarks/analysis-bench.ts
+++ b/e2e/benchmarks/analysis-bench.ts
@@ -1,34 +1,33 @@
 /**
  * Phase 0-C microbenchmark: analysis-pipeline baseline.
  *
- * Measures three metrics for a single `generateSchemasFromProgram` call
- * against the 20-field AnalysisBenchFixture:
+ * Measures build-path timing and plugin-path cache behavior against the
+ * 20-field AnalysisBenchFixture:
  *
- *   1. wallTimeMs      — end-to-end elapsed time
- *   2. peakRssBytes    — peak resident set size observed via polling
- *   3. syntheticProgramCount — ts.createProgram invocations inside the
- *                             synthetic constraint-checker
+ *   1. wallTimeMs             — build-path end-to-end elapsed time
+ *   2. peakRssBytes           — build-path peak resident set size
+ *   3. fileSnapshotCache      — plugin-path cache hit/miss deltas
  *
  * ### Run model
  *
- * Five runs are collected per metric path. Run 1 is the **cold run** for the
- * measured call (first invocation/JIT effects + empty synthetic-batch cache;
- * module imports run before the timer starts). Runs 2–5 are **warm runs**
- * (subsequent invocations with the synthetic-batch cache populated). Median is
- * computed over warm runs (2–5) for wall time and RSS. The cold-run
- * synthetic-program count is reported separately because subsequent runs hit
- * the module-level LRU cache in @formspec/analysis and produce a count of 0.
+ * Five runs are collected per metric path. For the build path, run 1 is the
+ * **cold run** for the measured call (first invocation/JIT effects; module
+ * imports run before the timer starts). Runs 2–5 are **warm runs**, and the
+ * median is computed over warm runs for wall time and RSS.
  *
- * ### Synthetic-program count methodology
+ * For the plugin path, each run creates a fresh `FormSpecSemanticService` and
+ * records file-snapshot cache deltas for one diagnostics query. Those deltas
+ * show initial snapshot behavior for the query path, not cross-run cache reuse.
+ *
+ * ### File-snapshot cache methodology
  *
  * TypeScript 5.9+ exports are sealed (non-configurable getters), so
  * monkey-patching `ts.createProgram` at runtime is not possible on Node.js 24.
- * Instead the count is obtained via the `FormSpecSemanticService` from
- * `@formspec/ts-plugin`, which exposes `syntheticCompileCount` in its
- * `getStats()` method and increments it on every synthetic-checker
- * `ts.createProgram` call. The service is driven to produce diagnostics for
- * the fixture file, which exercises the same constraint-validation path as
- * `generateSchemasFromProgram`.
+ * Instead the benchmark drives `FormSpecSemanticService` diagnostics for the
+ * fixture file and reads `getStats()` before and after each fresh-service
+ * query. The file-snapshot cache deltas exercise the same host-program,
+ * typed-parser validation model while keeping the benchmark aligned with
+ * single-program analysis.
  *
  * Run with:
  *   pnpm --filter @formspec/e2e run bench:analysis
@@ -122,15 +121,14 @@ function runBuildBenchOnce(filePath: string): BuildRunResult {
 }
 
 // ---------------------------------------------------------------------------
-// §5 Phase 5C — synthetic program count measurement is retired.
+// §5 Phase 5C — parallel program-construction measurement is retired.
 //
 // Historically this benchmark reported `syntheticCompileCount` from
 // FormSpecSemanticService.getStats() as a proxy for how many parallel
-// ts.createProgram calls the analysis pipeline was issuing. The synthetic
-// TypeScript program has been deleted, so the counter always reads zero and
-// has been removed from the stats surface. The plugin-path loop is kept to
-// continue measuring the warm/cold query path totals and file-snapshot cache
-// hit ratio, which remain meaningful for wall-time / RSS tracking.
+// ts.createProgram calls the analysis pipeline was issuing. That stats field
+// has been removed with the synthetic TypeScript program. The plugin-path loop
+// is kept to continue measuring fresh-service query-path cache deltas, which
+// remain meaningful for wall-time / RSS tracking.
 // ---------------------------------------------------------------------------
 
 interface PluginRunResult {
@@ -182,9 +180,7 @@ function median(values: readonly number[]): number {
 const RUNS = 5;
 
 async function main(): Promise<void> {
-  const workspaceRoot = await fs.mkdtemp(
-    path.join(os.tmpdir(), "formspec-analysis-bench-")
-  );
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "formspec-analysis-bench-"));
 
   try {
     // Write the fixture TypeScript file to a temp directory so ts.createProgram
@@ -219,14 +215,14 @@ async function main(): Promise<void> {
 
     // --- TS-plugin-path measurements ---
     // §5 Phase 5C — no more synthetic program counter; we still record
-    // file-snapshot cache hit/miss ratios across cold/warm runs because they
-    // are the most useful signal for caching regressions.
+    // file-snapshot cache hit/miss deltas for fresh-service diagnostics
+    // queries because they are useful for tracking snapshot-construction
+    // behavior.
     const allPluginResults: PluginRunResult[] = [];
 
     process.stderr.write("\n  Plugin-path (FormSpecSemanticService.getDiagnostics):\n");
     for (let i = 0; i < RUNS; i++) {
-      const label = i === 0 ? "cold" : "warm";
-      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [${label}]...`);
+      process.stderr.write(`    run ${String(i + 1)}/${String(RUNS)} [fresh-service]...`);
       const result = runPluginBenchOnce(workspaceRoot, fixturePath);
       allPluginResults.push(result);
       process.stderr.write(
@@ -241,12 +237,8 @@ async function main(): Promise<void> {
 
     // Human-readable summary to stderr
     process.stderr.write("\n--- Analysis Baseline (Phase 5C) ---\n");
-    process.stderr.write(
-      `  wallTimeMs cold:             ${coldWallTimeMs.toFixed(2)}\n`
-    );
-    process.stderr.write(
-      `  wallTimeMs warm (median):    ${medianWarmWallTimeMs.toFixed(2)}\n`
-    );
+    process.stderr.write(`  wallTimeMs cold:             ${coldWallTimeMs.toFixed(2)}\n`);
+    process.stderr.write(`  wallTimeMs warm (median):    ${medianWarmWallTimeMs.toFixed(2)}\n`);
     process.stderr.write(
       `  peakRssBytes warm (median):  ${String(Math.round(medianWarmPeakRssBytes))} (${(medianWarmPeakRssBytes / 1024 / 1024).toFixed(1)} MB)\n`
     );
@@ -265,7 +257,7 @@ async function main(): Promise<void> {
           warmMedian: medianWarmWallTimeMs,
           all: allWallTimeMs,
           path: "generateSchemasFromProgram",
-          note: "Run 1 (cold) measures the first invocation of generateSchemasFromProgram with an empty synthetic-batch cache. Module imports run before the timer starts, so module-load overhead is excluded. Warm median (runs 2-5) is the steady-state cost.",
+          note: "Run 1 (cold) measures the first invocation of generateSchemasFromProgram. Module imports run before the timer starts, so module-load overhead is excluded. Warm median (runs 2-5) is the steady-state cost.",
         },
         peakRssBytes: {
           warmMedian: medianWarmPeakRssBytes,
@@ -279,8 +271,9 @@ async function main(): Promise<void> {
           note:
             "§5 Phase 5C — `syntheticProgramCount` retired with the synthetic " +
             "program batch. `fileSnapshotCache.hits/misses` now provide the " +
-            "warm/cold signal: the first (cold) run records a miss, subsequent " +
-            "(warm) runs should report a hit for the same source text.",
+            "fresh-service query-path signal: each run creates a new " +
+            "FormSpecSemanticService and records cache deltas for one " +
+            "diagnostics query.",
         },
       },
       commitSha,

--- a/e2e/benchmarks/stripe-realistic-tsserver-bench.ts
+++ b/e2e/benchmarks/stripe-realistic-tsserver-bench.ts
@@ -22,7 +22,8 @@
  *   1. wallTimeMs   — end-to-end elapsed time (cold + warm median over 3 runs)
  *   2. peakRSS_MB   — peak resident set size (polling, warm median)
  *   3. didOOM       — whether the process OOMs at a 1 GB heap cap
- *   4. syntheticCompileCount — ts.createProgram invocations per run
+ *   4. syntheticCompileCount — legacy compatibility field, always 0 after
+ *      synthetic-checker retirement
  *
  * ### OOM detection
  *

--- a/scripts/check-stale-doc-references.mjs
+++ b/scripts/check-stale-doc-references.mjs
@@ -4,7 +4,17 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-const STALE_PATTERNS = ["src/__tests__/", "@formspec/constraints", "packages/constraints/"];
+const STALE_PATTERNS = [
+  "src/__tests__/",
+  "@formspec/constraints",
+  "packages/constraints/",
+  "synthetic `ts.createProgram`",
+  "synthetic ts.createProgram",
+  "ts.createProgram invocations per run",
+  "synthetic-program count",
+  "synthetic-batch cache",
+  "synthetic constraint-checker",
+];
 
 /**
  * @typedef {object} StaleDocReferenceMatch
@@ -17,6 +27,9 @@ const STALE_PATTERNS = ["src/__tests__/", "@formspec/constraints", "packages/con
  * @property {boolean} ok
  * @property {StaleDocReferenceMatch[]} matches
  * @property {string} report
+ *
+ * @typedef {object} CurrentFileScanOptions
+ * @property {boolean} [optional]
  */
 
 /**
@@ -26,22 +39,57 @@ const STALE_PATTERNS = ["src/__tests__/", "@formspec/constraints", "packages/con
  * @param {string} root
  * @returns {AsyncGenerator<string>}
  */
-async function* currentMarkdownFiles(root) {
-  for (const entry of await readdir(root, { withFileTypes: true })) {
-    if (entry.isFile() && entry.name.endsWith(".md")) {
-      yield entry.name;
+async function* currentGuidanceFiles(root) {
+  yield* currentTopLevelFiles(root, "", (name) => name.endsWith(".md"));
+  yield* currentTopLevelFiles(root, "e2e", (name) => name.endsWith(".md"), { optional: true });
+  yield* currentDocsMarkdownFiles(root, "docs", { optional: true });
+  yield* currentTopLevelFiles(
+    root,
+    "e2e/benchmarks",
+    (name) => name.endsWith(".md") || name.endsWith(".ts"),
+    { optional: true }
+  );
+}
+
+/**
+ * Top-level files in selected guidance directories are current documentation
+ * surfaces. Nested benchmark baselines and archival fixtures are intentionally
+ * out of scope for this gate.
+ *
+ * @param {string} root
+ * @param {string} relativeDir
+ * @param {(name: string) => boolean} matches
+ * @param {CurrentFileScanOptions} [options]
+ * @returns {AsyncGenerator<string>}
+ */
+async function* currentTopLevelFiles(root, relativeDir, matches, options = {}) {
+  let entries;
+  try {
+    entries = await readdir(path.join(root, relativeDir || "."), { withFileTypes: true });
+  } catch (error) {
+    if (options.optional && error && typeof error === "object" && "code" in error) {
+      if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+        return;
+      }
     }
+
+    throw error;
   }
 
-  yield* currentDocsMarkdownFiles(root, "docs");
+  for (const entry of entries) {
+    if (entry.isFile() && matches(entry.name)) {
+      yield relativeDir === "" ? entry.name : path.posix.join(relativeDir, entry.name);
+    }
+  }
 }
 
 /**
  * @param {string} root
  * @param {string} relativeDir
+ * @param {CurrentFileScanOptions} [options]
  * @returns {AsyncGenerator<string>}
  */
-async function* currentDocsMarkdownFiles(root, relativeDir) {
+async function* currentDocsMarkdownFiles(root, relativeDir, options = {}) {
   if (relativeDir === "docs/refactors") {
     return;
   }
@@ -49,8 +97,14 @@ async function* currentDocsMarkdownFiles(root, relativeDir) {
   let entries;
   try {
     entries = await readdir(path.join(root, relativeDir), { withFileTypes: true });
-  } catch {
-    return;
+  } catch (error) {
+    if (options.optional && error && typeof error === "object" && "code" in error) {
+      if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+        return;
+      }
+    }
+
+    throw error;
   }
 
   for (const entry of entries) {
@@ -116,7 +170,7 @@ export async function checkStaleDocReferences(options = {}) {
   /** @type {StaleDocReferenceMatch[]} */
   const matches = [];
 
-  for await (const filePath of currentMarkdownFiles(root)) {
+  for await (const filePath of currentGuidanceFiles(root)) {
     const source = await readFile(path.join(root, filePath), "utf8");
     for (const pattern of STALE_PATTERNS) {
       for (const location of findPatternLocations(source, pattern)) {

--- a/scripts/check-stale-doc-references.test.mjs
+++ b/scripts/check-stale-doc-references.test.mjs
@@ -34,6 +34,19 @@ async function withFixture(files, testFn) {
 }
 
 void describe("checkStaleDocReferences", () => {
+  void it("rejects missing scan roots instead of passing cleanly", async () => {
+    const missingRoot = path.join(
+      tmpdir(),
+      `formspec-stale-docs-missing-${String(process.pid)}-${String(Date.now())}`
+    );
+
+    await rm(missingRoot, { force: true, recursive: true });
+
+    await assert.rejects(() => checkStaleDocReferences({ root: missingRoot }), {
+      code: "ENOENT",
+    });
+  });
+
   void it("flags each blocked literal in root Markdown files", async () => {
     await withFixture(
       {
@@ -91,6 +104,68 @@ void describe("checkStaleDocReferences", () => {
     );
   });
 
+  void it("flags retired benchmark wording in current benchmark docs and sources", async () => {
+    await withFixture(
+      {
+        "e2e/README.md": [
+          "Measures `generateSchemasFromProgram` wall time, peak RSS, and synthetic `ts.createProgram`",
+          "invocation count.",
+        ].join("\n"),
+        "e2e/benchmarks/README.md": [
+          "Reports synthetic-program count.",
+          "Historical synthetic ts.createProgram wording.",
+        ].join("\n"),
+        "e2e/benchmarks/analysis-bench.ts":
+          "const note = 'empty synthetic-batch cache in the synthetic constraint-checker';",
+        "e2e/benchmarks/stripe-realistic-tsserver-bench.ts":
+          "syntheticCompileCount — ts.createProgram invocations per run",
+      },
+      async (root) => {
+        const result = await checkStaleDocReferences({ root });
+
+        assert.equal(result.ok, false);
+        assert.deepEqual(result.matches, [
+          {
+            filePath: "e2e/benchmarks/analysis-bench.ts",
+            line: 1,
+            column: 21,
+            pattern: "synthetic-batch cache",
+          },
+          {
+            filePath: "e2e/benchmarks/analysis-bench.ts",
+            line: 1,
+            column: 50,
+            pattern: "synthetic constraint-checker",
+          },
+          {
+            filePath: "e2e/benchmarks/README.md",
+            line: 1,
+            column: 9,
+            pattern: "synthetic-program count",
+          },
+          {
+            filePath: "e2e/benchmarks/README.md",
+            line: 2,
+            column: 12,
+            pattern: "synthetic ts.createProgram",
+          },
+          {
+            filePath: "e2e/benchmarks/stripe-realistic-tsserver-bench.ts",
+            line: 1,
+            column: 25,
+            pattern: "ts.createProgram invocations per run",
+          },
+          {
+            filePath: "e2e/README.md",
+            line: 1,
+            column: 64,
+            pattern: "synthetic `ts.createProgram`",
+          },
+        ]);
+      }
+    );
+  });
+
   void it("accepts current test paths", async () => {
     await withFixture(
       {
@@ -98,6 +173,38 @@ void describe("checkStaleDocReferences", () => {
           "Parity tests live in packages/build/tests/parity/.",
           "Fixtures now live in tests/fixtures/.",
         ].join("\n"),
+      },
+      async (root) => {
+        const result = await checkStaleDocReferences({ root });
+
+        assert.equal(result.ok, true);
+        assert.deepEqual(result.matches, []);
+      }
+    );
+  });
+
+  void it("accepts current benchmark cache wording", async () => {
+    await withFixture(
+      {
+        "e2e/README.md": "Measures file-snapshot cache hit/miss totals.",
+        "e2e/benchmarks/README.md": "Reports file-snapshot cache hit/miss totals.",
+        "e2e/benchmarks/analysis-bench.ts": "const note = 'empty file-snapshot cache';",
+      },
+      async (root) => {
+        const result = await checkStaleDocReferences({ root });
+
+        assert.equal(result.ok, true);
+        assert.deepEqual(result.matches, []);
+      }
+    );
+  });
+
+  void it("does not flag compatibility field names by themselves", async () => {
+    await withFixture(
+      {
+        "e2e/benchmarks/stripe-realistic-tsserver-bench.ts":
+          "readonly syntheticCompileCount: number;",
+        "e2e/README.md": "`syntheticProgramCount` = 0 after synthetic deletion.",
       },
       async (root) => {
         const result = await checkStaleDocReferences({ root });
@@ -174,9 +281,13 @@ void describe("checkStaleDocReferences", () => {
   });
 
   void it("runs as a CLI entrypoint when invoked with a relative script path", async () => {
-    const result = await execFileAsync(process.execPath, ["scripts/check-stale-doc-references.mjs"], {
-      cwd: repoRoot,
-    });
+    const result = await execFileAsync(
+      process.execPath,
+      ["scripts/check-stale-doc-references.mjs"],
+      {
+        cwd: repoRoot,
+      }
+    );
 
     assert.match(result.stdout, /No stale doc references found/);
   });


### PR DESCRIPTION
## Summary
- Follow up on the issue #435/#436 docs work by removing remaining benchmark prose that described retired synthetic-program counters.
- Update analysis benchmark docs/source comments to describe current timing/RSS and file-snapshot cache hit/miss metrics.
- Extend the stale-doc scanner and tests to cover current e2e benchmark docs/sources, all retired benchmark literals, and missing-root fail-closed behavior.
- Add a patch changeset for `@formspec/e2e`.

## Test plan
- `pnpm run build`
- `pnpm run lint`
- `pnpm run test`
- `pnpm changeset status --since origin/main`
- Prompt-backed multi-agent review: TypeScript Expert, Simplicity Expert, Testing Expert, Code Quality Expert, and Technical Writer
