### PR TITLE
Add e2e tsgo coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,9 +210,8 @@ jobs:
       - name: Typecheck with tsgo
         # FIXME(#469): scoped skipLibCheck workaround for the @types/chai
         # "containSubset" duplicate-identifier error under tsgo.
-        # Temporarily scope the root config to the package typecheck surface
-        # for this direct tsgo invocation. e2e tsgo coverage remains tracked
-        # in #471, and type-level negative tests continue to run through tsd.
+        # This wraps the package source/test surface plus the dedicated e2e
+        # tsgo project config. Type-level negative tests continue through tsd.
         run: pnpm exec tsx scripts/tsgo-ci.mts typecheck
 
       - name: Run tests

--- a/docs/typescript-compiler-compatibility.md
+++ b/docs/typescript-compiler-compatibility.md
@@ -11,12 +11,13 @@ The TS 7 job deliberately uses two TypeScript surfaces:
 - `@typescript/native-preview@beta` supplies the `tsgo` binary.
 - `@typescript/typescript6` supplies the JavaScript compiler API currently used by FormSpec packages and tooling.
 
-Keep this distinction intact. `pnpm run build`, `pnpm run test`, `tsup`, lint, and API Extractor still run through the TS 6 JavaScript API in that job. The direct native-preview check is only `pnpm exec tsgo --noEmit --skipLibCheck`, wrapped by `scripts/tsgo-ci.mts`.
+Keep this distinction intact. `pnpm run build`, `pnpm run test`, `tsup`, lint, and API Extractor still run through the TS 6 JavaScript API in that job. The direct native-preview checks are the package-scoped `pnpm exec tsgo --noEmit --skipLibCheck` check and the e2e `pnpm exec tsgo --noEmit --skipLibCheck -p e2e/tsconfig.tsgo.json` check, both wrapped by `scripts/tsgo-ci.mts`.
 
 ## Key Files
 
 - `.github/workflows/ci.yml`: owns the per-PR TypeScript matrix and the non-blocking `typescript-7-tsgo` job.
 - `.github/workflows/typescript-minor-smoke.yml`: owns weekly minor-version smoke coverage for supported TS 5/6 minors.
+- `e2e/tsconfig.tsgo.json`: owns the e2e-only TS 7 native-preview typecheck surface.
 - `scripts/tsgo-ci.mts`: owns TS 7 job setup details that would otherwise become embedded workflow JavaScript.
 - `scripts/tsgo-ci.test.mts`: tests the TS 7 setup helpers and should grow with the helper.
 - `knip.json`: ignores the CI-only `tsgo` binary.
@@ -64,7 +65,7 @@ Map failures to the step that owns them:
 - `Expose TypeScript 6 compatibility bins and server subpaths`: the `@typescript/typescript6` package layout changed, `tsc6` is missing, or tsserver subpaths moved.
 - `Assert TypeScript API alias resolution`: a workspace with a direct `typescript` dependency did not resolve to `@typescript/typescript6`. This often means a new package was added outside the discovery rules, or an override no longer applies to that package.
 - `Build` or `Run tests`: the TS 6 JavaScript API alias is not behaving like the supported compiler API. This is not a `tsgo` native check failure.
-- `Typecheck with tsgo`: the native-preview compiler rejected the scoped package source/test surface. The current `skipLibCheck` workaround is tracked in [#469](https://github.com/mike-north/formspec/issues/469); e2e tsgo coverage is tracked in [#471](https://github.com/mike-north/formspec/issues/471).
+- `Typecheck with tsgo`: the native-preview compiler rejected either the scoped package source/test surface or the dedicated e2e tsgo config. The current `skipLibCheck` workaround is tracked in [#469](https://github.com/mike-north/formspec/issues/469).
 
 When reproducing locally, use a temporary copy so `npm pkg set` and `pnpm install --no-frozen-lockfile` do not dirty the PR worktree. Run the workflow commands in the same order as CI, including `pnpm exec tsx scripts/tsgo-ci.mts prepare-compat`, `assert-alias`, and `typecheck`.
 

--- a/e2e/tests/hybrid-tooling-system.test.ts
+++ b/e2e/tests/hybrid-tooling-system.test.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import * as ts from "typescript";
 import { afterEach, describe, expect, it } from "vitest";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import { FORMSPEC_ANALYSIS_PROTOCOL_VERSION } from "../../packages/analysis/src/protocol.js";
 import { getHoverAtOffset } from "../../packages/language-server/src/providers/hover.js";
 import { getCompletionItemsAtOffset } from "../../packages/language-server/src/providers/completion.js";
@@ -196,17 +198,12 @@ describe("hybrid tooling system", () => {
       ])
     );
 
-    const document = {
-      uri: `file://${context.filePath}`,
-      positionAt(offset: number) {
-        const priorText = context.documentText.slice(0, offset);
-        const lines = priorText.split("\n");
-        return {
-          line: lines.length - 1,
-          character: lines.at(-1)?.length ?? 0,
-        };
-      },
-    };
+    const document = TextDocument.create(
+      pathToFileURL(context.filePath).href,
+      "typescript",
+      1,
+      context.documentText
+    );
     const lspDiagnostics = toLspDiagnostics(document, diagnostics ?? [], {
       source: "formspec-reference",
     });

--- a/e2e/tsconfig.tsgo.json
+++ b/e2e/tsconfig.tsgo.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "include": ["helpers/**/*.ts", "fixtures/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["benchmarks/**/*", "tests/hybrid-tooling-benchmark.test.ts"]
+}

--- a/scripts/tsgo-ci.mts
+++ b/scripts/tsgo-ci.mts
@@ -16,6 +16,9 @@ import { fileURLToPath } from "node:url";
 
 const SCOPED_TSGO_INCLUDE = ["packages/*/src/**/*", "packages/*/tests/**/*"];
 const SCOPED_TSGO_EXCLUDE = ["packages/*/tests/**/*.test-d.ts"];
+const TSGO_BASE_ARGS = ["exec", "tsgo", "--noEmit", "--skipLibCheck"] as const;
+const PACKAGE_TSGO_ARGS = TSGO_BASE_ARGS;
+const E2E_TSGO_ARGS = [...TSGO_BASE_ARGS, "-p", "e2e/tsconfig.tsgo.json"] as const;
 const TYPE_SCRIPT_SERVER_SUBPATHS = ["tsserver.js", "tsserverlibrary.d.ts", "tsserverlibrary.js"];
 const TYPE_SCRIPT_DEPENDENCY_SECTIONS = [
   "dependencies",
@@ -37,6 +40,8 @@ export interface CommandResult {
   signal?: string | null;
   error?: Error;
 }
+
+type TsgoCommandRunner = (args: readonly string[]) => CommandResult;
 
 function resolveFromRepoRoot(repoRoot: string, ...segments: string[]): string {
   return path.resolve(repoRoot, ...segments);
@@ -217,42 +222,46 @@ export function writeScopedTsgoRootConfig({
   writeFileSync(fileName, `${JSON.stringify(config, null, 2)}\n`);
 }
 
-export function runScopedTsgoTypecheck({
+function assertSuccessfulCommandResult(result: CommandResult, label: string): void {
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+
+  if (result.signal !== undefined && result.signal !== null) {
+    throw new Error(`${label} terminated by signal ${result.signal}`);
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${label} failed with exit status ${String(result.status)}`);
+  }
+}
+
+export function runTsgoTypecheck({
   repoRoot = process.cwd(),
   typescript = loadTypeScriptFromRepoRoot(repoRoot),
-  runCommand = () =>
-    spawnSync("pnpm", ["exec", "tsgo", "--noEmit", "--skipLibCheck"], {
+  runCommand = (args) =>
+    spawnSync("pnpm", [...args], {
       cwd: repoRoot,
       stdio: "inherit",
     }) as SpawnSyncReturns<Buffer>,
 }: {
   repoRoot?: string;
   typescript?: TypeScriptModule;
-  runCommand?: () => CommandResult;
+  runCommand?: TsgoCommandRunner;
 } = {}): CommandResult {
   const fileName = resolveFromRepoRoot(repoRoot, "tsconfig.json");
   const originalConfig = readFileSync(fileName, "utf8");
 
   try {
     writeScopedTsgoRootConfig({ repoRoot, typescript });
-    const result = runCommand();
-
-    if (result.error !== undefined) {
-      throw result.error;
-    }
-
-    if (result.signal !== undefined && result.signal !== null) {
-      throw new Error(`tsgo typecheck terminated by signal ${result.signal}`);
-    }
-
-    if (result.status !== 0) {
-      throw new Error(`tsgo typecheck failed with exit status ${String(result.status)}`);
-    }
-
-    return result;
+    assertSuccessfulCommandResult(runCommand(PACKAGE_TSGO_ARGS), "package tsgo typecheck");
   } finally {
     writeFileSync(fileName, originalConfig);
   }
+
+  const e2eResult = runCommand(E2E_TSGO_ARGS);
+  assertSuccessfulCommandResult(e2eResult, "e2e tsgo typecheck");
+  return e2eResult;
 }
 
 function printAliasResolution(): void {
@@ -276,7 +285,7 @@ function main(): void {
       printAliasResolution();
       break;
     case "typecheck":
-      runScopedTsgoTypecheck();
+      runTsgoTypecheck();
       break;
     default:
       printUsage();

--- a/scripts/tsgo-ci.test.mts
+++ b/scripts/tsgo-ci.test.mts
@@ -10,7 +10,7 @@ import {
   assertTypeScript6AliasResolution,
   discoverTypeScriptApiWorkspaceRoots,
   prepareTypeScript6Compatibility,
-  runScopedTsgoTypecheck,
+  runTsgoTypecheck,
   writeScopedTsgoRootConfig,
 } from "./tsgo-ci.mts";
 
@@ -197,8 +197,31 @@ void describe("writeScopedTsgoRootConfig", () => {
   });
 });
 
-void describe("runScopedTsgoTypecheck", () => {
-  void it("restores the root tsconfig after a passing tsgo command", async () => {
+void describe("e2e tsgo config", () => {
+  void it("keeps broad e2e coverage scoped away from benchmarks", async () => {
+    const parsed = parseJsonRecord(await readFile("e2e/tsconfig.tsgo.json", "utf8"));
+    const compilerOptions = parsed["compilerOptions"];
+    assert.equal(typeof compilerOptions, "object");
+    assert.notEqual(compilerOptions, null);
+    assert.equal(Array.isArray(compilerOptions), false);
+
+    const options = compilerOptions as Record<string, unknown>;
+    assert.equal(parsed["extends"], "../tsconfig.json");
+    assert.equal(options["rootDir"], "..");
+    assert.equal(options["noEmit"], true);
+    assert.equal(options["noUncheckedIndexedAccess"], false);
+    assert.equal(options["noPropertyAccessFromIndexSignature"], false);
+    assert.equal(options["paths"], undefined);
+    assert.deepEqual(parsed["include"], ["helpers/**/*.ts", "fixtures/**/*.ts", "tests/**/*.ts"]);
+    assert.deepEqual(parsed["exclude"], [
+      "benchmarks/**/*",
+      "tests/hybrid-tooling-benchmark.test.ts",
+    ]);
+  });
+});
+
+void describe("runTsgoTypecheck", () => {
+  void it("runs package and e2e tsgo checks after restoring the root tsconfig", async () => {
     const originalConfig = '{ "compilerOptions": { "strict": true } }\n';
 
     await withFixture(
@@ -207,29 +230,37 @@ void describe("runScopedTsgoTypecheck", () => {
         "tsconfig.json": originalConfig,
       },
       async (root) => {
-        let commandConfig: unknown;
-        const result = runScopedTsgoTypecheck({
+        const commandArgs: string[][] = [];
+        const commandConfigs: unknown[] = [];
+        const result = runTsgoTypecheck({
           repoRoot: root,
           typescript: ts,
-          runCommand: () => {
-            // The command must see the scoped config before restoration.
-            commandConfig = JSON.parse(readFileSync(path.join(root, "tsconfig.json"), "utf8"));
+          runCommand: (args) => {
+            commandArgs.push([...args]);
+            commandConfigs.push(JSON.parse(readFileSync(path.join(root, "tsconfig.json"), "utf8")));
             return { status: 0 };
           },
         });
 
-        assert.deepEqual(commandConfig, {
-          compilerOptions: { strict: true },
-          include: ["packages/*/src/**/*", "packages/*/tests/**/*"],
-          exclude: ["packages/*/tests/**/*.test-d.ts"],
-        });
+        assert.deepEqual(commandArgs, [
+          ["exec", "tsgo", "--noEmit", "--skipLibCheck"],
+          ["exec", "tsgo", "--noEmit", "--skipLibCheck", "-p", "e2e/tsconfig.tsgo.json"],
+        ]);
+        assert.deepEqual(commandConfigs, [
+          {
+            compilerOptions: { strict: true },
+            include: ["packages/*/src/**/*", "packages/*/tests/**/*"],
+            exclude: ["packages/*/tests/**/*.test-d.ts"],
+          },
+          { compilerOptions: { strict: true } },
+        ]);
         assert.equal(result.status, 0);
         assert.equal(await readFile(path.join(root, "tsconfig.json"), "utf8"), originalConfig);
       }
     );
   });
 
-  void it("restores the root tsconfig after a failing tsgo command", async () => {
+  void it("restores the root tsconfig after a failing package tsgo command", async () => {
     const originalConfig = '{ "compilerOptions": { "strict": true } }\n';
 
     await withFixture(
@@ -238,16 +269,63 @@ void describe("runScopedTsgoTypecheck", () => {
         "tsconfig.json": originalConfig,
       },
       async (root) => {
+        const commandArgs: string[][] = [];
+
         assert.throws(
           () =>
-            runScopedTsgoTypecheck({
+            runTsgoTypecheck({
               repoRoot: root,
               typescript: ts,
-              runCommand: () => ({ status: 1 }),
+              runCommand: (args) => {
+                commandArgs.push([...args]);
+                return { status: 1 };
+              },
             }),
-          /tsgo typecheck failed with exit status 1/
+          /package tsgo typecheck failed with exit status 1/
         );
 
+        assert.deepEqual(commandArgs, [["exec", "tsgo", "--noEmit", "--skipLibCheck"]]);
+        assert.equal(await readFile(path.join(root, "tsconfig.json"), "utf8"), originalConfig);
+      }
+    );
+  });
+
+  void it("reports e2e tsgo failures distinctly after restoring the root tsconfig", async () => {
+    const originalConfig = '{ "compilerOptions": { "strict": true } }\n';
+
+    await withFixture(
+      {
+        "package.json": packageJson({ private: true }),
+        "tsconfig.json": originalConfig,
+      },
+      async (root) => {
+        const commandArgs: string[][] = [];
+        let e2eCommandConfig: unknown;
+
+        assert.throws(
+          () =>
+            runTsgoTypecheck({
+              repoRoot: root,
+              typescript: ts,
+              runCommand: (args) => {
+                commandArgs.push([...args]);
+                if (args.includes("-p")) {
+                  e2eCommandConfig = JSON.parse(
+                    readFileSync(path.join(root, "tsconfig.json"), "utf8")
+                  );
+                  return { status: 1 };
+                }
+                return { status: 0 };
+              },
+            }),
+          /e2e tsgo typecheck failed with exit status 1/
+        );
+
+        assert.deepEqual(commandArgs, [
+          ["exec", "tsgo", "--noEmit", "--skipLibCheck"],
+          ["exec", "tsgo", "--noEmit", "--skipLibCheck", "-p", "e2e/tsconfig.tsgo.json"],
+        ]);
+        assert.deepEqual(e2eCommandConfig, { compilerOptions: { strict: true } });
         assert.equal(await readFile(path.join(root, "tsconfig.json"), "utf8"), originalConfig);
       }
     );


### PR DESCRIPTION
## Summary
- Add a dedicated e2e tsgo config that covers helpers, fixtures, and tests while excluding benchmark code.
- Extend the TS 7 native-preview helper to run package and e2e tsgo checks with root tsconfig restoration between phases.
- Document the new e2e tsgo surface and update the hybrid tooling diagnostic test to use a real `TextDocument`.

Closes #471

## Test plan
- `pnpm run test:scripts`
- `pnpm run build`
- `pnpm --filter @formspec/e2e exec tsc --noEmit -p tsconfig.tsgo.json`
- `pnpm --filter @formspec/e2e exec vitest run tests/hybrid-tooling-system.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec prettier --check e2e/tsconfig.tsgo.json scripts/tsgo-ci.mts scripts/tsgo-ci.test.mts e2e/tests/hybrid-tooling-system.test.ts docs/typescript-compiler-compatibility.md .github/workflows/ci.yml`
- `pnpm --filter @formspec/e2e exec tsc --listFilesOnly -p tsconfig.tsgo.json | rg 'e2e/benchmarks|hybrid-tooling-benchmark' || true`
- TS 7 native-preview temp copy: `prepare-compat`, `assert-alias`, `build`, and `scripts/tsgo-ci.mts typecheck`

## Notes
- No changeset: this is CI/test tooling and documentation coverage only, with no public npm API or consumer-facing package behavior change.
- I tried removing `--skipLibCheck` in the TS 7 native-preview temp copy. Both package and e2e checks still hit the #469 `containSubset` declaration conflict, so this PR keeps the scoped workaround and leaves removal to the #469 follow-up.
