### PR TITLE
feat(core): reconcile IR shape with spec 001 (#417 PR-A)

### DIFF
--- a/.changeset/issue-417-ir-shape.md
+++ b/.changeset/issue-417-ir-shape.md
@@ -1,0 +1,10 @@
+---
+"@formspec/core": minor
+"@formspec/build": patch
+---
+
+Reconcile the Canonical IR object and enum-member shapes with spec 001 decisions for issue #417 PR-A.
+
+`EnumMember.displayName` is now `EnumMember.label` with no deprecated alias because the package is still alpha. `ObjectTypeNode.additionalProperties` now distinguishes omitted policy-defaulted objects from explicit `true`, explicit `false`, and TypeNode-constrained additional values. `ObjectTypeNode.passthrough` is now available for the future `passthroughObject` policy keyword emission path.
+
+The JSON Schema emitter now handles all `additionalProperties` arms and preserves the `passthrough` bit as a no-op until #416 PR-2 wires keyword emission.

--- a/.changeset/issue-417-ir-shape.md
+++ b/.changeset/issue-417-ir-shape.md
@@ -1,6 +1,15 @@
 ---
-"@formspec/core": minor
+"@formspec/analysis": patch
 "@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/config": patch
+"@formspec/core": minor
+"@formspec/dsl": patch
+"@formspec/eslint-plugin": patch
+"@formspec/language-server": patch
+"@formspec/runtime": patch
+"@formspec/ts-plugin": patch
+"formspec": patch
 ---
 
 Reconcile the Canonical IR object and enum-member shapes with spec 001 decisions for issue #417 PR-A.

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -126,7 +126,6 @@ function isTypeReference(type: ts.Type): type is ts.TypeReference {
 const RESOLVING_TYPE_PLACEHOLDER: TypeNode = {
   kind: "object",
   properties: [],
-  additionalProperties: true,
 };
 
 function makeParseOptions(
@@ -1781,7 +1780,7 @@ export function getAnalyzableObjectLikePropertyName(name: ts.PropertyName): stri
 }
 
 /**
- * Rewrites enum-member display-name annotations into EnumMember.displayName
+ * Rewrites enum-member display-name annotations into EnumMember.label
  * values and strips those annotations from the field-level annotation list.
  *
  * The TSDoc surface uses `@displayName :value Label` for enum member labels.
@@ -1841,7 +1840,7 @@ function applyEnumMemberDisplayNamesToEnum(
   annotations: readonly AnnotationNode[],
   consumed: Set<AnnotationNode>
 ): EnumTypeNode {
-  const displayNames = new Map<string, string>();
+  const labels = new Map<string, string>();
 
   for (const annotation of annotations) {
     if (annotation.annotationKind !== "displayName") continue;
@@ -1856,18 +1855,18 @@ function applyEnumMemberDisplayNamesToEnum(
     const member = type.members.find((m) => String(m.value) === parsed.value);
     if (!member) continue;
 
-    displayNames.set(String(member.value), parsed.label);
+    labels.set(String(member.value), parsed.label);
   }
 
-  if (displayNames.size === 0) {
+  if (labels.size === 0) {
     return type;
   }
 
   return {
     ...type,
     members: type.members.map((member) => {
-      const displayName = displayNames.get(String(member.value));
-      return displayName !== undefined ? { ...member, displayName } : member;
+      const label = labels.get(String(member.value));
+      return label !== undefined ? { ...member, label } : member;
     }),
   };
 }
@@ -2448,8 +2447,8 @@ function resolveUnionType(
 
   const applyMemberLabels = (members: readonly (string | number)[]): EnumMember[] =>
     members.map((value) => {
-      const displayName = memberDisplayNames.get(String(value));
-      return displayName !== undefined ? { value, displayName } : { value };
+      const label = memberDisplayNames.get(String(value));
+      return label !== undefined ? { value, label } : { value };
     });
 
   const isBooleanUnion =
@@ -3012,7 +3011,6 @@ function resolveObjectType(
             metadataPolicy
           )
         : properties,
-    additionalProperties: true,
   };
 
   // Register named types

--- a/packages/build/src/canonicalize/chain-dsl-canonicalizer.ts
+++ b/packages/build/src/canonicalize/chain-dsl-canonicalizer.ts
@@ -320,7 +320,7 @@ function canonicalizeStaticEnumField(
       return { value: opt } satisfies EnumMember;
     }
     // Object option with id/label
-    return { value: opt.id, displayName: opt.label } satisfies EnumMember;
+    return { value: opt.id, label: opt.label } satisfies EnumMember;
   });
 
   const type: EnumTypeNode = { kind: "enum", members };
@@ -380,7 +380,6 @@ function canonicalizeArrayField(
   const itemsType: ObjectTypeNode = {
     kind: "object",
     properties: itemProperties,
-    additionalProperties: true,
   };
   const type: ArrayTypeNode = { kind: "array", items: itemsType };
 
@@ -422,7 +421,6 @@ function canonicalizeObjectField(
   const type: ObjectTypeNode = {
     kind: "object",
     properties,
-    additionalProperties: true,
   };
   return buildFieldNode(
     field.name,

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -615,9 +615,9 @@ function generateTypeNode(type: TypeNode, ctx: GeneratorContext): JsonSchema2020
 /**
  * Maps primitive IR types to JSON Schema type keywords.
  *
- * Note: `integer` is NOT a primitive kind in the IR. Integer semantics are
- * expressed via a `multipleOf: 1` constraint on a number type; `applyConstraints`
- * handles the promotion (per the JSON Schema vocabulary spec §2.1).
+ * `integer` is represented directly in the IR and emits JSON Schema `integer`.
+ * Number types can also be promoted to `integer` through a `multipleOf: 1`
+ * constraint in `applyConstraints`.
  */
 function generatePrimitiveType(type: PrimitiveTypeNode): JsonSchema2020 {
   return {
@@ -648,8 +648,7 @@ function generateEnumType(type: EnumTypeNode, ctx: GeneratorContext): JsonSchema
     return {
       oneOf: type.members.map((m) => {
         const stringValue = String(m.value);
-        const title =
-          m.displayName !== undefined && m.displayName !== stringValue ? m.displayName : undefined;
+        const title = m.label !== undefined && m.label !== stringValue ? m.label : undefined;
         return title !== undefined ? { const: m.value, title } : { const: m.value };
       }),
     };
@@ -674,13 +673,13 @@ function generateEnumType(type: EnumTypeNode, ctx: GeneratorContext): JsonSchema
  */
 function shouldSerializeEnumAsOneOf(type: EnumTypeNode): boolean {
   return type.members.some((member) => {
-    const title = member.displayName ?? String(member.value);
+    const title = member.label ?? String(member.value);
     return title !== String(member.value);
   });
 }
 
 function buildEnumDisplayNameExtension(type: EnumTypeNode): Record<string, string> | undefined {
-  if (!type.members.some((member) => member.displayName !== undefined)) {
+  if (!type.members.some((member) => member.label !== undefined)) {
     return undefined;
   }
 
@@ -693,7 +692,7 @@ function buildEnumDisplayNameExtension(type: EnumTypeNode): Record<string, strin
           `Use oneOf serialization for mixed string/number enum values that collide.`
       );
     }
-    displayNames[key] = member.displayName ?? key;
+    displayNames[key] = member.label ?? key;
   }
 
   return displayNames;
@@ -714,9 +713,8 @@ function generateArrayType(type: ArrayTypeNode, ctx: GeneratorContext): JsonSche
 /**
  * Generates JSON Schema for an object type.
  *
- * `additionalProperties` is emitted only when the IR explicitly closes the
- * object. Ordinary static object types now canonicalize to
- * `additionalProperties: true`, which omits the keyword per spec 003 §2.5.
+ * `additionalProperties` is emitted only when the IR carries explicit author
+ * intent. When absent, downstream strict-mode policy decides.
  */
 function generateObjectType(type: ObjectTypeNode, ctx: GeneratorContext): JsonSchema2020 {
   const properties: Record<string, JsonSchema2020> = {};
@@ -736,8 +734,15 @@ function generateObjectType(type: ObjectTypeNode, ctx: GeneratorContext): JsonSc
     schema.required = required.sort();
   }
 
-  if (!type.additionalProperties) {
+  // #416 PR-2 will emit the passthroughObject policy keyword from this flag.
+  void type.passthrough;
+
+  if (type.additionalProperties === true) {
+    schema.additionalProperties = true;
+  } else if (type.additionalProperties === false) {
     schema.additionalProperties = false;
+  } else if (type.additionalProperties !== undefined) {
+    schema.additionalProperties = generateTypeNode(type.additionalProperties, ctx);
   }
 
   return schema;

--- a/packages/build/src/json-schema/ir-generator.ts
+++ b/packages/build/src/json-schema/ir-generator.ts
@@ -734,8 +734,9 @@ function generateObjectType(type: ObjectTypeNode, ctx: GeneratorContext): JsonSc
     schema.required = required.sort();
   }
 
-  // #416 PR-2 will emit the passthroughObject policy keyword from this flag.
-  void type.passthrough;
+  if (type.passthrough === true) {
+    // #416 PR-2 will emit the passthroughObject policy keyword from this flag.
+  }
 
   if (type.additionalProperties === true) {
     schema.additionalProperties = true;

--- a/packages/build/src/metadata/resolve.ts
+++ b/packages/build/src/metadata/resolve.ts
@@ -191,8 +191,8 @@ function resolveEnumTypeMetadata(
   options: ResolveFormIRMetadataOptions
 ): EnumTypeNode {
   const members = type.members.map((member) => {
-    const displayName = resolveEnumMemberDisplayName(
-      member.displayName,
+    const label = resolveEnumMemberDisplayName(
+      member.label,
       options.policy.enumMember.displayName,
       {
         surface: options.surface,
@@ -202,13 +202,11 @@ function resolveEnumTypeMetadata(
       }
     );
 
-    if (displayName === member.displayName) {
+    if (label === member.label) {
       return member;
     }
 
-    return displayName === undefined
-      ? { value: member.value }
-      : { value: member.value, displayName };
+    return label === undefined ? { value: member.value } : { value: member.value, label };
   });
 
   return members.some((member, index) => member !== type.members[index])
@@ -224,13 +222,20 @@ function resolveTypeNodeMetadata(type: TypeNode, options: ResolveFormIRMetadataO
         items: resolveTypeNodeMetadata(type.items, options),
       };
 
-    case "object":
+    case "object": {
+      const additionalProperties =
+        type.additionalProperties !== undefined && typeof type.additionalProperties !== "boolean"
+          ? resolveTypeNodeMetadata(type.additionalProperties, options)
+          : type.additionalProperties;
+
       return {
         ...type,
         properties: type.properties.map((property) =>
           resolveObjectPropertyMetadata(property, options)
         ),
+        ...(additionalProperties !== type.additionalProperties && { additionalProperties }),
       };
+    }
 
     case "record":
       return {

--- a/packages/build/tests/chain-dsl-canonicalizer.test.ts
+++ b/packages/build/tests/chain-dsl-canonicalizer.test.ts
@@ -291,7 +291,7 @@ describe("canonicalizeChainDSL", () => {
       expect(type.members).toEqual([{ value: "draft" }, { value: "sent" }, { value: "paid" }]);
     });
 
-    it("maps object options to EnumMember with displayName", () => {
+    it("maps object options to EnumMember with label", () => {
       const form = formspec(
         field.enum("priority", [
           { id: "low", label: "Low Priority" },
@@ -303,8 +303,8 @@ describe("canonicalizeChainDSL", () => {
 
       const type = f.type as EnumTypeNode;
       expect(type.members).toEqual([
-        { value: "low", displayName: "Low Priority" },
-        { value: "high", displayName: "High Priority" },
+        { value: "low", label: "Low Priority" },
+        { value: "high", label: "High Priority" },
       ]);
     });
 
@@ -440,14 +440,14 @@ describe("canonicalizeChainDSL", () => {
       expect(f.constraints).toHaveLength(0);
     });
 
-    it("uses open-object defaults on items object", () => {
+    it("omits additionalProperties when array items are policy-defaulted objects", () => {
       const form = formspec(field.array("items", field.text("name")));
       const ir = canonicalizeChainDSL(form);
       const f = getField(ir, "items");
 
       const type = f.type as ArrayTypeNode;
       const items = type.items as ObjectTypeNode;
-      expect(items.additionalProperties).toBe(true);
+      expect(items.additionalProperties).toBeUndefined();
     });
 
     it("item properties have correct optional flag based on required", () => {
@@ -480,7 +480,7 @@ describe("canonicalizeChainDSL", () => {
 
       const type = f.type as ObjectTypeNode;
       expect(type.kind).toBe("object");
-      expect(type.additionalProperties).toBe(true);
+      expect(type.additionalProperties).toBeUndefined();
       expect(type.properties).toHaveLength(2);
       expect(type.properties[0]).toMatchObject({ name: "street" });
       expect(type.properties[1]).toMatchObject({ name: "city" });

--- a/packages/build/tests/default-value-custom-type-coercion.test.ts
+++ b/packages/build/tests/default-value-custom-type-coercion.test.ts
@@ -190,7 +190,9 @@ describe("issue #358: @defaultValue coercion for custom-type fields", () => {
       // Covers the `typeof value === "bigint"` branch of the inference fallback.
       // bigint is not a JsonValue; the cast exercises the runtime coercion path
       // that handles bigint values that may reach the pipeline through TSDoc parsing.
-      const ir = makeIR([makeDecimalField("price", [defaultValueAnnotation(9n as unknown as JsonValue)])]);
+      const ir = makeIR([
+        makeDecimalField("price", [defaultValueAnnotation(9n as unknown as JsonValue)]),
+      ]);
       const schema = generateJsonSchemaFromIR(ir, {
         extensionRegistry: registryWith(inferredDecimalType),
       });
@@ -245,7 +247,6 @@ describe("issue #358: @defaultValue coercion for custom-type fields", () => {
             type: {
               kind: "object",
               properties: [priceProperty],
-              additionalProperties: true,
             },
             required: false,
             constraints: [],

--- a/packages/build/tests/inline-object-sibling-keywords.test.ts
+++ b/packages/build/tests/inline-object-sibling-keywords.test.ts
@@ -96,11 +96,11 @@ function getProperty(schema: JsonSchema2020, name: string): JsonSchema2020 {
 
 describe("inline object: path-targeted constraints on missing properties (issue #366)", () => {
   /**
-   * Case 1 (the fix): missing property, additionalProperties: true.
+   * Case 1 (the fix): missing property, policy-defaulted additionalProperties.
    * The constraint target ("street") does not exist in schema.properties.
    * The fix merges the override directly into properties — no allOf wrapper.
    */
-  it("merges missing-property override flat into properties when additionalProperties is true", () => {
+  it("merges missing-property override flat into properties when additionalProperties is policy-defaulted", () => {
     const ir = makeIR([
       {
         kind: "field",
@@ -117,7 +117,6 @@ describe("inline object: path-targeted constraints on missing properties (issue 
               provenance: PROVENANCE,
             },
           ],
-          additionalProperties: true,
         },
         required: true,
         constraints: [makePathMinLength(["street"], 1)],
@@ -191,7 +190,7 @@ describe("inline object: path-targeted constraints on missing properties (issue 
    * Both should end up in the flat properties object — no allOf.
    *
    * - "zip" already exists → merged via mergeSchemaOverride (existing path)
-   * - "street" is missing, additionalProperties: true → merged flat (new path)
+   * - "street" is missing, additionalProperties omitted → merged flat (new path)
    * Result should be a single flat object with no allOf.
    */
   it("produces a single flat object when mixing existing and missing property overrides", () => {
@@ -211,7 +210,6 @@ describe("inline object: path-targeted constraints on missing properties (issue 
               provenance: PROVENANCE,
             },
           ],
-          additionalProperties: true,
         },
         required: true,
         constraints: [makePathPattern(["zip"], "^\\d{5}$"), makePathMinLength(["street"], 1)],
@@ -251,7 +249,6 @@ describe("inline object: path-targeted constraints on missing properties (issue 
         type: {
           kind: "object",
           properties: [],
-          additionalProperties: true,
         },
         required: true,
         constraints: [makePathMinLength(["street"], 1), makePathPattern(["street"], "^\\d+")],
@@ -280,7 +277,6 @@ describe("inline object: path-targeted constraints on missing properties (issue 
         type: {
           kind: "object",
           properties: [],
-          additionalProperties: true,
         },
         required: true,
         constraints: [makePathMinLength(["street"], 1), makePathMinLength(["city"], 2)],
@@ -312,7 +308,6 @@ describe("inline object: path-targeted constraints on missing properties (issue 
         type: {
           kind: "object",
           properties: [],
-          additionalProperties: true,
         },
         required: true,
         constraints: [makePathMinLength(["address", "street"], 1)],
@@ -357,7 +352,6 @@ describe("inline object: path-targeted constraints on missing properties (issue 
                 provenance: PROVENANCE,
               },
             ],
-            additionalProperties: true,
           },
         },
         required: true,
@@ -407,7 +401,6 @@ describe("inline object: path-targeted constraints on missing properties (issue 
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             { kind: "primitive", primitiveKind: "null" },
           ],

--- a/packages/build/tests/ir-json-schema-generator.test.ts
+++ b/packages/build/tests/ir-json-schema-generator.test.ts
@@ -185,7 +185,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 } satisfies ObjectProperty,
               ],
-              additionalProperties: true,
             },
             provenance: PROVENANCE,
           },
@@ -244,7 +243,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 } satisfies ObjectProperty,
               ],
-              additionalProperties: true,
             },
             provenance: PROVENANCE,
           },
@@ -386,9 +384,9 @@ describe("generateJsonSchemaFromIR", () => {
         makeField("status", {
           kind: "enum",
           members: [
-            { value: "draft", displayName: "Draft" },
-            { value: "sent", displayName: "Sent to Customer" },
-            { value: "paid", displayName: "Paid in Full" },
+            { value: "draft", label: "Draft" },
+            { value: "sent", label: "Sent to Customer" },
+            { value: "paid", label: "Paid in Full" },
           ],
         }),
       ]);
@@ -410,8 +408,8 @@ describe("generateJsonSchemaFromIR", () => {
         makeField("priority", {
           kind: "enum",
           members: [
-            { value: "low", displayName: "Low" },
-            { value: "high" }, // no displayName
+            { value: "low", label: "Low" },
+            { value: "high" }, // no label
           ],
         }),
       ]);
@@ -441,17 +439,17 @@ describe("generateJsonSchemaFromIR", () => {
     });
 
     it("supports oneOf serialization and omits title when it matches the value (issue #310)", () => {
-      // Updated for #310: title is only emitted when displayName differs from the const value.
-      // "sent" has no displayName, so its title is omitted (was redundant).
-      // "draft" has displayName "Draft" (differs from value) → title emitted.
-      // "paid" has displayName "Paid in Full" (differs from value) → title emitted.
+      // Updated for #310: title is only emitted when label differs from the const value.
+      // "sent" has no label, so its title is omitted (was redundant).
+      // "draft" has label "Draft" (differs from value) → title emitted.
+      // "paid" has label "Paid in Full" (differs from value) → title emitted.
       const ir = makeIR([
         makeField("status", {
           kind: "enum",
           members: [
-            { value: "draft", displayName: "Draft" },
+            { value: "draft", label: "Draft" },
             { value: "sent" },
-            { value: "paid", displayName: "Paid in Full" },
+            { value: "paid", label: "Paid in Full" },
           ],
         }),
       ]);
@@ -467,8 +465,8 @@ describe("generateJsonSchemaFromIR", () => {
       });
     });
 
-    it("supports oneOf serialization when no member has a displayName", () => {
-      // Updated for #310: when no member has a displayName, no titles are emitted.
+    it("supports oneOf serialization when no member has a label", () => {
+      // Updated for #310: when no member has a label, no titles are emitted.
       // Previously emitted title equal to const (e.g. { const: "draft", title: "draft" }),
       // which was redundant.
       const ir = makeIR([
@@ -485,15 +483,15 @@ describe("generateJsonSchemaFromIR", () => {
       });
     });
 
-    it("emits title only for members whose displayName differs from the value (issue #310)", () => {
-      // Mixed: some members have a meaningful displayName, others do not (or it matches).
+    it("emits title only for members whose label differs from the value (issue #310)", () => {
+      // Mixed: some members have a meaningful label, others do not (or it matches).
       const ir = makeIR([
         makeField("currency", {
           kind: "enum",
           members: [
             { value: "USD" },
-            { value: "EUR", displayName: "Euro" },
-            { value: "GBP", displayName: "GBP" }, // displayName === value → omit title
+            { value: "EUR", label: "Euro" },
+            { value: "GBP", label: "GBP" }, // label === value → omit title
           ],
         }),
       ]);
@@ -505,46 +503,46 @@ describe("generateJsonSchemaFromIR", () => {
       });
     });
 
-    // Parameterized edge cases for #310: displayName === String(m.value) comparison semantics.
+    // Parameterized edge cases for #310: label === String(m.value) comparison semantics.
     // EnumMember.value is `string | number` — boolean values are not part of the IR type,
     // so there is no boolean edge case to test.
     it.each([
       {
         label: "numeric const matching stringified value — omit title",
         value: 42 as string | number,
-        displayName: "42",
+        memberLabel: "42",
         expectedTitle: false,
       },
       {
-        label: "numeric const with different displayName — emit title",
+        label: "numeric const with different label — emit title",
         value: 1 as string | number,
-        displayName: "One",
+        memberLabel: "One",
         expectedTitle: true,
       },
       {
-        label: "empty-string displayName matching empty-string value — omit title",
+        label: "empty-string label matching empty-string value — omit title",
         value: "" as string | number,
-        displayName: "",
+        memberLabel: "",
         expectedTitle: false,
       },
       {
-        label: "case-differing displayName — emit title (strict !== semantics, issue #310)",
+        label: "case-differing label — emit title (strict !== semantics, issue #310)",
         value: "USD" as string | number,
-        displayName: "usd",
+        memberLabel: "usd",
         expectedTitle: true,
       },
-    ])("oneOf title omission edge case: $label", ({ value, displayName, expectedTitle }) => {
+    ])("oneOf title omission edge case: $label", ({ value, memberLabel, expectedTitle }) => {
       const ir = makeIR([
         makeField("f", {
           kind: "enum",
-          members: [{ value, displayName }],
+          members: [{ value, label: memberLabel }],
         }),
       ]);
       const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "oneOf" });
       const prop = (schema.properties as Record<string, unknown>)["f"];
 
       if (expectedTitle) {
-        expect(prop).toEqual({ oneOf: [{ const: value, title: displayName }] });
+        expect(prop).toEqual({ oneOf: [{ const: value, title: memberLabel }] });
       } else {
         expect(prop).toEqual({ oneOf: [{ const: value }] });
       }
@@ -554,7 +552,7 @@ describe("generateJsonSchemaFromIR", () => {
       const ir = makeIR([
         makeField("status", {
           kind: "enum",
-          members: [{ value: "draft", displayName: "draft" }, { value: "sent" }],
+          members: [{ value: "draft", label: "draft" }, { value: "sent" }],
         }),
       ]);
       const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "smart-size" });
@@ -569,7 +567,7 @@ describe("generateJsonSchemaFromIR", () => {
       const ir = makeIR([
         makeField("status", {
           kind: "enum",
-          members: [{ value: "draft", displayName: "Draft" }, { value: "sent" }],
+          members: [{ value: "draft", label: "Draft" }, { value: "sent" }],
         }),
       ]);
       const schema = generateJsonSchemaFromIR(ir, { enumSerialization: "smart-size" });
@@ -596,8 +594,8 @@ describe("generateJsonSchemaFromIR", () => {
         makeField("status", {
           kind: "enum",
           members: [
-            { value: "draft", displayName: "Draft" },
-            { value: "sent", displayName: "Sent" },
+            { value: "draft", label: "Draft" },
+            { value: "sent", label: "Sent" },
           ],
         }),
       ]);
@@ -618,8 +616,8 @@ describe("generateJsonSchemaFromIR", () => {
         makeField("status", {
           kind: "enum",
           members: [
-            { value: 1, displayName: "Numeric One" },
-            { value: "1", displayName: "String One" },
+            { value: 1, label: "Numeric One" },
+            { value: "1", label: "String One" },
           ],
         }),
       ]);
@@ -632,8 +630,8 @@ describe("generateJsonSchemaFromIR", () => {
         makeField("status", {
           kind: "enum",
           members: [
-            { value: "__proto__", displayName: "Prototype" },
-            { value: "constructor", displayName: "Constructor" },
+            { value: "__proto__", label: "Prototype" },
+            { value: "constructor", label: "Constructor" },
           ],
         }),
       ]);
@@ -794,14 +792,53 @@ describe("generateJsonSchemaFromIR", () => {
       expect(prop["additionalProperties"]).toBe(false);
     });
 
-    it("omits additionalProperties when IR allows it", () => {
+    it("omits additionalProperties when object openness is policy-defaulted", () => {
+      const ir = makeIR([makeField("obj", { kind: "object", properties: [] })]);
+      const schema = generateJsonSchemaFromIR(ir);
+      const prop = (schema.properties as Record<string, unknown>)["obj"] as Record<string, unknown>;
+
+      expect(prop).not.toHaveProperty("additionalProperties");
+    });
+
+    it("emits additionalProperties:true when IR explicitly opens the object", () => {
       const ir = makeIR([
         makeField("obj", { kind: "object", properties: [], additionalProperties: true }),
       ]);
       const schema = generateJsonSchemaFromIR(ir);
       const prop = (schema.properties as Record<string, unknown>)["obj"] as Record<string, unknown>;
 
-      expect(prop).not.toHaveProperty("additionalProperties");
+      expect(prop["additionalProperties"]).toBe(true);
+    });
+
+    it("emits additionalProperties as a subschema when IR constrains extra values", () => {
+      const ir = makeIR([
+        makeField("obj", {
+          kind: "object",
+          properties: [],
+          additionalProperties: { kind: "primitive", primitiveKind: "string" },
+        }),
+      ]);
+      const schema = generateJsonSchemaFromIR(ir);
+      const prop = (schema.properties as Record<string, unknown>)["obj"] as Record<string, unknown>;
+
+      expect(prop["additionalProperties"]).toEqual({ type: "string" });
+    });
+
+    it("does not emit passthroughObject before issue #416 PR-2 wires the keyword", () => {
+      const ir = makeIR([
+        makeField("obj", {
+          kind: "object",
+          properties: [],
+          additionalProperties: true,
+          passthrough: true,
+        }),
+      ]);
+      const schema = generateJsonSchemaFromIR(ir);
+      const prop = (schema.properties as Record<string, unknown>)["obj"] as Record<string, unknown>;
+
+      expect(prop["additionalProperties"]).toBe(true);
+      expect(prop).not.toHaveProperty("passthroughObject");
+      expect(prop).not.toHaveProperty("x-formspec-passthroughObject");
     });
 
     it("applies use-site constraints on object properties", () => {
@@ -1027,7 +1064,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             provenance: PROVENANCE,
           },
@@ -1062,7 +1098,6 @@ describe("generateJsonSchemaFromIR", () => {
             provenance: PROVENANCE,
           },
         ],
-        additionalProperties: true,
       };
 
       const ir: FormIR = {
@@ -1116,7 +1151,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             provenance: PROVENANCE,
           },
@@ -1801,8 +1835,8 @@ describe("generateJsonSchemaFromIR", () => {
           makeField("status", {
             kind: "enum",
             members: [
-              { value: "active", displayName: "Active" },
-              { value: "inactive", displayName: "Inactive" },
+              { value: "active", label: "Active" },
+              { value: "inactive", label: "Inactive" },
             ],
           }),
         ],
@@ -1821,7 +1855,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             provenance: PROVENANCE,
           },
@@ -1930,9 +1963,9 @@ describe("generateJsonSchemaFromIR", () => {
             {
               kind: "enum",
               members: [
-                { value: "draft", displayName: "Draft" },
-                { value: "sent", displayName: "Sent to Customer" },
-                { value: "paid", displayName: "Paid in Full" },
+                { value: "draft", label: "Draft" },
+                { value: "sent", label: "Sent to Customer" },
+                { value: "paid", label: "Paid in Full" },
               ],
             },
             true,
@@ -1985,7 +2018,7 @@ describe("generateJsonSchemaFromIR", () => {
         typeRegistry: {
           Address: {
             name: "Address",
-            type: { kind: "object", properties: addressProperties, additionalProperties: true },
+            type: { kind: "object", properties: addressProperties },
             provenance: PROVENANCE,
           },
         },
@@ -2077,7 +2110,6 @@ describe("generateJsonSchemaFromIR", () => {
               provenance: PROVENANCE,
             },
           ],
-          additionalProperties: true,
         } satisfies TypeNode,
         provenance: PROVENANCE,
       },
@@ -2141,7 +2173,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             true,
             [
@@ -2281,7 +2312,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             provenance: PROVENANCE,
           },
@@ -2333,7 +2363,6 @@ describe("generateJsonSchemaFromIR", () => {
                         provenance: PROVENANCE,
                       },
                     ],
-                    additionalProperties: true,
                   },
                   optional: false,
                   constraints: [],
@@ -2341,7 +2370,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             true,
             [
@@ -2415,7 +2443,6 @@ describe("generateJsonSchemaFromIR", () => {
                             provenance: PROVENANCE,
                           },
                         ],
-                        additionalProperties: true,
                       },
                       { kind: "primitive", primitiveKind: "null" },
                     ],
@@ -2426,7 +2453,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             true,
             [
@@ -2507,7 +2533,6 @@ describe("generateJsonSchemaFromIR", () => {
                               provenance: PROVENANCE,
                             },
                           ],
-                          additionalProperties: true,
                         },
                       },
                       { kind: "primitive", primitiveKind: "null" },
@@ -2519,7 +2544,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             true,
             [
@@ -2600,7 +2624,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             true,
             [
@@ -2638,7 +2661,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             provenance: PROVENANCE,
           },
@@ -2684,7 +2706,6 @@ describe("generateJsonSchemaFromIR", () => {
                   provenance: PROVENANCE,
                 },
               ],
-              additionalProperties: true,
             },
             true,
             [
@@ -2718,7 +2739,7 @@ describe("generateJsonSchemaFromIR", () => {
       // it regardless of the `additionalProperties` value.
       expect(address["allOf"]).toBeUndefined();
       expect(address["type"]).toBe("object");
-      // spec 003 §2.5: additionalProperties: true is the default and omitted.
+      // spec 003 §2.5: omitted additionalProperties lets policy decide.
       expect(address["additionalProperties"]).toBeUndefined();
       expect(address["properties"]).toEqual({
         city: { type: "string" },

--- a/packages/build/tests/metadata-resolve.test.ts
+++ b/packages/build/tests/metadata-resolve.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { FieldNode, FormIR, Provenance } from "@formspec/core/internals";
+import { IR_VERSION } from "@formspec/core/internals";
+import { normalizeMetadataPolicy, resolveFormIRMetadata } from "../src/metadata/index.js";
+
+const PROVENANCE: Provenance = {
+  surface: "chain-dsl",
+  file: "/test.ts",
+  line: 1,
+  column: 0,
+};
+
+function makeIR(field: FieldNode): FormIR {
+  return {
+    kind: "form-ir",
+    irVersion: IR_VERSION,
+    elements: [field],
+    typeRegistry: {},
+    provenance: PROVENANCE,
+  };
+}
+
+describe("resolveFormIRMetadata", () => {
+  it("resolves enum member labels inside ObjectTypeNode.additionalProperties TypeNode", () => {
+    const ir = makeIR({
+      kind: "field",
+      name: "metadataBag",
+      type: {
+        kind: "object",
+        properties: [],
+        additionalProperties: {
+          kind: "enum",
+          members: [{ value: "usd" }],
+        },
+      },
+      required: false,
+      constraints: [],
+      annotations: [],
+      provenance: PROVENANCE,
+    });
+
+    const resolved = resolveFormIRMetadata(ir, {
+      surface: "chain-dsl",
+      policy: normalizeMetadataPolicy({
+        enumMember: {
+          displayName: {
+            mode: "infer-if-missing",
+            infer: ({ logicalName }) => `Label ${logicalName}`,
+          },
+        },
+      }),
+    });
+
+    const element = resolved.elements[0];
+    expect(element?.kind).toBe("field");
+    if (element?.kind !== "field") {
+      throw new Error("Expected a field element.");
+    }
+
+    expect(element.type.kind).toBe("object");
+    if (element.type.kind !== "object") {
+      throw new Error("Expected an object type.");
+    }
+
+    expect(element.type.additionalProperties).toEqual({
+      kind: "enum",
+      members: [{ value: "usd", label: "Label usd" }],
+    });
+  });
+});

--- a/packages/build/tests/parity/fixtures/plan-status/expected-ir.ts
+++ b/packages/build/tests/parity/fixtures/plan-status/expected-ir.ts
@@ -14,9 +14,9 @@ export const expectedIR: ProvenanceFreeFormIR = {
       type: {
         kind: "enum",
         members: [
-          { value: "active", displayName: "Active" },
-          { value: "paused", displayName: "Paused" },
-          { value: "cancelled", displayName: "Cancelled" },
+          { value: "active", label: "Active" },
+          { value: "paused", label: "Paused" },
+          { value: "cancelled", label: "Cancelled" },
         ],
       },
       required: true,

--- a/packages/build/tests/parity/fixtures/product-config/expected-ir.ts
+++ b/packages/build/tests/parity/fixtures/product-config/expected-ir.ts
@@ -56,7 +56,6 @@ export const expectedIR: ProvenanceFreeFormIR = {
             annotations: [],
           },
         ],
-        additionalProperties: true,
       },
       required: true,
       constraints: [],

--- a/packages/build/tests/parity/utils.ts
+++ b/packages/build/tests/parity/utils.ts
@@ -89,7 +89,8 @@ export interface ProvenanceFreeObjectProperty {
 export interface ProvenanceFreeObjectTypeNode {
   readonly kind: "object";
   readonly properties: readonly ProvenanceFreeObjectProperty[];
-  readonly additionalProperties: boolean;
+  readonly additionalProperties?: boolean | ProvenanceFreeTypeNode | undefined;
+  readonly passthrough?: boolean;
 }
 
 /** Record type node — valueType is recursively provenance-free. */
@@ -327,7 +328,13 @@ function stripProvenanceFromObjectType(type: ObjectTypeNode): ProvenanceFreeObje
   return {
     kind: "object",
     properties: type.properties.map(stripProvenanceFromObjectProperty),
-    additionalProperties: type.additionalProperties,
+    ...(type.additionalProperties !== undefined && {
+      additionalProperties:
+        typeof type.additionalProperties === "boolean"
+          ? type.additionalProperties
+          : stripProvenanceFromTypeNode(type.additionalProperties),
+    }),
+    ...(type.passthrough !== undefined && { passthrough: type.passthrough }),
   };
 }
 

--- a/packages/build/tests/ref-with-sibling-keywords.test.ts
+++ b/packages/build/tests/ref-with-sibling-keywords.test.ts
@@ -89,7 +89,6 @@ const MONETARY_AMOUNT_REGISTRY: FormIR["typeRegistry"] = {
           provenance: PROVENANCE,
         },
       ],
-      additionalProperties: true,
     },
     provenance: PROVENANCE,
   },
@@ -433,7 +432,6 @@ describe("$ref with sibling keywords — issue #364", () => {
                       provenance: PROVENANCE,
                     },
                   ],
-                  additionalProperties: true,
                 },
                 optional: false,
                 constraints: [],
@@ -441,7 +439,6 @@ describe("$ref with sibling keywords — issue #364", () => {
                 provenance: PROVENANCE,
               },
             ],
-            additionalProperties: true,
           },
           provenance: PROVENANCE,
         },
@@ -507,7 +504,6 @@ describe("$ref with sibling keywords — issue #364", () => {
               provenance: PROVENANCE,
             },
           ],
-          additionalProperties: true,
         },
         provenance: PROVENANCE,
       },
@@ -671,7 +667,7 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
   // ---------------------------------------------------------------------------
   describe("Site 1: inline-object with path target naming a property that does not exist (#382)", () => {
     it("emits a single flat object (no allOf wrapper) with sibling properties and preserved additionalProperties", () => {
-      // Scenario: an inline object field has `additionalProperties: true` and
+      // Scenario: an inline object field has policy-defaulted additionalProperties and
       // receives a path-targeted constraint pointing at a property that is not
       // declared on the base type. Historically this wrapped the base in
       // `allOf: [base, { properties: { missing: ... } }]`. The fix emits a
@@ -695,7 +691,6 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
                 provenance: PROVENANCE,
               },
             ],
-            additionalProperties: true,
           },
           required: true,
           constraints: [
@@ -721,9 +716,8 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
       // Flat object: type is a sibling key, not buried inside allOf[0].
       expect(address?.["type"]).toBe("object");
 
-      // `additionalProperties: true` is the default and is intentionally
-      // omitted from output (spec 003 §2.5); the semantics are preserved by
-      // absence of the keyword, not by its explicit presence.
+      // Omitted `additionalProperties` lets downstream policy decide (spec 003
+      // §2.5); the semantics are preserved by absence of the keyword.
       expect(address?.["additionalProperties"]).toBeUndefined();
 
       // Base property ("city") and the missing-override property ("missing")
@@ -805,7 +799,6 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
                 provenance: PROVENANCE,
               },
             ],
-            additionalProperties: true,
           },
           required: true,
           constraints: [
@@ -874,7 +867,6 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
             type: {
               kind: "object",
               properties: [],
-              additionalProperties: true,
             },
             required: true,
             constraints: [
@@ -918,7 +910,6 @@ describe("remaining allOf emission sites flattened to siblings — issue #382", 
             type: {
               kind: "object",
               properties: [],
-              additionalProperties: true,
             },
             required: true,
             constraints: [

--- a/packages/core/api-report/core.alpha.api.md
+++ b/packages/core/api-report/core.alpha.api.md
@@ -275,7 +275,7 @@ export interface DynamicTypeNode {
 
 // @beta
 export interface EnumMember {
-    readonly displayName?: string;
+    readonly label?: string;
     readonly value: string | number;
 }
 
@@ -793,8 +793,9 @@ export interface ObjectProperty {
 
 // @beta
 export interface ObjectTypeNode {
-    readonly additionalProperties: boolean;
+    readonly additionalProperties?: boolean | TypeNode | undefined;
     readonly kind: "object";
+    readonly passthrough?: boolean;
     readonly properties: readonly ObjectProperty[];
 }
 

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -275,7 +275,7 @@ export interface DynamicTypeNode {
 
 // @beta
 export interface EnumMember {
-    readonly displayName?: string;
+    readonly label?: string;
     readonly value: string | number;
 }
 
@@ -793,8 +793,9 @@ export interface ObjectProperty {
 
 // @beta
 export interface ObjectTypeNode {
-    readonly additionalProperties: boolean;
+    readonly additionalProperties?: boolean | TypeNode | undefined;
     readonly kind: "object";
+    readonly passthrough?: boolean;
     readonly properties: readonly ObjectProperty[];
 }
 

--- a/packages/core/api-report/core.beta.api.md
+++ b/packages/core/api-report/core.beta.api.md
@@ -273,7 +273,7 @@ export interface DynamicTypeNode {
 
 // @beta
 export interface EnumMember {
-    readonly displayName?: string;
+    readonly label?: string;
     readonly value: string | number;
 }
 
@@ -791,8 +791,9 @@ export interface ObjectProperty {
 
 // @beta
 export interface ObjectTypeNode {
-    readonly additionalProperties: boolean;
+    readonly additionalProperties?: boolean | TypeNode | undefined;
     readonly kind: "object";
+    readonly passthrough?: boolean;
     readonly properties: readonly ObjectProperty[];
 }
 

--- a/packages/core/src/types/ir.ts
+++ b/packages/core/src/types/ir.ts
@@ -112,9 +112,6 @@ export type TypeNode =
 /**
  * Primitive types mapping directly to JSON Schema primitives.
  *
- * Note: integer is NOT a primitive kind — integer semantics are expressed
- * via a `multipleOf: 1` constraint on a number type.
- *
  * @beta
  */
 export interface PrimitiveTypeNode {
@@ -132,8 +129,8 @@ export interface PrimitiveTypeNode {
 export interface EnumMember {
   /** The serialized value stored in data. */
   readonly value: string | number;
-  /** Optional per-member display name. */
-  readonly displayName?: string;
+  /** Optional per-member label. */
+  readonly label?: string;
 }
 
 /**
@@ -201,11 +198,26 @@ export interface ObjectTypeNode {
    */
   readonly properties: readonly ObjectProperty[];
   /**
-   * Whether additional properties beyond those listed are permitted.
-   * Ordinary static object types default to true under the current spec.
-   * Explicitly closed-object modes may still set this to false.
+   * Additional-property policy carried by this object node.
+   *
+   * - `undefined` — authoring was silent; emission policy decides whether to
+   *   add `additionalProperties`.
+   * - `true` — the author explicitly declared the object open.
+   * - `false` — the author explicitly declared the object closed.
+   * - `TypeNode` — the author explicitly declared the object open with a type
+   *   constraint for additional values. Reserved for future authoring support.
    */
-  readonly additionalProperties: boolean;
+  readonly additionalProperties?: boolean | TypeNode | undefined;
+  /**
+   * Build-time policy marker for intentionally permissive objects.
+   *
+   * This composes with `additionalProperties`: an object with both
+   * `additionalProperties: true` and `passthrough: true` means the author
+   * explicitly declared the object open and wants the `passthroughObject`
+   * policy keyword emitted. The JSON Schema emitter accepts the flag now;
+   * keyword emission is deferred to #416 PR-2.
+   */
+  readonly passthrough?: boolean;
 }
 
 /**

--- a/packages/core/tests/ir.test-d.ts
+++ b/packages/core/tests/ir.test-d.ts
@@ -137,14 +137,16 @@ expectAssignable<TypeNode>(nullNode);
 // EnumTypeNode
 const enumNode: EnumTypeNode = {
   kind: "enum",
-  members: [{ value: "draft" }, { value: "sent", displayName: "Sent" }, { value: 1 }],
+  members: [{ value: "draft" }, { value: "sent", label: "Sent" }, { value: 1 }],
 };
 expectAssignable<TypeNode>(enumNode);
 
 const enumMember: EnumMember = { value: "active" };
 expectAssignable<EnumMember>(enumMember);
 expectAssignable<EnumMember>({ value: 42 });
-expectAssignable<EnumMember>({ value: "active", displayName: "Active" });
+expectAssignable<EnumMember>({ value: "active", label: "Active" });
+expectError<EnumMember>({ value: "active", label: 123 });
+expectError<EnumMember>({ value: "active", displayName: "Active" });
 
 // ArrayTypeNode
 const arrayNode: ArrayTypeNode = { kind: "array", items: stringNode };
@@ -170,6 +172,40 @@ const objectNode: ObjectTypeNode = {
   additionalProperties: false,
 };
 expectAssignable<TypeNode>(objectNode);
+expectAssignable<ObjectTypeNode>({
+  kind: "object",
+  properties: [objectProp],
+});
+expectAssignable<ObjectTypeNode>({
+  kind: "object",
+  properties: [objectProp],
+  additionalProperties: undefined,
+});
+expectAssignable<ObjectTypeNode>({
+  kind: "object",
+  properties: [objectProp],
+  additionalProperties: true,
+});
+expectAssignable<ObjectTypeNode>({
+  kind: "object",
+  properties: [objectProp],
+  additionalProperties: stringNode,
+});
+expectAssignable<ObjectTypeNode>({
+  kind: "object",
+  properties: [objectProp],
+  passthrough: true,
+});
+expectAssignable<ObjectTypeNode>({
+  kind: "object",
+  properties: [objectProp],
+  passthrough: false,
+});
+expectError<ObjectTypeNode>({
+  kind: "object",
+  properties: [objectProp],
+  passthrough: "true",
+});
 
 // UnionTypeNode (e.g., nullable type T | null)
 const unionNode: UnionTypeNode = {


### PR DESCRIPTION
## Summary
- Rename Canonical IR enum-member `displayName` to `label` and update downstream analyzer, canonicalizer, emitter, fixtures, and API reports with no alpha-era alias.
- Widen `ObjectTypeNode.additionalProperties` to the PR-A tristate shape and add the orthogonal `passthrough` flag.
- Update JSON Schema IR emission and metadata resolution for omitted, `true`, `false`, and TypeNode-constrained `additionalProperties`, with `passthrough` intentionally preserved as a no-op until #416 PR-2.

## Test plan
- `pnpm --filter @formspec/core run test:types`
- `pnpm --filter @formspec/build run typecheck`
- `pnpm --filter @formspec/build exec vitest run tests/ir-json-schema-generator.test.ts tests/metadata-resolve.test.ts tests/parity/parity.test.ts tests/parity-divergences.test.ts`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run api-extractor`
- `git diff --check`

Refs #417

#416 PR-2 depends on the `passthrough` flag and can begin once this lands.
