### PR TITLE
docs(spec): catch up 001 to current IR shape (#417 PR-B)

### DIFF
--- a/docs/001-canonical-ir.md
+++ b/docs/001-canonical-ir.md
@@ -53,6 +53,7 @@ type TypeNode =
   | EnumTypeNode
   | ArrayTypeNode
   | ObjectTypeNode
+  | RecordTypeNode
   | UnionTypeNode
   | ReferenceTypeNode
   | DynamicTypeNode
@@ -114,26 +115,29 @@ interface ObjectTypeNode {
   readonly kind: "object";
   /**
    * Named properties of this object. Order is preserved from the source
-   * declaration (for deterministic D3 output).
+   * declaration for deterministic output.
    */
   readonly properties: readonly ObjectProperty[];
   /**
-   * Value type for unconstrained additional properties when the source type
-   * includes an unrestricted string/number index signature
-   * (e.g. `{ [k: string]: T }` or `Record<string, T>`).
+   * Additional-property policy carried by this object node.
    *
-   * When absent, openness is determined later by JSON Schema emission policy
-   * and project configuration rather than by the IR node alone.
+   * - `undefined` — authoring was silent; emission policy decides whether to
+   *   add `additionalProperties`.
+   * - `true` — the author explicitly declared the object open.
+   * - `false` — the author explicitly declared the object closed.
+   * - `TypeNode` — the author explicitly declared the object open with a type
+   *   constraint for additional values. Reserved for future authoring support.
    */
-  readonly additionalProperties?: TypeNode;
+  readonly additionalProperties?: boolean | TypeNode | undefined;
   /**
-   * Constrained key families inferred from TypeScript key types that describe
-   * pattern-shaped object keys (for example `Record<\`env_${string}\`, T>`).
+   * Build-time policy marker for intentionally permissive objects.
    *
-   * Finite key sets such as `Record<'a' | 'b', T>` do not appear here; they
-   * are normalized to ordinary named properties.
+   * This composes with `additionalProperties`: an object with both
+   * `additionalProperties: true` and `passthrough: true` means the author
+   * explicitly declared the object open and wants the `passthroughObject`
+   * policy keyword emitted. Keyword emission is tracked by issue #416.
    */
-  readonly patternProperties?: readonly PatternProperty[];
+  readonly passthrough?: boolean;
 }
 
 interface ObjectProperty {
@@ -152,19 +156,30 @@ interface ObjectProperty {
   readonly annotations: readonly AnnotationNode[];
   readonly provenance: Provenance;
 }
+```
 
-interface PatternProperty {
-  /**
-   * ECMA-262 regular expression, without delimiters, suitable for JSON Schema
-   * `patternProperties`.
-   */
-  readonly keyPattern: string;
+`additionalProperties` carries four states: `undefined` means the authoring surface was silent and emission policy decides the output; `true` means the author explicitly declared the object open; `false` means the author explicitly declared the object closed; a `TypeNode` means the object is open with a value-type constraint for extra properties. The `TypeNode` arm is reserved for future authoring support and has no authoring surface today.
+
+`passthrough` is a build-time policy marker that composes orthogonally with `additionalProperties`. It records intent for the FormSpec `passthroughObject` policy keyword; keyword emission is tracked in [#416](https://github.com/mike-north/formspec/issues/416).
+
+> `patternProperties` for template-literal record types (for example, ``Record<`prefix-${string}`, T>``) is **deferred** — no implementation today. Tracked in [#490](https://github.com/mike-north/formspec/issues/490).
+
+### 2.6 Record Types
+
+`RecordTypeNode` represents dictionary-like object types with no fixed property set. The analyzer produces it for TypeScript `Record<K, V>` and indexed-object types when the key family is the currently implemented unrestricted string case, such as `Record<string, T>` and `{ [k: string]: T }`.
+
+```typescript
+interface RecordTypeNode {
+  readonly kind: "record";
   readonly valueType: TypeNode;
-  readonly provenance: Provenance;
 }
 ```
 
-### 2.6 Union Types
+Unlike `ObjectTypeNode` (§2.5), `RecordTypeNode` does not carry named properties. Its keys are pattern-typed by the TypeScript source shape, and the currently implemented key family is the unrestricted string key family emitted as JSON Schema `additionalProperties`.
+
+Pattern-shaped key families such as template-literal records remain deferred rather than being represented as `RecordTypeNode` today. See the §2.5 `patternProperties` deferral.
+
+### 2.7 Union Types
 
 Union types that are not all-string-literal or all-number-literal enums (those are `EnumTypeNode`) become `UnionTypeNode`.
 
@@ -177,7 +192,7 @@ interface UnionTypeNode {
 
 Nullable types (`T | null`) are represented as `UnionTypeNode` with a `PrimitiveTypeNode` (`null`) member — there is no special nullable wrapper. This keeps the model uniform and mirrors JSON Schema's `oneOf` representation (PP6).
 
-### 2.7 Reference Types
+### 2.8 Reference Types
 
 Named types that appear as references in the source are preserved as references in the IR (PP7). Inlining them would erase the distinction between a reusable named type and an inline structural type.
 
@@ -204,24 +219,22 @@ The IR registry (section 10.3) maintains a `TypeDefinition` map from reference n
 
 Anonymous recursive shapes are not part of this supported path because they have no stable registry identity to reference. The analyzer emits `ANONYMOUS_RECURSIVE_TYPE` rather than silently collapsing to an empty fallback object, advising authors to extract the recursive shape to a named class, interface, or type alias.
 
-### 2.8 Dynamic Types
+### 2.9 Dynamic Types
 
-Dynamic types are reserved for fields whose schema is discovered at runtime.
+Dynamic types are runtime-resolved types whose enum options or schema are supplied by a named data source.
 
 ```typescript
 interface DynamicTypeNode {
   readonly kind: "dynamic";
-  readonly dynamicKind: "schema";
-  /**
-   * Key identifying the runtime schema provider.
-   */
+  readonly dynamicKind: "enum" | "schema";
   readonly sourceKey: string;
+  readonly parameterFields: readonly string[];
 }
 ```
 
-Dynamic option retrieval does **not** use `DynamicTypeNode`. The field's stored value type remains statically known (for example `string`), and runtime option-provider metadata is layered onto that static field definition by the chain DSL or mixed-authoring composition.
+Dynamic enum and schema nodes carry a `sourceKey` identifying the runtime data source or schema provider. For dynamic enums, `parameterFields` lists field names whose current values are passed as parameters to the data-source resolver.
 
-### 2.9 Custom Types
+### 2.10 Custom Types
 
 Custom types registered by extensions (E1, E5) that do not map to any built-in kind.
 
@@ -265,12 +278,13 @@ type ConstraintNode =
   | PatternConstraintNode
   | ArrayCardinalityConstraintNode
   | EnumMemberConstraintNode
+  | ConstConstraintNode
   | CustomConstraintNode;
 ```
 
 ### 3.2 Numeric Constraints
 
-Apply to `number`, `integer`, and `bigint` fields. `minimum` and `maximum` are inclusive; `exclusiveMinimum` and `exclusiveMaximum` are exclusive bounds (matching JSON Schema 2020-12 semantics, PP6).
+Numeric constraints represent bounds and `multipleOf`. `minimum` and `maximum` are inclusive; `exclusiveMinimum` and `exclusiveMaximum` are exclusive bounds (matching JSON Schema 2020-12 semantics, PP6).
 
 ```typescript
 interface NumericConstraintNode {
@@ -281,12 +295,11 @@ interface NumericConstraintNode {
     | "exclusiveMinimum"
     | "exclusiveMaximum"
     | "multipleOf";
-  readonly value: number | string;
+  readonly value: number;
+  readonly path?: PathTarget;
   readonly provenance: Provenance;
 }
 ```
-
-**Value representation:** `number` and `integer` constraints use numeric values. `bigint`-origin constraints may preserve the parsed decimal text as a string to avoid precision loss.
 
 **Type applicability (S4):** `NumericConstraintNode` may only attach to fields with `PrimitiveTypeNode("number" | "integer" | "bigint")` or a `ReferenceTypeNode` that resolves to one. Attaching to any other type is a static error.
 
@@ -299,6 +312,7 @@ interface LengthConstraintNode {
   readonly kind: "constraint";
   readonly constraintKind: "minLength" | "maxLength" | "minItems" | "maxItems";
   readonly value: number;
+  readonly path?: PathTarget;
   readonly provenance: Provenance;
 }
 ```
@@ -315,21 +329,23 @@ interface PatternConstraintNode {
   readonly constraintKind: "pattern";
   /** ECMA-262 regular expression, without delimiters. */
   readonly pattern: string;
+  readonly path?: PathTarget;
   readonly provenance: Provenance;
 }
 ```
 
-`PatternConstraintNode` is for string values, not object keys. Object-key patterns are represented structurally on `ObjectTypeNode.patternProperties`.
+`PatternConstraintNode` is for string values, not object keys. Object-key `patternProperties` support is deferred separately from string-value pattern constraints (see §2.5 and [#490](https://github.com/mike-north/formspec/issues/490)).
 
 ### 3.5 Array Cardinality Constraints
 
-These are split from `LengthConstraintNode` above only if array cardinality needs different semantics (e.g., `uniqueItems`). The current model folds them into `LengthConstraintNode` for uniformity.
+Array cardinality constraints cover array validation rules that do not share the numeric bound semantics of `LengthConstraintNode`.
 
 ```typescript
 interface ArrayCardinalityConstraintNode {
   readonly kind: "constraint";
   readonly constraintKind: "uniqueItems";
   readonly value: true;
+  readonly path?: PathTarget;
   readonly provenance: Provenance;
 }
 ```
@@ -343,11 +359,28 @@ interface EnumMemberConstraintNode {
   readonly kind: "constraint";
   readonly constraintKind: "allowedMembers";
   readonly members: readonly (string | number)[];
+  readonly path?: PathTarget;
   readonly provenance: Provenance;
 }
 ```
 
-### 3.7 Custom Constraints
+### 3.7 Const Constraints
+
+`ConstConstraintNode` is a literal equality constraint: the constrained value must equal the JSON-serializable literal carried in `value`. It is produced by the `@const` TSDoc tag; see 002 §2.1 and §3.2 for tag inventory and argument grammar.
+
+```typescript
+interface ConstConstraintNode {
+  readonly kind: "constraint";
+  readonly constraintKind: "const";
+  readonly value: JsonValue;
+  readonly path?: PathTarget;
+  readonly provenance: Provenance;
+}
+```
+
+Because `value` is `JsonValue`, constants may be `null`, booleans, numbers, strings, arrays, or JSON objects. Type compatibility is checked during validation, not by changing the IR node shape.
+
+### 3.8 Custom Constraints
 
 Extensions register custom constraints that carry an opaque payload. The `compositionRule` declaration fulfills E2 — the system cannot guess the composition rule.
 
@@ -374,11 +407,12 @@ interface CustomConstraintNode {
    *   Suitable for constraints that produce a single value (like a format hint).
    */
   readonly compositionRule: "intersect" | "override";
+  readonly path?: PathTarget;
   readonly provenance: Provenance;
 }
 ```
 
-### 3.8 Constraint Composition Rules
+### 3.9 Constraint Composition Rules
 
 Per C1, constraints are set-influencing and compose via intersection. The practical meaning for each built-in kind:
 
@@ -395,6 +429,7 @@ Per C1, constraints are set-influencing and compose via intersection. The practi
 | `maxItems`         | Take the min                                         |                                                               |
 | `pattern`          | All patterns must match (implicit `allOf`)           |                                                               |
 | `allowedMembers`   | Set intersection                                     |                                                               |
+| `const`            | Literal equality                                     | `@const "USD"` means the value must equal `"USD"`             |
 
 **Intersection never broadens (S1):** Adding a constraint can only make the valid set smaller or equal. The merge algorithm (section 7) enforces this invariant.
 
@@ -408,7 +443,10 @@ Annotations are value-influencing metadata (C1): they carry a single scalar that
 
 ```typescript
 type AnnotationNode =
+  | DisplayNameAnnotationNode
   | DescriptionAnnotationNode
+  | RemarksAnnotationNode
+  | FormatAnnotationNode
   | PlaceholderAnnotationNode
   | DefaultValueAnnotationNode
   | DeprecatedAnnotationNode
@@ -418,10 +456,33 @@ type AnnotationNode =
 
 ### 4.2 Built-in Annotations
 
+Built-in annotation interfaces use the same `kind: "annotation"` discriminator and compose by override unless a later section specifies a more specialized metadata-policy path.
+
 ```typescript
+interface DisplayNameAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "displayName";
+  readonly value: string;
+  readonly provenance: Provenance;
+}
+
 interface DescriptionAnnotationNode {
   readonly kind: "annotation";
   readonly annotationKind: "description";
+  readonly value: string;
+  readonly provenance: Provenance;
+}
+
+interface RemarksAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "remarks";
+  readonly value: string;
+  readonly provenance: Provenance;
+}
+
+interface FormatAnnotationNode {
+  readonly kind: "annotation";
+  readonly annotationKind: "format";
   readonly value: string;
   readonly provenance: Provenance;
 }
@@ -469,7 +530,13 @@ interface FormatHintAnnotationNode {
 }
 ```
 
-**Ecosystem tag alignment (S6):** `description` derives from TSDoc summary text (bare text before the first block tag), `remarks` derives from `@remarks`, `defaultValue` from `@defaultValue`, and `deprecated` from `@deprecated`. `displayName` is FormSpec-specific rather than a standard TSDoc tag.
+Newly documented variants:
+
+- `DisplayNameAnnotationNode` carries a human-readable display label. `@displayName` primarily feeds resolved identity metadata (§4.5; see 002 §2.2, §3.2, and §5), so this node documents the IR annotation shape without making ordinary `AnnotationNode` canonicalization override `ResolvedMetadata`.
+- `RemarksAnnotationNode` carries long-form programmatic-persona documentation from `@remarks`; see 002 §2.3 and §3.2. JSON Schema emission uses the `x-<vendor>-remarks` extension keyword described in 003 §3.2.
+- `FormatAnnotationNode` carries a JSON Schema `format` keyword value from `@format`; see 002 §2.2 and §3.2. This is distinct from `FormatHintAnnotationNode`, which carries renderer-specific hints and never emits JSON Schema `format`.
+
+**Ecosystem tag alignment (S6):** `description` derives from TSDoc summary text (bare text before the first block tag), `remarks` derives from `@remarks`, `defaultValue` from `@defaultValue`, and `deprecated` from `@deprecated`. `displayName`, `format`, and `placeholder` are FormSpec-specific metadata or annotation tags.
 
 ### 4.3 Custom Annotations
 
@@ -770,7 +837,7 @@ Sources, in ascending specificity order:
 
 ### 7.2 Constraint Merge (Intersection)
 
-All constraints at every specificity level are accumulated and composed via intersection (C1, S1). The effective value for each `constraintKind` is computed according to the table in section 3.8.
+All constraints at every specificity level are accumulated and composed via intersection (C1, S1). The effective value for each `constraintKind` is computed according to the table in section 3.9.
 
 ```
 effective(minimum) = max(base.minimum, alias.minimum, field.minimum)
@@ -1152,7 +1219,7 @@ interface FormIR {
    * Keys are fully-qualified type names matching `ReferenceTypeNode.name`.
    * Generators use this to emit `$defs` in JSON Schema (PP7).
    */
-  readonly typeRegistry: Record<string, TypeDefinition>;
+  readonly typeRegistry: Readonly<Record<string, TypeDefinition>>;
   /** Additional top-level annotations emitted alongside the form root. */
   readonly annotations?: readonly AnnotationNode[];
   /**

--- a/docs/003-json-schema-vocabulary.md
+++ b/docs/003-json-schema-vocabulary.md
@@ -109,7 +109,7 @@ If any member has a resolved display name, the extension contains a complete set
 | Optional `ObjectProperty`                                                                    | Absent from `"required"` array                                 |
 | `RecordTypeNode` (from `Record<string, T>` or `{ [k: string]: T }`)                          | `{ "type": "object", "additionalProperties": <T schema> }`     |
 | Finite constrained key set (e.g. `Record<'a' \| 'b', T>`, `Record<keyof SomeFiniteType, T>`) | Expanded to ordinary `"properties"` and `"required"` entries   |
-| Pattern-shaped constrained key type (e.g. `Record<\`env\_${string}\`, T>`)                   | Deferred — no implementation today                             |
+| Pattern-shaped constrained key type (e.g. ``Record<`env_${string}`, T>``)                    | Deferred — no implementation today                             |
 | Mixed (known + string index signature)                                                       | `"properties"` + `"additionalProperties"` combined             |
 | Mixed (known + constrained key family)                                                       | Deferred — no implementation today                             |
 

--- a/docs/003-json-schema-vocabulary.md
+++ b/docs/003-json-schema-vocabulary.md
@@ -42,18 +42,18 @@ FormSpec targets **JSON Schema 2020-12** (`https://json-schema.org/draft/2020-12
 
 ### 2.1 Primitive Types
 
-| IR type                                           | JSON Schema output                                                                                                                                                                        |
-| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `string`                                          | `{ "type": "string" }`                                                                                                                                                                    |
-| `number`                                          | `{ "type": "number" }`                                                                                                                                                                    |
-| `integer`                                         | `{ "type": "integer" }`                                                                                                                                                                   |
-| `bigint`                                          | `{ "type": "integer" }` (schema-level integer semantics; runtime transport/serialization is outside the JSON Schema contract)                                                             |
-| `number` with `MultipleOfConstraint { value: 1 }` | `{ "type": "integer" }` (the canonicalization pipeline recognizes this common TypeScript authoring pattern and emits integer semantics; the redundant `multipleOf: 1` keyword is omitted) |
-| `boolean`                                         | `{ "type": "boolean" }`                                                                                                                                                                   |
-| `null`                                            | `{ "type": "null" }`                                                                                                                                                                      |
-| `undefined`                                       | Not emitted (optionality is expressed via `required`, per S8)                                                                                                                             |
-| `unknown` / `any`                                 | `{}` (accepts any value)                                                                                                                                                                  |
-| `never`                                           | `{ "not": {} }`                                                                                                                                                                           |
+| IR type                                                                          | JSON Schema output                                                                                                                                                                        |
+| -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `string`                                                                         | `{ "type": "string" }`                                                                                                                                                                    |
+| `number`                                                                         | `{ "type": "number" }`                                                                                                                                                                    |
+| `integer`                                                                        | `{ "type": "integer" }`                                                                                                                                                                   |
+| `bigint`                                                                         | `{ "type": "integer" }` (schema-level integer semantics; runtime transport/serialization is outside the JSON Schema contract)                                                             |
+| `number` with `NumericConstraintNode { constraintKind: "multipleOf", value: 1 }` | `{ "type": "integer" }` (the canonicalization pipeline recognizes this common TypeScript authoring pattern and emits integer semantics; the redundant `multipleOf: 1` keyword is omitted) |
+| `boolean`                                                                        | `{ "type": "boolean" }`                                                                                                                                                                   |
+| `null`                                                                           | `{ "type": "null" }`                                                                                                                                                                      |
+| `undefined`                                                                      | Not emitted (optionality is expressed via `required`, per S8)                                                                                                                             |
+| `unknown` / `any`                                                                | `{}` (accepts any value)                                                                                                                                                                  |
+| `never`                                                                          | `{ "not": {} }`                                                                                                                                                                           |
 
 ### 2.2 String Literal, Number Literal, Boolean Literal
 
@@ -102,17 +102,16 @@ If any member has a resolved display name, the extension contains a complete set
 
 ### 2.5 Object Types
 
-| IR node                                                                                      | JSON Schema output                                                     |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| Object with known properties                                                                 | `{ "type": "object", "properties": {...}, "required": [...] }`         |
-| Required property                                                                            | Listed in `"required"` array                                           |
-| Optional property                                                                            | Absent from `"required"` array                                         |
-| Index signature `{ [k: string]: T }`                                                         | `{ "type": "object", "additionalProperties": <T schema> }`             |
-| `Record<string, T>` / unconstrained string key type                                          | `{ "type": "object", "additionalProperties": <T schema> }`             |
-| Finite constrained key set (e.g. `Record<'a' \| 'b', T>`, `Record<keyof SomeFiniteType, T>`) | Expanded to ordinary `"properties"` and `"required"` entries           |
-| Pattern-shaped constrained key type (e.g. `Record<\`env\_${string}\`, T>`)                   | `{ "type": "object", "patternProperties": { "<regex>": <T schema> } }` |
-| Mixed (known + index signature)                                                              | `"properties"` + `"additionalProperties"` combined                     |
-| Mixed (known + constrained key family)                                                       | `"properties"` + `"patternProperties"` combined                        |
+| IR node or source shape                                                                      | JSON Schema output                                             |
+| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `ObjectTypeNode` with known properties                                                       | `{ "type": "object", "properties": {...}, "required": [...] }` |
+| Required `ObjectProperty`                                                                    | Listed in `"required"` array                                   |
+| Optional `ObjectProperty`                                                                    | Absent from `"required"` array                                 |
+| `RecordTypeNode` (from `Record<string, T>` or `{ [k: string]: T }`)                          | `{ "type": "object", "additionalProperties": <T schema> }`     |
+| Finite constrained key set (e.g. `Record<'a' \| 'b', T>`, `Record<keyof SomeFiniteType, T>`) | Expanded to ordinary `"properties"` and `"required"` entries   |
+| Pattern-shaped constrained key type (e.g. `Record<\`env\_${string}\`, T>`)                   | Deferred — no implementation today                             |
+| Mixed (known + string index signature)                                                       | `"properties"` + `"additionalProperties"` combined             |
+| Mixed (known + constrained key family)                                                       | Deferred — no implementation today                             |
 
 **`additionalProperties` policy:** When a TypeScript type has only known properties and no index signature, `additionalProperties` is **not** set to `false` by default. Setting it to `false` would cause validation failures when form renderers add extra fields (e.g., `_id`, `_timestamp`). This is intentional and matches B4 (the JSON Schema represents the data contract, not the full TypeScript structural check).
 
@@ -120,44 +119,41 @@ If any member has a resolved display name, the extension contains a complete set
 
 **Constrained key-type rule:** FormSpec derives object-key behavior from what TypeScript can actually express:
 
-- Unconstrained string/number index signatures become `additionalProperties`
+- Unconstrained string index signatures become `additionalProperties`
 - Finite key sets become explicit named `properties`
-- Pattern-shaped key families become `patternProperties`
+- Pattern-shaped key families are deferred
 
-FormSpec does **not** promise arbitrary regex-to-TypeScript or TypeScript-to-regex equivalence. `patternProperties` is limited to the subset of key constraints that can be expressed clearly and canonically in TypeScript, primarily template-literal key families and similarly unambiguous constrained key types.
+> `patternProperties` for template-literal record types (for example, ``Record<`prefix-${string}`, T>``) is **deferred** — no implementation today. Tracked in [#490](https://github.com/mike-north/formspec/issues/490).
 
 ### 2.6 Numeric Constraints
 
-| IR constraint                                           | JSON Schema validation keyword                                                                                                                                                                            |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NumericBoundConstraint { bound: "minimum" }`           | `"minimum"`                                                                                                                                                                                               |
-| `NumericBoundConstraint { bound: "maximum" }`           | `"maximum"`                                                                                                                                                                                               |
-| `NumericBoundConstraint { bound: "exclusive-minimum" }` | `"exclusiveMinimum"`                                                                                                                                                                                      |
-| `NumericBoundConstraint { bound: "exclusive-maximum" }` | `"exclusiveMaximum"`                                                                                                                                                                                      |
-| `MultipleOfConstraint`                                  | `"multipleOf"` (when the resolved type is integer and the only source of that integer semantic is `value = 1` on a `number`-derived alias, the redundant `"multipleOf": 1` keyword is omitted — see §2.1) |
+| IR constraint                                                  | JSON Schema validation keyword                                                                                                                                                                            |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NumericConstraintNode { constraintKind: "minimum" }`          | `"minimum"`                                                                                                                                                                                               |
+| `NumericConstraintNode { constraintKind: "maximum" }`          | `"maximum"`                                                                                                                                                                                               |
+| `NumericConstraintNode { constraintKind: "exclusiveMinimum" }` | `"exclusiveMinimum"`                                                                                                                                                                                      |
+| `NumericConstraintNode { constraintKind: "exclusiveMaximum" }` | `"exclusiveMaximum"`                                                                                                                                                                                      |
+| `NumericConstraintNode { constraintKind: "multipleOf" }`       | `"multipleOf"` (when the resolved type is integer and the only source of that integer semantic is `value = 1` on a `number`-derived alias, the redundant `"multipleOf": 1` keyword is omitted — see §2.1) |
 
 ### 2.7 String Constraints
 
-| IR constraint                                   | JSON Schema validation keyword |
-| ----------------------------------------------- | ------------------------------ |
-| `StringLengthConstraint { bound: "minLength" }` | `"minLength"`                  |
-| `StringLengthConstraint { bound: "maxLength" }` | `"maxLength"`                  |
-| `PatternConstraint`                             | `"pattern"`                    |
-| `FormatAnnotation`                              | `"format"`                     |
+| IR constraint or annotation                            | JSON Schema validation keyword |
+| ------------------------------------------------------ | ------------------------------ |
+| `LengthConstraintNode { constraintKind: "minLength" }` | `"minLength"`                  |
+| `LengthConstraintNode { constraintKind: "maxLength" }` | `"maxLength"`                  |
+| `PatternConstraintNode { constraintKind: "pattern" }`  | `"pattern"`                    |
+| `FormatAnnotationNode { annotationKind: "format" }`    | `"format"`                     |
 
 ### 2.8 Metadata and Annotation → JSON Schema Annotation Keywords
 
-| IR metadata or annotation      | JSON Schema annotation key                                                                 |
-| ------------------------------ | ------------------------------------------------------------------------------------------ |
-| `ResolvedMetadata.displayName` | `"title"`                                                                                  |
-| `DescriptionAnnotation`        | `"description"` — populated from TSDoc summary text (bare text before first block tag)     |
-| `RemarksAnnotation`            | `"x-<vendor>-remarks"` — programmatic-persona documentation from `@remarks`                |
-| `DefaultValueAnnotation`       | `"default"`                                                                                |
-| `ExampleAnnotation[]`          | `"examples"` (array)                                                                       |
-| `DeprecatedAnnotation`         | `"deprecated": true` plus `"x-<vendor>-deprecation-description"` when a message is present |
-| `ReadOnlyAnnotation`           | `"readOnly"`                                                                               |
-| `WriteOnlyAnnotation`          | `"writeOnly"`                                                                              |
-| `ConstConstraint`              | `"const"`                                                                                  |
+| IR metadata, annotation, or constraint                          | JSON Schema annotation key                                                                 |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `ResolvedMetadata.displayName`                                  | `"title"`                                                                                  |
+| `DescriptionAnnotationNode { annotationKind: "description" }`   | `"description"` — populated from TSDoc summary text (bare text before first block tag)     |
+| `RemarksAnnotationNode { annotationKind: "remarks" }`           | `"x-<vendor>-remarks"` — programmatic-persona documentation from `@remarks`                |
+| `DefaultValueAnnotationNode { annotationKind: "defaultValue" }` | `"default"`                                                                                |
+| `DeprecatedAnnotationNode { annotationKind: "deprecated" }`     | `"deprecated": true` plus `"x-<vendor>-deprecation-description"` when a message is present |
+| `ConstConstraintNode { constraintKind: "const" }`               | `"const"`                                                                                  |
 
 ### 2.9 Declaration-Level Discriminator Specialization
 

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -8,6 +8,25 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
 - Group entries by the spec document being changed.
 - Link each entry back to the corresponding item in `scratch/spec-risk-log.md` when applicable.
 
+# 2026-04-30
+
+## docs/001-canonical-ir.md
+
+- §2.3: kept `EnumMember.label` as the documented per-member label field to match implementation.
+- §2.5: lifted `ObjectTypeNode.additionalProperties` to `?: boolean | TypeNode | undefined`; added `passthrough?: boolean`; marked `patternProperties` deferred ([#490](https://github.com/mike-north/formspec/issues/490)).
+- §2.6 (new): documented `RecordTypeNode` and its distinction from `ObjectTypeNode`.
+- §2.9: updated `DynamicTypeNode` to include `"enum"` and `parameterFields`.
+- §3.1: added `ConstConstraintNode` to the constraint union and aligned built-in constraint interfaces with path-target fields.
+- §3.7 (new): documented `ConstConstraintNode`.
+- §4.1: added `DisplayNameAnnotationNode`, `RemarksAnnotationNode`, and `FormatAnnotationNode` to the annotation union.
+- §4.2: defined the missing annotation variants and clarified `FormatAnnotationNode` versus `FormatHintAnnotationNode`.
+- §10.4: aligned `FormIR.typeRegistry` with the implementation's `Readonly<Record<string, TypeDefinition>>` shape.
+
+## docs/003-json-schema-vocabulary.md
+
+- §2.5: marked `patternProperties` deferred ([#490](https://github.com/mike-north/formspec/issues/490)).
+- §2.1 and §2.6-§2.8: refreshed stale IR node names in vocabulary mapping tables.
+
 # 2026-04-28
 
 ## 000-principles.md
@@ -77,7 +96,7 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
 
 ## 001-canonical-ir
 
-- Updated §2.7 to match the 2026-03-26 circular-reference supersession.
+- Updated §2.8 to match the 2026-03-26 circular-reference supersession.
   - Named recursive class/interface/type-alias graphs are supported through registry-backed `ReferenceTypeNode` back-edges.
   - Anonymous recursive shapes now produce the `ANONYMOUS_RECURSIVE_TYPE` diagnostic rather than silently collapsing.
 


### PR DESCRIPTION
## Summary

- align `docs/001-canonical-ir.md` with the current IR shapes from `packages/core/src/types/ir.ts`
- mark template-literal record `patternProperties` support deferred in 001/003 and link follow-up #490
- refresh the spec changelog and stale 003 vocabulary node names touched by this catch-up

## Follow-up

- Tracks deferred `patternProperties` implementation in #490

## Test plan

- `pnpm exec prettier --check docs/001-canonical-ir.md docs/003-json-schema-vocabulary.md docs/spec-changelog.md`
- `pnpm run lint:docs`
- `git diff --check`
- Spot-checked 001 interface signatures against `packages/core/src/types/ir.ts`

Closes #417
