### PR TITLE
feat(analysis): enroll @deprecated in heritage inheritance (#380)

### DIFF
--- a/.changeset/deprecated-heritage-inheritance.md
+++ b/.changeset/deprecated-heritage-inheritance.md
@@ -1,0 +1,11 @@
+---
+"@formspec/analysis": minor
+"@formspec/build": minor
+"@formspec/cli": minor
+"@formspec/eslint-plugin": minor
+"@formspec/language-server": minor
+"@formspec/ts-plugin": minor
+"formspec": minor
+---
+
+Enroll the built-in `@deprecated` tag in type-level heritage inheritance so derived declarations inherit base deprecation messages unless they provide a non-empty local message.

--- a/docs/002-tsdoc-grammar.md
+++ b/docs/002-tsdoc-grammar.md
@@ -511,9 +511,11 @@ Unknown format values are accepted (with an info diagnostic D4) for extensibilit
 
 ##### Inheritance through `extends` heritage
 
-Type-level annotations that opt in to inheritance flow from a base declaration to a derived class or interface along `extends` clauses. This lets authors declare a semantic format or extension annotation once on a domain base and have every derived narrowing type carry it through without repetition.
+Type-level annotations that opt in to inheritance flow from a base declaration to a derived class or interface along `extends` clauses. This lets authors declare semantic metadata such as a JSON Schema format, deprecation guidance, or extension annotation once on a domain base and have every derived narrowing type carry it through without repetition.
 
-**Allow-list:** Only annotations whose registration opts in to type-level heritage inheritance participate. The only inheriting built-in annotation is `@format`. Extension-defined custom annotations may opt in by setting `inheritFromBase: "local-wins"` on their `defineAnnotation()` registration. Other built-in type-level annotations — `@remarks`, `@deprecated`, `@displayName`, `@placeholder`, `@defaultValue`, `@description` (via summary text) — do **not** inherit through `extends`.
+**Allow-list:** Only annotations whose registration opts in to type-level heritage inheritance participate. The inheriting built-in annotations are `@format` and `@deprecated`. Extension-defined custom annotations may opt in by setting `inheritFromBase: "local-wins"` on their `defineAnnotation()` registration. Other built-in type-level annotations — `@remarks`, `@displayName`, `@placeholder`, `@defaultValue`, `@description` (via summary text) — do **not** inherit through `extends`.
+
+`@deprecated` uses the same local-wins policy as `@format`: a derived type inherits the nearest base declaration's deprecation message unless the derived type declares its own non-empty message. A presence-only tag such as `/** @deprecated */`, or a whitespace-only payload, confirms that the derived type is deprecated but does not suppress the base's specific migration guidance.
 
 **Scope — `extends` only:**
 
@@ -550,7 +552,7 @@ interface D extends B, C {}
 
 **Known limitations:**
 
-- Among built-ins, only `@format` currently participates. Extension custom annotations participate only when their registration sets `inheritFromBase: "local-wins"`. This is semantic inheritance, not schema serialization; output behavior remains controlled separately.
+- Among built-ins, only `@format` and `@deprecated` currently participate. Extension custom annotations participate only when their registration sets `inheritFromBase: "local-wins"`. This is semantic inheritance, not schema serialization; output behavior remains controlled separately.
 - Property-level annotation inheritance and metadata-slot inheritance are out of scope for this type-level heritage rule.
 
 #### `@defaultValue`

--- a/docs/spec-changelog.md
+++ b/docs/spec-changelog.md
@@ -10,6 +10,14 @@ This file tracks agreed changes and clarifications to the spec documents in `scr
 
 # 2026-04-28
 
+## 002-tsdoc-grammar.md
+
+- Added `@deprecated` to the type-level heritage inheritance allow-list.
+  - Derived classes and interfaces inherit the nearest base deprecation message through `extends` heritage.
+  - Named type aliases inherit through `type Derived = Base` RHS derivation chains.
+  - Local non-empty `@deprecated` messages override inherited messages.
+  - Presence-only and whitespace-only local `@deprecated` tags do not override the inherited message.
+
 ## 000-principles.md
 
 - Extended the PP15 cross-reference for the DSL-policy package split.

--- a/packages/analysis/src/heritage-annotations.ts
+++ b/packages/analysis/src/heritage-annotations.ts
@@ -34,6 +34,7 @@ export interface HeritageAnnotationOptions {
  */
 function getInheritableAnnotationStringValue(annotation: AnnotationNode): string | undefined {
   if (annotation.annotationKind === "format") return annotation.value;
+  if (annotation.annotationKind === "deprecated") return annotation.message ?? "";
   if ("value" in annotation && typeof annotation.value === "string") return annotation.value;
   return undefined;
 }
@@ -48,6 +49,14 @@ function isOverridingInheritableAnnotation(annotation: AnnotationNode): boolean 
   const value = getInheritableAnnotationStringValue(annotation);
   if (value === undefined) return true;
   return value.trim().length > 0;
+}
+
+function canFillInheritedAnnotationSlot(annotation: AnnotationNode): boolean {
+  // `@deprecated` is meaningful by presence: a base declaration with
+  // `/** @deprecated */` still marks derived types as deprecated, even though
+  // an empty local tag must not override a base message.
+  if (annotation.annotationKind === "deprecated") return true;
+  return isOverridingInheritableAnnotation(annotation);
 }
 
 /**
@@ -230,9 +239,10 @@ export function collectInheritedTypeAnnotations(
     for (const annotation of baseAnnotations) {
       const annotationKey = getAnnotationInheritanceKey(annotation);
       if (!needed.has(annotationKey)) continue;
-      // Skip empty-payload annotations on the base as well — they cannot
-      // meaningfully fill an inherited slot.
-      if (!isOverridingInheritableAnnotation(annotation)) continue;
+      // Most base annotations need a non-empty payload to fill an inherited
+      // slot. Presence-only `@deprecated` is the exception because the marker
+      // itself carries user-visible schema meaning.
+      if (!canFillInheritedAnnotationSlot(annotation)) continue;
       inherited.push(annotation);
       needed.delete(annotationKey);
     }
@@ -281,8 +291,8 @@ export function extractNamedTypeAnnotations(
 
 /**
  * Returns `true` when `namedDecl` carries an inheritable type-level
- * annotation identity, either locally with a meaningful payload or reachable
- * through the alias / heritage chain. Used by build to decide whether a
+ * annotation identity, either locally with inherited schema meaning or
+ * reachable through the alias / heritage chain. Used by build to decide whether a
  * pass-through alias warrants its own `$defs` entry
  * (issue #374) or should collapse to the base (issue #364 sibling-keyword
  * composition).
@@ -301,7 +311,7 @@ export function hasInheritableTypeAnnotation(
   const all = extractNamedTypeAnnotations(namedDecl, checker, file, extractAnnotations, options);
   for (const annotation of all) {
     if (!inheritableAnnotationKeys.has(getAnnotationInheritanceKey(annotation))) continue;
-    if (!isOverridingInheritableAnnotation(annotation)) continue;
+    if (!canFillInheritedAnnotationSlot(annotation)) continue;
     return true;
   }
   return false;

--- a/packages/analysis/src/tag-registry.ts
+++ b/packages/analysis/src/tag-registry.ts
@@ -744,6 +744,7 @@ const EXTRA_TAG_SPECS = {
     allowDuplicates: false,
     category: "ecosystem",
     placements: ALL_PLACEMENTS,
+    inheritFromBase: "local-wins",
     completionDetail: "Marks a declaration as deprecated.",
     hoverSummary: "Marks the declaration as deprecated.",
   },

--- a/packages/analysis/tests/heritage-annotations.test.ts
+++ b/packages/analysis/tests/heritage-annotations.test.ts
@@ -17,11 +17,13 @@ import * as ts from "typescript";
 import type {
   AnnotationNode,
   CustomAnnotationNode,
+  DeprecatedAnnotationNode,
   FormatAnnotationNode,
 } from "@formspec/core/internals";
 import {
   collectInheritedTypeAnnotations,
   extractNamedTypeAnnotations,
+  hasInheritableTypeAnnotation,
   type HeritageAnnotationExtractor,
 } from "../src/internal.js";
 import { createProgram } from "./helpers.js";
@@ -55,6 +57,18 @@ function makeFormatAnnotation(value: string, file = "/virtual/formspec.ts"): For
     kind: "annotation",
     annotationKind: "format",
     value,
+    provenance: { surface: "tsdoc", file, line: 1, column: 0 },
+  };
+}
+
+function makeDeprecatedAnnotation(
+  message: string | undefined,
+  file = "/virtual/formspec.ts"
+): DeprecatedAnnotationNode {
+  return {
+    kind: "annotation",
+    annotationKind: "deprecated",
+    ...(message !== undefined && { message }),
     provenance: { surface: "tsdoc", file, line: 1, column: 0 },
   };
 }
@@ -117,6 +131,83 @@ function makeStubExtractor(): HeritageAnnotationExtractor {
 }
 
 describe("collectInheritedTypeAnnotations", () => {
+  it("treats presence-only local @deprecated as a non-override", () => {
+    const { sourceFile, checker } = createProgram(`
+      interface BaseCustomer { id: string; }
+      export interface DerivedCustomer extends BaseCustomer { email?: string; }
+    `);
+    const derived = findInterface(sourceFile, "DerivedCustomer");
+    const localDeprecated = makeDeprecatedAnnotation(undefined);
+    const baseDeprecated = makeDeprecatedAnnotation("Use BaseCustomerV2 instead");
+
+    const inherited = collectInheritedTypeAnnotations(
+      derived,
+      [localDeprecated],
+      checker,
+      makeNamedAnnotationExtractor({ BaseCustomer: [baseDeprecated] }),
+      inheritanceKeys(["deprecated"])
+    );
+
+    expect(inherited).toEqual([baseDeprecated]);
+  });
+
+  it("treats whitespace-only local @deprecated as a non-override", () => {
+    const { sourceFile, checker } = createProgram(`
+      interface BaseCustomer { id: string; }
+      export interface DerivedCustomer extends BaseCustomer { email?: string; }
+    `);
+    const derived = findInterface(sourceFile, "DerivedCustomer");
+    const localDeprecated = makeDeprecatedAnnotation("   ");
+    const baseDeprecated = makeDeprecatedAnnotation("Use BaseCustomerV2 instead");
+
+    const inherited = collectInheritedTypeAnnotations(
+      derived,
+      [localDeprecated],
+      checker,
+      makeNamedAnnotationExtractor({ BaseCustomer: [baseDeprecated] }),
+      inheritanceKeys(["deprecated"])
+    );
+
+    expect(inherited).toEqual([baseDeprecated]);
+  });
+
+  it("inherits presence-only base @deprecated as a deprecation marker", () => {
+    const { sourceFile, checker } = createProgram(`
+      interface BaseCustomer { id: string; }
+      export interface DerivedCustomer extends BaseCustomer { email?: string; }
+    `);
+    const derived = findInterface(sourceFile, "DerivedCustomer");
+    const baseDeprecated = makeDeprecatedAnnotation(undefined);
+
+    const inherited = collectInheritedTypeAnnotations(
+      derived,
+      [],
+      checker,
+      makeNamedAnnotationExtractor({ BaseCustomer: [baseDeprecated] }),
+      inheritanceKeys(["deprecated"])
+    );
+
+    expect(inherited).toEqual([baseDeprecated]);
+  });
+
+  it("counts presence-only local @deprecated as an inheritable type annotation", () => {
+    const { sourceFile, checker } = createProgram(`
+      export type OldCustomer = { id: string };
+    `);
+    const oldCustomer = findTypeAlias(sourceFile, "OldCustomer");
+    const localDeprecated = makeDeprecatedAnnotation(undefined);
+
+    const hasInheritable = hasInheritableTypeAnnotation(
+      oldCustomer,
+      checker,
+      "/virtual/formspec.ts",
+      makeNamedAnnotationExtractor({ OldCustomer: [localDeprecated] }),
+      inheritanceKeys(["deprecated"])
+    );
+
+    expect(hasInheritable).toBe(true);
+  });
+
   it("returns the base @format when the derived interface omits one", () => {
     const { sourceFile, checker } = createProgram(`
       /** @format monetary-amount */
@@ -256,7 +347,13 @@ describe("collectInheritedTypeAnnotations", () => {
       return makeStubExtractor()(decl, file);
     };
 
-    const inherited = collectInheritedTypeAnnotations(leaf, [localFormat], checker, counting);
+    const inherited = collectInheritedTypeAnnotations(
+      leaf,
+      [localFormat],
+      checker,
+      counting,
+      inheritanceKeys(["format"])
+    );
 
     expect(inherited).toEqual([]);
     expect(calls).toBe(0);

--- a/packages/analysis/tests/tag-registry.test.ts
+++ b/packages/analysis/tests/tag-registry.test.ts
@@ -142,8 +142,8 @@ describe("tag-registry", () => {
       .map((definition) => definition.canonicalName)
       .sort();
 
-    expect(inheritableBuiltins).toEqual(["format"]);
-    expect([...getInheritableAnnotationKeys()]).toEqual(["format"]);
+    expect(inheritableBuiltins).toEqual(["deprecated", "format"]);
+    expect([...getInheritableAnnotationKeys()]).toEqual(["format", "deprecated"]);
     expect(getInheritableAnnotationKeys()).toBe(getInheritableAnnotationKeys());
   });
 
@@ -215,6 +215,7 @@ describe("tag-registry", () => {
     );
     expect([...getInheritableAnnotationKeys(extensions)].sort()).toEqual([
       "custom:x-example/currency/DisplayCurrency",
+      "deprecated",
       "format",
     ]);
     expect(getInheritableAnnotationKeys(extensions)).toBe(getInheritableAnnotationKeys(extensions));

--- a/packages/build/tests/deprecated-inheritance-derived-types.test.ts
+++ b/packages/build/tests/deprecated-inheritance-derived-types.test.ts
@@ -1,0 +1,538 @@
+/**
+ * Regression tests for issue #380: type-level `@deprecated` annotations
+ * declared on a base type must be inherited by derived declarations that opt
+ * in through `extends` or type-alias derivation. Local non-empty
+ * `@deprecated` messages win; presence-only and whitespace-only tags do not
+ * suppress the inherited message.
+ *
+ * @see https://github.com/mike-north/formspec/issues/380
+ * @see packages/analysis/src/heritage-annotations.ts — inheritance walk and
+ *      local override detection.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as ts from "typescript";
+import type { AnnotationNode, DeprecatedAnnotationNode } from "@formspec/core/internals";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { analyzeClassToIR, analyzeInterfaceToIR } from "../src/analyzer/class-analyzer.js";
+import {
+  createProgramContextFromProgram,
+  findClassByName,
+  findInterfaceByName,
+} from "../src/analyzer/program.js";
+import { generateSchemas, type GenerateSchemasOptions } from "../src/generators/class-schema.js";
+
+function generateSchemasOrThrow(options: Omit<GenerateSchemasOptions, "errorReporting">) {
+  return generateSchemas({ ...options, errorReporting: "throw" });
+}
+
+function expectRecord(value: unknown, message: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`${message}: expected object, got ${typeof value}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectDeprecatedAnnotation(
+  annotations: readonly AnnotationNode[] | undefined,
+  message: string
+): DeprecatedAnnotationNode {
+  const deprecated = annotations?.find(
+    (annotation): annotation is DeprecatedAnnotationNode =>
+      annotation.annotationKind === "deprecated"
+  );
+  expect(deprecated).toMatchObject({
+    annotationKind: "deprecated",
+    message,
+  });
+  if (deprecated === undefined) {
+    throw new Error(`Expected @deprecated annotation with message "${message}"`);
+  }
+  return deprecated;
+}
+
+function expectNoDeprecatedAnnotation(annotations: readonly AnnotationNode[] | undefined): void {
+  expect(
+    annotations?.some((annotation) => annotation.annotationKind === "deprecated") ?? false
+  ).toBe(false);
+}
+
+function expectDeprecatedSchema(schema: Record<string, unknown>, message: string): void {
+  expect(schema["deprecated"]).toBe(true);
+  expect(schema["x-formspec-deprecation-description"]).toBe(message);
+}
+
+const EXTENDS_INHERITANCE_SOURCE = [
+  "/** @deprecated Use CustomerV2 instead */",
+  "interface DeprecatedCustomer {",
+  "  id: string;",
+  "}",
+  "",
+  "interface DerivedCustomer extends DeprecatedCustomer {",
+  "  email?: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: DerivedCustomer;",
+  "}",
+].join("\n");
+
+const MULTI_LEVEL_SOURCE = [
+  "/** @deprecated Use RootV2 instead */",
+  "interface RootCustomer {",
+  "  id: string;",
+  "}",
+  "",
+  "interface MidCustomer extends RootCustomer {",
+  "  tier?: string;",
+  "}",
+  "",
+  "interface LeafCustomer extends MidCustomer {",
+  "  email?: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: LeafCustomer;",
+  "}",
+].join("\n");
+
+const NEAREST_ANCESTOR_SOURCE = [
+  "/** @deprecated Use RootV2 instead */",
+  "interface RootCustomer {",
+  "  id: string;",
+  "}",
+  "",
+  "/** @deprecated Use MidV2 instead */",
+  "interface MidCustomer extends RootCustomer {",
+  "  tier?: string;",
+  "}",
+  "",
+  "interface LeafCustomer extends MidCustomer {",
+  "  email?: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: LeafCustomer;",
+  "}",
+].join("\n");
+
+const TYPE_ALIAS_CHAIN_SOURCE = [
+  "/** @deprecated Use CustomerV2 instead */",
+  "interface DeprecatedCustomer {",
+  "  id: string;",
+  "}",
+  "",
+  "type AliasedCustomer = DeprecatedCustomer;",
+  "",
+  "interface DerivedCustomer extends AliasedCustomer {",
+  "  email?: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: DerivedCustomer;",
+  "}",
+].join("\n");
+
+const TYPE_ALIAS_PRESENCE_ONLY_SOURCE = [
+  "interface Customer {",
+  "  id: string;",
+  "}",
+  "",
+  "/** @deprecated */",
+  "type OldCustomer = Customer;",
+  "",
+  "export class Form {",
+  "  value!: OldCustomer;",
+  "}",
+].join("\n");
+
+const LOCAL_OVERRIDE_SOURCE = [
+  "/** @deprecated Use BaseV2 instead */",
+  "interface DeprecatedCustomer {",
+  "  id: string;",
+  "}",
+  "",
+  "/** @deprecated Use SpecificCustomerV2 instead */",
+  "interface SpecificCustomer extends DeprecatedCustomer {",
+  "  email?: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: SpecificCustomer;",
+  "}",
+].join("\n");
+
+const EMPTY_OVERRIDE_SOURCE = [
+  "/** @deprecated Use BaseV2 instead */",
+  "interface DeprecatedCustomer {",
+  "  id: string;",
+  "}",
+  "",
+  "/** @deprecated */",
+  "interface PresenceOnlyCustomer extends DeprecatedCustomer {",
+  "  email?: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: PresenceOnlyCustomer;",
+  "}",
+].join("\n");
+
+const WHITESPACE_OVERRIDE_SOURCE = [
+  "/** @deprecated Use BaseV2 instead */",
+  "interface DeprecatedCustomer {",
+  "  id: string;",
+  "}",
+  "",
+  "/** @deprecated    */",
+  "interface WhitespaceOnlyCustomer extends DeprecatedCustomer {",
+  "  email?: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: WhitespaceOnlyCustomer;",
+  "}",
+].join("\n");
+
+const CLASS_EXTENDS_SOURCE = [
+  "/** @deprecated Use CustomerBaseV2 instead */",
+  "class DeprecatedCustomerBase {",
+  "  id!: string;",
+  "}",
+  "",
+  "class DerivedCustomer extends DeprecatedCustomerBase {",
+  "  email?: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: DerivedCustomer;",
+  "}",
+].join("\n");
+
+const BASE_PRESENCE_ONLY_SOURCE = [
+  "/** @deprecated */",
+  "interface DeprecatedCustomer {",
+  "  id: string;",
+  "}",
+  "",
+  "interface DerivedCustomer extends DeprecatedCustomer {",
+  "  email?: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: DerivedCustomer;",
+  "}",
+].join("\n");
+
+const IMPLEMENTS_NEGATIVE_SOURCE = [
+  "/** @deprecated Use ICustomerV2 instead */",
+  "interface DeprecatedCustomer {",
+  "  id: string;",
+  "}",
+  "",
+  "class StructuralCustomer implements DeprecatedCustomer {",
+  "  id!: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: StructuralCustomer;",
+  "}",
+].join("\n");
+
+const NO_HERITAGE_SOURCE = [
+  "class StandaloneCustomer {",
+  "  id!: string;",
+  "}",
+  "",
+  "export class Form {",
+  "  value!: StandaloneCustomer;",
+  "}",
+].join("\n");
+
+let tmpDir: string;
+let extendsInheritanceFixturePath: string;
+let multiLevelFixturePath: string;
+let nearestAncestorFixturePath: string;
+let typeAliasChainFixturePath: string;
+let typeAliasPresenceOnlyFixturePath: string;
+let localOverrideFixturePath: string;
+let emptyOverrideFixturePath: string;
+let whitespaceOverrideFixturePath: string;
+let classExtendsFixturePath: string;
+let basePresenceOnlyFixturePath: string;
+let implementsNegativeFixturePath: string;
+let noHeritageFixturePath: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "formspec-deprecated-inherit-"));
+
+  fs.writeFileSync(
+    path.join(tmpDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "nodenext",
+          strict: true,
+          skipLibCheck: true,
+        },
+      },
+      null,
+      2
+    )
+  );
+
+  extendsInheritanceFixturePath = path.join(tmpDir, "extends-inheritance.ts");
+  fs.writeFileSync(extendsInheritanceFixturePath, EXTENDS_INHERITANCE_SOURCE);
+
+  multiLevelFixturePath = path.join(tmpDir, "multi-level.ts");
+  fs.writeFileSync(multiLevelFixturePath, MULTI_LEVEL_SOURCE);
+
+  nearestAncestorFixturePath = path.join(tmpDir, "nearest-ancestor.ts");
+  fs.writeFileSync(nearestAncestorFixturePath, NEAREST_ANCESTOR_SOURCE);
+
+  typeAliasChainFixturePath = path.join(tmpDir, "type-alias-chain.ts");
+  fs.writeFileSync(typeAliasChainFixturePath, TYPE_ALIAS_CHAIN_SOURCE);
+
+  typeAliasPresenceOnlyFixturePath = path.join(tmpDir, "type-alias-presence-only.ts");
+  fs.writeFileSync(typeAliasPresenceOnlyFixturePath, TYPE_ALIAS_PRESENCE_ONLY_SOURCE);
+
+  localOverrideFixturePath = path.join(tmpDir, "local-override.ts");
+  fs.writeFileSync(localOverrideFixturePath, LOCAL_OVERRIDE_SOURCE);
+
+  emptyOverrideFixturePath = path.join(tmpDir, "empty-override.ts");
+  fs.writeFileSync(emptyOverrideFixturePath, EMPTY_OVERRIDE_SOURCE);
+
+  whitespaceOverrideFixturePath = path.join(tmpDir, "whitespace-override.ts");
+  fs.writeFileSync(whitespaceOverrideFixturePath, WHITESPACE_OVERRIDE_SOURCE);
+
+  classExtendsFixturePath = path.join(tmpDir, "class-extends.ts");
+  fs.writeFileSync(classExtendsFixturePath, CLASS_EXTENDS_SOURCE);
+
+  basePresenceOnlyFixturePath = path.join(tmpDir, "base-presence-only.ts");
+  fs.writeFileSync(basePresenceOnlyFixturePath, BASE_PRESENCE_ONLY_SOURCE);
+
+  implementsNegativeFixturePath = path.join(tmpDir, "implements-negative.ts");
+  fs.writeFileSync(implementsNegativeFixturePath, IMPLEMENTS_NEGATIVE_SOURCE);
+
+  noHeritageFixturePath = path.join(tmpDir, "no-heritage.ts");
+  fs.writeFileSync(noHeritageFixturePath, NO_HERITAGE_SOURCE);
+});
+
+afterAll(() => {
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
+describe("type-level @deprecated inheritance on derived types — issue #380", () => {
+  it("inherits @deprecated from a base interface through single-level extends", () => {
+    const result = generateSchemasOrThrow({
+      filePath: extendsInheritanceFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const derived = expectRecord(defs["DerivedCustomer"], "$defs.DerivedCustomer");
+
+    expectDeprecatedSchema(derived, "Use CustomerV2 instead");
+
+    const program = ts.createProgram({
+      rootNames: [extendsInheritanceFixturePath],
+      options: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.NodeNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        strict: true,
+        skipLibCheck: true,
+      },
+    });
+    const ctx = createProgramContextFromProgram(program, extendsInheritanceFixturePath);
+    const derivedCustomer = findInterfaceByName(ctx.sourceFile, "DerivedCustomer");
+    if (derivedCustomer === null) throw new Error("DerivedCustomer interface not found");
+
+    const analysis = analyzeInterfaceToIR(
+      derivedCustomer,
+      ctx.checker,
+      extendsInheritanceFixturePath
+    );
+    expectDeprecatedAnnotation(analysis.annotations, "Use CustomerV2 instead");
+  });
+
+  it("walks a multi-level extends chain with nearest deprecated ancestor winning", () => {
+    const result = generateSchemasOrThrow({
+      filePath: multiLevelFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const leaf = expectRecord(defs["LeafCustomer"], "$defs.LeafCustomer");
+
+    expectDeprecatedSchema(leaf, "Use RootV2 instead");
+  });
+
+  it("prefers the nearest ancestor's @deprecated message in a multi-level extends chain", () => {
+    const result = generateSchemasOrThrow({
+      filePath: nearestAncestorFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const leaf = expectRecord(defs["LeafCustomer"], "$defs.LeafCustomer");
+
+    expectDeprecatedSchema(leaf, "Use MidV2 instead");
+  });
+
+  it("inherits @deprecated through an interface-extends-type-alias derivation chain", () => {
+    const result = generateSchemasOrThrow({
+      filePath: typeAliasChainFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const derived = expectRecord(defs["DerivedCustomer"], "$defs.DerivedCustomer");
+
+    expectDeprecatedSchema(derived, "Use CustomerV2 instead");
+  });
+
+  it("preserves pass-through aliases with presence-only @deprecated as deprecated definitions", () => {
+    const result = generateSchemasOrThrow({
+      filePath: typeAliasPresenceOnlyFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const oldCustomer = expectRecord(defs["OldCustomer"], "$defs.OldCustomer");
+
+    expect(oldCustomer["deprecated"]).toBe(true);
+    expect(oldCustomer["x-formspec-deprecation-description"]).toBeUndefined();
+  });
+
+  it("lets a local non-empty @deprecated message override the inherited message", () => {
+    const result = generateSchemasOrThrow({
+      filePath: localOverrideFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const specific = expectRecord(defs["SpecificCustomer"], "$defs.SpecificCustomer");
+
+    expectDeprecatedSchema(specific, "Use SpecificCustomerV2 instead");
+    expect(specific["x-formspec-deprecation-description"]).not.toBe("Use BaseV2 instead");
+  });
+
+  it("treats presence-only local @deprecated as non-overriding", () => {
+    const result = generateSchemasOrThrow({
+      filePath: emptyOverrideFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const presenceOnly = expectRecord(defs["PresenceOnlyCustomer"], "$defs.PresenceOnlyCustomer");
+
+    expectDeprecatedSchema(presenceOnly, "Use BaseV2 instead");
+  });
+
+  it("treats whitespace-only local @deprecated as non-overriding", () => {
+    const result = generateSchemasOrThrow({
+      filePath: whitespaceOverrideFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const whitespaceOnly = expectRecord(
+      defs["WhitespaceOnlyCustomer"],
+      "$defs.WhitespaceOnlyCustomer"
+    );
+
+    expectDeprecatedSchema(whitespaceOnly, "Use BaseV2 instead");
+  });
+
+  it("inherits @deprecated from a base class through class extends", () => {
+    const result = generateSchemasOrThrow({
+      filePath: classExtendsFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const derived = expectRecord(defs["DerivedCustomer"], "$defs.DerivedCustomer");
+
+    expectDeprecatedSchema(derived, "Use CustomerBaseV2 instead");
+
+    const program = ts.createProgram({
+      rootNames: [classExtendsFixturePath],
+      options: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.NodeNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        strict: true,
+        skipLibCheck: true,
+      },
+    });
+    const ctx = createProgramContextFromProgram(program, classExtendsFixturePath);
+    const derivedCustomer = findClassByName(ctx.sourceFile, "DerivedCustomer");
+    if (derivedCustomer === null) throw new Error("DerivedCustomer class not found");
+
+    const analysis = analyzeClassToIR(derivedCustomer, ctx.checker, classExtendsFixturePath);
+    expectDeprecatedAnnotation(analysis.annotations, "Use CustomerBaseV2 instead");
+  });
+
+  it("inherits presence-only base @deprecated as a deprecation marker", () => {
+    const result = generateSchemasOrThrow({
+      filePath: basePresenceOnlyFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const derived = expectRecord(defs["DerivedCustomer"], "$defs.DerivedCustomer");
+
+    expect(derived["deprecated"]).toBe(true);
+    expect(derived["x-formspec-deprecation-description"]).toBeUndefined();
+  });
+
+  it("does not inherit @deprecated through implements", () => {
+    const result = generateSchemasOrThrow({
+      filePath: implementsNegativeFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const structural = expectRecord(defs["StructuralCustomer"], "$defs.StructuralCustomer");
+
+    expect(structural["deprecated"]).toBeUndefined();
+    expect(structural["x-formspec-deprecation-description"]).toBeUndefined();
+  });
+
+  it("does not add @deprecated when a class has no heritage and no local tag", () => {
+    const result = generateSchemasOrThrow({
+      filePath: noHeritageFixturePath,
+      typeName: "Form",
+    });
+
+    const defs = expectRecord(result.jsonSchema.$defs ?? {}, "$defs");
+    const standalone = expectRecord(defs["StandaloneCustomer"], "$defs.StandaloneCustomer");
+
+    expect(standalone["deprecated"]).toBeUndefined();
+    expect(standalone["x-formspec-deprecation-description"]).toBeUndefined();
+
+    const program = ts.createProgram({
+      rootNames: [noHeritageFixturePath],
+      options: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.NodeNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        strict: true,
+        skipLibCheck: true,
+      },
+    });
+    const ctx = createProgramContextFromProgram(program, noHeritageFixturePath);
+    const standaloneCustomer = findClassByName(ctx.sourceFile, "StandaloneCustomer");
+    if (standaloneCustomer === null) throw new Error("StandaloneCustomer class not found");
+
+    const analysis = analyzeClassToIR(standaloneCustomer, ctx.checker, noHeritageFixturePath);
+    expectNoDeprecatedAnnotation(analysis.annotations);
+  });
+});


### PR DESCRIPTION
## Summary

- Enroll the built-in `@deprecated` tag in registration-driven type-level heritage inheritance with `inheritFromBase: "local-wins"`.
- Teach inherited annotation value handling that `@deprecated` stores its payload in `message`, while preserving presence-only base deprecations as inherited deprecation markers.
- Add focused analysis and build coverage for `extends`, nearest-ancestor behavior, type-alias derivation, local override semantics, presence/whitespace non-overrides, class inheritance, `implements` non-propagation, and no-heritage no-op behavior.
- Update the TSDoc grammar docs, spec changelog, and add a minor changeset for the affected published package graph.

## Test plan

- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run api-extractor`
- `pnpm exec prettier --check .changeset/deprecated-heritage-inheritance.md docs/002-tsdoc-grammar.md docs/spec-changelog.md packages/analysis/src/heritage-annotations.ts packages/analysis/src/tag-registry.ts packages/analysis/tests/heritage-annotations.test.ts packages/analysis/tests/tag-registry.test.ts packages/build/tests/deprecated-inheritance-derived-types.test.ts`
- `pnpm changeset status --since origin/main`

Refs #380

`@description`, `@formatHint`, `@displayName`, `@remarks`, `@placeholder`, and `@defaultValue` remain non-inheriting pending separate design conversations.