### PR TITLE
Fix Ref target discriminator fallback

### DIFF
--- a/.changeset/fix-ref-union-type-discriminator.md
+++ b/.changeset/fix-ref-union-type-discriminator.md
@@ -1,0 +1,8 @@
+---
+"@formspec/build": patch
+"@formspec/cli": patch
+"@formspec/eslint-plugin": patch
+"formspec": patch
+---
+
+Allow `Ref<T>` targets with unrelated union-valued `type` fields to resolve their literal `object` discriminator value.

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -1331,11 +1331,7 @@ function resolveDiscriminatorValue(
       // but Ref<T>-style wrappers may bind Stripe-like targets whose unrelated
       // `type` field is a union. Defer the v1 union diagnostic until the fallback
       // `object` identity property has had a chance to resolve.
-      if (
-        fieldName !== "type" ||
-        identityPropertyName !== "type" ||
-        !allowObjectFallbackForUnionTypeIdentity
-      ) {
+      if (!allowObjectFallbackForUnionTypeIdentity || identityPropertyName !== "type") {
         diagnostics.push(
           makeAnalysisDiagnostic(
             "INVALID_TAG_ARGUMENT",

--- a/packages/build/src/analyzer/class-analyzer.ts
+++ b/packages/build/src/analyzer/class-analyzer.ts
@@ -813,6 +813,15 @@ interface ResolvedDiscriminatorProperty {
   readonly optional: boolean;
 }
 
+const UNION_VALUED_DISCRIMINATOR_PROPERTY: unique symbol = Symbol(
+  "union-valued discriminator property"
+);
+
+type LiteralDiscriminatorPropertyValue =
+  | string
+  | typeof UNION_VALUED_DISCRIMINATOR_PROPERTY
+  | undefined;
+
 function makeAnalysisDiagnostic(
   code: string,
   message: string,
@@ -1160,10 +1169,8 @@ function getConcreteTypeArgumentForDiscriminator(
 function resolveLiteralDiscriminatorPropertyValue(
   boundType: ts.Type,
   propertyName: string,
-  checker: ts.TypeChecker,
-  provenance: Provenance,
-  diagnostics: ConstraintSemanticDiagnostic[]
-): string | null | undefined {
+  checker: ts.TypeChecker
+): LiteralDiscriminatorPropertyValue {
   const propertySymbol = boundType.getProperty(propertyName);
   if (propertySymbol === undefined) {
     return undefined;
@@ -1186,14 +1193,7 @@ function resolveLiteralDiscriminatorPropertyValue(
       (member) => !(member.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined))
     );
     if (nonNullMembers.length > 0 && nonNullMembers.every((member) => member.isStringLiteral())) {
-      diagnostics.push(
-        makeAnalysisDiagnostic(
-          "INVALID_TAG_ARGUMENT",
-          "Discriminator resolution for union-valued identity properties is out of scope for v1.",
-          provenance
-        )
-      );
-      return null;
+      return UNION_VALUED_DISCRIMINATOR_PROPERTY;
     }
   }
 
@@ -1285,7 +1285,8 @@ function resolveDiscriminatorValue(
   checker: ts.TypeChecker,
   provenance: Provenance,
   diagnostics: ConstraintSemanticDiagnostic[],
-  metadataPolicy: AnalyzerMetadataPolicy
+  metadataPolicy: AnalyzerMetadataPolicy,
+  allowObjectFallbackForUnionTypeIdentity: boolean
 ): string | null {
   if (boundType === null) {
     diagnostics.push(
@@ -1318,20 +1319,49 @@ function resolveDiscriminatorValue(
     }
   }
 
+  let sawUnionValuedIdentityProperty = false;
   for (const identityPropertyName of getDiscriminatorIdentityPropertyNames(fieldName)) {
     const literalIdentityValue = resolveLiteralDiscriminatorPropertyValue(
       boundType,
       identityPropertyName,
-      checker,
-      provenance,
-      diagnostics
+      checker
     );
-    if (literalIdentityValue === null) {
-      return null;
+    if (literalIdentityValue === UNION_VALUED_DISCRIMINATOR_PROPERTY) {
+      // `@discriminator :type T` prefers T.type when it is a singleton literal,
+      // but Ref<T>-style wrappers may bind Stripe-like targets whose unrelated
+      // `type` field is a union. Defer the v1 union diagnostic until the fallback
+      // `object` identity property has had a chance to resolve.
+      if (
+        fieldName !== "type" ||
+        identityPropertyName !== "type" ||
+        !allowObjectFallbackForUnionTypeIdentity
+      ) {
+        diagnostics.push(
+          makeAnalysisDiagnostic(
+            "INVALID_TAG_ARGUMENT",
+            "Discriminator resolution for union-valued identity properties is out of scope for v1.",
+            provenance
+          )
+        );
+        return null;
+      }
+      sawUnionValuedIdentityProperty = true;
+      continue;
     }
     if (literalIdentityValue !== undefined) {
       return literalIdentityValue;
     }
+  }
+
+  if (sawUnionValuedIdentityProperty) {
+    diagnostics.push(
+      makeAnalysisDiagnostic(
+        "INVALID_TAG_ARGUMENT",
+        "Discriminator resolution for union-valued identity properties is out of scope for v1.",
+        provenance
+      )
+    );
+    return null;
   }
 
   const apiName = resolveDiscriminatorApiName(boundType, checker, metadataPolicy);
@@ -1350,6 +1380,178 @@ function resolveDiscriminatorValue(
     )
   );
   return null;
+}
+
+function discriminatorFieldAllowsObjectFallback(
+  node: DiscriminatorDeclarationNode,
+  checker: ts.TypeChecker,
+  directive: DiscriminatorDirective
+): boolean {
+  if (directive.fieldName !== "type") {
+    return false;
+  }
+
+  const property = resolveDiscriminatorProperty(node, checker, directive.fieldName);
+  const propertyTypeNode = getDeclarationTypeNode(property?.declaration);
+  return (
+    propertyTypeNode !== undefined &&
+    isObjectIdentityExtractorTypeNode(propertyTypeNode, checker, directive.typeParameterName)
+  );
+}
+
+function getDeclarationTypeNode(declaration: ts.Declaration | undefined): ts.TypeNode | undefined {
+  if (declaration === undefined) {
+    return undefined;
+  }
+
+  if (
+    (ts.isPropertySignature(declaration) ||
+      ts.isPropertyDeclaration(declaration) ||
+      ts.isParameter(declaration)) &&
+    declaration.type !== undefined
+  ) {
+    return declaration.type;
+  }
+
+  return undefined;
+}
+
+function isObjectIdentityExtractorTypeNode(
+  typeNode: ts.TypeNode,
+  checker: ts.TypeChecker,
+  typeParameterName: string,
+  seenAliases: Set<ts.TypeAliasDeclaration> = new Set<ts.TypeAliasDeclaration>()
+): boolean {
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return isObjectIdentityExtractorTypeNode(
+      typeNode.type,
+      checker,
+      typeParameterName,
+      seenAliases
+    );
+  }
+
+  if (isObjectIndexedAccessTypeNode(typeNode, typeParameterName)) {
+    return true;
+  }
+
+  if (isObjectConditionalExtractorTypeNode(typeNode, typeParameterName)) {
+    return true;
+  }
+
+  if (!ts.isTypeReferenceNode(typeNode)) {
+    return false;
+  }
+
+  const aliasDecl = getTypeAliasDeclarationFromTypeReference(typeNode, checker);
+  if (aliasDecl === undefined || seenAliases.has(aliasDecl)) {
+    return false;
+  }
+
+  const [aliasTypeParameter] = aliasDecl.typeParameters ?? [];
+  const [aliasArgument] = typeNode.typeArguments ?? [];
+  if (
+    aliasTypeParameter === undefined ||
+    aliasArgument === undefined ||
+    !typeNodeReferencesTypeParameter(aliasArgument, typeParameterName)
+  ) {
+    return false;
+  }
+
+  seenAliases.add(aliasDecl);
+  return isObjectIdentityExtractorTypeNode(
+    aliasDecl.type,
+    checker,
+    aliasTypeParameter.name.text,
+    seenAliases
+  );
+}
+
+function isObjectIndexedAccessTypeNode(typeNode: ts.TypeNode, typeParameterName: string): boolean {
+  if (!ts.isIndexedAccessTypeNode(typeNode)) {
+    return false;
+  }
+
+  return (
+    typeNodeReferencesTypeParameter(typeNode.objectType, typeParameterName) &&
+    isObjectStringLiteralTypeNode(typeNode.indexType)
+  );
+}
+
+function isObjectConditionalExtractorTypeNode(
+  typeNode: ts.TypeNode,
+  typeParameterName: string
+): boolean {
+  if (!ts.isConditionalTypeNode(typeNode)) {
+    return false;
+  }
+
+  return (
+    typeNodeReferencesTypeParameter(typeNode.checkType, typeParameterName) &&
+    typeNodeHasObjectProperty(typeNode.extendsType) &&
+    typeNodeContainsInferTypeNode(typeNode.extendsType)
+  );
+}
+
+function typeNodeReferencesTypeParameter(
+  typeNode: ts.TypeNode,
+  typeParameterName: string
+): boolean {
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return typeNodeReferencesTypeParameter(typeNode.type, typeParameterName);
+  }
+
+  return ts.isTypeReferenceNode(typeNode)
+    ? ts.isIdentifier(typeNode.typeName) && typeNode.typeName.text === typeParameterName
+    : false;
+}
+
+function isObjectStringLiteralTypeNode(typeNode: ts.TypeNode): boolean {
+  return (
+    ts.isLiteralTypeNode(typeNode) &&
+    ts.isStringLiteral(typeNode.literal) &&
+    typeNode.literal.text === "object"
+  );
+}
+
+function typeNodeHasObjectProperty(typeNode: ts.TypeNode): boolean {
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return typeNodeHasObjectProperty(typeNode.type);
+  }
+
+  if (ts.isIntersectionTypeNode(typeNode)) {
+    return typeNode.types.some(typeNodeHasObjectProperty);
+  }
+
+  if (!ts.isTypeLiteralNode(typeNode)) {
+    return false;
+  }
+
+  return typeNode.members.some(
+    (member) =>
+      ts.isPropertySignature(member) &&
+      getAnalyzableObjectLikePropertyName(member.name) === "object"
+  );
+}
+
+function typeNodeContainsInferTypeNode(typeNode: ts.TypeNode): boolean {
+  if (ts.isInferTypeNode(typeNode)) {
+    return true;
+  }
+
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) {
+      return;
+    }
+    if (ts.isInferTypeNode(node)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(typeNode);
+  return found;
 }
 
 function getDeclarationName(node: ts.Declaration): string {
@@ -1410,7 +1612,8 @@ function applyDeclarationDiscriminatorToFields(
     checker,
     directive.provenance,
     diagnostics,
-    metadataPolicy
+    metadataPolicy,
+    discriminatorFieldAllowsObjectFallback(node, checker, directive)
   );
   if (discriminatorValue === null) {
     return [...fields];
@@ -1550,7 +1753,8 @@ function applyDiscriminatorToObjectProperties(
     checker,
     directive.provenance,
     diagnostics,
-    metadataPolicy
+    metadataPolicy,
+    discriminatorFieldAllowsObjectFallback(node, checker, directive)
   );
   if (discriminatorValue === null) {
     return properties;

--- a/packages/build/tests/discriminator.test.ts
+++ b/packages/build/tests/discriminator.test.ts
@@ -132,6 +132,18 @@ describe("@discriminator schema generation", () => {
         "  id: string;",
         "}",
         "",
+        "export interface UnionKindWithObjectCarrier {",
+        '  readonly object: "union_kind_with_object";',
+        '  kind: "customer" | "organization";',
+        "  id: string;",
+        "}",
+        "",
+        "export interface UnionTypeWithObjectCarrier {",
+        '  readonly object: "union_type_with_object";',
+        '  type: "customer" | "organization";',
+        "  id: string;",
+        "}",
+        "",
         "export interface GenericCarrier<T> {",
         "  id: T;",
         "}",
@@ -219,7 +231,7 @@ describe("@discriminator schema generation", () => {
     fs.writeFileSync(
       fixturePath,
       [
-        'import type { Customer, Organization, ApiNamedAccount, InferredAccountCarrier, CustomerObjectCarrier, ObjectAliasCarrier, IntersectionAliasCarrier, UnionIdentityCarrier, GenericCarrier, MissingCarrier, LargeObjectCarrier, ExtractObjectTag } from "./names.js";',
+        'import type { Customer, Organization, ApiNamedAccount, InferredAccountCarrier, CustomerObjectCarrier, ObjectAliasCarrier, IntersectionAliasCarrier, UnionIdentityCarrier, UnionKindWithObjectCarrier, UnionTypeWithObjectCarrier, GenericCarrier, MissingCarrier, LargeObjectCarrier, ExtractObjectTag } from "./names.js";',
         'import { Bar, InferredObjectCarrier } from "./names.js";',
         'import type { ReExportedCustomer, ReExportedOrganization } from "./aliases.js";',
         'import type { Ref as ImportedRef } from "./refs.js";',
@@ -227,6 +239,12 @@ describe("@discriminator schema generation", () => {
         "/** @discriminator :kind T */",
         "export interface TaggedValue<T> {",
         "  kind: string;",
+        "  id: string;",
+        "}",
+        "",
+        "/** @discriminator :type T */",
+        "export interface TypeTaggedValue<T> {",
+        "  type: string;",
         "  id: string;",
         "}",
         "",
@@ -382,6 +400,14 @@ describe("@discriminator schema generation", () => {
         "",
         "export interface UnionIdentityWrapper {",
         "  bad: TaggedValue<UnionIdentityCarrier>;",
+        "}",
+        "",
+        "export interface UnionKindWithObjectWrapper {",
+        "  bad: TaggedValue<UnionKindWithObjectCarrier>;",
+        "}",
+        "",
+        "export interface UnionTypeWithObjectWrapper {",
+        "  bad: TypeTaggedValue<UnionTypeWithObjectCarrier>;",
         "}",
         "",
         "/** @discriminator :kind T */",
@@ -783,6 +809,24 @@ describe("@discriminator schema generation", () => {
       generateSchemasOrThrow({
         filePath: fixturePath,
         typeName: "UnionIdentityWrapper",
+      })
+    ).toThrow(/INVALID_TAG_ARGUMENT/);
+  });
+
+  it("does not fall back to object when the requested identity field is union-valued", () => {
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "UnionKindWithObjectWrapper",
+      })
+    ).toThrow(/INVALID_TAG_ARGUMENT/);
+  });
+
+  it("does not allow object fallback for a :type field that is not derived from object identity", () => {
+    expect(() =>
+      generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "UnionTypeWithObjectWrapper",
       })
     ).toThrow(/INVALID_TAG_ARGUMENT/);
   });

--- a/packages/build/tests/ref-type-schema.test.ts
+++ b/packages/build/tests/ref-type-schema.test.ts
@@ -61,6 +61,21 @@ interface Invoice {
   customer: Ref<Customer>;
 }
 
+interface Product {
+  readonly object: 'product';
+  type: 'good' | 'service';
+  name: string;
+}
+
+type RelatedObject =
+  | { readonly object: 'customer'; id: string; type: 'individual' | 'business' }
+  | { readonly object: 'product'; id: string; type: 'good' | 'service' };
+
+interface V2Event {
+  readonly object: 'v2.core.event';
+  related_object: RelatedObject | null;
+}
+
 /** @apiName custom_loyalty */
 interface LoyaltyProgram {
   readonly object: string;
@@ -96,6 +111,14 @@ export interface OptionalRefForm {
 export interface NestedRefForm {
   /** Invoice whose customer field is itself a Ref<Customer>. */
   invoice: Ref<Invoice>;
+}
+
+export interface ProductRefForm {
+  product: Ref<Product>;
+}
+
+export interface EventRefForm {
+  event: Ref<V2Event>;
 }
 `.trimStart();
 
@@ -141,10 +164,7 @@ function expectRecord(value: unknown, message: string): Record<string, unknown> 
   return value as Record<string, unknown>;
 }
 
-function resolveRef(
-  schema: unknown,
-  root: Record<string, unknown>
-): Record<string, unknown> {
+function resolveRef(schema: unknown, root: Record<string, unknown>): Record<string, unknown> {
   // Fail fast if `schema` isn't an object — silently casting `undefined` here
   // produces confusing downstream errors (e.g. "cannot read properties of
   // undefined") that mask missing fields in the test setup.
@@ -273,19 +293,21 @@ describe("Ref<T> JSON Schema serialization", () => {
       // May be wrapped in a nullable schema — find the Ref properties
       const customerSchema = props["customer"] as Record<string, unknown>;
       // Try direct resolution first, then check oneOf/anyOf for nullable
-      const refSchema = customerSchema["$ref"] !== undefined
-        ? resolveRef(customerSchema, root)
-        : (() => {
-            const oneOf = customerSchema["oneOf"] as unknown[] | undefined;
-            const anyOf = customerSchema["anyOf"] as unknown[] | undefined;
-            const members = oneOf ?? anyOf ?? [customerSchema];
-            const nonNull = members.find(
-              (m) => typeof m === "object" && m !== null && (m as Record<string, unknown>)["type"] !== "null"
-            );
-            return nonNull !== undefined
-              ? resolveRef(nonNull, root)
-              : customerSchema;
-          })();
+      const refSchema =
+        customerSchema["$ref"] !== undefined
+          ? resolveRef(customerSchema, root)
+          : (() => {
+              const oneOf = customerSchema["oneOf"] as unknown[] | undefined;
+              const anyOf = customerSchema["anyOf"] as unknown[] | undefined;
+              const members = oneOf ?? anyOf ?? [customerSchema];
+              const nonNull = members.find(
+                (m) =>
+                  typeof m === "object" &&
+                  m !== null &&
+                  (m as Record<string, unknown>)["type"] !== "null"
+              );
+              return nonNull !== undefined ? resolveRef(nonNull, root) : customerSchema;
+            })();
 
       // Assert properties are emitted unconditionally — a regression that drops
       // the Ref body on optional fields must fail this test, not silently pass.
@@ -328,6 +350,41 @@ describe("Ref<T> JSON Schema serialization", () => {
       const invoiceRefProps = expectRecord(invoiceRef["properties"], "Missing Ref<Invoice> props");
       const typeSchema = expectRecord(invoiceRefProps["type"], "Missing type property");
       expect(typeSchema["enum"]).toEqual(["invoice"]);
+    });
+  });
+
+  describe("Ref<T> targets with non-Ref discriminator-like fields", () => {
+    it("uses the target object's literal object value when the target also has a union-valued type field", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "ProductRefForm",
+      });
+
+      const props = result.jsonSchema.properties as Record<string, unknown>;
+      const root = result.jsonSchema as Record<string, unknown>;
+      const productRef = resolveRef(props["product"], root);
+      const productRefProps = expectRecord(productRef["properties"], "Missing Ref<Product> props");
+      const typeSchema = expectRecord(productRefProps["type"], "Missing type property");
+
+      expect(Object.keys(productRefProps).sort()).toEqual(["id", "type"]);
+      expect(typeSchema["enum"]).toEqual(["product"]);
+    });
+
+    it("keeps Ref<T> compact when the target has unrelated nested union fields", () => {
+      const result = generateSchemasOrThrow({
+        filePath: fixturePath,
+        typeName: "EventRefForm",
+      });
+
+      const props = result.jsonSchema.properties as Record<string, unknown>;
+      const root = result.jsonSchema as Record<string, unknown>;
+      const eventRef = resolveRef(props["event"], root);
+      const eventRefProps = expectRecord(eventRef["properties"], "Missing Ref<V2Event> props");
+      const typeSchema = expectRecord(eventRefProps["type"], "Missing type property");
+
+      expect(Object.keys(eventRefProps).sort()).toEqual(["id", "type"]);
+      expect(eventRefProps).not.toHaveProperty("related_object");
+      expect(typeSchema["enum"]).toEqual(["v2.core.event"]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Allow `Ref<T>` discriminator resolution to use `T.object` when the target has an unrelated union-valued `type` field.
- Keep non-object-derived `:type` fields and other union-valued identity fields invalid instead of falling back to `object`.
- Add regression coverage for Stripe-like `Product` and event reference targets.

Closes #496

## Test plan
- `pnpm exec prettier --check packages/build/src/analyzer/class-analyzer.ts packages/build/tests/discriminator.test.ts packages/build/tests/ref-type-schema.test.ts .changeset/fix-ref-union-type-discriminator.md`
- `git diff --check`
- `pnpm --filter @formspec/build run typecheck`
- `pnpm --filter @formspec/build exec vitest run tests/discriminator.test.ts tests/ref-type-schema.test.ts tests/large-type-argument.test.ts`
- `pnpm --filter @formspec/build run test`
- `pnpm changeset status --since origin/main`
